### PR TITLE
Fix hardcoded integer column type in plan generation

### DIFF
--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-sybaseiq/legend-engine-xt-relationalStore-sybaseiq-pure/src/main/resources/core_relational_sybaseiq/relational/executionPlan/tests/executionPlanTestSybaseIQ.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-sybaseiq/legend-engine-xt-relationalStore-sybaseiq-pure/src/main/resources/core_relational_sybaseiq/relational/executionPlan/tests/executionPlanTestSybaseIQ.pure
@@ -164,7 +164,7 @@ function <<test.Test>> meta::pure::executionPlan::tests::sybaseIQ::twoDBTestSpac
      '    Relational\n'+
      '    (\n'+
      '      type = TDS[(first name, String, VARCHAR(200), \"\"), (eID, Integer, INT, \"\"), (fID, Integer, INT, \"\"), (legalName, String, VARCHAR(200), \"\")]\n'+
-     '      resultColumns = [("first name", INT), ("eID", INT), ("fID", INT), ("legalName", VARCHAR(200))]\n'+
+     '      resultColumns = [("first name", VARCHAR(200)), ("eID", INT), ("fID", INT), ("legalName", VARCHAR(200))]\n'+
      '      sql = select "tdsvar_0_0"."first name" as "first name", "tdsvar_0_0".eID as "eID", "tdsvar_0_0"."fID" as "fID", "tdsvar_0_0"."legalName" as "legalName" from (select * from (${tdsVar_0}) as "tdsvar_0_1" inner join (select "root".ID as "fID", "root".LEGALNAME as "legalName" from firmTable as "root") as "firmtable_0" on ("tdsvar_0_1".eID = "firmtable_0"."fID")) as "tdsvar_0_0" where ("tdsvar_0_0"."first name" = \'Adam\' and "tdsvar_0_0"."legalName" = \'Firm X\')\n'+
      '      connection = TestDatabaseConnection(type = \"SybaseIQ\")\n'+
      '    )\n'+
@@ -202,7 +202,7 @@ function <<test.Test>> meta::pure::executionPlan::tests::sybaseIQ::twoDBTestSlas
      '    Relational\n'+
      '    (\n'+
      '      type = TDS[(first/name, String, VARCHAR(200), \"\"), (eID, Integer, INT, \"\"), (fID, Integer, INT, \"\"), (legalName, String, VARCHAR(200), \"\")]\n'+
-     '      resultColumns = [("first/name", INT), ("eID", INT), ("fID", INT), ("legalName", VARCHAR(200))]\n'+
+     '      resultColumns = [("first/name", VARCHAR(200)), ("eID", INT), ("fID", INT), ("legalName", VARCHAR(200))]\n'+
      '      sql = select "tdsvar_0_0"."first/name" as "first/name", "tdsvar_0_0".eID as "eID", "tdsvar_0_0"."fID" as "fID", "tdsvar_0_0"."legalName" as "legalName" from (select * from (${tdsVar_0}) as "tdsvar_0_1" inner join (select "root".ID as "fID", "root".LEGALNAME as "legalName" from firmTable as "root") as "firmtable_0" on ("tdsvar_0_1".eID = "firmtable_0"."fID")) as "tdsvar_0_0" where ("tdsvar_0_0"."first/name" = \'Adam\' and "tdsvar_0_0"."legalName" = \'Firm X\')\n'+
      '      connection = TestDatabaseConnection(type = \"SybaseIQ\")\n'+
      '    )\n'+

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/executionPlan/tests/executionPlanTest.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/executionPlan/tests/executionPlanTest.pure
@@ -1832,7 +1832,7 @@ function <<test.Test>> meta::pure::executionPlan::tests::tdsJoinTwoDBWithColumnM
                      '    Relational\n'+
                      '    (\n'+
                      '      type = TDS[(firstName, String, VARCHAR(200), \"\"), (eID, Integer, INT, \"\"), (managerID, Integer, INT, \"\"), (fID, Integer, INT, \"\"), (legalName, String, VARCHAR(200), \"\")]\n'+
-                     '      resultColumns = [(\"firstName\", INT), (\"eID\", INT), (\"managerID\", INT), (\"fID\", INT), (\"legalName\", VARCHAR(200))]\n'+
+                     '      resultColumns = [(\"firstName\", VARCHAR(200)), (\"eID\", INT), (\"managerID\", INT), (\"fID\", INT), (\"legalName\", VARCHAR(200))]\n'+
                      '      sql = select \"tdsvar_0\".firstName as \"firstName\", \"tdsvar_0\".eID as \"eID\", \"tdsvar_0\".managerID as \"managerID\", \"tdsvar_0\".\"fID\" as \"fID\", \"tdsvar_0\".\"legalName\" as \"legalName\" from (select * from (${tdsVar}) as \"tdsvar_1\" inner join (select \"root\".ID as \"fID\", \"root\".LEGALNAME as \"legalName\" from firmTable as \"root\") as \"firmtable_0\" on (\"tdsvar_1\".eID = \"firmtable_0\".\"fID\")) as \"tdsvar_0\"\n'+
                      '      connection = TestDatabaseConnection(type = \"H2\")\n'+
                      '    )\n'+
@@ -1893,7 +1893,7 @@ function <<test.Test>> meta::pure::executionPlan::tests::tdsJoinTwoDBExtend():Bo
      '    Relational\n'+
      '    (\n'+
      '      type = TDS[(firstName, String, VARCHAR(200), \"\"), (eID, Integer, INT, \"\"), (fID, Integer, INT, \"\"), (legalName, String, VARCHAR(200), \"\")]\n'+
-     '      resultColumns = [("firstName", INT), ("eID", INT), ("fID", INT), ("legalName", VARCHAR(200))]\n'+
+     '      resultColumns = [("firstName", VARCHAR(200)), ("eID", INT), ("fID", INT), ("legalName", VARCHAR(200))]\n'+
      '      sql = select \"tdsvar_0\".firstName as "firstName", \"tdsvar_0\".eID as "eID", \"tdsvar_0\".\"fID\" as \"fID\", \"tdsvar_0\".\"legalName\" as \"legalName\" from (select * from (${tdsVar}) as \"tdsvar_1\" inner join (select \"root\".ID as \"fID\", \"root\".LEGALNAME as \"legalName\" from firmTable as \"root\") as \"firmtable_0\" on (\"tdsvar_1\".eID = \"firmtable_0\".\"fID\")) as \"tdsvar_0\"\n'+
      '      connection = TestDatabaseConnection(type = \"H2\")\n'+
      '    )\n'+
@@ -1939,7 +1939,7 @@ function <<test.Test>> meta::pure::executionPlan::tests::tdsTwoJoinThreeDB():Boo
      '          Relational\n'+
      '          (\n'+
      '            type = TDS[(firstName, String, VARCHAR(200), \"\"), (eID, Integer, INT, \"\"), (fID, Integer, INT, \"\"), (firmAddrID, Integer, INT, \"\")]\n'+
-     '            resultColumns = [("firstName", INT), ("eID", INT), ("fID", INT), ("firmAddrID", INT)]\n'+
+     '            resultColumns = [("firstName", VARCHAR(200)), ("eID", INT), ("fID", INT), ("firmAddrID", INT)]\n'+
      '            sql = select \"tdsvar_0_0\".firstName as "firstName", \"tdsvar_0_0\".eID as "eID", \"tdsvar_0_0\".\"fID\" as \"fID\", \"tdsvar_0_0\".\"firmAddrID\" as \"firmAddrID\" from (select * from (${tdsVar_0}) as \"tdsvar_0_1\" inner join (select \"root\".ID as \"fID\", \"root\".ADDRESSID as \"firmAddrID\" from firmTable as \"root\") as \"firmtable_0\" on (\"tdsvar_0_1\".eID = \"firmtable_0\".\"fID\")) as \"tdsvar_0_0\"\n'+
      '            connection = TestDatabaseConnection(type = \"H2\")\n'+
      '          )\n'+
@@ -1948,7 +1948,7 @@ function <<test.Test>> meta::pure::executionPlan::tests::tdsTwoJoinThreeDB():Boo
      '    Relational\n'+
      '    (\n'+
      '      type = TDS[(firstName, String, VARCHAR(200), \"\"), (eID, Integer, INT, \"\"), (fID, Integer, INT, \"\"), (firmAddrID, Integer, INT, \"\"), (addrName, String, VARCHAR(200), \"\"), (addrID, Integer, INT, \"\")]\n'+
-     '      resultColumns = [("firstName", INT), ("eID", INT), ("fID", INT), ("firmAddrID", INT), ("addrName", VARCHAR(200)), ("addrID", INT)]\n'+
+     '      resultColumns = [("firstName", VARCHAR(200)), ("eID", INT), ("fID", INT), ("firmAddrID", INT), ("addrName", VARCHAR(200)), ("addrID", INT)]\n'+
      '      sql = select \"tdsvar_0\".firstName as "firstName", \"tdsvar_0\".eID as "eID", \"tdsvar_0\".fID as "fID", \"tdsvar_0\".firmAddrID as "firmAddrID", \"tdsvar_0\".\"addrName\" as \"addrName\", \"tdsvar_0\".\"addrID\" as \"addrID\" from (select * from (${tdsVar}) as \"tdsvar_1\" inner join (select \"root\".NAME as \"addrName\", \"root\".ID as \"addrID\" from addressTable as \"root\") as \"addresstable_0\" on (\"tdsvar_1\".firmAddrID = \"addresstable_0\".\"addrID\")) as \"tdsvar_0\"\n'+
      '      connection = TestDatabaseConnection(type = \"H2\")\n'+
     '    )\n'+
@@ -2013,7 +2013,7 @@ function <<test.Test>> meta::pure::executionPlan::tests::testCrossDbPlanGenerati
      '    Relational\n'+
      '    (\n'+
      '      type = TDS[(firstName, String, VARCHAR(200), \"\"), (eID, Integer, INT, \"\"), (fID, Integer, INT, \"\"), (legalName, String, VARCHAR(200), \"\")]\n'+
-     '      resultColumns = [("firstName", INT), ("eID", INT), ("fID", INT), ("legalName", VARCHAR(200))]\n'+
+     '      resultColumns = [("firstName", VARCHAR(200)), ("eID", INT), ("fID", INT), ("legalName", VARCHAR(200))]\n'+
      '      sql = select \"tdsvar_0\".firstName as "firstName", \"tdsvar_0\".eID as "eID", \"tdsvar_0\".\"fID\" as \"fID\", \"tdsvar_0\".\"legalName\" as \"legalName\" from (select * from (${tdsVar}) as \"tdsvar_1\" inner join (select \"root\".ID as \"fID\", \"root\".LEGALNAME as \"legalName\" from firmTable as \"root\") as \"firmtable_0\" on (\"tdsvar_1\".eID = \"firmtable_0\".\"fID\")) as \"tdsvar_0\"\n'+
      '      connection = TestDatabaseConnection(type = \"H2\")\n'+
      '    )\n'+
@@ -2068,8 +2068,71 @@ function <<test.Test>> meta::pure::executionPlan::tests::testCrossDbPlanGenerati
                   '    Relational\n'+
                   '    (\n'+
                   '      type = TDS[(firstName, meta::pure::precisePrimitives::Varchar, VARCHAR(200), ""), (eID, meta::pure::precisePrimitives::Int, INT, ""), (lastName, meta::pure::precisePrimitives::Varchar, VARCHAR(200), ""), (fID, meta::pure::precisePrimitives::Int, INT, "")]\n'+
-                  '      resultColumns = [("firstName", INT), ("eID", INT), ("lastName", VARCHAR(200)), ("fID", INT)]\n'+
+                  '      resultColumns = [("firstName", VARCHAR(200)), ("eID", INT), ("lastName", VARCHAR(200)), ("fID", INT)]\n'+
                   '      sql = select "tdsvar_0".firstName as "firstName", "tdsvar_0".eID as "eID", "tdsvar_0"."lastName" as "lastName", "tdsvar_0"."fID" as "fID" from (select * from (${tdsVar}) as "tdsvar_1" left outer join (select "persontable_1".LASTNAME as "lastName", "persontable_1".ID as "fID" from personTable as "persontable_1") as "persontable_0" on ("tdsvar_1".eID = "persontable_0"."fID")) as "tdsvar_0"\n'+
