### PR TITLE
Null-safe composite key handling in data reconciliation joins

### DIFF
--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure-test/src/main/resources/core_dataquality_test/datarecon_test.pure
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure-test/src/main/resources/core_dataquality_test/datarecon_test.pure
@@ -43,7 +43,7 @@ function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_
           ->select(~[ID_TARGET,DIGEST_TARGET])
           ->from($runtime),
         JoinKind.FULL,
-        {x,y| $x.ID_SOURCE == $y.ID_TARGET}
+        {x,y| ($x.ID_SOURCE->isEmpty() && $y.ID_TARGET->isEmpty()) || ($x.ID_SOURCE == $y.ID_TARGET)}
     )->filter(row | not($row.DIGEST_SOURCE == $row.DIGEST_TARGET))
   };
 
@@ -65,7 +65,7 @@ function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_
           ->select(~[ID_TARGET,HASH_TARGET])
           ->from($runtime),
         JoinKind.FULL,
-        {x,y| $x.ID_SOURCE == $y.ID_TARGET}
+        {x,y| ($x.ID_SOURCE->isEmpty() && $y.ID_TARGET->isEmpty()) || ($x.ID_SOURCE == $y.ID_TARGET)}
     )->filter(row | not($row.HASH_SOURCE == $row.HASH_TARGET))
   };
 
@@ -95,7 +95,7 @@ function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_
           ->select(~[FIRMID_TARGET,DIGEST_TARGET])
           ->from($runtime),
         JoinKind.FULL,
-        {x,y| $x.FIRMID_SOURCE == $y.FIRMID_TARGET}
+        {x,y| ($x.FIRMID_SOURCE->isEmpty() && $y.FIRMID_TARGET->isEmpty()) || ($x.FIRMID_SOURCE == $y.FIRMID_TARGET)}
     )->filter(row | not($row.DIGEST_SOURCE == $row.DIGEST_TARGET))
   };
 
@@ -117,7 +117,7 @@ function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_
           ->select(~[DOB_TARGET,CODE_TARGET,COUPOUN_TARGET,CREATED_TARGET])
           ->from($runtime),
         JoinKind.FULL,
-        {x,y| ($x.CREATED_SOURCE == $y.CREATED_TARGET) && (($x.COUPOUN_SOURCE == $y.COUPOUN_TARGET) && (($x.CODE_SOURCE == $y.CODE_TARGET) && ($x.DOB_SOURCE == $y.DOB_TARGET)))}
+        {x,y| (($x.CREATED_SOURCE->isEmpty() && $y.CREATED_TARGET->isEmpty()) || ($x.CREATED_SOURCE == $y.CREATED_TARGET)) && ((($x.COUPOUN_SOURCE->isEmpty() && $y.COUPOUN_TARGET->isEmpty()) || ($x.COUPOUN_SOURCE == $y.COUPOUN_TARGET)) && ((($x.CODE_SOURCE->isEmpty() && $y.CODE_TARGET->isEmpty()) || ($x.CODE_SOURCE == $y.CODE_TARGET)) && (($x.DOB_SOURCE->isEmpty() && $y.DOB_TARGET->isEmpty()) || ($x.DOB_SOURCE == $y.DOB_TARGET))))}
     )->filter(row | not($row.DOB_SOURCE == $row.DOB_TARGET))
   };
 
@@ -144,7 +144,7 @@ function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_
           ->select(~[ID_TARGET,DIGEST_TARGET])
           ->from($runtime),
         JoinKind.FULL,
-        {x,y| $x.ID_SOURCE == $y.ID_TARGET}
+        {x,y| ($x.ID_SOURCE->isEmpty() && $y.ID_TARGET->isEmpty()) || ($x.ID_SOURCE == $y.ID_TARGET)}
     )->filter(row | not($row.DIGEST_SOURCE == $row.DIGEST_TARGET))
   };
 
@@ -170,7 +170,7 @@ function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_
           ->select(~[DIGEST_TARGET])
           ->from($runtime),
         JoinKind.FULL,
-        {x,y| $x.DIGEST_SOURCE == $y.DIGEST_TARGET}
+        {x,y| ($x.DIGEST_SOURCE->isEmpty() && $y.DIGEST_TARGET->isEmpty()) || ($x.DIGEST_SOURCE == $y.DIGEST_TARGET)}
     )->filter(row | not($row.DIGEST_SOURCE == $row.DIGEST_TARGET))
   };
 
@@ -194,7 +194,7 @@ function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_
           ->select(~[HASH_TARGET])
           ->from($runtime),
         JoinKind.FULL,
-        {x,y| $x.DIGEST_SOURCE == $y.HASH_TARGET}
+        {x,y| ($x.DIGEST_SOURCE->isEmpty() && $y.HASH_TARGET->isEmpty()) || ($x.DIGEST_SOURCE == $y.HASH_TARGET)}
     )->filter(row | not($row.DIGEST_SOURCE == $row.HASH_TARGET))
   };
 
