### PR TITLE
DQ - propogate compile function from current compile context similiar to new SQL flow

### DIFF
--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-generation/pom.xml
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-generation/pom.xml
@@ -58,6 +58,10 @@
             <groupId>org.finos.legend.pure</groupId>
             <artifactId>legend-pure-m3-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-runtime-java-engine-compiled</artifactId>
+        </dependency>
         <!-- PURE -->
 
         <!-- ENGINE -->
@@ -94,6 +98,10 @@
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-xt-relationalStore-javaPlatformBinding-pure</artifactId>
             <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-language-pure-grammar</artifactId>
         </dependency>
         <!-- ENGINE -->
 

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-generation/src/main/java/org/finos/legend/engine/generation/dataquality/DataQualityProfilingLambdaGenerator.java
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-generation/src/main/java/org/finos/legend/engine/generation/dataquality/DataQualityProfilingLambdaGenerator.java
@@ -14,12 +14,18 @@
 
 package org.finos.legend.engine.generation.dataquality;
 
+import org.finos.legend.engine.language.pure.compiler.toPureGraph.HelperValueSpecificationBuilder;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
+import org.finos.legend.engine.language.pure.grammar.from.PureGrammarParser;
 import org.finos.legend.engine.shared.core.operational.errorManagement.EngineException;
 import org.finos.legend.engine.shared.core.operational.errorManagement.ExceptionCategory;
+import org.finos.legend.pure.generated.PureCompiledLambda;
 import org.finos.legend.pure.generated.Root_meta_external_dataquality_DataQualityRelationValidation;
 import org.finos.legend.pure.generated.core_dataquality_generation_dataprofile;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction;
+import org.finos.legend.pure.m3.execution.ExecutionSupport;
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.function.DefaultPureLambdaFunction1;
 
 public class DataQualityProfilingLambdaGenerator
 {
@@ -42,6 +48,19 @@ public class DataQualityProfilingLambdaGenerator
 
     private static org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction<Object> generateDataProfileLambda(PureModel pureModel, Root_meta_external_dataquality_DataQualityRelationValidation packageableElement, boolean excludePlatformColumns)
     {
-        return (org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction<Object>) core_dataquality_generation_dataprofile.Root_meta_external_dataquality_dataprofile_getProfilingLambda_DataQualityRelationValidation_1__Boolean_1__Boolean_1__LambdaFunction_1_(packageableElement, true, excludePlatformColumns, pureModel.getExecutionSupport());
+        return (org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction<Object>) core_dataquality_generation_dataprofile.Root_meta_external_dataquality_dataprofile_getProfilingLambda_DataQualityRelationValidation_1__Boolean_1__Boolean_1__Function_1__LambdaFunction_1_(packageableElement, true, excludePlatformColumns, getLambdaCompiler(pureModel), pureModel.getExecutionSupport());
+    }
+
+    public static org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.Function<?> getLambdaCompiler(PureModel pureModel)
+    {
+        PureCompiledLambda stringLambdaCompiler = new PureCompiledLambda(pureModel.getExecutionSupport(), "", new DefaultPureLambdaFunction1<String, LambdaFunction<? extends Object>>()
+        {
+            @Override
+            public org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction<? extends Object> value(String code, ExecutionSupport executionSupport)
+            {
+                return HelperValueSpecificationBuilder.buildLambda(PureGrammarParser.newInstance().parseLambda(code), pureModel.getContext());
+            }
+        });
+        return core_dataquality_generation_dataprofile.Root_meta_external_dataquality_dataprofile_getLambdaCompiler_Function_1__Function_1_(stringLambdaCompiler, pureModel.getExecutionSupport());
     }
 }

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-generation/src/main/java/org/finos/legend/engine/generation/dataquality/DataQualityReconLambdaGenerator.java
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-generation/src/main/java/org/finos/legend/engine/generation/dataquality/DataQualityReconLambdaGenerator.java
@@ -18,11 +18,13 @@ import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
 import org.finos.legend.pure.generated.Root_meta_external_dataquality_datarecon_DataQualityReconInput;
 import org.finos.legend.pure.generated.core_dataquality_generation_datarecon;
 