+                  '      connection = RelationalDatabaseConnection(type = "H2")\n'+
+                  '    )\n'+
+                  '  )\n'+
+                  ')\n'
+    , $result->planToString(meta::relational::extension::relationalExtensions()));
+}
+
+function <<test.Test>> meta::pure::executionPlan::tests::testCrossDbPlanGenerationWithRelationUsesCorrectColumnTypes():Boolean[1]
+{
+
+    let runtime1 = ^Runtime(
+     connectionStores= ^ConnectionStore(
+      element = meta::relational::tests::db,
+      connection=^meta::external::store::relational::runtime::RelationalDatabaseConnection(
+         type = DatabaseType.H2,
+         datasourceSpecification = ^meta::pure::alloy::connections::alloy::specification::LocalH2DatasourceSpecification(testDataSetupCsv = ''),
+         authenticationStrategy = ^meta::pure::alloy::connections::alloy::authentication::TestDatabaseAuthenticationStrategy()
+      )));
+
+    let runtime2 = ^Runtime(
+     connectionStores= ^ConnectionStore(
+      element = meta::relational::tests::db,
+      connection=^meta::external::store::relational::runtime::RelationalDatabaseConnection(
+         type = DatabaseType.H2,
+         datasourceSpecification = ^meta::pure::alloy::connections::alloy::specification::EmbeddedH2DatasourceSpecification(databaseName = 'a', directory = 'b',autoServerMode = true),
+         authenticationStrategy = ^meta::pure::alloy::connections::alloy::authentication::TestDatabaseAuthenticationStrategy()
+      )));
+
+    let result = executionPlan({|#>{meta::relational::tests::dbInc.personTable}#
+    ->extend(~newCol: row|if($row.FIRSTNAME == 'Peter', |'abc', |'123'))
+    ->distinct()
+    ->extend(~newCol_SOURCE: row | $row.newCol)
+    ->select(~[newCol_SOURCE])
+    ->from($runtime1)
+    ->join(#>{meta::relational::tests::dbInc.personTable}#
+      ->extend(~newCol_TARGET: row|'testing')
+      ->select(~[newCol_TARGET])
+      ->from($runtime2), JoinKind.LEFT, {x,y| $x.newCol_SOURCE == $y.newCol_TARGET})}, meta::relational::extension::relationalExtensions());
+
+    assertEquals('Sequence\n'+
+                  '(\n'+
+                  '  type = TDS[(newCol_SOURCE, String, VARCHAR(8192), ""), (newCol_TARGET, String, VARCHAR(8192), "")]\n'+
+                  '  (\n'+
+                  '    Allocation\n'+
+                  '    (\n'+
+                  '      type = TDS[(newCol_SOURCE, String, VARCHAR(8192), "")]\n'+
+                  '      name = tdsVar\n'+
+                  '      value = \n'+
+                  '        (\n'+
+                  '          Relational\n'+
+                  '          (\n'+
+                  '            type = TDS[(newCol_SOURCE, String, VARCHAR(8192), "")]\n'+
+                  '            resultColumns = [("newCol_SOURCE", VARCHAR(3))]\n'+
+                  '            sql = select "persontable_0"."newCol_SOURCE" as "newCol_SOURCE" from (select distinct "persontable_1".ID as "ID", "persontable_1".FIRSTNAME as "FIRSTNAME", "persontable_1".LASTNAME as "LASTNAME", "persontable_1".AGE as "AGE", "persontable_1".ADDRESSID as "ADDRESSID", "persontable_1".FIRMID as "FIRMID", "persontable_1".MANAGERID as "MANAGERID", case when "persontable_1".FIRSTNAME = \'Peter\' then \'abc\' else \'123\' end as "newCol", case when "persontable_1".FIRSTNAME = \'Peter\' then \'abc\' else \'123\' end as "newCol_SOURCE" from personTable as "persontable_1") as "persontable_0"\n'+
+                  '            connection = RelationalDatabaseConnection(type = "H2")\n'+
+                  '          )\n'+
+                  '        )\n'+
+                  '    )\n'+
+                  '    Relational\n'+
+                  '    (\n'+
+                  '      type = TDS[(newCol_SOURCE, String, VARCHAR(8192), ""), (newCol_TARGET, String, VARCHAR(8192), "")]\n'+
+                  '      resultColumns = [("newCol_SOURCE", VARCHAR(8192)), ("newCol_TARGET", VARCHAR(7))]\n'+
+                  '      sql = select "tdsvar_0".newCol_SOURCE as "newCol_SOURCE", "tdsvar_0"."newCol_TARGET" as "newCol_TARGET" from (select * from (${tdsVar}) as "tdsvar_1" left outer join (select \'testing\' as "newCol_TARGET" from personTable as "persontable_1") as "persontable_0" on ("tdsvar_1".newCol_SOURCE = "persontable_0"."newCol_TARGET")) as "tdsvar_0"\n'+
                   '      connection = RelationalDatabaseConnection(type = "H2")\n'+
                   '    )\n'+
                   '  )\n'+

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery.pure
@@ -569,7 +569,7 @@ function meta::relational::functions::pureToSqlQuery::processValue(vals:Any[*], 
                                   v:PlanSetPlaceHolder[1] | let newTable = ^VarSetPlaceHolder(varName=$v.name,
                                                                                               columns=$v.tdsColumns->map(c|^Column(owner =^VarSetPlaceHolder(varName=$v.name),
                                                                                                                                    name= $c.name,
-                                                                                                                                   type = ^meta::relational::metamodel::datatype::Integer())),
+                                                                                                                                   type = $c->extractColumnTypeDefaultToInt())),
                                                                                               paths =  $v.tdsColumns->map(c| pair($c.name,^PathInformation(type = $c.type ->toOne(), relationalType = $c.sourceDataType->cast(@meta::relational::metamodel::datatype::DataType)->toOne()))));
                                                                                           ^$operation(select = ^$select(data=^RootJoinTreeNode(alias = ^TableAlias(name = 'root', relationalElement = $newTable))));,
                                   v:PlanVarPlaceHolder[1] |
@@ -1016,7 +1016,7 @@ function meta::relational::functions::pureToSqlQuery::tdsQualifier(fe:FunctionEx
    assert($valid, | 'Unsupported TDSRow function:' + $fe.func.functionName->toOne());
    let res1 = findColumnInTdsFromGetter($fe, $operation.select.columns->cast(@Alias),false, $vars, $state)->toOne();
    let newQuery = if($res1 ->instanceOf(WindowColumn),| $operation.select->moveSelectQueryToSubSelect($operation.currentTreeNode,[],'root', noDebug(), $extensions),|$operation.select);
-   let newfilterCol = if($res1->instanceOf(WindowColumn),| ^TableAliasColumn(alias = $newQuery.data->toOne().alias, column = ^Column(name = $res1->cast(@WindowColumn).columnName->addQuotesIfNecessary(), type =^meta::relational::metamodel::datatype::Integer())),|$res1);
+   let newfilterCol = if($res1->instanceOf(WindowColumn),| ^TableAliasColumn(alias = $newQuery.data->toOne().alias, column = ^Column(name = $res1->cast(@WindowColumn).columnName->addQuotesIfNecessary(), type =$res1->extractColumnTypeDefaultToInt())),|$res1);
 
    assert(!(($funcName=='isNull' || $funcName=='isNotNull' ) && $res1->instanceOf(WindowColumn)), | 'Window Column cannot be used in '+$funcName+' function');
 
@@ -1319,10 +1319,10 @@ function meta::relational::functions::pureToSqlQuery::buildCorrelatedSubQuery(se
                      childrenData=[]
                  );
 
-   let newFilters = $colForGroupBy->filter(f|$f.first==$select.filteringOperation).second->map(a|^TableAliasColumn(alias=$newTargetAlias, column=^Column(name=$a.name, type=^meta::relational::metamodel::datatype::Integer())))->concatenate($select.filteringOperation->filter(f|!$f->in($colForGroupBy.first)));
+   let newFilters = $colForGroupBy->filter(f|$f.first==$select.filteringOperation).second->map(a|^TableAliasColumn(alias=$newTargetAlias, column=^Column(name=$a.name, type=$a->extractColumnTypeDefaultToInt())))->concatenate($select.filteringOperation->filter(f|!$f->in($colForGroupBy.first)));
    let newRoot = $root->replaceJoin($child, $newJoin)->cast(@RootJoinTreeNode);
    let remappedOuterColumns = if($isolateGroupBy,
-                                   |^TableAliasColumn(alias=$newTargetAlias, column=^Column(name=$colForGroupBy.second->toOne().name, type=^meta::relational::metamodel::datatype::Integer())),
+                                   |^TableAliasColumn(alias=$newTargetAlias, column=^Column(name=$colForGroupBy.second->toOne().name, type=$colForGroupBy.second->toOne()->extractColumnTypeDefaultToInt())),
                                    |$select.columns->map(c |
                                       if($flattenColumnsInSelect->contains($c),
                                          |let colName = $c->extractColumnName();
@@ -1370,6 +1370,26 @@ function <<access.private>> meta::relational::functions::pureToSqlQuery::extract
                 c:Column[1]|$c.name,
                 r:RelationalOperationElement[1]|fail('Extracting column name from ' + $r->type().name->toOne() + ' not supported yet!'); '';
               ]);
+}
+
+//defaulting to Integer if we can't extract the column type to keep consistent with old logic where type was always hardcoded to Integer
+function <<access.private>> meta::relational::functions::pureToSqlQuery::extractColumnTypeDefaultToInt(col:TDSColumn[1]):meta::relational::metamodel::datatype::DataType[1]
+{
+   let type = $col.sourceDataType;
+   if ($type->isNotEmpty() && $type->toOne()->instanceOf(meta::relational::metamodel::datatype::DataType),
+    | $type->cast(@meta::relational::metamodel::datatype::DataType)->toOne(),
+    | ^meta::relational::metamodel::datatype::Integer()
+  );
+}
+
+//defaulting to Integer if we can't extract the column type to keep consistent with old logic where type was always hardcoded to Integer
+function <<access.private>> meta::relational::functions::pureToSqlQuery::extractColumnTypeDefaultToInt(rop: RelationalOperationElement[1]):meta::relational::metamodel::datatype::DataType[1]
+{
+  let inferredType = $rop->meta::relational::functions::typeInference::inferRelationalType(false);
+  let colType = if($inferredType->isEmpty(),
+    | ^meta::relational::metamodel::datatype::Integer(),
+    | $inferredType->toOne()
+  );
 }
 
 function meta::relational::functions::pureToSqlQuery::getNewColumnNameWithAlias(s: SelectSQLQuery[1], foundColumn: RelationalOperationElement[0..1], aliasesToUse: TableAliasColumn[*]): String[1] 
@@ -1848,8 +1868,7 @@ function meta::relational::functions::pureToSqlQuery::processRelationalOperation
                 | // We should not process the property mapping as it should have been done in the embedded selectSQLQuery....
                   let sel = $srcOperation.select;
                   //let embeddedSelect = $currentTreeNode.alias.relationalElement->cast(@SelectSQLQuery);
-                  // Warning the type of the column is bogus here....
-                  let newColumn = ^TableAliasColumn(alias=$newCurrentTreeNode.alias, column=^Column(name=$propName, type=^meta::relational::metamodel::datatype::Integer()));
+                  let newColumn = ^TableAliasColumn(alias=$newCurrentTreeNode.alias, column=^Column(name=$propName, type=$newCurrentTreeNode.alias->extractColumnTypeDefaultToInt()));
                   if ($state.inFilter,
                       |^$srcOperation(select = ^$sel(filteringOperation+=$newColumn)),
                       |^$srcOperation(select = ^$sel(columns+=$newColumn))
@@ -2457,7 +2476,7 @@ function meta::relational::functions::pureToSqlQuery::processConcatenate(f:Funct
        ^SelectWithCursor(
           select = ^$firstSel(
                          columns = $transformed.element->cast(@SelectWithCursor).select->at(0).columns
-                                      ->map(c|$c->match([a:Alias[1]|^$a(relationalElement=^TableAliasColumn(column=^Column(name=$a.name, type=^meta::relational::metamodel::datatype::Integer()), alias=$rootTable)),
+                                      ->map(c|$c->match([a:Alias[1]|^$a(relationalElement=^TableAliasColumn(column=^Column(name=$a.name, type=$a->extractColumnTypeDefaultToInt()), alias=$rootTable)),
                                                          t:TableAliasColumn[1]|^$t(alias=$rootTable)
                                                         ])),
                          data = $newRoot,
@@ -2552,13 +2571,13 @@ function meta::relational::functions::pureToSqlQuery::processConcatenate(f:Funct
                       columns = if($isDataType && !$state.inFilter,
                                       |let oldToNew = ^OldAliasToNewAlias(first=$firstChild.alias.name, second=$unionNode);
                                        let alias = $optimized->at(0).columns->at(0)->reprocessAliases($oldToNew)->cast(@Alias);
-                                       ^TableAliasColumn(alias=$unionNode, column=^Column(name=$alias.name, type=^meta::relational::metamodel::datatype::Integer()));,
+                                       ^TableAliasColumn(alias=$unionNode, column=^Column(name=$alias.name, type=$alias->extractColumnTypeDefaultToInt()));,
                                       |[]
                                 ),
                       savedFilteringOperation = [],
                       data = $newRoot,
                       leftSideOfFilter = if($sel.leftSideOfFilter->isEmpty(),|[],|$sel.leftSideOfFilter->toOne()->findOneNode($data, $newRoot)),
-                      filteringOperation = if($isDataType && $state.inFilter, |^TableAliasColumn(alias = $unionNode, column = ^Column(name=$propertyName, type=^meta::relational::metamodel::datatype::Integer())), |[])
+                      filteringOperation = if($isDataType && $state.inFilter, |^TableAliasColumn(alias = $unionNode, column = ^Column(name=$propertyName, type=$unionNode->extractColumnTypeDefaultToInt())), |[])
                    ),
           currentTreeNode = $newChild
        );
@@ -5019,8 +5038,8 @@ function meta::relational::functions::pureToSqlQuery::processGetAll(expression: 
                                                                                         let union = buildUnion($setImpls, [], $joinType, false, $state.inProject, $milestoningContext, $nodeId, $state, $context, $extensions);
                                                                                         let newRoot = ^RootJoinTreeNode(alias = ^TableAlias(name='unionBase', relationalElement=$union));
                                                                                         let fullCols = $union.queries->at(0).columns->cast(@Alias).name->filter(n | $n != 'u_type');
-                                                                                        ^SelectWithCursor( select = ^SelectSQLQuery( columns = ^Alias(name= 'u_type', relationalElement = ^TableAliasColumn(alias = $newRoot.alias, column = ^Column(name='u_type', type=^meta::relational::metamodel::datatype::Integer())))
-                                                                                                                                               ->concatenate($fullCols->map(p|^Alias(name=$p, relationalElement =^TableAliasColumn(alias = $newRoot.alias, column = ^Column(name=$p, type=^meta::relational::metamodel::datatype::Integer()))))),
+                                                                                        ^SelectWithCursor( select = ^SelectSQLQuery( columns = ^Alias(name= 'u_type', relationalElement = ^TableAliasColumn(alias = $newRoot.alias, column = ^Column(name='u_type', type=$newRoot.alias->extractColumnTypeDefaultToInt())))
+                                                                                                                                               ->concatenate($fullCols->map(p|^Alias(name=$p, relationalElement =^TableAliasColumn(alias = $newRoot.alias, column = ^Column(name=$p, type=$newRoot.alias->extractColumnTypeDefaultToInt()))))),
                                                                                                                                      data = $newRoot,
                                                                                                                                      filteringOperation = []
                                                                                                                                    ),
@@ -6183,7 +6202,7 @@ function meta::relational::functions::pureToSqlQuery::processRelationMap(a:AggCo
                                                       column = ^Column
                                                               (
                                                                   name = $name,
-                                                                  type = ^meta::relational::metamodel::datatype::Integer() // this type here does not mean much so we set it arbitrarily to Integer
+                                                                  type = $c->extractColumnTypeDefaultToInt()
                                                               )
                                                   )
                         );
@@ -6321,7 +6340,7 @@ function meta::relational::functions::pureToSqlQuery::processGroupBy(new:Boolean
                                                                                                    column = ^Column
                                                                                                             (
                                                                                                                name = $src.name,
-                                                                                                               type = ^meta::relational::metamodel::datatype::Integer()
+                                                                                                               type = $src->extractColumnTypeDefaultToInt()
                                                                                                             )
                                                                                                 )
                                                                      );
@@ -6494,10 +6513,10 @@ function meta::relational::functions::pureToSqlQuery::processDynamicPivot(expres
                                                                                                                             column = ^Column
                                                                                                                                     (
                                                                                                                                       name = $pivotColumnAliasName,
-                                                                                                                                      type = ^meta::relational::metamodel::datatype::Integer()
+                                                                                                                                      type = $alias->extractColumnTypeDefaultToInt()
                                                                                                                                     )
                                                                                                                           ));
-                                                                        let groupByAliases = $allButPivotAndAggregateColumns->concatenate($pivotColumnAlias)->map(c|$c->match([a:Alias[1]|^$a(relationalElement=^TableAliasColumn(column=^Column(name=$a.name, type=^meta::relational::metamodel::datatype::Integer()), alias=$alias)),
+                                                                        let groupByAliases = $allButPivotAndAggregateColumns->concatenate($pivotColumnAlias)->map(c|$c->match([a:Alias[1]|^$a(relationalElement=^TableAliasColumn(column=^Column(name=$a.name, type=$a->extractColumnTypeDefaultToInt()), alias=$alias)),
                                                                                                                                                                                t:TableAliasColumn[1]|^$t(alias=$alias)]
                                                                                              ));
                                                                         ^TdsSelectSqlQuery(
@@ -6514,7 +6533,7 @@ function meta::relational::functions::pureToSqlQuery::processDynamicPivot(expres
         );
         let newRoot = ^RootJoinTreeNode(alias = $rootTable);
         let unionAllQuery = ^TdsSelectSqlQuery(
-          columns = $groupByQueries.select->at(0).columns->map(c|$c->match([a:Alias[1]|^$a(relationalElement=^TableAliasColumn(column=^Column(name=$a.name, type=^meta::relational::metamodel::datatype::Integer()), alias=$rootTable)),
+          columns = $groupByQueries.select->at(0).columns->map(c|$c->match([a:Alias[1]|^$a(relationalElement=^TableAliasColumn(column=^Column(name=$a.name, type=$a->extractColumnTypeDefaultToInt()), alias=$rootTable)),
                                                                             t:TableAliasColumn[1]|^$t(alias=$rootTable)]
                                                               )),
           data = $newRoot,
@@ -6897,7 +6916,7 @@ function meta::relational::functions::pureToSqlQuery::processTdsRenameColumns(ex
                                        relationalElement = ^TableAliasColumn(
                                                                   alias=$newAlias,
                                                                   columnName = $newNamePair.second,
-                                                                  column=^Column(name=$newNamePair.first, type=^meta::relational::metamodel::datatype::Integer())
+                                                                  column=^Column(name=$newNamePair.first, type=$newAlias->extractColumnTypeDefaultToInt())
                                                          )
                                        );
                                  ),
@@ -7037,7 +7056,7 @@ function <<access.private>> meta::relational::functions::pureToSqlQuery::process
                                     data =$newData,
                                     columns = $newCols->map(c|
                                                 let tac = ^TableAliasColumn(alias=$newAlias,
-                                                                                column=^Column(name=$c->extractColumnName(), type=^meta::relational::metamodel::datatype::Integer()));
+                                                                                column=^Column(name=$c->extractColumnName(), type=$c->extractColumnTypeDefaultToInt()));
                                                 ^Alias(name=$tac.column.name, relationalElement=$tac);
                                              ),
                                     groupBy = []->cast(@Alias),
@@ -7241,23 +7260,24 @@ function <<access.protected>> meta::relational::functions::pureToSqlQuery::recur
 function meta::relational::functions::pureToSqlQuery::switchAliasForColumns(newAlias : TableAlias[1], columns : RelationalOperationElement[*]):Alias[*]
 {
    $columns->map(cl|
+      let colType = $cl->extractColumnTypeDefaultToInt();
       $cl->match([
         als: Alias[1] |
           $als.relationalElement->match([
                 tac:TableAliasColumn[1] | let col = $tac.column; ^Alias(name=$als.name, relationalElement=^TableAliasColumn(alias=$newAlias , column=^$col(name=$als.name)));,
-                tacn:TableAliasColumnName[1] | ^Alias(name=$als.name, relationalElement=^TableAliasColumn(alias=$newAlias , column=^Column(name = $tacn.columnName, type = ^meta::relational::metamodel::datatype::Integer())));,
-                cn:ColumnName[1] | ^Alias(name=$als.name, relationalElement=^TableAliasColumn( alias = $newAlias, column = ^Column(name = $cn.name, type = ^meta::relational::metamodel::datatype::Integer())));,
-                l:Literal[1] | ^Alias(name=$als.name, relationalElement=^TableAliasColumn( alias = $newAlias, column = ^Column(name = $als.name, type = ^meta::relational::metamodel::datatype::Integer())));,
-                o:Operation[1] |  ^Alias(name=$als.name, relationalElement=^TableAliasColumn(alias=$newAlias, column=^Column(name = $als.name, type = ^meta::relational::metamodel::datatype::Integer()))),
-                o:WindowColumn[1] |  ^Alias(name=$als.name, relationalElement=^TableAliasColumn(alias=$newAlias, column=^Column(name = $als.name, type = ^meta::relational::metamodel::datatype::Integer()))),
+                tacn:TableAliasColumnName[1] | ^Alias(name=$als.name, relationalElement=^TableAliasColumn(alias=$newAlias , column=^Column(name = $tacn.columnName, type = $colType)));,
+                cn:ColumnName[1] | ^Alias(name=$als.name, relationalElement=^TableAliasColumn( alias = $newAlias, column = ^Column(name = $cn.name, type = $colType)));,
+                l:Literal[1] | ^Alias(name=$als.name, relationalElement=^TableAliasColumn( alias = $newAlias, column = ^Column(name = $als.name, type = $colType)));,
+                o:Operation[1] |  ^Alias(name=$als.name, relationalElement=^TableAliasColumn(alias=$newAlias, column=^Column(name = $als.name, type = $colType))),
+                o:WindowColumn[1] |  ^Alias(name=$als.name, relationalElement=^TableAliasColumn(alias=$newAlias, column=^Column(name = $als.name, type = $colType))),
                 df:DynaFunction[1] |
                   ^Alias(
                       name=$als.name,
-                      relationalElement=^TableAliasColumn( alias = $newAlias, column = ^Column(name = $als.name, type = ^meta::relational::metamodel::datatype::Integer()))
+                      relationalElement=^TableAliasColumn( alias = $newAlias, column = ^Column(name = $als.name, type = $colType))
                   );
             ]);,
         tac: TableAliasColumn[1] | ^Alias(name=$tac.columnName->orElse($tac.column.name), relationalElement=^$tac(alias =$newAlias)),
-        cn:ColumnName[1] | ^Alias(name=$cn.name, relationalElement=^TableAliasColumn( alias = $newAlias, column = ^Column(name = $cn.name, type = ^meta::relational::metamodel::datatype::Integer())))
+        cn:ColumnName[1] | ^Alias(name=$cn.name, relationalElement=^TableAliasColumn( alias = $newAlias, column = ^Column(name = $cn.name, type = $colType)))
       ]);
    );
 }
@@ -7637,7 +7657,7 @@ function meta::relational::functions::pureToSqlQuery::processProject(ids:String[
                                                            (
                                                               columns = $u.queries->at(0).columns->cast(@Alias)
                                                                         ->filter(c|$c.name->startsWith('"pk_'))
-                                                                        ->map(a|^$a(relationalElement=^TableAliasColumn(alias=$merge.data.alias->toOne(), column=^Column(name=$a.name, type=^meta::relational::metamodel::datatype::Integer()))))
+                                                                        ->map(a|^$a(relationalElement=^TableAliasColumn(alias=$merge.data.alias->toOne(), column=^Column(name=$a.name, type=$a->extractColumnTypeDefaultToInt()))))
                                                            );
                                          ]
                                         );
@@ -7819,8 +7839,8 @@ function meta::relational::functions::pureToSqlQuery::reAliasAndRemoveTopLevelDy
          if ($columnFound->isEmpty(), | $a, |
          $a.relationalElement->match(
             [
-               d:DynaFunction[1] |  ^Alias(name=$a.name, relationalElement=^TableAliasColumn(alias=$select.data->toOne().alias, column=^Column(name=$a.name, type=^meta::relational::metamodel::datatype::Integer()))),
-               o:Operation[1] |  ^Alias(name=$a.name, relationalElement=^TableAliasColumn(alias=$select.data->toOne().alias, column=^Column(name=$a.name, type=^meta::relational::metamodel::datatype::Integer()))),
+               d:DynaFunction[1] |  ^Alias(name=$a.name, relationalElement=^TableAliasColumn(alias=$select.data->toOne().alias, column=^Column(name=$a.name, type=$a->extractColumnTypeDefaultToInt()))),
+               o:Operation[1] |  ^Alias(name=$a.name, relationalElement=^TableAliasColumn(alias=$select.data->toOne().alias, column=^Column(name=$a.name, type=$a->extractColumnTypeDefaultToInt()))),
                t:TableAliasColumn[1] | $a
             ]););,
          a:RelationalOperationElement[1]|$a]));
@@ -8193,7 +8213,7 @@ function meta::relational::functions::pureToSqlQuery::moveSelectQueryToSubSelect
     let newSelect = ^$newSelectClass(
                       data= ^RootJoinTreeNode(alias = $newAlias),
                       columns=$select.columns->map(c|let index = $select.columns->indexOf($c);
-                                                     let newCol = ^TableAliasColumn(column=^Column(name=$names->at($index), type=^meta::relational::metamodel::datatype::Integer()), alias=$newAlias);
+                                                     let newCol = ^TableAliasColumn(column=^Column(name=$names->at($index), type=$newAlias->extractColumnTypeDefaultToInt()), alias=$newAlias);
                                                      $c->match([
                                                                 a:Alias[1]|^$a(relationalElement=$newCol),
                                                                 t:RelationalOperationElement[1]|$newCol

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/relationalExtension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/relationalExtension.pure
@@ -172,7 +172,7 @@ function meta::relational::functions::typeInference::inferRelationalType(rop: Re
       ]),
       j : meta::relational::metamodel::operation::JoinStrings[1] | 
         ^meta::relational::metamodel::datatype::Varchar(size = $j.strings->concatenate($j.prefix)->concatenate($j.separator)->concatenate($j.suffix)
-          ->map(x | let stringType = $x->inferRelationalType($failOnMatchFailure); if($stringType->isEmpty(), | 1024, | $stringType->toOne()->getSize());) //if can't infer size then default to 1024 
+          ->map(x | $x->inferRelationalType($failOnMatchFailure)->getSize()) //if can't infer size then default to 1024 
           ->sum()
         ),
       c:Column[1] | $c.type,
@@ -218,7 +218,7 @@ function <<access.private>> meta::relational::functions::typeInference::getDynaF
          list([
             pair(
                {params: RelationalOperationElement[*] | [$params->at(0)->inferRelationalType($failOnMatchFailure)->toOne(), $params->at(1)->inferRelationalType($failOnMatchFailure)->toOne()]->isSafeTypePossible() && [$params->at(0)->inferRelationalType($failOnMatchFailure)->toOne(), $params->at(1)->inferRelationalType($failOnMatchFailure)->toOne()]->getSafeType()->instanceOf(meta::relational::metamodel::datatype::Varchar)},
-               {params: RelationalOperationElement[*] | ^meta::relational::metamodel::datatype::Varchar(size = $params->at(0)->inferRelationalType($failOnMatchFailure)->toOne()->getSize() + $params->at(1)->inferRelationalType($failOnMatchFailure)->toOne()->getSize())}
+               {params: RelationalOperationElement[*] | ^meta::relational::metamodel::datatype::Varchar(size = $params->at(0)->inferRelationalType($failOnMatchFailure)->getSize() + $params->at(1)->inferRelationalType($failOnMatchFailure)->getSize())}
             ),
             pair(
                {params: RelationalOperationElement[*] | [$params->at(0)->inferRelationalType($failOnMatchFailure)->toOne(), $params->at(1)->inferRelationalType($failOnMatchFailure)->toOne()]->isSafeTypePossible()},
@@ -1016,7 +1016,7 @@ function <<access.private>> meta::relational::functions::typeInference::getDynaF
          list([
             pair(
                {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)->toOne()->instanceOf(meta::relational::metamodel::datatype::Char) || $params->at(0)->inferRelationalType($failOnMatchFailure)->toOne()->instanceOf(meta::relational::metamodel::datatype::Varchar)},
-               {params: RelationalOperationElement[*] | let size = $params->at(0)->inferRelationalType($failOnMatchFailure)->toOne()->getSize(); ^meta::relational::metamodel::datatype::Varchar(size = max([4000, $size]));}
+               {params: RelationalOperationElement[*] | let size = $params->at(0)->inferRelationalType($failOnMatchFailure)->getSize(); ^meta::relational::metamodel::datatype::Varchar(size = max([4000, $size]));}
             )
          ])
       ),
@@ -1965,11 +1965,12 @@ function <<access.private>> meta::relational::functions::typeInference::getDecim
    ])
 }
 
-function <<access.private>> meta::relational::functions::typeInference::getSize(t: meta::relational::metamodel::datatype::DataType[1]):Integer[1]
+function <<access.private>> meta::relational::functions::typeInference::getSize(t: meta::relational::metamodel::datatype::DataType[0..1]):Integer[1]
 {
    $t->match([
       c:meta::relational::metamodel::datatype::Char[1]|$c.size,
-      c:meta::relational::metamodel::datatype::Varchar[1]|$c.size
+      c:meta::relational::metamodel::datatype::Varchar[1]|$c.size,
+      c:Any[0..1]|1024; //if can't infer size then default to 1024 
    ])
 }
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/relationalExtension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/relationalExtension.pure
@@ -217,12 +217,12 @@ function <<access.private>> meta::relational::functions::typeInference::getDynaF
          'add',
          list([
             pair(
-               {params: RelationalOperationElement[*] | [$params->at(0)->inferRelationalType($failOnMatchFailure)->toOne(), $params->at(1)->inferRelationalType($failOnMatchFailure)->toOne()]->isSafeTypePossible() && [$params->at(0)->inferRelationalType($failOnMatchFailure)->toOne(), $params->at(1)->inferRelationalType($failOnMatchFailure)->toOne()]->getSafeType()->instanceOf(meta::relational::metamodel::datatype::Varchar)},
+               {params: RelationalOperationElement[*] | isSafeTypePossible($params->at(0)->inferRelationalType($failOnMatchFailure), $params->at(1)->inferRelationalType($failOnMatchFailure)) && getSafeType($params->at(0)->inferRelationalType($failOnMatchFailure), $params->at(1)->inferRelationalType($failOnMatchFailure))->exists(t | $t->instanceOf(meta::relational::metamodel::datatype::Varchar))},
                {params: RelationalOperationElement[*] | ^meta::relational::metamodel::datatype::Varchar(size = $params->at(0)->inferRelationalType($failOnMatchFailure)->getSize() + $params->at(1)->inferRelationalType($failOnMatchFailure)->getSize())}
             ),
             pair(
-               {params: RelationalOperationElement[*] | [$params->at(0)->inferRelationalType($failOnMatchFailure)->toOne(), $params->at(1)->inferRelationalType($failOnMatchFailure)->toOne()]->isSafeTypePossible()},
-               {params: RelationalOperationElement[*] | [$params->at(0)->inferRelationalType($failOnMatchFailure)->toOne(), $params->at(1)->inferRelationalType($failOnMatchFailure)->toOne()]->getSafeType()}
+               {params: RelationalOperationElement[*] | isSafeTypePossible($params->at(0)->inferRelationalType($failOnMatchFailure), $params->at(1)->inferRelationalType($failOnMatchFailure))},
+               {params: RelationalOperationElement[*] | getSafeType($params->at(0)->inferRelationalType($failOnMatchFailure), $params->at(1)->inferRelationalType($failOnMatchFailure))}
             )
          ])
       ),
@@ -231,7 +231,7 @@ function <<access.private>> meta::relational::functions::typeInference::getDynaF
          'adjust',
          list([
             pair(
-               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)->toOne()->instanceOf(meta::relational::metamodel::datatype::Char) || $params->at(0)->inferRelationalType($failOnMatchFailure)->toOne()->instanceOf(meta::relational::metamodel::datatype::Varchar)},
+               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)->exists(t | $t->instanceOf(meta::relational::metamodel::datatype::Char)) || $params->at(0)->inferRelationalType($failOnMatchFailure)->exists(t | $t->instanceOf(meta::relational::metamodel::datatype::Varchar))},
                {params: RelationalOperationElement[*] | ^meta::relational::metamodel::datatype::Timestamp()}
             ),
             pair(
@@ -429,12 +429,12 @@ function <<access.private>> meta::relational::functions::typeInference::getDynaF
          'ceiling',
          list([
             pair(
-               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)->toOne()->instanceOf(meta::relational::metamodel::datatype::Numeric)},
-               {params: RelationalOperationElement[*] | let type = $params->at(0)->inferRelationalType($failOnMatchFailure)->toOne()->cast(@meta::relational::metamodel::datatype::Numeric); ^$type(scale = 0);}
+               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)->exists(t | $t->instanceOf(meta::relational::metamodel::datatype::Numeric))},
+               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)->map(t | let type = $t->cast(@meta::relational::metamodel::datatype::Numeric); ^$type(scale = 0);)}
             ),
             pair(
-               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)->toOne()->instanceOf(meta::relational::metamodel::datatype::Decimal)},
-               {params: RelationalOperationElement[*] | let type = $params->at(0)->inferRelationalType($failOnMatchFailure)->toOne()->cast(@meta::relational::metamodel::datatype::Decimal); ^$type(scale = 0);}
+               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)->exists(t | $t->instanceOf(meta::relational::metamodel::datatype::Decimal))},
+               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)->map(t | let type = $t->cast(@meta::relational::metamodel::datatype::Decimal); ^$type(scale = 0);)}
             ),
             pair(
                {params: RelationalOperationElement[*] | true},
@@ -857,12 +857,12 @@ function <<access.private>> meta::relational::functions::typeInference::getDynaF
          'floor',
          list([
             pair(
-               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)->toOne()->instanceOf(meta::relational::metamodel::datatype::Numeric)},
-               {params: RelationalOperationElement[*] | let type = $params->at(0)->inferRelationalType($failOnMatchFailure)->toOne()->cast(@meta::relational::metamodel::datatype::Numeric); ^$type(scale = 0);}
+               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)->exists(t | $t->instanceOf(meta::relational::metamodel::datatype::Numeric))},
+               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)->map(t | let type = $t->cast(@meta::relational::metamodel::datatype::Numeric); ^$type(scale = 0);)}
             ),
             pair(
-               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)->toOne()->instanceOf(meta::relational::metamodel::datatype::Decimal)},
-               {params: RelationalOperationElement[*] | let type = $params->at(0)->inferRelationalType($failOnMatchFailure)->toOne()->cast(@meta::relational::metamodel::datatype::Decimal); ^$type(scale = 0);}
+               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)->exists(t | $t->instanceOf(meta::relational::metamodel::datatype::Decimal))},
+               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)->map(t | let type = $t->cast(@meta::relational::metamodel::datatype::Decimal); ^$type(scale = 0);)}
             ),
             pair(
                {params: RelationalOperationElement[*] | true},
@@ -925,8 +925,8 @@ function <<access.private>> meta::relational::functions::typeInference::getDynaF
          'if',
          list([
             pair(
-               {params: RelationalOperationElement[*] | [$params->at(1)->inferRelationalType($failOnMatchFailure)->toOne(), $params->at(2)->inferRelationalType($failOnMatchFailure)->toOne()]->isSafeTypePossible()},
-               {params: RelationalOperationElement[*] | [$params->at(1)->inferRelationalType($failOnMatchFailure)->toOne(), $params->at(2)->inferRelationalType($failOnMatchFailure)->toOne()]->getSafeType()}
+               {params: RelationalOperationElement[*] | isSafeTypePossible($params->at(1)->inferRelationalType($failOnMatchFailure), $params->at(2)->inferRelationalType($failOnMatchFailure))},
+               {params: RelationalOperationElement[*] | getSafeType($params->at(1)->inferRelationalType($failOnMatchFailure), $params->at(2)->inferRelationalType($failOnMatchFailure))}
             )
          ])
       ),