@@ -228,7 +228,7 @@ function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_
           ->select(~[DIGEST_TARGET])
           ->from($runtime),
         JoinKind.FULL,
-        {x,y| $x.DIGEST_SOURCE == $y.DIGEST_TARGET}
+        {x,y| ($x.DIGEST_SOURCE->isEmpty() && $y.DIGEST_TARGET->isEmpty()) || ($x.DIGEST_SOURCE == $y.DIGEST_TARGET)}
     )->filter(row | not($row.DIGEST_SOURCE == $row.DIGEST_TARGET))
   };
 
@@ -251,7 +251,7 @@ function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_
           ->select(~[ID_TARGET,FIRSTNAME_TARGET,LASTNAME_TARGET,HASH_TARGET])
           ->from($runtime),
         JoinKind.FULL,
-        {x,y| $x.ID_SOURCE == $y.ID_TARGET}
+        {x,y| ($x.ID_SOURCE->isEmpty() && $y.ID_TARGET->isEmpty()) || ($x.ID_SOURCE == $y.ID_TARGET)}
     )->filter(row | not($row.DIGEST_SOURCE == $row.HASH_TARGET))
   };
 
@@ -277,7 +277,7 @@ function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_
           ->select(~[ID_TARGET,DIGEST_TARGET])
           ->from($runtime),
         JoinKind.FULL,
-        {x,y| $x.ID_SOURCE == $y.ID_TARGET}
+        {x,y| ($x.ID_SOURCE->isEmpty() && $y.ID_TARGET->isEmpty()) || ($x.ID_SOURCE == $y.ID_TARGET)}
     )->filter(row | not($row.DIGEST_SOURCE == $row.DIGEST_TARGET))
     ->limit(100)
   };
@@ -308,7 +308,7 @@ function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_
           ->select(~[ID_TARGET,DIGEST_TARGET])
           ->from($runtime),
         JoinKind.FULL,
-        {x,y| $x.ID_SOURCE == $y.ID_TARGET}
+        {x,y| ($x.ID_SOURCE->isEmpty() && $y.ID_TARGET->isEmpty()) || ($x.ID_SOURCE == $y.ID_TARGET)}
     )->filter(row | not($row.DIGEST_SOURCE == $row.DIGEST_TARGET))
   };
 
@@ -337,7 +337,7 @@ function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_
           ->select(~[ID_TARGET,DIGEST_TARGET])
           ->from($runtime),
         JoinKind.FULL,
-        {x,y| $x.ID_SOURCE == $y.ID_TARGET}
+        {x,y| ($x.ID_SOURCE->isEmpty() && $y.ID_TARGET->isEmpty()) || ($x.ID_SOURCE == $y.ID_TARGET)}
     )->filter(row | not($row.DIGEST_SOURCE == $row.DIGEST_TARGET))
   };
 
@@ -367,7 +367,7 @@ function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_
           ->select(~[ID_TARGET,DIGEST_TARGET])
           ->from($runtime),
         JoinKind.FULL,
-        {x,y| $x.ID_SOURCE == $y.ID_TARGET}
+        {x,y| ($x.ID_SOURCE->isEmpty() && $y.ID_TARGET->isEmpty()) || ($x.ID_SOURCE == $y.ID_TARGET)}
     )->filter(row | not($row.DIGEST_SOURCE == $row.DIGEST_TARGET))
   };
 
@@ -386,7 +386,7 @@ function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_
           ->extend(~[ID_TARGET: row | $row.ID, HASH_TARGET: row | $row.HASH])
           ->select(~[ID_TARGET,HASH_TARGET]),
         JoinKind.FULL,
-        {x,y| $x.ID_SOURCE == $y.ID_TARGET}
+        {x,y| ($x.ID_SOURCE->isEmpty() && $y.ID_TARGET->isEmpty()) || ($x.ID_SOURCE == $y.ID_TARGET)}
     )->filter(row | not($row.HASH_SOURCE == $row.HASH_TARGET))
   };
 
@@ -407,7 +407,7 @@ function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_
           ->extend(~[ID_TARGET: row | $row.ID, HASH_TARGET: row | $row.HASH])
           ->select(~[ID_TARGET,HASH_TARGET]),
         JoinKind.FULL,
-        {x,y| $x.ID_SOURCE == $y.ID_TARGET}
+        {x,y| ($x.ID_SOURCE->isEmpty() && $y.ID_TARGET->isEmpty()) || ($x.ID_SOURCE == $y.ID_TARGET)}
     )->filter(row | not($row.HASH_SOURCE == $row.HASH_TARGET))
   };
 
@@ -433,7 +433,7 @@ function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_
           ->select(~[ID_TARGET,HASH_TARGET])
           ->from($mapping, $runtime),
         JoinKind.FULL,
-        {x,y| $x.ID_SOURCE == $y.ID_TARGET}
+        {x,y| ($x.ID_SOURCE->isEmpty() && $y.ID_TARGET->isEmpty()) || ($x.ID_SOURCE == $y.ID_TARGET)}
     )->filter(row | not($row.HASH_SOURCE == $row.HASH_TARGET))
   };
 