+import static org.finos.legend.engine.generation.dataquality.DataQualityProfilingLambdaGenerator.getLambdaCompiler;
+
 public class DataQualityReconLambdaGenerator
 {
 
     public static org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction<Object> generateLambda(PureModel pureModel, Root_meta_external_dataquality_datarecon_DataQualityReconInput reconInput)
     {
-        return (org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction<Object>) core_dataquality_generation_datarecon.Root_meta_external_dataquality_datarecon_getDataReconLambda_DataQualityReconInput_1__LambdaFunction_1_(reconInput, pureModel.getExecutionSupport());
+        return (org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction<Object>) core_dataquality_generation_datarecon.Root_meta_external_dataquality_datarecon_getDataReconLambda_DataQualityReconInput_1__Function_1__LambdaFunction_1_(reconInput, getLambdaCompiler(pureModel), pureModel.getExecutionSupport());
     }
 }

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-generation/src/main/java/org/finos/legend/engine/generation/dataquality/DataQualitySampleValuesLambdaGenerator.java
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-generation/src/main/java/org/finos/legend/engine/generation/dataquality/DataQualitySampleValuesLambdaGenerator.java
@@ -23,6 +23,8 @@ import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElem
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.ConcreteFunctionDefinition;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction;
 
+import static org.finos.legend.engine.generation.dataquality.DataQualityProfilingLambdaGenerator.getLambdaCompiler;
+
 public class DataQualitySampleValuesLambdaGenerator
 {
     /**
@@ -77,13 +79,13 @@ public class DataQualitySampleValuesLambdaGenerator
         if (maxNumberOfSampleValues != null)
         {
             return core_dataquality_generation_samplevalues
-                            .Root_meta_external_dataquality_samplevalues_getSampleValuesLambda_LambdaFunction_1__Integer_1__Boolean_1__Boolean_1__LambdaFunction_1_(
-                                    pureLambda, (long) maxNumberOfSampleValues, true, excludePlatformColumns, pureModel.getExecutionSupport());
+                            .Root_meta_external_dataquality_samplevalues_getSampleValuesLambda_LambdaFunction_1__Integer_1__Boolean_1__Boolean_1__Function_1__LambdaFunction_1_(
+                                    pureLambda, (long) maxNumberOfSampleValues, true, excludePlatformColumns, getLambdaCompiler(pureModel), pureModel.getExecutionSupport());
         }
 
         // maxNumberOfSampleValues omitted — sensible default from within the PURE layer applies
         return core_dataquality_generation_samplevalues
-                        .Root_meta_external_dataquality_samplevalues_getSampleValuesLambda_LambdaFunction_1__Boolean_1__Boolean_1__LambdaFunction_1_(
-                                pureLambda, true, excludePlatformColumns, pureModel.getExecutionSupport());
+                        .Root_meta_external_dataquality_samplevalues_getSampleValuesLambda_LambdaFunction_1__Boolean_1__Boolean_1__Function_1__LambdaFunction_1_(
+                                pureLambda, true, excludePlatformColumns, getLambdaCompiler(pureModel), pureModel.getExecutionSupport());
     }
 }

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure-test/pom.xml
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure-test/pom.xml
@@ -107,6 +107,10 @@
             <artifactId>legend-pure-m2-dsl-graph-pure</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-sql-pure</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.finos.legend.pure</groupId>
             <artifactId>legend-pure-m2-dsl-mapping-pure</artifactId>
         </dependency>

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure-test/src/main/resources/core_dataquality_test.definition.json
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure-test/src/main/resources/core_dataquality_test.definition.json
@@ -15,6 +15,7 @@
     "platform_store_relational",
     "platform_precise_primitives",
     "core_dataquality",
-    "core_external_compiler"
+    "core_external_compiler",
+    "core_external_query_sql"
   ]
 }

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure-test/src/main/resources/core_dataquality_test/dataprofile_test.pure
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure-test/src/main/resources/core_dataquality_test/dataprofile_test.pure
@@ -19,6 +19,7 @@ import meta::external::dataquality::dataprofile::*;
 import meta::external::dataquality::tests::*;
 import meta::external::dataquality::dataprofile::tests::*;
 import meta::pure::router::preeval::*;
+import meta::external::query::sql::transformation::compile::utils::*;
 
 function <<test.Test>> meta::external::dataquality::tests::testDataProfileLambdaGeneration():Boolean[1]
 {
@@ -98,7 +99,7 @@ function meta::external::dataquality::tests::doTest(dq:String[1], expected:Funct
 {
   let dataqualityRelationValidation = $dq->loadDataQualityRelationValidation();
 
-  let actual = $dataqualityRelationValidation->getProfilingLambda($wrapWithFrom, true);
+  let actual = $dataqualityRelationValidation->getProfilingLambda($wrapWithFrom, true, {l:LambdaFunction<Any>[1] | compileViaGrammar($l)});
 
   let expectedPrevaled = if ($wrapWithFrom, | $expected->preval([]), | $expected);
   let actualPrevaled = if ($wrapWithFrom, | $actual->preval([]), | $actual);

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure-test/src/main/resources/core_dataquality_test/datarecon_test.pure
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure-test/src/main/resources/core_dataquality_test/datarecon_test.pure
@@ -23,6 +23,7 @@ import meta::external::dataquality::*;
 import meta::pure::precisePrimitives::*;
 import meta::external::dataquality::tests::domain::*;
 import meta::pure::metamodel::relation::*;
+import meta::external::query::sql::transformation::compile::utils::*;
 
 function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_dataRecon_dynamicHash():Boolean[1]
 {
@@ -490,7 +491,7 @@ function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_
 
   let source = {| #>{meta::external::dataquality::tests::domain::db.personTable}#->from($runtime)};
   let target = {| #>{meta::external::dataquality::tests::domain::db.personTable}#->from($runtime)};
-  let actual = getDataReconLambda(^DataQualityReconInput(source = $source, target = $target, keys = 'ID', colsForHash = ['FIRSTNAME', 'LASTNAME'], targetHashCol = 'HASH', includeColumnValues = true, enrichDQColumns = true));
+  let actual = getDataReconLambda(^DataQualityReconInput(source = $source, target = $target, keys = 'ID', colsForHash = ['FIRSTNAME', 'LASTNAME'], targetHashCol = 'HASH', includeColumnValues = true, enrichDQColumns = true), {l:LambdaFunction<Any>[1] | compileViaGrammar($l)});
   assertLambdaEquals($expected, $actual, false);
 }
 
@@ -513,6 +514,6 @@ function meta::external::dataquality::tests::testRecon(expected:FunctionDefiniti
 
 function meta::external::dataquality::tests::testRecon(expected:FunctionDefinition<Any>[1], source: LambdaFunction<Any>[1], target: LambdaFunction<Any>[1], keys: String[*], aggregatedHash: Boolean[1], colsForHash: String[*], sourceHashCol: String[0..1], targetHashCol: String[0..1], includeColumnValues: Boolean[1], defectLimit: Integer[0..1], removeFrom: Boolean[1]):Boolean[1]
 {
-  let actual = getDataReconLambda(createReconInput($source, $target, $keys, $aggregatedHash, $colsForHash, $sourceHashCol, $targetHashCol, $includeColumnValues, $defectLimit, $removeFrom, false));
+  let actual = getDataReconLambda(createReconInput($source, $target, $keys, $aggregatedHash, $colsForHash, $sourceHashCol, $targetHashCol, $includeColumnValues, $defectLimit, $removeFrom, false), {l:LambdaFunction<Any>[1] | compileViaGrammar($l)});
   assertLambdaEquals($expected, $actual, false);
 }

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure-test/src/main/resources/core_dataquality_test/samplevalues_test.pure
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure-test/src/main/resources/core_dataquality_test/samplevalues_test.pure
@@ -19,6 +19,7 @@ import meta::pure::metamodel::serialization::grammar::*;
 import meta::external::dataquality::samplevalues::*;
 import meta::external::dataquality::tests::*;
 import meta::pure::router::preeval::*;
+import meta::external::query::sql::transformation::compile::utils::*;
 
 // ─── String column: values appear in string_value; all other value columns null ──
 function <<test.Test>> meta::external::dataquality::tests::testSampleValuesStringColumn():Boolean[1]
@@ -226,7 +227,7 @@ function <<test.Test>> meta::external::dataquality::tests::testSampleValuesDefau
   };
 
   // Use the 5-arg overload with no mapping/runtime to verify default limit of 20
-  let actual = getSampleValuesLambda($query->cast(@LambdaFunction<Any>), [], [], 20, false, true);
+  let actual = getSampleValuesLambda($query->cast(@LambdaFunction<Any>), [], [], 20, false, true, {l:LambdaFunction<Any>[1] | compileViaGrammar($l)});
 
   assertLambdaEquals($expected, $actual->cast(@LambdaFunction<Any>), false);
 }
@@ -349,6 +350,6 @@ function <<test.Test>> meta::external::dataquality::tests::testSampleValuesColum
 // ─── Test helper ──
 function meta::external::dataquality::tests::doSampleValuesTest(query: FunctionDefinition<Any>[1], expected: FunctionDefinition<Any>[1], maxNumberOfSampleValues: Integer[1]):Boolean[1]
 {
-  let actual = getSampleValuesLambda($query->cast(@LambdaFunction<Any>), [], [], $maxNumberOfSampleValues, false, true);
+  let actual = getSampleValuesLambda($query->cast(@LambdaFunction<Any>), [], [], $maxNumberOfSampleValues, false, true, {l:LambdaFunction<Any>[1] | compileViaGrammar($l)});
   assertLambdaEquals($expected, $actual->cast(@LambdaFunction<Any>), false);
 }

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure/src/main/resources/core_dataquality/generation/dataprofile.pure
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure/src/main/resources/core_dataquality/generation/dataprofile.pure
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import meta::external::query::sql::transformation::queryToPure::*;
 import meta::core::runtime::*;
 import meta::pure::mapping::*;
 import meta::external::query::sql::transformation::utils::*;
@@ -23,7 +24,7 @@ import meta::external::dataquality::*;
 import meta::external::dataquality::dataprofile::*;
 import meta::pure::metamodel::relation::*;
 
-function meta::external::dataquality::dataprofile::getProfilingLambda(dqRelationValidation: meta::external::dataquality::DataQualityRelationValidation[1], wrapWithFrom:Boolean[1], excludePlatformCols: Boolean[1]): LambdaFunction<Any>[1]
+function meta::external::dataquality::dataprofile::getProfilingLambda(dqRelationValidation: meta::external::dataquality::DataQualityRelationValidation[1], wrapWithFrom:Boolean[1], excludePlatformCols: Boolean[1], compiler:Function<{LambdaFunction<Any>[1]->LambdaFunction<Any>[1]}>[1]): LambdaFunction<Any>[1]
 {
   assert($dqRelationValidation.query->isEndingWithFromFunction(), 'Query must end with a from in order to execute');
   let lambda = $dqRelationValidation.query->popTerminalFunctionExpression();
@@ -35,10 +36,10 @@ function meta::external::dataquality::dataprofile::getProfilingLambda(dqRelation
   assert($runtime->isEmpty() || $runtime->size() == 1, | 'multiple runtimes not supported');
   assert($mapping->isEmpty() || $mapping->size() == 1, | 'multiple mappings not supported');
 
-  getProfilingLambda($lambda, $mapping->first(), $runtime->first(), $wrapWithFrom, $excludePlatformCols);
+  getProfilingLambda($lambda, $mapping->first(), $runtime->first(), $wrapWithFrom, $excludePlatformCols, $compiler);
 }
 
-function meta::external::dataquality::dataprofile::getProfilingLambda(l:LambdaFunction<Any>[1], mapping:Mapping[0..1], runtime:Any[0..1], wrapWithFrom:Boolean[1], excludePlatformCols: Boolean[1]):LambdaFunction<Any>[1]
+function meta::external::dataquality::dataprofile::getProfilingLambda(l:LambdaFunction<Any>[1], mapping:Mapping[0..1], runtime:Any[0..1], wrapWithFrom:Boolean[1], excludePlatformCols: Boolean[1], compiler:Function<{LambdaFunction<Any>[1]->LambdaFunction<Any>[1]}>[1]):LambdaFunction<Any>[1]
 {
   assert($l->functionReturnType().rawType->toOne()->subTypeOf(meta::pure::metamodel::relation::Relation), 'only relation functions supported');
 
@@ -78,11 +79,9 @@ function meta::external::dataquality::dataprofile::getProfilingLambda(l:LambdaFu
   let lambda = ^$l(expressionSequence = $l.expressionSequence->evaluateAndDeactivate()->init()->concatenate([$letCte, $func])->toOneMany());//->preval(relationalExtensions())->cast(@LambdaFunction<Any>);
 
   if ($wrapWithFrom,
-                    | ^$lambda(expressionSequence = sfe(eval_Function_1__V_m_, [iv($lambda)])
-                        ->compileViaGrammar()
-                        ->wrapWithFrom($mapping, $runtime, [], true) //TODO this should ideally be done before compile but there are issues with testing
-                      ),
-                    | $lambda->compileViaGrammar());
+                    | let updatedLambda = $compiler->eval(^$lambda(expressionSequence = sfe(eval_Function_1__V_m_, [iv($lambda)])));
+                      ^$updatedLambda(expressionSequence = $updatedLambda.expressionSequence->toOne()->wrapWithFrom($mapping, $runtime, [], true));,
+                    | $compiler->eval($lambda));                
 }
 
 function meta::external::dataquality::dataprofile::agg(name:ProfileColumn[1], fn:Function<Any>[1], column:Column<Nil,Any|*>[1]):AggColSpec<Any, Any, Any>[1]
@@ -200,4 +199,9 @@ function meta::external::dataquality::dataprofile::getPlatformColumnsToExclude(e
     | getDQExtensions().platformColumns->distinct(),
     | []
   );
+}
+
+function meta::external::dataquality::dataprofile::getLambdaCompiler(compiler:Function<{String[1]->LambdaFunction<Any>[1]}>[1]):Function<{LambdaFunction<Any>[1]->LambdaFunction<Any>[1]}>[1]
+{
+  {l:LambdaFunction<Any>[1]| $compiler->eval($l->printFunctionDefinition(dynamicGrammarConfiguration(), ^GContext(space='')))}
 }

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure/src/main/resources/core_dataquality/generation/dataqualitysqlextension.pure
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure/src/main/resources/core_dataquality/generation/dataqualitysqlextension.pure
@@ -42,7 +42,7 @@ function <<sql.Extension>> meta::external::dataquality::dataProfileCoreExtension
             v:ValueSpecification[1] | fail('invalid parameter to data_profile'); {|1};
           ]);
 
-          let profilingLambda = iv(getProfilingLambda($relationLambda, [], [], false, true));
+          let profilingLambda = iv(getProfilingLambda($relationLambda, [], [], false, true, {l:LambdaFunction<Any>[1] | compileViaGrammar($l)}));
 
           sfe(eval_Function_1__V_m_, $profilingLambda);
           }

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure/src/main/resources/core_dataquality/generation/datarecon.pure
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure/src/main/resources/core_dataquality/generation/datarecon.pure
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import meta::pure::metamodel::serialization::grammar::*;
 import meta::pure::metamodel::relation::*;
 import meta::pure::mapping::*;
 import meta::external::query::sql::transformation::compile::utils::*;
@@ -33,7 +34,7 @@ import meta::pure::tds::schema::*;
     6) join 2 datasets using keys
     7) filter where source and target hash are different
 */
-function meta::external::dataquality::datarecon::getDataReconLambda(reconInput: DataQualityReconInput[1]): LambdaFunction<Any>[1]
+function meta::external::dataquality::datarecon::getDataReconLambda(reconInput: DataQualityReconInput[1], compiler:Function<{LambdaFunction<Any>[1]->LambdaFunction<Any>[1]}>[1]): LambdaFunction<Any>[1]
 {  
   let baseLambda = $reconInput.source;
 
@@ -47,8 +48,8 @@ function meta::external::dataquality::datarecon::getDataReconLambda(reconInput: 
 
   let allParams = $renamedSourceParams->concatenate($renamedTargetParams);
 
-  let sourceDataset = $sourceParams->fold({param, valueSpecification | $valueSpecification->replaceVariableWithVariable($param.name, 'source_' + $param.name)}, prepareDataset($reconInput.source, 'source', $reconInput.keys, $reconInput.aggregatedHash, $reconInput.colsForHash, $reconInput.sourceHashCol, $reconInput.includeColumnValues, $reconInput.removeFrom));
-  let targetDataset = $targetParams->fold({param, valueSpecification | $valueSpecification->replaceVariableWithVariable($param.name, 'target_' + $param.name)}, prepareDataset($reconInput.target, 'target', $reconInput.keys, $reconInput.aggregatedHash, $reconInput.colsForHash, $reconInput.targetHashCol, $reconInput.includeColumnValues, $reconInput.removeFrom));
+  let sourceDataset = $sourceParams->fold({param, valueSpecification | $valueSpecification->replaceVariableWithVariable($param.name, 'source_' + $param.name)}, prepareDataset($reconInput.source, 'source', $reconInput.keys, $reconInput.aggregatedHash, $reconInput.colsForHash, $reconInput.sourceHashCol, $reconInput.includeColumnValues, $reconInput.removeFrom, $compiler));
+  let targetDataset = $targetParams->fold({param, valueSpecification | $valueSpecification->replaceVariableWithVariable($param.name, 'target_' + $param.name)}, prepareDataset($reconInput.target, 'target', $reconInput.keys, $reconInput.aggregatedHash, $reconInput.colsForHash, $reconInput.targetHashCol, $reconInput.includeColumnValues, $reconInput.removeFrom, $compiler));
 
   //join by keys
   let withJoin = buildJoinExpression($sourceDataset, $targetDataset, JoinKind.FULL, getJoinColumns($reconInput.keys), $reconInput.sourceHashCol, $reconInput.targetHashCol);
@@ -77,7 +78,7 @@ function meta::external::dataquality::datarecon::getDataReconLambda(reconInput: 
   );
 }
 
-function meta::external::dataquality::datarecon::prepareDataset(dataset: LambdaFunction<Any>[1], type: String[1], keys: String[*], aggregatedHash: Boolean[1], colsForHash: String[*], hashCol: String[0..1], includeColumnValues: Boolean[1], removeFrom: Boolean[1]): ValueSpecification[1]
+function meta::external::dataquality::datarecon::prepareDataset(dataset: LambdaFunction<Any>[1], type: String[1], keys: String[*], aggregatedHash: Boolean[1], colsForHash: String[*], hashCol: String[0..1], includeColumnValues: Boolean[1], removeFrom: Boolean[1], compiler:Function<{LambdaFunction<Any>[1]->LambdaFunction<Any>[1]}>[1]): ValueSpecification[1]
 {  
   let hasFrom = $dataset->isEndingWithFromFunction();
   let withoutFrom = if ($hasFrom,
@@ -109,7 +110,7 @@ function meta::external::dataquality::datarecon::prepareDataset(dataset: LambdaF
   //create hash
   let withHash = if ($hashCol->isNotEmpty(), 
     | $withNormalizedCols,
-    | let withRowHash = buildRowHash($withNormalizedCols, $suffix, $type, true, $dataset);
+    | let withRowHash = buildRowHash($withNormalizedCols, $suffix, $type, true, $dataset, $compiler);
       if ($includeColumnValues && !$aggregatedHash,
         | $withRowHash,
         | //select only hash col + keys
@@ -121,11 +122,11 @@ function meta::external::dataquality::datarecon::prepareDataset(dataset: LambdaF
   //create aggregated hash
   let hashColumn = if ($hashCol->isNotEmpty(), | $hashCol->toOne(), | 'DIGEST') + $suffix;
   let withAggregatedHash = if ($aggregatedHash,
-    | buildAggregatedHash($withHash, getRelType($withHash->compileViaGrammarWithContext($dataset)), $hashColumn, $keys->map(col | $col + $suffix), $suffix, $type, $dataset),
+    | buildAggregatedHash($withHash, getRelType($withHash->compileViaGrammarWithContext($dataset, $compiler)), $hashColumn, $keys->map(col | $col + $suffix), $suffix, $type, $dataset, $compiler),
     | $withHash
   );
 
-  let compiled = $withAggregatedHash->compileViaGrammarWithContext($dataset);
+  let compiled = $withAggregatedHash->compileViaGrammarWithContext($dataset, $compiler);
   if ($hasFrom && !$removeFrom,
     | let from = $dataset.expressionSequence->evaluateAndDeactivate()->last()->cast(@SimpleFunctionExpression)->toOne();
       sfe($from.func, $compiled.genericType, [], $compiled->concatenate($from.parametersValues->tail()));,
@@ -202,7 +203,7 @@ function meta::external::dataquality::datarecon::normalizeColumns(input: ValueSp
   let withSelect = buildSelectExpression($withNormalized, $columns.name->map(col | $col + $suffix));
 }
 
-function meta::external::dataquality::datarecon::buildAggregatedHash(input: ValueSpecification[1], relType: RelationType<Any>[1], hashColumn: String[1], groupingCols: String[*], suffix: String[1], type: String[1], contextLambda: LambdaFunction<Any>[1]):ValueSpecification[1]
+function meta::external::dataquality::datarecon::buildAggregatedHash(input: ValueSpecification[1], relType: RelationType<Any>[1], hashColumn: String[1], groupingCols: String[*], suffix: String[1], type: String[1], contextLambda: LambdaFunction<Any>[1], compiler:Function<{LambdaFunction<Any>[1]->LambdaFunction<Any>[1]}>[1]):ValueSpecification[1]
 {
   //sort by hash column to ensure aggregated hash created in determinstic manner. 
   //TODO- the correct order by is not used in the generated SQL, we need the order by to be within the group in the aggregation to ensure consistency across different sql engines
@@ -218,7 +219,7 @@ function meta::external::dataquality::datarecon::buildAggregatedHash(input: Valu
   );
 
   //calculate hash of hashes
-  let aggHash = buildRowHash($groupBy, $suffix, $type, false, $contextLambda);
+  let aggHash = buildRowHash($groupBy, $suffix, $type, false, $contextLambda, $compiler);
 
   //select only grouping cols and hash col
   let selectCols = $groupingCols->union('DIGEST' + $suffix);
@@ -252,9 +253,9 @@ function meta::external::dataquality::datarecon::buildExtendExpression(input: Va
   );
 }
 
-function meta::external::dataquality::datarecon::buildRowHash(input: ValueSpecification[1], suffix: String[1], type: String[1], includeColName: Boolean[1], contextLambda: LambdaFunction<Any>[1]):ValueSpecification[1]
+function meta::external::dataquality::datarecon::buildRowHash(input: ValueSpecification[1], suffix: String[1], type: String[1], includeColName: Boolean[1], contextLambda: LambdaFunction<Any>[1], compiler:Function<{LambdaFunction<Any>[1]->LambdaFunction<Any>[1]}>[1]):ValueSpecification[1]
 {
-  let relType = getRelType($input->compileViaGrammarWithContext($contextLambda));
+  let relType = getRelType($input->compileViaGrammarWithContext($contextLambda, $compiler));
   $input->buildExtendExpression('DIGEST' + $suffix, String, buildHashFunctionExpression($relType, $relType.columns.name->sort(), 'row', $includeColName, $suffix));
 }
 
@@ -460,9 +461,9 @@ function meta::external::dataquality::datarecon::getRelType(input: ValueSpecific
   $input.genericType.typeArguments.rawType->toOne()->cast(@RelationType<Any>);
 }
 
-function meta::external::dataquality::datarecon::compileViaGrammarWithContext(vs:ValueSpecification[1], contextLambda: LambdaFunction<Any>[1]):ValueSpecification[1]
+function meta::external::dataquality::datarecon::compileViaGrammarWithContext(vs:ValueSpecification[1], contextLambda: LambdaFunction<Any>[1], compiler:Function<{LambdaFunction<Any>[1]->LambdaFunction<Any>[1]}>[1]):ValueSpecification[1]
 {
-  let compiled = ^$contextLambda(expressionSequence = $contextLambda.expressionSequence->evaluateAndDeactivate()->init()->concatenate([$vs])->toOneMany())->compileViaGrammar();
+  let compiled = $compiler->eval(^$contextLambda(expressionSequence = $contextLambda.expressionSequence->evaluateAndDeactivate()->init()->concatenate([$vs])->toOneMany()));
   $compiled.expressionSequence->evaluateAndDeactivate()->last()->toOne();
 }
 

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure/src/main/resources/core_dataquality/generation/samplevalues.pure
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure/src/main/resources/core_dataquality/generation/samplevalues.pure
@@ -28,12 +28,12 @@ function meta::external::dataquality::samplevalues::wrapFunctionDefinitionAsLamb
   lambda($f->functionType(), $f.expressionSequence);
 }
 
-function meta::external::dataquality::samplevalues::getSampleValuesLambda(lambda: LambdaFunction<Any>[1], wrapWithFrom: Boolean[1], excludePlatformCols: Boolean[1]): LambdaFunction<Any>[1]
+function meta::external::dataquality::samplevalues::getSampleValuesLambda(lambda: LambdaFunction<Any>[1], wrapWithFrom: Boolean[1], excludePlatformCols: Boolean[1], compiler:Function<{LambdaFunction<Any>[1]->LambdaFunction<Any>[1]}>[1]): LambdaFunction<Any>[1]
 {
-  getSampleValuesLambda($lambda, 20, $wrapWithFrom, $excludePlatformCols);
+  getSampleValuesLambda($lambda, 20, $wrapWithFrom, $excludePlatformCols, $compiler);
 }
 
-function meta::external::dataquality::samplevalues::getSampleValuesLambda(lambda: LambdaFunction<Any>[1], maxNumberOfSampleValues: Integer[1], wrapWithFrom:Boolean[1], excludePlatformCols: Boolean[1]): LambdaFunction<Any>[1]
+function meta::external::dataquality::samplevalues::getSampleValuesLambda(lambda: LambdaFunction<Any>[1], maxNumberOfSampleValues: Integer[1], wrapWithFrom:Boolean[1], excludePlatformCols: Boolean[1], compiler:Function<{LambdaFunction<Any>[1]->LambdaFunction<Any>[1]}>[1]): LambdaFunction<Any>[1]
 {
   assert($lambda->functionReturnType().rawType->toOne()->subTypeOf(meta::pure::metamodel::relation::Relation), 'only relation functions supported');
   assert($lambda->isEndingWithFromFunction(), 'Query must end with a from in order to execute');
@@ -46,10 +46,10 @@ function meta::external::dataquality::samplevalues::getSampleValuesLambda(lambda
   assert($runtime->isEmpty() || $runtime->size() == 1, | 'multiple runtimes not supported');
   assert($mapping->isEmpty() || $mapping->size() == 1, | 'multiple mappings not supported');
 
-  getSampleValuesLambda($poppedLambda, $mapping->first(), $runtime->first(), $maxNumberOfSampleValues, $wrapWithFrom, $excludePlatformCols);
+  getSampleValuesLambda($poppedLambda, $mapping->first(), $runtime->first(), $maxNumberOfSampleValues, $wrapWithFrom, $excludePlatformCols, $compiler);
 }
 
-function meta::external::dataquality::samplevalues::getSampleValuesLambda(l: LambdaFunction<Any>[1], mapping: Mapping[0..1], runtime: Any[0..1], maxNumberOfSampleValues: Integer[1], wrapWithFrom: Boolean[1], excludePlatformCols: Boolean[1]): LambdaFunction<Any>[1]
+function meta::external::dataquality::samplevalues::getSampleValuesLambda(l: LambdaFunction<Any>[1], mapping: Mapping[0..1], runtime: Any[0..1], maxNumberOfSampleValues: Integer[1], wrapWithFrom: Boolean[1], excludePlatformCols: Boolean[1], compiler:Function<{LambdaFunction<Any>[1]->LambdaFunction<Any>[1]}>[1]): LambdaFunction<Any>[1]
 {
   let relationType = $l.expressionSequence->evaluateAndDeactivate()->last().genericType.typeArguments.rawType->cast(@meta::pure::metamodel::relation::RelationType<Any>);
 
@@ -167,13 +167,10 @@ function meta::external::dataquality::samplevalues::getSampleValuesLambda(l: Lam
 
   let lambda = ^$l(expressionSequence = $l.expressionSequence->evaluateAndDeactivate()->init()->concatenate([$letCte, $func])->toOneMany());
 
-  // Compile and optionally wrap with from
   if ($wrapWithFrom,
-                    | ^$lambda(expressionSequence = sfe(eval_Function_1__V_m_, [iv($lambda)])
-                        ->compileViaGrammar()
-                        ->wrapWithFrom($mapping, $runtime, [], true)
-                      ),
-                    | $lambda->compileViaGrammar());
+                    | let updatedLambda = $compiler->eval(^$lambda(expressionSequence = sfe(eval_Function_1__V_m_, [iv($lambda)])));
+                      ^$updatedLambda(expressionSequence = $updatedLambda.expressionSequence->toOne()->wrapWithFrom($mapping, $runtime, [], true));,
+                    | $compiler->eval($lambda));                    
 }
 
 // Helper: reference a column on a row variable


### PR DESCRIPTION
#### What type of PR is this?

- Improvement


#### What does this PR do / why is it needed ?

Pass in compile function using the current compile context, this means we have all dependencies in scope and do not need to scan and serialise the dependencies. This has a huge performance improvement and allows compilation when user defined functions used in DQ recon/data profile etc. This has taken same approach that was done in SQL flow recently.