@@ -1015,7 +1015,7 @@ function <<access.private>> meta::relational::functions::typeInference::getDynaF
          'joinStrings',
          list([
             pair(
-               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)->toOne()->instanceOf(meta::relational::metamodel::datatype::Char) || $params->at(0)->inferRelationalType($failOnMatchFailure)->toOne()->instanceOf(meta::relational::metamodel::datatype::Varchar)},
+               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)->exists(t | $t->instanceOf(meta::relational::metamodel::datatype::Char)) || $params->at(0)->inferRelationalType($failOnMatchFailure)->exists(t | $t->instanceOf(meta::relational::metamodel::datatype::Varchar))},
                {params: RelationalOperationElement[*] | let size = $params->at(0)->inferRelationalType($failOnMatchFailure)->getSize(); ^meta::relational::metamodel::datatype::Varchar(size = max([4000, $size]));}
             )
          ])
@@ -1373,23 +1373,23 @@ function <<access.private>> meta::relational::functions::typeInference::getDynaF
          'plus',
          list([
             pair(
-               {params: RelationalOperationElement[*] | $params->size() == 1 && $params->at(0)->inferRelationalType($failOnMatchFailure)->genericType().rawType->toOne()->cast(@Class<Any>)->in([meta::relational::metamodel::datatype::SmallInt, meta::relational::metamodel::datatype::TinyInt])},
+               {params: RelationalOperationElement[*] | $params->size() == 1 && $params->at(0)->inferRelationalType($failOnMatchFailure)->exists(t | $t->genericType().rawType->toOne()->cast(@Class<Any>)->in([meta::relational::metamodel::datatype::SmallInt, meta::relational::metamodel::datatype::TinyInt]))},
                {params: RelationalOperationElement[*] | ^meta::relational::metamodel::datatype::Integer()}
             ),
             pair(
-               {params: RelationalOperationElement[*] | $params->size() == 1 && $params->at(0)->inferRelationalType($failOnMatchFailure)->genericType().rawType->toOne()->cast(@Class<Any>)->in([meta::relational::metamodel::datatype::Integer, meta::relational::metamodel::datatype::BigInt])},
+               {params: RelationalOperationElement[*] | $params->size() == 1 && $params->at(0)->inferRelationalType($failOnMatchFailure)->exists(t | $t->genericType().rawType->toOne()->cast(@Class<Any>)->in([meta::relational::metamodel::datatype::Integer, meta::relational::metamodel::datatype::BigInt]))},
                {params: RelationalOperationElement[*] | ^meta::relational::metamodel::datatype::BigInt()}
             ),
             pair(
-               {params: RelationalOperationElement[*] | $params->size() == 1 && $params->at(0)->inferRelationalType($failOnMatchFailure)->genericType().rawType->toOne()->cast(@Class<Any>) == meta::relational::metamodel::datatype::Decimal},
-               {params: RelationalOperationElement[*] | ^meta::relational::metamodel::datatype::Decimal(precision = min([31, $params->at(0)->inferRelationalType($failOnMatchFailure)->toOne()->cast(@meta::relational::metamodel::datatype::Decimal).precision]), scale = $params->at(0)->inferRelationalType($failOnMatchFailure)->toOne()->cast(@meta::relational::metamodel::datatype::Decimal).scale)}
+               {params: RelationalOperationElement[*] | $params->size() == 1 && $params->at(0)->inferRelationalType($failOnMatchFailure)->exists(t | $t->genericType().rawType->toOne()->cast(@Class<Any>) == meta::relational::metamodel::datatype::Decimal)},
+               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)->map(t | ^meta::relational::metamodel::datatype::Decimal(precision = min([31, $t->cast(@meta::relational::metamodel::datatype::Decimal).precision]), scale = $t->cast(@meta::relational::metamodel::datatype::Decimal).scale))}
             ),
             pair(
-               {params: RelationalOperationElement[*] | $params->size() == 1 && $params->at(0)->inferRelationalType($failOnMatchFailure)->genericType().rawType->toOne()->cast(@Class<Any>) == meta::relational::metamodel::datatype::Numeric},
-               {params: RelationalOperationElement[*] | ^meta::relational::metamodel::datatype::Numeric(precision = min([31, $params->at(0)->inferRelationalType($failOnMatchFailure)->toOne()->cast(@meta::relational::metamodel::datatype::Numeric).precision]), scale = $params->at(0)->inferRelationalType($failOnMatchFailure)->toOne()->cast(@meta::relational::metamodel::datatype::Numeric).scale)}
+               {params: RelationalOperationElement[*] | $params->size() == 1 && $params->at(0)->inferRelationalType($failOnMatchFailure)->exists(t | $t->genericType().rawType->toOne()->cast(@Class<Any>) == meta::relational::metamodel::datatype::Numeric)},
+               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)->map(t | ^meta::relational::metamodel::datatype::Numeric(precision = min([31, $t->cast(@meta::relational::metamodel::datatype::Numeric).precision]), scale = $t->cast(@meta::relational::metamodel::datatype::Numeric).scale))}
             ),
             pair(
-               {params: RelationalOperationElement[*] | $params->size() == 1 && $params->at(0)->inferRelationalType($failOnMatchFailure)->genericType().rawType->toOne()->cast(@Class<Any>)->in([meta::relational::metamodel::datatype::Float, meta::relational::metamodel::datatype::Double])},
+               {params: RelationalOperationElement[*] | $params->size() == 1 && $params->at(0)->inferRelationalType($failOnMatchFailure)->exists(t | $t->genericType().rawType->toOne()->cast(@Class<Any>)->in([meta::relational::metamodel::datatype::Float, meta::relational::metamodel::datatype::Double]))},
                {params: RelationalOperationElement[*] | ^meta::relational::metamodel::datatype::Double()}
             ),
             pair(
@@ -1493,12 +1493,12 @@ function <<access.private>> meta::relational::functions::typeInference::getDynaF
          'round',
          list([
             pair(
-               {params: RelationalOperationElement[*] | $params->size() == 1 && $params->at(0)->inferRelationalType($failOnMatchFailure)->genericType().rawType->toOne()->cast(@Class<Any>) == meta::relational::metamodel::datatype::Decimal},
-               {params: RelationalOperationElement[*] | ^meta::relational::metamodel::datatype::Decimal(precision = min([31, ($params->at(0)->inferRelationalType($failOnMatchFailure)->toOne()->cast(@meta::relational::metamodel::datatype::Decimal).precision + 1)]), scale = $params->at(0)->inferRelationalType($failOnMatchFailure)->toOne()->cast(@meta::relational::metamodel::datatype::Decimal).scale)}
+               {params: RelationalOperationElement[*] | $params->size() == 1 && $params->at(0)->inferRelationalType($failOnMatchFailure)->exists(t | $t->genericType().rawType->toOne()->cast(@Class<Any>) == meta::relational::metamodel::datatype::Decimal)},
+               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)->map(t | ^meta::relational::metamodel::datatype::Decimal(precision = min([31, ($t->cast(@meta::relational::metamodel::datatype::Decimal).precision + 1)]), scale = $t->cast(@meta::relational::metamodel::datatype::Decimal).scale))}
             ),
             pair(
-               {params: RelationalOperationElement[*] | $params->size() == 1 && $params->at(0)->inferRelationalType($failOnMatchFailure)->genericType().rawType->toOne()->cast(@Class<Any>) == meta::relational::metamodel::datatype::Numeric},
-               {params: RelationalOperationElement[*] | ^meta::relational::metamodel::datatype::Numeric(precision = min([31, ($params->at(0)->inferRelationalType($failOnMatchFailure)->toOne()->cast(@meta::relational::metamodel::datatype::Numeric).precision + 1)]), scale = $params->at(0)->inferRelationalType($failOnMatchFailure)->toOne()->cast(@meta::relational::metamodel::datatype::Numeric).scale)}
+               {params: RelationalOperationElement[*] | $params->size() == 1 && $params->at(0)->inferRelationalType($failOnMatchFailure)->exists(t | $t->genericType().rawType->toOne()->cast(@Class<Any>) == meta::relational::metamodel::datatype::Numeric)},
+               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)->map(t | ^meta::relational::metamodel::datatype::Numeric(precision = min([31, ($t->cast(@meta::relational::metamodel::datatype::Numeric).precision + 1)]), scale = $t->cast(@meta::relational::metamodel::datatype::Numeric).scale))}
             ),
             pair(
                {params: RelationalOperationElement[*] | true},
@@ -1601,7 +1601,7 @@ function <<access.private>> meta::relational::functions::typeInference::getDynaF
          'sub',
          list([
             pair(
-               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)->genericType().rawType->toOne()->cast(@Class<Any>) == $params->at(1)->inferRelationalType($failOnMatchFailure)->genericType().rawType->toOne()->cast(@Class<Any>)},
+               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)->exists(t0 | $params->at(1)->inferRelationalType($failOnMatchFailure)->exists(t1 | $t0->genericType().rawType->toOne()->cast(@Class<Any>) == $t1->genericType().rawType->toOne()->cast(@Class<Any>)))},
                {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)}
             )
          ])