@@ -457,7 +457,7 @@ function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_
           ->extend(~[ID_TARGET: row | $row.ID, HASH_TARGET: row | $row.HASH])
           ->select(~[ID_TARGET,HASH_TARGET]),
         JoinKind.FULL,
-        {x,y| $x.ID_SOURCE == $y.ID_TARGET}
+        {x,y| ($x.ID_SOURCE->isEmpty() && $y.ID_TARGET->isEmpty()) || ($x.ID_SOURCE == $y.ID_TARGET)}
     )->filter(row | not($row.HASH_SOURCE == $row.HASH_TARGET))
   };
 
@@ -482,7 +482,7 @@ function <<test.Test>> meta::external::dataquality::tests::testLambdaGeneration_
           ->select(~[ID_TARGET,FIRSTNAME_TARGET,LASTNAME_TARGET,HASH_TARGET])
           ->from($runtime),
         JoinKind.FULL,
-        {x,y| $x.ID_SOURCE == $y.ID_TARGET}
+        {x,y| ($x.ID_SOURCE->isEmpty() && $y.ID_TARGET->isEmpty()) || ($x.ID_SOURCE == $y.ID_TARGET)}
     )->filter(row | not($row.DIGEST_SOURCE == $row.HASH_TARGET))
     ->extend(~DQ_RULE_NAME: row | 'DQ_RECONCILIATION')
     ->extend(~DQ_LOGICAL_DEFECT_ID: row | hash(if($row.DIGEST_SOURCE->isEmpty(), | '', |$row.DIGEST_SOURCE->toOne()->toString()) + if($row.HASH_TARGET->isEmpty(), | '', |$row.HASH_TARGET->toOne()->toString()), HashType.MD5))

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure/src/main/resources/core_dataquality/generation/datarecon.pure
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure/src/main/resources/core_dataquality/generation/datarecon.pure
@@ -294,7 +294,8 @@ function meta::external::dataquality::datarecon::buildJoinFunction(joinFields: S
   let joinCondition = $joinFields->map(field | 
     let sourceCol = if ($field == 'DIGEST' && $sourceHashCol->isNotEmpty(), | $sourceHashCol->toOne(), | $field) + '_SOURCE';
     let targetCol = if ($field == 'DIGEST' && $targetHashCol->isNotEmpty(), | $targetHashCol->toOne(), | $field) + '_TARGET';
-    buildComparisonExpression(equal_Any_MANY__Any_MANY__Boolean_1_, 'x', $relTypeParam1, $sourceCol, 'y', $relTypeParam2, $targetCol, getColGenericType($relTypeParam1, $sourceCol));
+    let colType = getColGenericType($relTypeParam1, $sourceCol);
+    buildNullSafeComparisonExpression('x', $relTypeParam1, $sourceCol, 'y', $relTypeParam2, $targetCol, $colType);
   );
   let andCondition = $joinCondition->tail()->fold({val1, val2 | buildAndExpression($val1->evaluateAndDeactivate(), $val2->evaluateAndDeactivate())}, $joinCondition->head()->toOne()->evaluateAndDeactivate());
 
@@ -415,6 +416,20 @@ function meta::external::dataquality::datarecon::buildAndExpression(param1: Func
       $param2
     ]
   )->evaluateAndDeactivate()
+}
+
+// Null-safe equality: (isEmpty(left) && isEmpty(right)) || (left == right)
+// Equivalent to SQL IS NOT DISTINCT FROM — ensures NULL == NULL evaluates to TRUE in join conditions
+function meta::external::dataquality::datarecon::buildNullSafeComparisonExpression(param1Name: String[1], relTypeParam1: RelationType<Any>[1], colNameParam1: String[1], param2Name: String[1], relTypeParam2: RelationType<Any>[1], colNameParam2: String[1], colType: GenericType[1]):SimpleFunctionExpression[1]
+{
+  let left = buildGetValueAtColumnFunctionExpression($relTypeParam1, $colNameParam1, $param1Name, $colType);
+  let right = buildGetValueAtColumnFunctionExpression($relTypeParam2, $colNameParam2, $param2Name, $colType);
+  let bothEmpty = sfe(and_Boolean_1__Boolean_1__Boolean_1_, [
+    sfe(isEmpty_Any_$0_1$__Boolean_1_, $left),
+    sfe(isEmpty_Any_$0_1$__Boolean_1_, $right)
+  ]);
+  let bothEqual = sfe(equal_Any_MANY__Any_MANY__Boolean_1_, [$left, $right]);
+  sfe(or_Boolean_1__Boolean_1__Boolean_1_, [$bothEmpty, $bothEqual]);
 }
 
 function meta::external::dataquality::datarecon::buildNormalizeExpression(input: ValueSpecification[1], type: Type[1]):Pair<ValueSpecification, Type>[1]


### PR DESCRIPTION
Fixed case when user had composite keys where one or more of those columns contain null values.

In sql null = null -> falsy