@@ -1681,23 +1681,23 @@ function <<access.private>> meta::relational::functions::typeInference::getDynaF
          'sum',
          list([
             pair(
-               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)->genericType().rawType->toOne()->cast(@Class<Any>)->in([meta::relational::metamodel::datatype::SmallInt, meta::relational::metamodel::datatype::TinyInt, meta::relational::metamodel::datatype::Integer])},
+               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)->exists(t | $t->genericType().rawType->toOne()->cast(@Class<Any>)->in([meta::relational::metamodel::datatype::SmallInt, meta::relational::metamodel::datatype::TinyInt, meta::relational::metamodel::datatype::Integer]))},
                {params: RelationalOperationElement[*] | ^meta::relational::metamodel::datatype::Integer()}
             ),
             pair(
-               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)->genericType().rawType->toOne()->cast(@Class<Any>)->in([meta::relational::metamodel::datatype::BigInt])},
+               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)->exists(t | $t->genericType().rawType->toOne()->cast(@Class<Any>)->in([meta::relational::metamodel::datatype::BigInt]))},
                {params: RelationalOperationElement[*] | ^meta::relational::metamodel::datatype::BigInt()}
             ),
             pair(
-               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)->genericType().rawType->toOne()->cast(@Class<Any>) == meta::relational::metamodel::datatype::Decimal},
-               {params: RelationalOperationElement[*] | ^meta::relational::metamodel::datatype::Decimal(precision = min([31, $params->at(0)->inferRelationalType($failOnMatchFailure)->toOne()->cast(@meta::relational::metamodel::datatype::Decimal).precision]), scale = $params->at(0)->inferRelationalType($failOnMatchFailure)->toOne()->cast(@meta::relational::metamodel::datatype::Decimal).scale)}
+               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)->exists(t | $t->genericType().rawType->toOne()->cast(@Class<Any>) == meta::relational::metamodel::datatype::Decimal)},
+               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)->map(t | ^meta::relational::metamodel::datatype::Decimal(precision = min([31, $t->cast(@meta::relational::metamodel::datatype::Decimal).precision]), scale = $t->cast(@meta::relational::metamodel::datatype::Decimal).scale))}
             ),
             pair(
-               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)->genericType().rawType->toOne()->cast(@Class<Any>) == meta::relational::metamodel::datatype::Numeric},
-               {params: RelationalOperationElement[*] | ^meta::relational::metamodel::datatype::Numeric(precision = min([31, $params->at(0)->inferRelationalType($failOnMatchFailure)->toOne()->cast(@meta::relational::metamodel::datatype::Numeric).precision]), scale = $params->at(0)->inferRelationalType($failOnMatchFailure)->toOne()->cast(@meta::relational::metamodel::datatype::Numeric).scale)}
+               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)->exists(t | $t->genericType().rawType->toOne()->cast(@Class<Any>) == meta::relational::metamodel::datatype::Numeric)},
+               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)->map(t | ^meta::relational::metamodel::datatype::Numeric(precision = min([31, $t->cast(@meta::relational::metamodel::datatype::Numeric).precision]), scale = $t->cast(@meta::relational::metamodel::datatype::Numeric).scale))}
             ),
             pair(
-               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)->genericType().rawType->toOne()->cast(@Class<Any>)->in([meta::relational::metamodel::datatype::Float, meta::relational::metamodel::datatype::Double])},
+               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)->exists(t | $t->genericType().rawType->toOne()->cast(@Class<Any>)->in([meta::relational::metamodel::datatype::Float, meta::relational::metamodel::datatype::Double]))},
                {params: RelationalOperationElement[*] | ^meta::relational::metamodel::datatype::Double()}
             )
          ])
@@ -1737,8 +1737,8 @@ function <<access.private>> meta::relational::functions::typeInference::getDynaF
          'times',
          list([
             pair(
-               {params: RelationalOperationElement[*] | [$params->at(0)->inferRelationalType($failOnMatchFailure)->toOne(), $params->at(1)->inferRelationalType($failOnMatchFailure)->toOne()]->isSafeTypePossible()},
-               {params: RelationalOperationElement[*] | [$params->at(0)->inferRelationalType($failOnMatchFailure)->toOne(), $params->at(1)->inferRelationalType($failOnMatchFailure)->toOne()]->getSafeType()}
+               {params: RelationalOperationElement[*] | isSafeTypePossible($params->at(0)->inferRelationalType($failOnMatchFailure), $params->at(1)->inferRelationalType($failOnMatchFailure))},
+               {params: RelationalOperationElement[*] | getSafeType($params->at(0)->inferRelationalType($failOnMatchFailure), $params->at(1)->inferRelationalType($failOnMatchFailure))}
             )
          ])
       ),
@@ -1947,6 +1947,14 @@ function <<access.private>> meta::relational::functions::typeInference::getSafeT
    );
 }
 
+function <<access.private>> meta::relational::functions::typeInference::isSafeTypePossible(type1: meta::relational::metamodel::datatype::DataType[0..1], type2: meta::relational::metamodel::datatype::DataType[0..1]):Boolean[1]
+{
+   $type1->isNotEmpty() && $type2->isNotEmpty() && isSafeTypePossible($type1->toOne(), $type2->toOne())
+}
+function <<access.private>> meta::relational::functions::typeInference::getSafeType(type1: meta::relational::metamodel::datatype::DataType[0..1], type2: meta::relational::metamodel::datatype::DataType[0..1]):meta::relational::metamodel::datatype::DataType[0..1]
+{
+   if($type1->isNotEmpty() && $type2->isNotEmpty(), | getSafeType($type1->toOne(), $type2->toOne()), | [])
+}
 function <<access.private>> meta::relational::functions::typeInference::getDecimalScale(t: meta::relational::metamodel::datatype::DataType[1]):Integer[1]
 {
    $t->match([

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/relationalExtension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/relationalExtension.pure
@@ -110,7 +110,7 @@ function meta::relational::runtime::dataSourceEquality(a:DataSource[1],b:DataSou
 
 function meta::relational::functions::typeInference::inferDynaFunctionReturnType(d: DynaFunction[1], failOnMatchFailure:Boolean[1]):meta::relational::metamodel::datatype::DataType[0..1]
 {
-   let dfToReturnFunctionMap = meta::relational::functions::typeInference::getDynaFunctionTypeInferenceMap();
+   let dfToReturnFunctionMap = meta::relational::functions::typeInference::getDynaFunctionTypeInferenceMap($failOnMatchFailure);
    let candidateMatchAndDTypePairs = $dfToReturnFunctionMap->get($d.name).values;
    let filteredMatchAndDTypePairs = $candidateMatchAndDTypePairs->filter(p | $p.first->eval($d.parameters));
    if($failOnMatchFailure, | assert($filteredMatchAndDTypePairs->size() >= 1, 'Type inference not supported yet! Dyna function: ' + $d.name);, | []);
@@ -161,7 +161,7 @@ function meta::relational::functions::typeInference::inferRelationalType(rop: Re
                                    | ^meta::relational::metamodel::datatype::Timestamp(),
                                    | if($d.type == StrictDate,
                                         | ^meta::relational::metamodel::datatype::Date(),
-                                        | fail('Not supported yet!'); ^meta::relational::metamodel::datatype::DataType();
+                                        | if($failOnMatchFailure, | fail('Not supported yet!'); ^meta::relational::metamodel::datatype::DataType();, |[])
                                      )
                                 )
                            )
@@ -170,7 +170,11 @@ function meta::relational::functions::typeInference::inferRelationalType(rop: Re
             ),
          a: Any[1]     | if($failOnMatchFailure, | fail('Not supported yet!'); ^meta::relational::metamodel::datatype::DataType();, |[]);
       ]),
-      j : meta::relational::metamodel::operation::JoinStrings[1] | ^meta::relational::metamodel::datatype::Varchar(size = $j.strings->concatenate($j.prefix)->concatenate($j.separator)->concatenate($j.suffix)->map(x | $x->inferRelationalType($failOnMatchFailure)->toOne()->getSize())->sum()),
+      j : meta::relational::metamodel::operation::JoinStrings[1] | 
+        ^meta::relational::metamodel::datatype::Varchar(size = $j.strings->concatenate($j.prefix)->concatenate($j.separator)->concatenate($j.suffix)
+          ->map(x | let stringType = $x->inferRelationalType($failOnMatchFailure); if($stringType->isEmpty(), | 1024, | $stringType->toOne()->getSize());) //if can't infer size then default to 1024 
+          ->sum()
+        ),
       c:Column[1] | $c.type,
       s: meta::relational::metamodel::operation::SemiStructuredPropertyAccess[1] | 
         let type = $s.operand->inferRelationalType($failOnMatchFailure)->filter(x | $x->instanceOf(meta::relational::metamodel::datatype::Object))->map(x | $x->cast(@meta::relational::metamodel::datatype::Object).valueType);
@@ -185,7 +189,7 @@ function meta::relational::functions::typeInference::inferRelationalType(rop: Re
    ]);
 }
 
-function <<access.private>> meta::relational::functions::typeInference::getDynaFunctionTypeInferenceMap():Map<String, List<Pair<meta::pure::metamodel::function::Function<{RelationalOperationElement[*]->Boolean[1]}>, meta::pure::metamodel::function::Function<{RelationalOperationElement[*]->meta::relational::metamodel::datatype::DataType[0..1]}>>>>[1]
+function <<access.private>> meta::relational::functions::typeInference::getDynaFunctionTypeInferenceMap(failOnMatchFailure: Boolean[1]):Map<String, List<Pair<meta::pure::metamodel::function::Function<{RelationalOperationElement[*]->Boolean[1]}>, meta::pure::metamodel::function::Function<{RelationalOperationElement[*]->meta::relational::metamodel::datatype::DataType[0..1]}>>>>[1]
 {
    newMap([
 
@@ -194,7 +198,7 @@ function <<access.private>> meta::relational::functions::typeInference::getDynaF
          list([
             pair(
                {params: RelationalOperationElement[*] | true},
-               {params: RelationalOperationElement[*] | $params->toOne()->inferRelationalType()}
+               {params: RelationalOperationElement[*] | $params->toOne()->inferRelationalType($failOnMatchFailure)}
             )
          ])
       ),
@@ -213,12 +217,12 @@ function <<access.private>> meta::relational::functions::typeInference::getDynaF
          'add',
          list([
             pair(
-               {params: RelationalOperationElement[*] | [$params->at(0)->inferRelationalType()->toOne(), $params->at(1)->inferRelationalType()->toOne()]->isSafeTypePossible() && [$params->at(0)->inferRelationalType()->toOne(), $params->at(1)->inferRelationalType()->toOne()]->getSafeType()->instanceOf(meta::relational::metamodel::datatype::Varchar)},
-               {params: RelationalOperationElement[*] | ^meta::relational::metamodel::datatype::Varchar(size = $params->at(0)->inferRelationalType()->toOne()->getSize() + $params->at(1)->inferRelationalType()->toOne()->getSize())}
+               {params: RelationalOperationElement[*] | [$params->at(0)->inferRelationalType($failOnMatchFailure)->toOne(), $params->at(1)->inferRelationalType($failOnMatchFailure)->toOne()]->isSafeTypePossible() && [$params->at(0)->inferRelationalType($failOnMatchFailure)->toOne(), $params->at(1)->inferRelationalType($failOnMatchFailure)->toOne()]->getSafeType()->instanceOf(meta::relational::metamodel::datatype::Varchar)},
+               {params: RelationalOperationElement[*] | ^meta::relational::metamodel::datatype::Varchar(size = $params->at(0)->inferRelationalType($failOnMatchFailure)->toOne()->getSize() + $params->at(1)->inferRelationalType($failOnMatchFailure)->toOne()->getSize())}
             ),
             pair(
-               {params: RelationalOperationElement[*] | [$params->at(0)->inferRelationalType()->toOne(), $params->at(1)->inferRelationalType()->toOne()]->isSafeTypePossible()},
-               {params: RelationalOperationElement[*] | [$params->at(0)->inferRelationalType()->toOne(), $params->at(1)->inferRelationalType()->toOne()]->getSafeType()}
+               {params: RelationalOperationElement[*] | [$params->at(0)->inferRelationalType($failOnMatchFailure)->toOne(), $params->at(1)->inferRelationalType($failOnMatchFailure)->toOne()]->isSafeTypePossible()},
+               {params: RelationalOperationElement[*] | [$params->at(0)->inferRelationalType($failOnMatchFailure)->toOne(), $params->at(1)->inferRelationalType($failOnMatchFailure)->toOne()]->getSafeType()}
             )
          ])
       ),
@@ -227,12 +231,12 @@ function <<access.private>> meta::relational::functions::typeInference::getDynaF
          'adjust',
          list([
             pair(
-               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType()->toOne()->instanceOf(meta::relational::metamodel::datatype::Char) || $params->at(0)->inferRelationalType()->toOne()->instanceOf(meta::relational::metamodel::datatype::Varchar)},
+               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)->toOne()->instanceOf(meta::relational::metamodel::datatype::Char) || $params->at(0)->inferRelationalType($failOnMatchFailure)->toOne()->instanceOf(meta::relational::metamodel::datatype::Varchar)},
                {params: RelationalOperationElement[*] | ^meta::relational::metamodel::datatype::Timestamp()}
             ),
             pair(
                {params: RelationalOperationElement[*] | true},
-               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType()}
+               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)}
             )
          ])
       ),
@@ -403,10 +407,10 @@ function <<access.private>> meta::relational::functions::typeInference::getDynaF
             pair(
                {params: RelationalOperationElement[*] | let size = ($params->size()-1)/2;
                                                         let range = range(0, $size->floor()*2, 2);
-                                                        $range->map(o | $params->at($o + 1)->inferRelationalType())->concatenate($params->at($params->size()-1)->inferRelationalType())->isSafeTypePossible();},
+                                                        $range->map(o | $params->at($o + 1)->inferRelationalType($failOnMatchFailure))->concatenate($params->at($params->size()-1)->inferRelationalType($failOnMatchFailure))->isSafeTypePossible();},
                {params: RelationalOperationElement[*] | let size = ($params->size()-1)/2;
                                                         let range = range(0, $size->floor()*2, 2);
-                                                        $range->map(o | $params->at($o + 1)->inferRelationalType())->concatenate($params->at($params->size()-1)->inferRelationalType())->getSafeType();}
+                                                        $range->map(o | $params->at($o + 1)->inferRelationalType($failOnMatchFailure))->concatenate($params->at($params->size()-1)->inferRelationalType($failOnMatchFailure))->getSafeType();}
             )
          ])
       ),
@@ -425,16 +429,16 @@ function <<access.private>> meta::relational::functions::typeInference::getDynaF
          'ceiling',
          list([
             pair(
-               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType()->toOne()->instanceOf(meta::relational::metamodel::datatype::Numeric)},
-               {params: RelationalOperationElement[*] | let type = $params->at(0)->inferRelationalType()->toOne()->cast(@meta::relational::metamodel::datatype::Numeric); ^$type(scale = 0);}
+               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)->toOne()->instanceOf(meta::relational::metamodel::datatype::Numeric)},
+               {params: RelationalOperationElement[*] | let type = $params->at(0)->inferRelationalType($failOnMatchFailure)->toOne()->cast(@meta::relational::metamodel::datatype::Numeric); ^$type(scale = 0);}
             ),
             pair(
-               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType()->toOne()->instanceOf(meta::relational::metamodel::datatype::Decimal)},
-               {params: RelationalOperationElement[*] | let type = $params->at(0)->inferRelationalType()->toOne()->cast(@meta::relational::metamodel::datatype::Decimal); ^$type(scale = 0);}
+               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)->toOne()->instanceOf(meta::relational::metamodel::datatype::Decimal)},
+               {params: RelationalOperationElement[*] | let type = $params->at(0)->inferRelationalType($failOnMatchFailure)->toOne()->cast(@meta::relational::metamodel::datatype::Decimal); ^$type(scale = 0);}
             ),
             pair(
                {params: RelationalOperationElement[*] | true},
-               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType()}
+               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)}
             )
          ])
       ),
@@ -453,8 +457,8 @@ function <<access.private>> meta::relational::functions::typeInference::getDynaF
          'coalesce',
          list([
             pair(
-               {params: RelationalOperationElement[*] | $params->map(p |$p->inferRelationalType())->isSafeTypePossible()},
-               {params: RelationalOperationElement[*] | $params->map(p |$p->inferRelationalType())->getSafeType()}
+               {params: RelationalOperationElement[*] | $params->map(p |$p->inferRelationalType($failOnMatchFailure))->isSafeTypePossible()},
+               {params: RelationalOperationElement[*] | $params->map(p |$p->inferRelationalType($failOnMatchFailure))->getSafeType()}
             )
          ])
       ),
@@ -463,8 +467,8 @@ function <<access.private>> meta::relational::functions::typeInference::getDynaF
          'concat',
          list([
             pair(
-               {params: RelationalOperationElement[*] | $params->map(p |$p->inferRelationalType())->forAll(x | $x->instanceOf(meta::relational::metamodel::datatype::Char) || $x->instanceOf(meta::relational::metamodel::datatype::Varchar))},
-               {params: RelationalOperationElement[*] | ^meta::relational::metamodel::datatype::Varchar(size = $params->map(p |$p->inferRelationalType())->map(x|$x->getSize())->sum())}
+               {params: RelationalOperationElement[*] | $params->map(p |$p->inferRelationalType($failOnMatchFailure))->forAll(x | $x->instanceOf(meta::relational::metamodel::datatype::Char) || $x->instanceOf(meta::relational::metamodel::datatype::Varchar))},
+               {params: RelationalOperationElement[*] | ^meta::relational::metamodel::datatype::Varchar(size = $params->map(p |$p->inferRelationalType($failOnMatchFailure))->map(x|$x->getSize())->sum())}
             )
          ])
       ),
@@ -684,7 +688,7 @@ function <<access.private>> meta::relational::functions::typeInference::getDynaF
          list([
             pair(
                {params: RelationalOperationElement[*] | $params->isNotEmpty()},
-               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType()}
+               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)}
             )
          ])
       ),
@@ -853,16 +857,16 @@ function <<access.private>> meta::relational::functions::typeInference::getDynaF
          'floor',
          list([
             pair(
-               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType()->toOne()->instanceOf(meta::relational::metamodel::datatype::Numeric)},
-               {params: RelationalOperationElement[*] | let type = $params->at(0)->inferRelationalType()->toOne()->cast(@meta::relational::metamodel::datatype::Numeric); ^$type(scale = 0);}
+               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)->toOne()->instanceOf(meta::relational::metamodel::datatype::Numeric)},
+               {params: RelationalOperationElement[*] | let type = $params->at(0)->inferRelationalType($failOnMatchFailure)->toOne()->cast(@meta::relational::metamodel::datatype::Numeric); ^$type(scale = 0);}
             ),
             pair(
-               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType()->toOne()->instanceOf(meta::relational::metamodel::datatype::Decimal)},
-               {params: RelationalOperationElement[*] | let type = $params->at(0)->inferRelationalType()->toOne()->cast(@meta::relational::metamodel::datatype::Decimal); ^$type(scale = 0);}
+               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)->toOne()->instanceOf(meta::relational::metamodel::datatype::Decimal)},
+               {params: RelationalOperationElement[*] | let type = $params->at(0)->inferRelationalType($failOnMatchFailure)->toOne()->cast(@meta::relational::metamodel::datatype::Decimal); ^$type(scale = 0);}
             ),
             pair(
                {params: RelationalOperationElement[*] | true},
-               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType()}
+               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)}
             )
          ])
       ),
@@ -892,7 +896,7 @@ function <<access.private>> meta::relational::functions::typeInference::getDynaF
          list([
             pair(
                {params: RelationalOperationElement[*] | true},
-               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType()}
+               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)}
             )
          ])
       ),
@@ -902,7 +906,7 @@ function <<access.private>> meta::relational::functions::typeInference::getDynaF
          list([
             pair(
                {params: RelationalOperationElement[*] | true},
-               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType()}
+               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)}
             )
          ])
       ),      
@@ -921,8 +925,8 @@ function <<access.private>> meta::relational::functions::typeInference::getDynaF
          'if',
          list([
             pair(
-               {params: RelationalOperationElement[*] | [$params->at(1)->inferRelationalType()->toOne(), $params->at(2)->inferRelationalType()->toOne()]->isSafeTypePossible()},
-               {params: RelationalOperationElement[*] | [$params->at(1)->inferRelationalType()->toOne(), $params->at(2)->inferRelationalType()->toOne()]->getSafeType()}
+               {params: RelationalOperationElement[*] | [$params->at(1)->inferRelationalType($failOnMatchFailure)->toOne(), $params->at(2)->inferRelationalType($failOnMatchFailure)->toOne()]->isSafeTypePossible()},
+               {params: RelationalOperationElement[*] | [$params->at(1)->inferRelationalType($failOnMatchFailure)->toOne(), $params->at(2)->inferRelationalType($failOnMatchFailure)->toOne()]->getSafeType()}
             )
          ])
       ),
@@ -1011,8 +1015,8 @@ function <<access.private>> meta::relational::functions::typeInference::getDynaF
          'joinStrings',
          list([
             pair(
-               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType()->toOne()->instanceOf(meta::relational::metamodel::datatype::Char) || $params->at(0)->inferRelationalType()->toOne()->instanceOf(meta::relational::metamodel::datatype::Varchar)},
-               {params: RelationalOperationElement[*] | let size = $params->at(0)->inferRelationalType()->toOne()->getSize(); ^meta::relational::metamodel::datatype::Varchar(size = max([4000, $size]));}
+               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)->toOne()->instanceOf(meta::relational::metamodel::datatype::Char) || $params->at(0)->inferRelationalType($failOnMatchFailure)->toOne()->instanceOf(meta::relational::metamodel::datatype::Varchar)},
+               {params: RelationalOperationElement[*] | let size = $params->at(0)->inferRelationalType($failOnMatchFailure)->toOne()->getSize(); ^meta::relational::metamodel::datatype::Varchar(size = max([4000, $size]));}
             )
          ])
       ),
@@ -1022,7 +1026,7 @@ function <<access.private>> meta::relational::functions::typeInference::getDynaF
          list([
             pair(
                {params: RelationalOperationElement[*] | true},
-               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType()}
+               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)}
             )
          ])
       ),            
@@ -1032,7 +1036,7 @@ function <<access.private>> meta::relational::functions::typeInference::getDynaF
          list([
             pair(
                {params: RelationalOperationElement[*] | true},
-               {params: RelationalOperationElement[*] | ^meta::relational::metamodel::datatype::Varchar(size = $params->at(0)->inferRelationalType()->match([c:meta::relational::metamodel::datatype::Char[1]|$c.size,c:meta::relational::metamodel::datatype::Varchar[1]|$c.size]))}
+               {params: RelationalOperationElement[*] | ^meta::relational::metamodel::datatype::Varchar(size = $params->at(0)->inferRelationalType($failOnMatchFailure)->match([c:meta::relational::metamodel::datatype::Char[1]|$c.size,c:meta::relational::metamodel::datatype::Varchar[1]|$c.size]))}
             )
          ])
       ),
@@ -1102,7 +1106,7 @@ function <<access.private>> meta::relational::functions::typeInference::getDynaF
          list([
             pair(
                {params: RelationalOperationElement[*] | true},
-               {params: RelationalOperationElement[*] | ^meta::relational::metamodel::datatype::Varchar(size = $params->at(0)->inferRelationalType()->match([c:meta::relational::metamodel::datatype::Char[1]|$c.size,c:meta::relational::metamodel::datatype::Varchar[1]|$c.size]))}
+               {params: RelationalOperationElement[*] | ^meta::relational::metamodel::datatype::Varchar(size = $params->at(0)->inferRelationalType($failOnMatchFailure)->match([c:meta::relational::metamodel::datatype::Char[1]|$c.size,c:meta::relational::metamodel::datatype::Varchar[1]|$c.size]))}
             )
          ])
       ),
@@ -1131,12 +1135,12 @@ function <<access.private>> meta::relational::functions::typeInference::getDynaF
          'max',
          list([
             pair(
-               {params: RelationalOperationElement[*] | $params->size() > 1 && $params->map(x | $x->inferRelationalType())->isSafeTypePossible()},
-               {params: RelationalOperationElement[*] | $params->map(x | $x->inferRelationalType())->getSafeType()}
+               {params: RelationalOperationElement[*] | $params->size() > 1 && $params->map(x | $x->inferRelationalType($failOnMatchFailure))->isSafeTypePossible()},
+               {params: RelationalOperationElement[*] | $params->map(x | $x->inferRelationalType($failOnMatchFailure))->getSafeType()}
             ),
             pair(
                {params: RelationalOperationElement[*] | true},
-               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType()}
+               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)}
             )
          ])
       ),
@@ -1165,12 +1169,12 @@ function <<access.private>> meta::relational::functions::typeInference::getDynaF
          'min',
          list([
             pair(
-               {params: RelationalOperationElement[*] | $params->size() > 1 && $params->map(x | $x->inferRelationalType())->isSafeTypePossible()},
-               {params: RelationalOperationElement[*] | $params->map(x | $x->inferRelationalType())->getSafeType()}
+               {params: RelationalOperationElement[*] | $params->size() > 1 && $params->map(x | $x->inferRelationalType($failOnMatchFailure))->isSafeTypePossible()},
+               {params: RelationalOperationElement[*] | $params->map(x | $x->inferRelationalType($failOnMatchFailure))->getSafeType()}
             ),
             pair(
                {params: RelationalOperationElement[*] | true},
-               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType()}
+               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)}
             )
          ])
       ),
@@ -1189,8 +1193,8 @@ function <<access.private>> meta::relational::functions::typeInference::getDynaF
          'minus',
          list([
             pair(
-               {params: RelationalOperationElement[*] | $params->size() > 1 && $params->map(x | $x->inferRelationalType())->isSafeTypePossible()},
-               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType()}
+               {params: RelationalOperationElement[*] | $params->size() > 1 && $params->map(x | $x->inferRelationalType($failOnMatchFailure))->isSafeTypePossible()},
+               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)}
             )
          ])
       ),
@@ -1369,28 +1373,28 @@ function <<access.private>> meta::relational::functions::typeInference::getDynaF
          'plus',
          list([
             pair(
-               {params: RelationalOperationElement[*] | $params->size() == 1 && $params->at(0)->inferRelationalType()->genericType().rawType->toOne()->cast(@Class<Any>)->in([meta::relational::metamodel::datatype::SmallInt, meta::relational::metamodel::datatype::TinyInt])},
+               {params: RelationalOperationElement[*] | $params->size() == 1 && $params->at(0)->inferRelationalType($failOnMatchFailure)->genericType().rawType->toOne()->cast(@Class<Any>)->in([meta::relational::metamodel::datatype::SmallInt, meta::relational::metamodel::datatype::TinyInt])},
                {params: RelationalOperationElement[*] | ^meta::relational::metamodel::datatype::Integer()}
             ),
             pair(
-               {params: RelationalOperationElement[*] | $params->size() == 1 && $params->at(0)->inferRelationalType()->genericType().rawType->toOne()->cast(@Class<Any>)->in([meta::relational::metamodel::datatype::Integer, meta::relational::metamodel::datatype::BigInt])},
+               {params: RelationalOperationElement[*] | $params->size() == 1 && $params->at(0)->inferRelationalType($failOnMatchFailure)->genericType().rawType->toOne()->cast(@Class<Any>)->in([meta::relational::metamodel::datatype::Integer, meta::relational::metamodel::datatype::BigInt])},
                {params: RelationalOperationElement[*] | ^meta::relational::metamodel::datatype::BigInt()}
             ),
             pair(
-               {params: RelationalOperationElement[*] | $params->size() == 1 && $params->at(0)->inferRelationalType()->genericType().rawType->toOne()->cast(@Class<Any>) == meta::relational::metamodel::datatype::Decimal},
-               {params: RelationalOperationElement[*] | ^meta::relational::metamodel::datatype::Decimal(precision = min([31, $params->at(0)->inferRelationalType()->toOne()->cast(@meta::relational::metamodel::datatype::Decimal).precision]), scale = $params->at(0)->inferRelationalType()->toOne()->cast(@meta::relational::metamodel::datatype::Decimal).scale)}
+               {params: RelationalOperationElement[*] | $params->size() == 1 && $params->at(0)->inferRelationalType($failOnMatchFailure)->genericType().rawType->toOne()->cast(@Class<Any>) == meta::relational::metamodel::datatype::Decimal},
+               {params: RelationalOperationElement[*] | ^meta::relational::metamodel::datatype::Decimal(precision = min([31, $params->at(0)->inferRelationalType($failOnMatchFailure)->toOne()->cast(@meta::relational::metamodel::datatype::Decimal).precision]), scale = $params->at(0)->inferRelationalType($failOnMatchFailure)->toOne()->cast(@meta::relational::metamodel::datatype::Decimal).scale)}
             ),
             pair(
-               {params: RelationalOperationElement[*] | $params->size() == 1 && $params->at(0)->inferRelationalType()->genericType().rawType->toOne()->cast(@Class<Any>) == meta::relational::metamodel::datatype::Numeric},
-               {params: RelationalOperationElement[*] | ^meta::relational::metamodel::datatype::Numeric(precision = min([31, $params->at(0)->inferRelationalType()->toOne()->cast(@meta::relational::metamodel::datatype::Numeric).precision]), scale = $params->at(0)->inferRelationalType()->toOne()->cast(@meta::relational::metamodel::datatype::Numeric).scale)}
+               {params: RelationalOperationElement[*] | $params->size() == 1 && $params->at(0)->inferRelationalType($failOnMatchFailure)->genericType().rawType->toOne()->cast(@Class<Any>) == meta::relational::metamodel::datatype::Numeric},
+               {params: RelationalOperationElement[*] | ^meta::relational::metamodel::datatype::Numeric(precision = min([31, $params->at(0)->inferRelationalType($failOnMatchFailure)->toOne()->cast(@meta::relational::metamodel::datatype::Numeric).precision]), scale = $params->at(0)->inferRelationalType($failOnMatchFailure)->toOne()->cast(@meta::relational::metamodel::datatype::Numeric).scale)}
             ),
             pair(
-               {params: RelationalOperationElement[*] | $params->size() == 1 && $params->at(0)->inferRelationalType()->genericType().rawType->toOne()->cast(@Class<Any>)->in([meta::relational::metamodel::datatype::Float, meta::relational::metamodel::datatype::Double])},
+               {params: RelationalOperationElement[*] | $params->size() == 1 && $params->at(0)->inferRelationalType($failOnMatchFailure)->genericType().rawType->toOne()->cast(@Class<Any>)->in([meta::relational::metamodel::datatype::Float, meta::relational::metamodel::datatype::Double])},
                {params: RelationalOperationElement[*] | ^meta::relational::metamodel::datatype::Double()}
             ),
             pair(
-               {params: RelationalOperationElement[*] | $params->size() > 1 && $params->map(x | $x->inferRelationalType())->isSafeTypePossible()},
-               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType()}
+               {params: RelationalOperationElement[*] | $params->size() > 1 && $params->map(x | $x->inferRelationalType($failOnMatchFailure))->isSafeTypePossible()},
+               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)}
             )
          ])
       ),
@@ -1450,7 +1454,7 @@ function <<access.private>> meta::relational::functions::typeInference::getDynaF
          list([
             pair(
                {params: RelationalOperationElement[*] | true},
-               {params: RelationalOperationElement[*] | ^meta::relational::metamodel::datatype::Varchar(size = $params->at(0)->inferRelationalType()->match([c:meta::relational::metamodel::datatype::Char[1]|$c.size,c:meta::relational::metamodel::datatype::Varchar[1]|$c.size]) * 2)} // Safe
+               {params: RelationalOperationElement[*] | ^meta::relational::metamodel::datatype::Varchar(size = $params->at(0)->inferRelationalType($failOnMatchFailure)->match([c:meta::relational::metamodel::datatype::Char[1]|$c.size,c:meta::relational::metamodel::datatype::Varchar[1]|$c.size]) * 2)} // Safe
             )
          ])
       ),
@@ -1460,7 +1464,7 @@ function <<access.private>> meta::relational::functions::typeInference::getDynaF
          list([
             pair(
                {params: RelationalOperationElement[*] | true},
-               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType()}
+               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)}
             )
          ])
       ),
@@ -1470,7 +1474,7 @@ function <<access.private>> meta::relational::functions::typeInference::getDynaF
          list([
             pair(
                {params: RelationalOperationElement[*] | true},
-               {params: RelationalOperationElement[*] | ^meta::relational::metamodel::datatype::Varchar(size = $params->at(0)->inferRelationalType()->match([c:meta::relational::metamodel::datatype::Char[1]|$c.size,c:meta::relational::metamodel::datatype::Varchar[1]|$c.size]))}
+               {params: RelationalOperationElement[*] | ^meta::relational::metamodel::datatype::Varchar(size = $params->at(0)->inferRelationalType($failOnMatchFailure)->match([c:meta::relational::metamodel::datatype::Char[1]|$c.size,c:meta::relational::metamodel::datatype::Varchar[1]|$c.size]))}
             )
          ])
       ),
@@ -1489,16 +1493,16 @@ function <<access.private>> meta::relational::functions::typeInference::getDynaF
          'round',
          list([
             pair(
-               {params: RelationalOperationElement[*] | $params->size() == 1 && $params->at(0)->inferRelationalType()->genericType().rawType->toOne()->cast(@Class<Any>) == meta::relational::metamodel::datatype::Decimal},
-               {params: RelationalOperationElement[*] | ^meta::relational::metamodel::datatype::Decimal(precision = min([31, ($params->at(0)->inferRelationalType()->toOne()->cast(@meta::relational::metamodel::datatype::Decimal).precision + 1)]), scale = $params->at(0)->inferRelationalType()->toOne()->cast(@meta::relational::metamodel::datatype::Decimal).scale)}
+               {params: RelationalOperationElement[*] | $params->size() == 1 && $params->at(0)->inferRelationalType($failOnMatchFailure)->genericType().rawType->toOne()->cast(@Class<Any>) == meta::relational::metamodel::datatype::Decimal},
+               {params: RelationalOperationElement[*] | ^meta::relational::metamodel::datatype::Decimal(precision = min([31, ($params->at(0)->inferRelationalType($failOnMatchFailure)->toOne()->cast(@meta::relational::metamodel::datatype::Decimal).precision + 1)]), scale = $params->at(0)->inferRelationalType($failOnMatchFailure)->toOne()->cast(@meta::relational::metamodel::datatype::Decimal).scale)}
             ),
             pair(
-               {params: RelationalOperationElement[*] | $params->size() == 1 && $params->at(0)->inferRelationalType()->genericType().rawType->toOne()->cast(@Class<Any>) == meta::relational::metamodel::datatype::Numeric},
-               {params: RelationalOperationElement[*] | ^meta::relational::metamodel::datatype::Numeric(precision = min([31, ($params->at(0)->inferRelationalType()->toOne()->cast(@meta::relational::metamodel::datatype::Numeric).precision + 1)]), scale = $params->at(0)->inferRelationalType()->toOne()->cast(@meta::relational::metamodel::datatype::Numeric).scale)}
+               {params: RelationalOperationElement[*] | $params->size() == 1 && $params->at(0)->inferRelationalType($failOnMatchFailure)->genericType().rawType->toOne()->cast(@Class<Any>) == meta::relational::metamodel::datatype::Numeric},
+               {params: RelationalOperationElement[*] | ^meta::relational::metamodel::datatype::Numeric(precision = min([31, ($params->at(0)->inferRelationalType($failOnMatchFailure)->toOne()->cast(@meta::relational::metamodel::datatype::Numeric).precision + 1)]), scale = $params->at(0)->inferRelationalType($failOnMatchFailure)->toOne()->cast(@meta::relational::metamodel::datatype::Numeric).scale)}
             ),
             pair(
                {params: RelationalOperationElement[*] | true},
-               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType()}
+               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)}
             )
          ])
       ),
@@ -1508,7 +1512,7 @@ function <<access.private>> meta::relational::functions::typeInference::getDynaF
          list([
             pair(
                {params: RelationalOperationElement[*] | true},
-               {params: RelationalOperationElement[*] | ^meta::relational::metamodel::datatype::Varchar(size = $params->at(0)->inferRelationalType()->match([c:meta::relational::metamodel::datatype::Char[1]|$c.size,c:meta::relational::metamodel::datatype::Varchar[1]|$c.size]))}
+               {params: RelationalOperationElement[*] | ^meta::relational::metamodel::datatype::Varchar(size = $params->at(0)->inferRelationalType($failOnMatchFailure)->match([c:meta::relational::metamodel::datatype::Char[1]|$c.size,c:meta::relational::metamodel::datatype::Varchar[1]|$c.size]))}
             )
          ])
       ),
@@ -1597,8 +1601,8 @@ function <<access.private>> meta::relational::functions::typeInference::getDynaF
          'sub',
          list([
             pair(
-               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType()->genericType().rawType->toOne()->cast(@Class<Any>) == $params->at(1)->inferRelationalType()->genericType().rawType->toOne()->cast(@Class<Any>)},
-               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType()}
+               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)->genericType().rawType->toOne()->cast(@Class<Any>) == $params->at(1)->inferRelationalType($failOnMatchFailure)->genericType().rawType->toOne()->cast(@Class<Any>)},
+               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)}
             )
          ])
       ),
@@ -1608,7 +1612,7 @@ function <<access.private>> meta::relational::functions::typeInference::getDynaF
          list([
             pair(
                {params: RelationalOperationElement[*] | true},
-               {params: RelationalOperationElement[*] | ^meta::relational::metamodel::datatype::Varchar(size = $params->at(0)->inferRelationalType()->match([c:meta::relational::metamodel::datatype::Char[1]|$c.size,c:meta::relational::metamodel::datatype::Varchar[1]|$c.size]))}
+               {params: RelationalOperationElement[*] | ^meta::relational::metamodel::datatype::Varchar(size = $params->at(0)->inferRelationalType($failOnMatchFailure)->match([c:meta::relational::metamodel::datatype::Char[1]|$c.size,c:meta::relational::metamodel::datatype::Varchar[1]|$c.size]))}
             )
          ])
       ),
@@ -1677,23 +1681,23 @@ function <<access.private>> meta::relational::functions::typeInference::getDynaF
          'sum',
          list([
             pair(
-               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType()->genericType().rawType->toOne()->cast(@Class<Any>)->in([meta::relational::metamodel::datatype::SmallInt, meta::relational::metamodel::datatype::TinyInt, meta::relational::metamodel::datatype::Integer])},
+               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)->genericType().rawType->toOne()->cast(@Class<Any>)->in([meta::relational::metamodel::datatype::SmallInt, meta::relational::metamodel::datatype::TinyInt, meta::relational::metamodel::datatype::Integer])},
                {params: RelationalOperationElement[*] | ^meta::relational::metamodel::datatype::Integer()}
             ),
             pair(
-               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType()->genericType().rawType->toOne()->cast(@Class<Any>)->in([meta::relational::metamodel::datatype::BigInt])},
+               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)->genericType().rawType->toOne()->cast(@Class<Any>)->in([meta::relational::metamodel::datatype::BigInt])},
                {params: RelationalOperationElement[*] | ^meta::relational::metamodel::datatype::BigInt()}
             ),
             pair(
-               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType()->genericType().rawType->toOne()->cast(@Class<Any>) == meta::relational::metamodel::datatype::Decimal},
-               {params: RelationalOperationElement[*] | ^meta::relational::metamodel::datatype::Decimal(precision = min([31, $params->at(0)->inferRelationalType()->toOne()->cast(@meta::relational::metamodel::datatype::Decimal).precision]), scale = $params->at(0)->inferRelationalType()->toOne()->cast(@meta::relational::metamodel::datatype::Decimal).scale)}
+               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)->genericType().rawType->toOne()->cast(@Class<Any>) == meta::relational::metamodel::datatype::Decimal},
+               {params: RelationalOperationElement[*] | ^meta::relational::metamodel::datatype::Decimal(precision = min([31, $params->at(0)->inferRelationalType($failOnMatchFailure)->toOne()->cast(@meta::relational::metamodel::datatype::Decimal).precision]), scale = $params->at(0)->inferRelationalType($failOnMatchFailure)->toOne()->cast(@meta::relational::metamodel::datatype::Decimal).scale)}
             ),
             pair(
-               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType()->genericType().rawType->toOne()->cast(@Class<Any>) == meta::relational::metamodel::datatype::Numeric},
-               {params: RelationalOperationElement[*] | ^meta::relational::metamodel::datatype::Numeric(precision = min([31, $params->at(0)->inferRelationalType()->toOne()->cast(@meta::relational::metamodel::datatype::Numeric).precision]), scale = $params->at(0)->inferRelationalType()->toOne()->cast(@meta::relational::metamodel::datatype::Numeric).scale)}
+               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)->genericType().rawType->toOne()->cast(@Class<Any>) == meta::relational::metamodel::datatype::Numeric},
+               {params: RelationalOperationElement[*] | ^meta::relational::metamodel::datatype::Numeric(precision = min([31, $params->at(0)->inferRelationalType($failOnMatchFailure)->toOne()->cast(@meta::relational::metamodel::datatype::Numeric).precision]), scale = $params->at(0)->inferRelationalType($failOnMatchFailure)->toOne()->cast(@meta::relational::metamodel::datatype::Numeric).scale)}
             ),
             pair(
-               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType()->genericType().rawType->toOne()->cast(@Class<Any>)->in([meta::relational::metamodel::datatype::Float, meta::relational::metamodel::datatype::Double])},
+               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)->genericType().rawType->toOne()->cast(@Class<Any>)->in([meta::relational::metamodel::datatype::Float, meta::relational::metamodel::datatype::Double])},
                {params: RelationalOperationElement[*] | ^meta::relational::metamodel::datatype::Double()}
             )
          ])
@@ -1724,7 +1728,7 @@ function <<access.private>> meta::relational::functions::typeInference::getDynaF
          list([
             pair(
                {params: RelationalOperationElement[*] | true},
-               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType()}
+               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)}
             )
          ])
       ),
@@ -1733,8 +1737,8 @@ function <<access.private>> meta::relational::functions::typeInference::getDynaF
          'times',
          list([
             pair(
-               {params: RelationalOperationElement[*] | [$params->at(0)->inferRelationalType()->toOne(), $params->at(1)->inferRelationalType()->toOne()]->isSafeTypePossible()},
-               {params: RelationalOperationElement[*] | [$params->at(0)->inferRelationalType()->toOne(), $params->at(1)->inferRelationalType()->toOne()]->getSafeType()}
+               {params: RelationalOperationElement[*] | [$params->at(0)->inferRelationalType($failOnMatchFailure)->toOne(), $params->at(1)->inferRelationalType($failOnMatchFailure)->toOne()]->isSafeTypePossible()},
+               {params: RelationalOperationElement[*] | [$params->at(0)->inferRelationalType($failOnMatchFailure)->toOne(), $params->at(1)->inferRelationalType($failOnMatchFailure)->toOne()]->getSafeType()}
             )
          ])
       ),
@@ -1754,7 +1758,7 @@ function <<access.private>> meta::relational::functions::typeInference::getDynaF
          list([
             pair(
                {params: RelationalOperationElement[*] | true},
-               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType()}
+               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)}
             )
          ])
       ),
@@ -1764,7 +1768,7 @@ function <<access.private>> meta::relational::functions::typeInference::getDynaF
          list([
             pair(
                {params: RelationalOperationElement[*] | true},
-               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType()}
+               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)}
             )
          ])
       ),
@@ -1804,7 +1808,7 @@ function <<access.private>> meta::relational::functions::typeInference::getDynaF
          list([
             pair(
                {params: RelationalOperationElement[*] | true},
-               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType()}
+               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType($failOnMatchFailure)}
             )
          ])
       ),
@@ -1814,7 +1818,7 @@ function <<access.private>> meta::relational::functions::typeInference::getDynaF
          list([
             pair(
                {params: RelationalOperationElement[*] | true},
-               {params: RelationalOperationElement[*] | ^meta::relational::metamodel::datatype::Varchar(size = $params->at(0)->inferRelationalType()->match([c:meta::relational::metamodel::datatype::Char[1]|$c.size,c:meta::relational::metamodel::datatype::Varchar[1]|$c.size]))}
+               {params: RelationalOperationElement[*] | ^meta::relational::metamodel::datatype::Varchar(size = $params->at(0)->inferRelationalType($failOnMatchFailure)->match([c:meta::relational::metamodel::datatype::Char[1]|$c.size,c:meta::relational::metamodel::datatype::Varchar[1]|$c.size]))}
             )
          ])
       ),


### PR DESCRIPTION
#### What type of PR is this?

- Bug Fix

#### What does this PR do / why is it needed ?

There were about 20 places in pureToSQL.pure where the column was hardcoded to Integer - this was causing some issues in some cross store join executions as this column type is used to create the schema of the temporary table leading to columns being incorrectly created as integer for string types.

This fix calls the correct method to infer the correct column type and only falls back to Integer if we can't derive the type for whatever reason (fall back to existing logic). Adds some safety checks so that if we can't infer the column we don't fail but instead fall back to Integer (where ever we were previously hardcoding to Integer) so that those queries still work as before
