### PR TITLE
Update Testable framework to support TestSuiteSession

### DIFF
--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/pom.xml
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/pom.xml
@@ -77,6 +77,10 @@
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-shared-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-testable</artifactId>
+        </dependency>
         <!-- ENGINE -->
 
         <!-- ECLIPSE COLLECTIONS -->

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/main/java/org/finos/legend/engine/test/emit/junit/EMITTestSuiteBuilder.java
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/main/java/org/finos/legend/engine/test/emit/junit/EMITTestSuiteBuilder.java
@@ -17,6 +17,7 @@ package org.finos.legend.engine.test.emit.junit;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.fileGeneration.FileGenerationSpecification;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service.Service;
+import org.finos.legend.engine.protocol.pure.v1.model.test.result.TestResult;
 import org.finos.legend.engine.test.emit.EMITModel;
 import org.finos.legend.engine.test.emit.EMITModelLoader;
 import org.finos.legend.engine.test.emit.EMITSourceSet;
@@ -24,15 +25,19 @@ import org.finos.legend.engine.test.emit.EMITTasks;
 import org.finos.legend.engine.test.emit.EMITTasks.ParseResult;
 import org.finos.legend.engine.test.emit.EMITTasks.TestCandidate;
 import org.finos.legend.engine.test.emit.error.EMITAssertionError;
+import org.finos.legend.engine.testable.extension.TestSuiteSession;
 import org.junit.jupiter.api.DynamicContainer;
 import org.junit.jupiter.api.DynamicNode;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.function.Executable;
 
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -391,8 +396,7 @@ public final class EMITTestSuiteBuilder
         if (!(testCandidates.isEmpty() && legacyMappingTestCandidates.isEmpty() && legacyServiceTestCandidates.isEmpty()))
         {
             String containerName = "Test";
-            Stream<DynamicNode> testableStream = testCandidates.isEmpty() ? null : testCandidates.stream().map(candidate ->
-                    test(() -> assertTestPassed(model, candidate), verboseNames, label, containerName, candidate.testablePath + ((candidate.suiteId == null) ? "" : (" / " + candidate.suiteId)) + " / " + candidate.atomicTestId));
+            Stream<DynamicNode> testableStream = testCandidates.isEmpty() ? null : sessionGroupedTestStream(verboseNames, label, containerName, model, testCandidates);
             Stream<DynamicNode> legacyMappingTestStream = legacyMappingTestCandidates.isEmpty() ? null : legacyMappingTestCandidates.stream().map(candidate ->
                     test(() -> EMITTasks.assertLegacyMappingTestPassed(EMITTasks.runLegacyMappingTest(candidate.mappingPath, candidate.test, model.getPureModel())), verboseNames, label, containerName, "Legacy Mapping Test", candidate.mappingPath + " / " + candidate.test.name));
             Stream<DynamicNode> legacyServiceTestSteam = legacyServiceTestCandidates.isEmpty() ? null : legacyServiceTestCandidates.stream().map(candidate ->
@@ -407,6 +411,101 @@ public final class EMITTestSuiteBuilder
         }
     }
 
+    /**
+     * Group the test candidates by {@code (testablePath, suiteId)} and yield
+     * one {@link DynamicTest} per atomic test. Each group opens a single
+     * {@link TestSuiteSession} lazily (so empty/filtered groups pay no
+     * setup) and closes it when its sub-stream is exhausted (so every
+     * runtime / connection resource the session held is released
+     * regardless of test outcome). Suite-level setup — plan generation,
+     * runtime build — is therefore paid once per suite instead of once per
+     * atomic test.
+     */
+    private static Stream<DynamicNode> sessionGroupedTestStream(boolean verboseNames, String label, String containerName, EMITModel model, List<TestCandidate> testCandidates)
+    {
+        Map<String, List<TestCandidate>> groups = new LinkedHashMap<>();
+        testCandidates.forEach(candidate -> groups.computeIfAbsent(candidate.testablePath + "\0" + ((candidate.suiteId == null) ? "" : candidate.suiteId), k -> new ArrayList<>()).add(candidate));
+        return groups.values().stream().flatMap(group -> sessionGroupStream(verboseNames, label, containerName, model, group));
+    }
+
+    private static Stream<DynamicNode> sessionGroupStream(boolean verboseNames, String label, String containerName, EMITModel model, List<TestCandidate> group)
+    {
+        TestCandidate head = group.get(0);
+        LazyTestSession lazy = new LazyTestSession(head.testablePath, head.suiteId, model);
+        return group.stream()
+                .<DynamicNode>map(candidate -> test(
+                        () -> EMITTasks.assertTestPassed(lazy.get().runAtomicTest(candidate.atomicTestId)),
+                        verboseNames, label, containerName,
+                        candidate.testablePath + ((candidate.suiteId == null) ? "" : (" / " + candidate.suiteId)) + " / " + candidate.atomicTestId))
+                .onClose(lazy::close);
+    }
+
+    /**
+     * Memoized opener for a {@link TestSuiteSession}. The first
+     * {@link #get} attempts the open and caches either the live session or
+     * the failure that prevented it; subsequent calls return the cached
+     * outcome rather than retrying. {@link #close} releases the live
+     * session if there is one, and is a no-op otherwise so it is safe to
+     * register on stream close handlers even when no test ever runs.
+     */
+    private static class LazyTestSession
+    {
+        private final String testablePath;
+        private final String suiteId;
+        private final EMITModel model;
+        private boolean opened;
+        private TestSuiteSession<TestResult> session;
+        private RuntimeException openError;
+
+        LazyTestSession(String testablePath, String suiteId, EMITModel model)
+        {
+            this.testablePath = testablePath;
+            this.suiteId = suiteId;
+            this.model = model;
+        }
+
+        TestSuiteSession<TestResult> get()
+        {
+            if (!this.opened)
+            {
+                this.opened = true;
+                try
+                {
+                    this.session = EMITTasks.openTestSession(this.testablePath, this.suiteId, this.model.getPmcd(), this.model.getPureModel());
+                }
+                catch (RuntimeException e)
+                {
+                    this.openError = e;
+                }
+                catch (Exception e)
+                {
+                    this.openError = new RuntimeException(e);
+                }
+            }
+            if (this.openError != null)
+            {
+                throw this.openError;
+            }
+            return this.session;
+        }
+
+        void close()
+        {
+            if (this.session != null)
+            {
+                try
+                {
+                    this.session.close();
+                }
+                catch (Exception ignored)
+                {
+                    // Best-effort cleanup; surfacing close failures past test completion has no useful destination.
+                }
+                this.session = null;
+            }
+        }
+    }
+
     private static void servicePlanTasks(boolean verboseNames, String label, EMITModel model, Consumer<? super DynamicContainer> containerConsumer)
     {
         List<Service> services = EMITTasks.findServices(model);
@@ -415,11 +514,6 @@ public final class EMITTestSuiteBuilder
             containerConsumer.accept(DynamicContainer.dynamicContainer("Service Plan Generation", services.stream()
                     .map(service -> test(() -> EMITTasks.runPlan(service, model.getPureModel()), verboseNames, label, "Plan", service.getPath()))));
         }
-    }
-
-    private static void assertTestPassed(EMITModel model, TestCandidate candidate)
-    {
-        EMITTasks.assertTestPassed(EMITTasks.runTest(candidate.testablePath, candidate.suiteId, candidate.atomicTestId, model.getPmcd(), model.getPureModel()));
     }
 
     private static DynamicTest test(Executable executable, boolean verboseName, String name, String... moreNames)

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/test/java/org/finos/legend/engine/test/emit/junit/TestEMITTestSuiteBuilder.java
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/test/java/org/finos/legend/engine/test/emit/junit/TestEMITTestSuiteBuilder.java
@@ -144,6 +144,61 @@ public class TestEMITTestSuiteBuilder
     }
 
     @Test
+    void m2mPassingExecutingASingleAtomicTaskPasses() throws Throwable
+    {
+        // A single atomic-test DynamicTest must run cleanly on its own — the
+        // per-group LazyTestSession has to open the session on first use rather
+        // than relying on a previous task to have done so. Without that
+        // invariant, selecting and running one atomic test from an IDE would
+        // fail; this regression-guards the lazy-open path independently of the
+        // bulk-execution path that {@link #m2mPassingYieldsOneTaskPerAtomicTest}
+        // covers.
+        MutableList<DynamicTest> tasks = tasksFor("emit-models/", "basic/m2m-passing");
+        DynamicTest atomic = tasks.detect(t -> "[m2m-passing] Test: demo::PersonM2MMapping / fullNameSuite / johnSmith".equals(t.getDisplayName()));
+        Assertions.assertNotNull(atomic, () -> "expected to find the johnSmith atomic-test task; got:\n" + names(tasks));
+        atomic.getExecutable().execute();
+    }
+
+    @Test
+    void m2mPassingAtomicTaskCanBeExecutedAcrossDistinctStreamConstructions() throws Throwable
+    {
+        // Re-discovering the m2m-passing model from scratch must yield a fresh
+        // LazyTestSession each time, so executing the same atomic test against
+        // two independently-built streams must both succeed — i.e. the close
+        // on a prior session leaves no residual static state that breaks the
+        // next open. Pairs with {@code TestEMITTaskSessions.reopeningASession…}
+        // at the underlying TestSuiteSession layer.
+        MutableList<DynamicTest> firstStream = tasksFor("emit-models/", "basic/m2m-passing");
+        DynamicTest firstJohn = firstStream.detect(t -> t.getDisplayName().endsWith("johnSmith"));
+        Assertions.assertNotNull(firstJohn, "expected johnSmith in the first stream");
+        firstJohn.getExecutable().execute();
+
+        MutableList<DynamicTest> secondStream = tasksFor("emit-models/", "basic/m2m-passing");
+        DynamicTest secondJane = secondStream.detect(t -> t.getDisplayName().endsWith("janeDoe"));
+        Assertions.assertNotNull(secondJane, "expected janeDoe in the second stream");
+        secondJane.getExecutable().execute();
+    }
+
+    @Test
+    void m2mPassingAtomicTasksAreGroupedAdjacentlyByTestableAndSuite()
+    {
+        // The session-grouped stream emits all atomic tests for a given
+        // (testable, suite) consecutively so the per-group LazyTestSession can
+        // amortize plan generation across them and so Stream#onClose can
+        // release the session exactly once at the end of the group.
+        // Interleaving tasks across suites would defeat both. m2m-passing has
+        // only one suite, so this regression-guards by checking the two
+        // atomic-test entries are immediate neighbors in the stream output.
+        MutableList<DynamicTest> tasks = tasksFor("emit-models/", "basic/m2m-passing");
+        MutableList<String> names = tasks.collect(DynamicTest::getDisplayName);
+        int john = names.indexOf("[m2m-passing] Test: demo::PersonM2MMapping / fullNameSuite / johnSmith");
+        int jane = names.indexOf("[m2m-passing] Test: demo::PersonM2MMapping / fullNameSuite / janeDoe");
+        Assertions.assertTrue(john >= 0 && jane >= 0, () -> "expected both atomic-test tasks; got:\n" + names(tasks));
+        Assertions.assertEquals(1, Math.abs(john - jane),
+                () -> "atomic tests in the same suite must be emitted consecutively so the per-group session amortizes and closes correctly; got positions " + john + " and " + jane);
+    }
+
+    @Test
     void modelGenerationYieldsOnlyTheInitializationPhase() throws Throwable
     {
         MutableList<DynamicTest> tasks = tasksFor("emit-models/", "basic/model-generation");

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/main/java/org/finos/legend/engine/test/emit/EMITTasks.java
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/main/java/org/finos/legend/engine/test/emit/EMITTasks.java
@@ -72,6 +72,8 @@ import org.finos.legend.engine.test.runner.mapping.RichMappingTestResult;
 import org.finos.legend.engine.test.runner.service.RichServiceTestResult;
 import org.finos.legend.engine.test.runner.service.ServiceTestRunner;
 import org.finos.legend.engine.testable.TestableRunner;
+import org.finos.legend.engine.testable.extension.TestRunner;
+import org.finos.legend.engine.testable.extension.TestSuiteSession;
 import org.finos.legend.engine.testable.extension.TestableRunnerExtensionLoader;
 import org.finos.legend.engine.testable.model.RunTestsResult;
 import org.finos.legend.engine.testable.model.RunTestsTestableInput;
@@ -86,6 +88,8 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.ServiceLoader;
@@ -338,6 +342,91 @@ public final class EMITTasks
             throw new EMITException(EMITPhase.TEST_EXECUTION, "Test runner returned no results for " + testablePath + " / " + suiteId + " / " + atomicTestId);
         }
         return result.results.get(0);
+    }
+
+    /**
+     * Open a session against the given {@code (testable, suite)} that holds
+     * expensive per-suite setup (execution plan, runtime, connections,
+     * …) so the caller can drive many atomic tests against it without
+     * re-paying that setup cost per test. The caller owns the session
+     * lifetime and MUST close it.
+     *
+     * <p>For a top-level atomic test ({@code suiteId == null}), no
+     * amortization is possible and the returned session simply delegates
+     * each {@link TestSuiteSession#runAtomicTest} call back to
+     * {@link #runTest}.</p>
+     */
+    public static TestSuiteSession<TestResult> openTestSession(String testablePath, String suiteId, PureModelContextData pmcd, PureModel pureModel)
+    {
+        if (suiteId == null)
+        {
+            return new TestSuiteSession<TestResult>()
+            {
+                @Override
+                public String getTestSuiteId()
+                {
+                    return null;
+                }
+
+                @Override
+                public Collection<String> getAtomicTestIds()
+                {
+                    return Collections.emptyList();
+                }
+
+                @Override
+                public boolean isAtomicTestId(String id)
+                {
+                    return false;
+                }
+
+                @Override
+                public void initialize()
+                {
+                    // no initialization
+                }
+
+                @Override
+                public TestResult runAtomicTest(String atomicTestId)
+                {
+                    return runTest(testablePath, getTestSuiteId(), atomicTestId, pmcd, pureModel);
+                }
+
+                @Override
+                public void close()
+                {
+                    // nothing to close
+                }
+            };
+        }
+        org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement element;
+        try
+        {
+            element = pureModel.getPackageableElement(testablePath);
+        }
+        catch (Exception e)
+        {
+            throw new EMITException(EMITPhase.TEST_EXECUTION, "Failed to resolve testable element '" + testablePath + "'", e);
+        }
+        if (!(element instanceof Testable))
+        {
+            throw new EMITException(EMITPhase.TEST_EXECUTION, "Element '" + testablePath + "' is not a testable element");
+        }
+        Testable testable = (Testable) element;
+        Root_meta_pure_test_TestSuite suite = (Root_meta_pure_test_TestSuite) testable._tests().detect(t -> (t instanceof Root_meta_pure_test_TestSuite) && suiteId.equals(((Root_meta_pure_test_TestSuite) t)._id()));
+        if (suite == null)
+        {
+            throw new EMITException(EMITPhase.TEST_EXECUTION, "Test suite '" + suiteId + "' not found on testable '" + testablePath + "'");
+        }
+        TestRunner runner = TestableRunnerExtensionLoader.forTestable(testable);
+        try
+        {
+            return runner.openTestSuiteSession(suite, pureModel, pmcd);
+        }
+        catch (Exception e)
+        {
+            throw new EMITException(EMITPhase.TEST_EXECUTION, "Failed to open test session for " + testablePath + " / " + suiteId, e);
+        }
     }
 
     /**

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/java/org/finos/legend/engine/test/emit/TestEMITTaskSessions.java
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/java/org/finos/legend/engine/test/emit/TestEMITTaskSessions.java
@@ -1,0 +1,176 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.test.emit;
+
+import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
+import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
+import org.finos.legend.engine.protocol.pure.v1.model.test.result.TestExecuted;
+import org.finos.legend.engine.protocol.pure.v1.model.test.result.TestExecutionStatus;
+import org.finos.legend.engine.protocol.pure.v1.model.test.result.TestResult;
+import org.finos.legend.engine.test.emit.EMITTasks.ParseResult;
+import org.finos.legend.engine.test.emit.error.EMITException;
+import org.finos.legend.engine.testable.extension.TestSuiteSession;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Direct coverage of {@link EMITTasks#openTestSession} and the
+ * {@link TestSuiteSession} contract it returns. The fixtures are loaded
+ * via {@link EMITModelLoader} + {@link EMITTasks#parse} + {@link EMITTasks#compile}
+ * so the tests can drive the session API independently of the JUnit
+ * builder, isolating session semantics from the per-test wiring in
+ * {@code EMITTestSuiteBuilder}.
+ *
+ * <p>The {@code m2m-passing} model carries a Mapping with one test suite
+ * ({@code fullNameSuite}) of two atomic tests ({@code johnSmith} and
+ * {@code janeDoe}) — the canonical shape for verifying that a session can
+ * drive more than one atomic test against the same per-suite setup.</p>
+ */
+public class TestEMITTaskSessions
+{
+    private static final String TESTABLE_PATH = "demo::PersonM2MMapping";
+    private static final String SUITE_ID = "fullNameSuite";
+
+    private static PureModelContextData pmcd;
+    private static PureModel pureModel;
+
+    @BeforeAll
+    static void parseAndCompileOnce() throws IOException
+    {
+        EMITSourceSet sourceSet = new EMITModelLoader().load(resource("emit-models/basic/m2m-passing.emit.yaml"));
+        ParseResult parseResult = EMITTasks.parse(sourceSet);
+        pmcd = parseResult.getPmcd();
+        pureModel = EMITTasks.compile(pmcd);
+    }
+
+    @Test
+    void sessionDrivesEveryAtomicTestInTheSuite()
+    {
+        try (TestSuiteSession<TestResult> session = EMITTasks.openTestSession(TESTABLE_PATH, SUITE_ID, pmcd, pureModel))
+        {
+            assertPasses(session.runAtomicTest("johnSmith"), "johnSmith");
+            assertPasses(session.runAtomicTest("janeDoe"), "janeDoe");
+        }
+    }
+
+    @Test
+    void sessionAtomicTestsAreIndependentAcrossCalls()
+    {
+        // Running the same atomic test twice through one session must yield
+        // the same outcome each time — the cached suite setup is not consumed
+        // by an invocation and is safe to reuse.
+        try (TestSuiteSession<TestResult> session = EMITTasks.openTestSession(TESTABLE_PATH, SUITE_ID, pmcd, pureModel))
+        {
+            assertPasses(session.runAtomicTest("johnSmith"), "johnSmith (first call)");
+            assertPasses(session.runAtomicTest("johnSmith"), "johnSmith (second call)");
+            assertPasses(session.runAtomicTest("janeDoe"), "janeDoe (after re-run of johnSmith)");
+        }
+    }
+
+    @Test
+    void sessionRunAtomicTestForUnknownIdReturnsNull()
+    {
+        try (TestSuiteSession<TestResult> session = EMITTasks.openTestSession(TESTABLE_PATH, SUITE_ID, pmcd, pureModel))
+        {
+            Assertions.assertNull(session.runAtomicTest("does-not-exist"),
+                    "runAtomicTest with an unknown id should return null, not throw");
+        }
+    }
+
+    @Test
+    void sessionRunAtomicTestAfterCloseThrows()
+    {
+        TestSuiteSession<TestResult> session = EMITTasks.openTestSession(TESTABLE_PATH, SUITE_ID, pmcd, pureModel);
+        session.close();
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> session.runAtomicTest("johnSmith"),
+                "runAtomicTest after close must throw IllegalStateException");
+    }
+
+    @Test
+    void sessionCloseIsIdempotent()
+    {
+        TestSuiteSession<TestResult> session = EMITTasks.openTestSession(TESTABLE_PATH, SUITE_ID, pmcd, pureModel);
+        session.close();
+        Assertions.assertDoesNotThrow(session::close, "Second close must be a no-op");
+    }
+
+    @Test
+    void reopeningASessionForTheSameSuiteWorksIndependently()
+    {
+        // A fresh session after the previous one was closed must build its own
+        // setup and run cleanly — i.e. the close on a prior session leaves no
+        // residual state that breaks a later open.
+        try (TestSuiteSession<TestResult> first = EMITTasks.openTestSession(TESTABLE_PATH, SUITE_ID, pmcd, pureModel))
+        {
+            assertPasses(first.runAtomicTest("johnSmith"), "first session / johnSmith");
+        }
+        try (TestSuiteSession<TestResult> second = EMITTasks.openTestSession(TESTABLE_PATH, SUITE_ID, pmcd, pureModel))
+        {
+            assertPasses(second.runAtomicTest("janeDoe"), "second session / janeDoe");
+        }
+    }
+
+    @Test
+    void openTestSessionForUnknownSuiteThrowsEmitException()
+    {
+        EMITException ex = Assertions.assertThrows(EMITException.class,
+                () -> EMITTasks.openTestSession(TESTABLE_PATH, "no-such-suite", pmcd, pureModel),
+                "Opening a session for a non-existent suite id should fail fast");
+        Assertions.assertEquals(EMITPhase.TEST_EXECUTION, ex.getPhase());
+        Assertions.assertTrue(ex.getMessage().contains("no-such-suite"), () -> "Message should mention the missing suite id; got: " + ex.getMessage());
+    }
+
+    @Test
+    void openTestSessionForNonTestableElementThrowsEmitException()
+    {
+        EMITException ex = Assertions.assertThrows(EMITException.class,
+                () -> EMITTasks.openTestSession("demo::source::Person", SUITE_ID, pmcd, pureModel),
+                "Opening a session against a non-testable element should fail fast");
+        Assertions.assertEquals(EMITPhase.TEST_EXECUTION, ex.getPhase());
+        Assertions.assertTrue(ex.getMessage().contains("not a testable element") || ex.getMessage().contains("demo::source::Person"),
+                () -> "Message should explain the testable-element rejection; got: " + ex.getMessage());
+    }
+
+    private static void assertPasses(TestResult result, String label)
+    {
+        Assertions.assertNotNull(result, () -> "Expected a TestResult for " + label + " but got null");
+        Assertions.assertInstanceOf(TestExecuted.class, result, () -> "Expected TestExecuted for " + label + " but got " + result.getClass().getSimpleName());
+        TestExecuted executed = (TestExecuted) result;
+        Assertions.assertEquals(TestExecutionStatus.PASS, executed.testExecutionStatus,
+                () -> "Expected " + label + " to PASS but got " + executed.testExecutionStatus + "; assertions=" + executed.assertStatuses);
+    }
+
+    private static Path resource(String name)
+    {
+        URL url = Thread.currentThread().getContextClassLoader().getResource(name);
+        Assertions.assertNotNull(url, "test resource not found: " + name);
+        try
+        {
+            return Paths.get(url.toURI());
+        }
+        catch (URISyntaxException e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/legend-engine-core/legend-engine-core-testable/legend-engine-test-runner-function/pom.xml
+++ b/legend-engine-core/legend-engine-core-testable/legend-engine-test-runner-function/pom.xml
@@ -185,13 +185,6 @@
         <!-- Data Space -->
         <!-- TESTS -->
 
-        <!-- LOGS -->
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
-        <!-- LOGS -->
-
         <!-- ECLIPSE COLLECTIONS -->
         <dependency>
             <groupId>org.eclipse.collections</groupId>

--- a/legend-engine-core/legend-engine-core-testable/legend-engine-test-runner-function/src/main/java/org/finos/legend/engine/testable/function/extension/FunctionTestRunner.java
+++ b/legend-engine-core/legend-engine-core-testable/legend-engine-test-runner-function/src/main/java/org/finos/legend/engine/testable/function/extension/FunctionTestRunner.java
@@ -35,7 +35,6 @@ import org.finos.legend.engine.plan.execution.result.Result;
 import org.finos.legend.engine.plan.execution.result.serialization.SerializationFormat;
 import org.finos.legend.engine.plan.generation.PlanGenerator;
 import org.finos.legend.engine.plan.generation.extension.PlanGeneratorExtension;
-import org.finos.legend.engine.plan.generation.transformers.PlanTransformer;
 import org.finos.legend.engine.plan.platform.PlanPlatform;
 import org.finos.legend.engine.protocol.pure.m3.function.Function;
 import org.finos.legend.engine.protocol.pure.v1.extension.ConnectionFactoryExtension;
@@ -60,25 +59,24 @@ import org.finos.legend.engine.protocol.pure.v1.model.test.result.TestResult;
 import org.finos.legend.engine.pure.code.core.PureCoreExtensionLoader;
 import org.finos.legend.engine.shared.core.operational.Assert;
 import org.finos.legend.engine.testable.assertion.TestAssertionEvaluator;
+import org.finos.legend.engine.testable.extension.AbstractTestSuiteSessionWithResources;
 import org.finos.legend.engine.testable.extension.TestRunner;
+import org.finos.legend.engine.testable.extension.TestSuiteSession;
 import org.finos.legend.engine.testable.helper.TestResultHelper;
 import org.finos.legend.engine.testable.helper.TestReturnTypeHelper;
 import org.finos.legend.pure.generated.Root_meta_core_runtime_Connection;
 import org.finos.legend.pure.generated.Root_meta_core_runtime_ConnectionStore;
+import org.finos.legend.pure.generated.Root_meta_core_runtime_Runtime;
 import org.finos.legend.pure.generated.Root_meta_external_store_model_JsonModelConnection;
 import org.finos.legend.pure.generated.Root_meta_external_store_model_PureModelConnection;
 import org.finos.legend.pure.generated.Root_meta_external_store_model_XmlModelConnection;
 import org.finos.legend.pure.generated.Root_meta_legend_function_metamodel_FunctionTestSuite;
-import org.finos.legend.pure.generated.Root_meta_pure_extension_Extension;
 import org.finos.legend.pure.generated.Root_meta_pure_test_AtomicTest;
 import org.finos.legend.pure.generated.Root_meta_pure_test_TestSuite;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.ConcreteFunctionDefinition;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.FunctionDefinition;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -86,26 +84,19 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.ServiceLoader;
-import java.util.stream.Collectors;
-
-import static org.finos.legend.engine.language.pure.compiler.toPureGraph.HelperModelBuilder.getElementFullPath;
+import java.util.function.Consumer;
 
 public class FunctionTestRunner implements TestRunner
 {
-    private static final Logger LOGGER = LoggerFactory.getLogger(FunctionTestRunner.class);
-    private final ConcreteFunctionDefinition functionDefinition;
-    private FunctionDefinition<?> modifiedFunctionDefinition;
+    private final ConcreteFunctionDefinition<?> functionDefinition;
     private final MutableList<PlanGeneratorExtension> extensions;
     private final PlanExecutor executor;
     private final String pureVersion;
 
-    private final MutableList<ConnectionFactoryExtension> connectionBuilders = org.eclipse.collections.api.factory.Lists.mutable.withAll(ServiceLoader.load(ConnectionFactoryExtension.class));
-    private final MutableList<RelationAccessorTestConnectionFactory> connectionAndDatabaseBuilders = org.eclipse.collections.api.factory.Lists.mutable.withAll(ServiceLoader.load(RelationAccessorTestConnectionFactory.class));
-    private List<Closeable> closeables = Lists.mutable.empty();
-    private List<Pair<Root_meta_core_runtime_ConnectionStore, Root_meta_core_runtime_Connection>> storeConnectionsPairs = Lists.mutable.empty();
-    private TestConnectionBuildParameters hints = TestConnectionBuildParameters.NONE;
+    private final MutableList<ConnectionFactoryExtension> connectionBuilders = Lists.mutable.withAll(ServiceLoader.load(ConnectionFactoryExtension.class));
+    private final MutableList<RelationAccessorTestConnectionFactory> connectionAndDatabaseBuilders = Lists.mutable.withAll(ServiceLoader.load(RelationAccessorTestConnectionFactory.class));
 
-    public FunctionTestRunner(ConcreteFunctionDefinition functionDefinition, String pureVersion)
+    public FunctionTestRunner(ConcreteFunctionDefinition<?> functionDefinition, String pureVersion)
     {
         this.pureVersion = pureVersion;
         this.functionDefinition = functionDefinition;
@@ -116,297 +107,272 @@ public class FunctionTestRunner implements TestRunner
     @Override
     public TestResult executeAtomicTest(Root_meta_pure_test_AtomicTest atomicTest, PureModel pureModel, PureModelContextData data)
     {
-        throw new UnsupportedOperationException("Function Test should be executed in context of Mapping Test Suite only");
+        throw new UnsupportedOperationException("Function Test should be executed in context of Function Test Suite only");
     }
 
     @Override
-    public List<TestResult> executeTestSuite(Root_meta_pure_test_TestSuite testSuite, List<String> atomicTestIds, PureModel pureModel, PureModelContextData pureModelContextData)
+    public TestSuiteSession<TestResult> openTestSuiteSession(Root_meta_pure_test_TestSuite testSuite, PureModel pureModel, PureModelContextData data)
     {
-        List<org.finos.legend.engine.protocol.pure.v1.model.test.result.TestResult> results = Lists.mutable.empty();
-        RichIterable<? extends Root_meta_pure_extension_Extension> routerExtensions = PureCoreExtensionLoader.extensions().flatCollect(e -> e.extraPureCoreExtensions(pureModel.getExecutionSupport()));
-        MutableList<PlanTransformer> planTransformers = extensions.flatCollect(PlanGeneratorExtension::getExtraPlanTransformers);
         Assert.assertTrue(testSuite instanceof Root_meta_legend_function_metamodel_FunctionTestSuite, () -> "Function test suite expected in functions");
-        Root_meta_legend_function_metamodel_FunctionTestSuite functionTestSuite = (Root_meta_legend_function_metamodel_FunctionTestSuite) testSuite;
-        String testablePath = getElementFullPath(this.functionDefinition, pureModel.getExecutionSupport());
-        try
-        {
-            boolean isRelation = TestReturnTypeHelper.isRelationReturnType(this.functionDefinition, pureModel);
-            this.hints = isRelation ? TestConnectionBuildParameters.newBuilder().withIsRelation(true).build() : TestConnectionBuildParameters.NONE;
-            // handle data
-            Function protocolFunc = ListIterate.detect(pureModelContextData.getElementsOfType(Function.class), el -> el.getPath().equals(testablePath));
-            FunctionTestSuite protocolSuite = ListIterate.detect(protocolFunc.tests, t -> t.id.equals(testSuite._id()));
-            FunctionTestRunnerContext runnerContext = new FunctionTestRunnerContext(Tuples.pair(pureModelContextData, pureModel), Tuples.pair(protocolSuite, functionTestSuite), extensions.flatCollect(PlanGeneratorExtension::getExtraPlanTransformers),
-                    new ConnectionFirstPassBuilder(pureModel.getContext()),
-                    PureCoreExtensionLoader.extensions().flatCollect(e -> e.extraPureCoreExtensions(pureModel.getExecutionSupport())));
-            List<FunctionTest> functionTests = protocolSuite.tests.stream().filter(t -> t instanceof FunctionTest)
-                            .map(t -> (FunctionTest) t).filter(t -> atomicTestIds.contains(t.id)).collect(Collectors.toList());
-            // setup
-            this.setup(runnerContext);
-            // run tests
-            for (FunctionTest functionTest: functionTests)
-            {
-                TestResult functionTestResult = executeFunctionTest(functionTest, runnerContext);
-                functionTestResult.testable = testablePath;
-                functionTestResult.testSuiteId = functionTestSuite._id();
-                results.add(functionTestResult);
-            }
-            //
-            this.tearDown();
-        }
-        catch (Exception e)
-        {
-            // this is to catch any error for the setup of the test suite. we return test error for each test run
-            for (Root_meta_pure_test_AtomicTest testedError: functionTestSuite._tests())
-            {
-                if (atomicTestIds.contains(testedError._id()) && results.stream().noneMatch(t -> t.atomicTestId.equals(testedError._id())))
-                {
-                    results.add(TestResultHelper.newTestError(testedError._id(), e));
-                }
-            }
-        }
-        return results;
-    }
-
-    private TestResult executeFunctionTest(FunctionTest functionTest, FunctionTestRunnerContext context)
-    {
-        try
-        {
-            // build plan
-            SingleExecutionPlan executionPlan = PlanGenerator.generateExecutionPlan(this.modifiedFunctionDefinition != null ? this.modifiedFunctionDefinition : this.functionDefinition, null, null, null, context.getPureModel(), this.pureVersion, PlanPlatform.JAVA, null, context.getRouterExtensions(), context.getExecutionPlanTransformers());
-            // execute assertion
-            TestAssertion assertion = functionTest.assertions.get(0);
-            // add execute
-            PlanExecutor.ExecuteArgsBuilder executeArgs = context.getExecuteBuilder().withPlan(executionPlan);
-            Map<String, Object> parameters = Maps.mutable.empty();
-            if (functionTest.parameters != null)
-            {
-                for (ParameterValue parameterValue : functionTest.parameters)
-                {
-                    parameters.put(parameterValue.name, parameterValue.value.accept(new PrimitiveValueSpecificationToObjectVisitor()));
-                }
-            }
-            executeArgs.withParams(parameters);
-            Result result = this.executor.executeWithArgs(executeArgs.build());
-            AssertionStatus assertionResult = assertion.accept(new TestAssertionEvaluator(result, SerializationFormat.RAW));
-            TestExecuted testResult = new TestExecuted(Collections.singletonList(assertionResult));
-            testResult.atomicTestId = functionTest.id;
-            return testResult;
-        }
-        catch (Exception error)
-        {
-            return TestResultHelper.newTestError(functionTest.id, error);
-        }
-    }
-
-    private void setup(FunctionTestRunnerContext context)
-    {
-        Root_meta_legend_function_metamodel_FunctionTestSuite functionTestSuite = context.getTestSuite();
-        FunctionTestSuite protocolFunctionSuite = context.getProtocolSuite();
-        if (functionTestSuite._testData() == null || functionTestSuite._testData().isEmpty())
-        {
-            return;
-        }
-        if (protocolFunctionSuite.testData == null || protocolFunctionSuite.testData.isEmpty())
-        {
-            return;
-        }
-        org.finos.legend.pure.generated.Root_meta_core_runtime_Runtime runtime = getRuntimesInFunction(context.getPureModel());
-        List<FunctionTestData> storeTestData = new ArrayList<>();
-        List<FunctionTestData> nonStoreRelationTestData = new ArrayList<>();
-        protocolFunctionSuite.testData.forEach(testData ->
-        {
-            try
-            {
-                StoreProviderCompilerHelper.getStoreFromPackageableElementPointer(testData.packageableElementPointer, context.getPureModel().getContext());
-                storeTestData.add(testData);
-            }
-            catch (Exception e)
-            {
-                nonStoreRelationTestData.add(testData);
-            }
-        });
-        if (!storeTestData.isEmpty() && !nonStoreRelationTestData.isEmpty())
-        {
-            throw new IllegalStateException("Error in function testSuite " + context.getTestSuite()._id() + ". The combination of store and non-store relation test data is not supported");
-        }
-        if (!storeTestData.isEmpty())
-        {
-            setupStoreTestData(storeTestData, context, runtime);
-        }
-        else if (!nonStoreRelationTestData.isEmpty())
-        {
-            setupNonStoreRelationTestData(nonStoreRelationTestData, context);
-        }
-    }
-
-    private void setupNonStoreRelationTestData(List<FunctionTestData> nonStoreRelationTestData, FunctionTestRunnerContext context)
-    {
-        Map<org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement, RelationElementsData> relationData = Maps.mutable.empty();
-        nonStoreRelationTestData.forEach(testData ->
-        {
-            org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement element = context.getPureModel().getPackageableElement(testData.packageableElementPointer.path, testData.packageableElementPointer.sourceInformation);
-            EmbeddedData data = (testData.data instanceof DataElementReference)
-                    ? EmbeddedDataCompilerHelper.getEmbeddedDataFromDataElement((DataElementReference) testData.data, context.getPureModelContextData())
-                    : testData.data;
-            if (data instanceof RelationElementsData)
-            {
-                relationData.put(element, (RelationElementsData) data);
-            }
-        });
-        List<FunctionDefinition<?>> modifiedFunctions = new ArrayList<>(this.connectionAndDatabaseBuilders.collect(f -> f.rewriteFunctionForTestDataExecution(this.functionDefinition, relationData, context.getPureModel())).select(Objects::nonNull));
-        if (modifiedFunctions.size() > 1)
-        {
-            throw new IllegalStateException("Error in function testSuite " + context.getTestSuite()._id() + ". The combination of accessors used is not supported");
-        }
-        if (modifiedFunctions.isEmpty())
-        {
-            throw new IllegalStateException("Error in function testSuite " + context.getTestSuite()._id() + ". Unsupported accessors type");
-        }
-        this.modifiedFunctionDefinition = modifiedFunctions.get(0);
-    }
-
-    private void setupStoreTestData(List<FunctionTestData> functionTestData, FunctionTestRunnerContext context, org.finos.legend.pure.generated.Root_meta_core_runtime_Runtime runtime)
-    {
-        if (runtime == null)
-        {
-            return;
-        }
-        Map<Root_meta_core_runtime_Connection, List<org.finos.legend.pure.generated.Root_meta_core_runtime_ConnectionStore>> connectionMap = Maps.mutable.empty();
-        runtime._connectionStores().forEach(connectionStores ->
-        {
-            List<org.finos.legend.pure.generated.Root_meta_core_runtime_ConnectionStore> stores = connectionMap.get(connectionStores._connection());
-            if (stores == null)
-            {
-                stores = Lists.mutable.empty();
-                connectionMap.putIfAbsent(connectionStores._connection(), stores);
-            }
-            stores.add(connectionStores);
-        });
-        for (Map.Entry<Root_meta_core_runtime_Connection, List<org.finos.legend.pure.generated.Root_meta_core_runtime_ConnectionStore>> entry : connectionMap.entrySet())
-        {
-
-            Root_meta_core_runtime_Connection key = entry.getKey();
-            List<org.finos.legend.pure.generated.Root_meta_core_runtime_ConnectionStore> values = entry.getValue();
-            Map<Store, EmbeddedData> storeTestDataList = Maps.mutable.empty();
-            // collect test data
-            entry.getValue().forEach(connectionStore ->
-            {
-                Object element = connectionStore._element();
-                if (element instanceof org.finos.legend.pure.m3.coreinstance.meta.pure.store.Store)
-                {
-                    org.finos.legend.pure.m3.coreinstance.meta.pure.store.Store metamodelStore = (org.finos.legend.pure.m3.coreinstance.meta.pure.store.Store) element;
-                    String connectionStorePath = getElementFullPath(metamodelStore, context.getPureModel().getExecutionSupport());
-                    Optional<FunctionTestData> optionalStoreTestData = functionTestData.stream().filter(
-                            pTestData ->
-                            {
-                                String testDataStorePath = getElementFullPath(StoreProviderCompilerHelper.getStoreFromPackageableElementPointer(pTestData.packageableElementPointer, context.getPureModel().getContext()), context.getPureModel().getExecutionSupport());
-                                return testDataStorePath.equals(connectionStorePath);
-                            }).findFirst();
-                    if (optionalStoreTestData.isPresent())
-                    {
-                        FunctionTestData resolvedStoreTestData = optionalStoreTestData.get();
-                        EmbeddedData testData = (resolvedStoreTestData.data instanceof DataElementReference)
-                                ? EmbeddedDataCompilerHelper.getEmbeddedDataFromDataElement((DataElementReference) resolvedStoreTestData.data, context.getPureModelContextData())
-                                : resolvedStoreTestData.data;
-                        org.finos.legend.pure.m3.coreinstance.meta.pure.store.Store store = StoreProviderCompilerHelper.getStoreFromPackageableElementPointer(resolvedStoreTestData.packageableElementPointer, context.getPureModel().getContext());
-                        Store protocolStore = this.resolveStore(context.getPureModelContextData(), getElementFullPath(store, context.getPureModel().getExecutionSupport()));
-                        storeTestDataList.put(protocolStore, testData);
-                    }
-                }
-            });
-            if (!storeTestDataList.isEmpty())
-            {
-                Pair<Connection, List<Closeable>> closeableMockedConnections = this.buildTestConnection(context, key, storeTestDataList);
-                Connection mockedConnection = closeableMockedConnections.getOne();
-                Root_meta_core_runtime_Connection mockedCompileConnection = mockedConnection.accept(context.getConnectionVisitor());
-                // we replace with mocked connection. We set back to original at cleanup
-                for (Root_meta_core_runtime_ConnectionStore value : values)
-                {
-                    Root_meta_core_runtime_Connection realConnection = value._connection();
-                    this.storeConnectionsPairs.add(Tuples.pair(value, realConnection));
-                    value._connection(mockedCompileConnection);
-                    this.closeables.addAll(closeableMockedConnections.getTwo());
-                }
-            }
-        }
-    }
-
-    private Pair<Connection, List<Closeable>> buildTestConnection(FunctionTestRunnerContext context,Root_meta_core_runtime_Connection connection, Map<Store, EmbeddedData> storeEmbeddedDataMap)
-    {
-        if (storeEmbeddedDataMap.size() == 1 && connection instanceof Root_meta_external_store_model_PureModelConnection)
-        {
-            EmbeddedData embeddedData = storeEmbeddedDataMap.values().stream().findFirst().get();
-            if (embeddedData instanceof ExternalFormatData)
-            {
-                ExternalFormatData externalFormatData = (ExternalFormatData) embeddedData;
-                if (connection instanceof Root_meta_external_store_model_JsonModelConnection)
-                {
-                    String _class = HelperModelBuilder.getElementFullPath(((Root_meta_external_store_model_JsonModelConnection) connection)._class(), context.getPureModel().getExecutionSupport());
-                    return new ModelStoreTestConnectionFactory().buildCloseableConnectionFromExternalFormat(externalFormatData, _class);
-                }
-                else if (connection instanceof Root_meta_external_store_model_XmlModelConnection)
-                {
-                    String _class = HelperModelBuilder.getElementFullPath(((Root_meta_external_store_model_XmlModelConnection) connection)._class(), context.getPureModel().getExecutionSupport());
-                    return  new ModelStoreTestConnectionFactory().buildCloseableConnectionFromExternalFormat(externalFormatData, _class);
-                }
-            }
-        }
-        return this.connectionBuilders.collect(f -> f.tryBuildConnectionForStoreData(context.getDataElementIndex(), storeEmbeddedDataMap, this.hints)).select(Objects::nonNull).select(Optional::isPresent)
-                .collect(Optional::get).getFirstOptional().orElseThrow(() -> new UnsupportedOperationException("Unsupported test data for function test suite: " + context.getTestSuite()._id()));
-    }
-
-    private void tearDown()
-    {
-        if (this.closeables != null)
-        {
-            this.closeables.forEach(closeable ->
-            {
-                try
-                {
-                    closeable.close();
-                }
-                catch (IOException e)
-                {
-                    LOGGER.warn("Exception occurred closing closeable resource" + e);
-                }
-            });
-        }
-        // restore original connection value
-        if (this.storeConnectionsPairs != null)
-        {
-            this.storeConnectionsPairs.forEach(storeConnectionsPairs ->
-            {
-                storeConnectionsPairs.getOne()._connection(storeConnectionsPairs.getTwo());
-            });
-        }
+        String testablePath = HelperModelBuilder.getElementFullPath(this.functionDefinition, pureModel.getExecutionSupport());
+        Function protocolFunc = ListIterate.detect(data.getElementsOfType(Function.class), el -> el.getPath().equals(testablePath));
+        FunctionTestSuite protocolSuite = ListIterate.detect(protocolFunc.tests, t -> t.id.equals(testSuite._id()));
+        return new FunctionTestSuiteSession(testSuite, protocolSuite, pureModel, data, testablePath);
     }
 
     private Store resolveStore(PureModelContextData pureModelContextData, String store)
     {
-        if (store.equals("ModelStore"))
-        {
-            return new ModelStore();
-        }
-        else
-        {
-            return ListIterate.detect(pureModelContextData.getElementsOfType(Store.class), x -> x.getPath().equals(store));
-        }
+        return "ModelStore".equals(store)
+               ? new ModelStore()
+               : ListIterate.detect(pureModelContextData.getElementsOfType(Store.class), x -> x.getPath().equals(store));
     }
 
-    public org.finos.legend.pure.generated.Root_meta_core_runtime_Runtime getRuntimesInFunction(PureModel pureModel)
+    private Root_meta_core_runtime_Runtime getRuntimesInFunction(PureModel pureModel)
     {
-            RichIterable<org.finos.legend.pure.generated.Root_meta_core_runtime_Runtime> runtimes =  org.finos.legend.pure.generated.core_pure_corefunctions_metaExtension.Root_meta_pure_functions_meta_extractRuntimesFromFunctionDefinition_FunctionDefinition_1__Runtime_MANY_(this.functionDefinition, pureModel.getExecutionSupport());
-            if (runtimes.isEmpty())
+        RichIterable<? extends Root_meta_core_runtime_Runtime> runtimes = org.finos.legend.pure.generated.core_pure_corefunctions_metaExtension.Root_meta_pure_functions_meta_extractRuntimesFromFunctionDefinition_FunctionDefinition_1__Runtime_MANY_(this.functionDefinition, pureModel.getExecutionSupport());
+        switch (runtimes.size())
+        {
+            case 0:
             {
                 return null;
             }
-            else if (runtimes.size() == 1)
+            case 1:
             {
-                return runtimes.getOnly();
+                return runtimes.getAny();
             }
-            else
+            default:
             {
                 throw new UnsupportedOperationException("Currently cannot test functions with more than one runtime present");
             }
+        }
+    }
+
+    private class FunctionTestSuiteSession extends AbstractTestSuiteSessionWithResources<FunctionTestSuite, FunctionTest, TestResult>
+    {
+        private final String testablePath;
+        private FunctionTestRunnerContext context;
+        private FunctionDefinition<?> modifiedFunctionDefinition;
+        private TestConnectionBuildParameters hints = TestConnectionBuildParameters.NONE;
+        private final List<Pair<Root_meta_core_runtime_ConnectionStore, Root_meta_core_runtime_Connection>> storeConnectionsPairs = Lists.mutable.empty();
+
+        FunctionTestSuiteSession(Root_meta_pure_test_TestSuite pureSuite, FunctionTestSuite protocolSuite, PureModel pureModel, PureModelContextData pmcd, String testablePath)
+        {
+            super(pureSuite, protocolSuite, pureModel, pmcd, FunctionTestSuiteSession::getTestSuiteTests, FunctionTestSuiteSession::getAtomicTestId);
+            this.testablePath = testablePath;
+        }
+
+        @Override
+        protected void initialize(Consumer<? super AutoCloseable> closeableConsumer)
+        {
+            boolean isRelation = TestReturnTypeHelper.isRelationReturnType(FunctionTestRunner.this.functionDefinition, this.pureModel);
+            this.hints = isRelation ? TestConnectionBuildParameters.newBuilder().withIsRelation(true).build() : TestConnectionBuildParameters.NONE;
+            Root_meta_legend_function_metamodel_FunctionTestSuite functionTestSuite = (Root_meta_legend_function_metamodel_FunctionTestSuite) this.pureSuite;
+            this.context = new FunctionTestRunnerContext(
+                    Tuples.pair(this.pmcd, this.pureModel),
+                    Tuples.pair(this.protocolSuite, functionTestSuite),
+                    FunctionTestRunner.this.extensions.flatCollect(PlanGeneratorExtension::getExtraPlanTransformers),
+                    new ConnectionFirstPassBuilder(this.pureModel.getContext()),
+                    PureCoreExtensionLoader.extensions().flatCollect(e -> e.extraPureCoreExtensions(this.pureModel.getExecutionSupport())));
+            closeableConsumer.accept((AutoCloseable) () -> this.storeConnectionsPairs.forEach(p -> p.getOne()._connection(p.getTwo())));
+            setup(closeableConsumer);
+        }
+
+        @Override
+        protected TestResult buildErrorResult(String atomicTestId, Throwable t)
+        {
+            return TestResultHelper.newTestError(this.testablePath, getTestSuiteId(), atomicTestId, t);
+        }
+
+        @Override
+        protected TestResult runAtomicTest(FunctionTest atomicTest)
+        {
+            TestResult testResult = executeFunctionTest(atomicTest);
+            testResult.testable = this.testablePath;
+            testResult.testSuiteId = getTestSuiteId();
+            return testResult;
+        }
+
+        private TestResult executeFunctionTest(FunctionTest functionTest)
+        {
+            try
+            {
+                FunctionDefinition<?> effectiveFunction = this.modifiedFunctionDefinition != null ? this.modifiedFunctionDefinition : FunctionTestRunner.this.functionDefinition;
+                SingleExecutionPlan executionPlan = PlanGenerator.generateExecutionPlan(effectiveFunction, null, null, null, this.context.getPureModel(), FunctionTestRunner.this.pureVersion, PlanPlatform.JAVA, null, this.context.getRouterExtensions(), this.context.getExecutionPlanTransformers());
+                TestAssertion assertion = functionTest.assertions.get(0);
+                PlanExecutor.ExecuteArgsBuilder executeArgs = this.context.getExecuteBuilder().withPlan(executionPlan);
+                Map<String, Object> parameters = Maps.mutable.empty();
+                if (functionTest.parameters != null)
+                {
+                    for (ParameterValue parameterValue : functionTest.parameters)
+                    {
+                        parameters.put(parameterValue.name, parameterValue.value.accept(new PrimitiveValueSpecificationToObjectVisitor()));
+                    }
+                }
+                executeArgs.withParams(parameters);
+                Result result = FunctionTestRunner.this.executor.executeWithArgs(executeArgs.build());
+                AssertionStatus assertionResult = assertion.accept(new TestAssertionEvaluator(result, SerializationFormat.RAW));
+                TestExecuted testResult = new TestExecuted(Collections.singletonList(assertionResult));
+                testResult.atomicTestId = functionTest.id;
+                return testResult;
+            }
+            catch (Exception error)
+            {
+                return TestResultHelper.newTestError(functionTest.id, error);
+            }
+        }
+
+        private void setup(Consumer<? super AutoCloseable> closeableConsumer)
+        {
+            Root_meta_legend_function_metamodel_FunctionTestSuite functionTestSuite = this.context.getTestSuite();
+            FunctionTestSuite protocolFunctionSuite = this.context.getProtocolSuite();
+            if (functionTestSuite._testData() == null || functionTestSuite._testData().isEmpty())
+            {
+                return;
+            }
+            if (protocolFunctionSuite.testData == null || protocolFunctionSuite.testData.isEmpty())
+            {
+                return;
+            }
+            Root_meta_core_runtime_Runtime runtime = getRuntimesInFunction(this.context.getPureModel());
+            List<FunctionTestData> storeTestData = new ArrayList<>();
+            List<FunctionTestData> nonStoreRelationTestData = new ArrayList<>();
+            protocolFunctionSuite.testData.forEach(testData ->
+            {
+                try
+                {
+                    StoreProviderCompilerHelper.getStoreFromPackageableElementPointer(testData.packageableElementPointer, this.context.getPureModel().getContext());
+                    storeTestData.add(testData);
+                }
+                catch (Exception e)
+                {
+                    nonStoreRelationTestData.add(testData);
+                }
+            });
+            if (!storeTestData.isEmpty() && !nonStoreRelationTestData.isEmpty())
+            {
+                throw new IllegalStateException("Error in function testSuite " + this.context.getTestSuite()._id() + ". The combination of store and non-store relation test data is not supported");
+            }
+            if (!storeTestData.isEmpty())
+            {
+                setupStoreTestData(storeTestData, runtime, closeableConsumer);
+            }
+            else if (!nonStoreRelationTestData.isEmpty())
+            {
+                setupNonStoreRelationTestData(nonStoreRelationTestData);
+            }
+        }
+
+        private void setupNonStoreRelationTestData(List<FunctionTestData> nonStoreRelationTestData)
+        {
+            Map<org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement, RelationElementsData> relationData = Maps.mutable.empty();
+            nonStoreRelationTestData.forEach(testData ->
+            {
+                org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement element = this.context.getPureModel().getPackageableElement(testData.packageableElementPointer.path, testData.packageableElementPointer.sourceInformation);
+                EmbeddedData data = (testData.data instanceof DataElementReference)
+                                    ? EmbeddedDataCompilerHelper.getEmbeddedDataFromDataElement((DataElementReference) testData.data, this.context.getPureModelContextData())
+                                    : testData.data;
+                if (data instanceof RelationElementsData)
+                {
+                    relationData.put(element, (RelationElementsData) data);
+                }
+            });
+            List<FunctionDefinition<?>> modifiedFunctions = new ArrayList<>(FunctionTestRunner.this.connectionAndDatabaseBuilders.collect(f -> f.rewriteFunctionForTestDataExecution(FunctionTestRunner.this.functionDefinition, relationData, this.context.getPureModel())).select(Objects::nonNull));
+            if (modifiedFunctions.size() > 1)
+            {
+                throw new IllegalStateException("Error in function testSuite " + this.context.getTestSuite()._id() + ". The combination of accessors used is not supported");
+            }
+            if (modifiedFunctions.isEmpty())
+            {
+                throw new IllegalStateException("Error in function testSuite " + this.context.getTestSuite()._id() + ". Unsupported accessors type");
+            }
+            this.modifiedFunctionDefinition = modifiedFunctions.get(0);
+        }
+
+        private void setupStoreTestData(List<FunctionTestData> functionTestData, Root_meta_core_runtime_Runtime runtime, Consumer<? super AutoCloseable> closeableConsumer)
+        {
+            if (runtime == null)
+            {
+                return;
+            }
+            Map<Root_meta_core_runtime_Connection, List<Root_meta_core_runtime_ConnectionStore>> connectionMap = Maps.mutable.empty();
+            runtime._connectionStores().forEach(connectionStores ->
+            {
+                List<Root_meta_core_runtime_ConnectionStore> stores = connectionMap.get(connectionStores._connection());
+                if (stores == null)
+                {
+                    stores = Lists.mutable.empty();
+                    connectionMap.putIfAbsent(connectionStores._connection(), stores);
+                }
+                stores.add(connectionStores);
+            });
+            for (Map.Entry<Root_meta_core_runtime_Connection, List<Root_meta_core_runtime_ConnectionStore>> entry : connectionMap.entrySet())
+            {
+                Root_meta_core_runtime_Connection key = entry.getKey();
+                List<Root_meta_core_runtime_ConnectionStore> values = entry.getValue();
+                Map<Store, EmbeddedData> storeTestDataList = Maps.mutable.empty();
+                entry.getValue().forEach(connectionStore ->
+                {
+                    Object element = connectionStore._element();
+                    if (element instanceof org.finos.legend.pure.m3.coreinstance.meta.pure.store.Store)
+                    {
+                        org.finos.legend.pure.m3.coreinstance.meta.pure.store.Store metamodelStore = (org.finos.legend.pure.m3.coreinstance.meta.pure.store.Store) element;
+                        String connectionStorePath = HelperModelBuilder.getElementFullPath(metamodelStore, this.context.getPureModel().getExecutionSupport());
+                        Optional<FunctionTestData> optionalStoreTestData = functionTestData.stream().filter(
+                                pTestData ->
+                                {
+                                    String testDataStorePath = HelperModelBuilder.getElementFullPath(StoreProviderCompilerHelper.getStoreFromPackageableElementPointer(pTestData.packageableElementPointer, this.context.getPureModel().getContext()), this.context.getPureModel().getExecutionSupport());
+                                    return testDataStorePath.equals(connectionStorePath);
+                                }).findFirst();
+                        if (optionalStoreTestData.isPresent())
+                        {
+                            FunctionTestData resolvedStoreTestData = optionalStoreTestData.get();
+                            EmbeddedData testData = (resolvedStoreTestData.data instanceof DataElementReference)
+                                                    ? EmbeddedDataCompilerHelper.getEmbeddedDataFromDataElement((DataElementReference) resolvedStoreTestData.data, this.context.getPureModelContextData())
+                                                    : resolvedStoreTestData.data;
+                            org.finos.legend.pure.m3.coreinstance.meta.pure.store.Store store = StoreProviderCompilerHelper.getStoreFromPackageableElementPointer(resolvedStoreTestData.packageableElementPointer, this.context.getPureModel().getContext());
+                            Store protocolStore = resolveStore(this.context.getPureModelContextData(), HelperModelBuilder.getElementFullPath(store, this.context.getPureModel().getExecutionSupport()));
+                            storeTestDataList.put(protocolStore, testData);
+                        }
+                    }
+                });
+                if (!storeTestDataList.isEmpty())
+                {
+                    Pair<Connection, List<Closeable>> closeableMockedConnections = buildTestConnection(key, storeTestDataList);
+                    Connection mockedConnection = closeableMockedConnections.getOne();
+                    Root_meta_core_runtime_Connection mockedCompileConnection = mockedConnection.accept(this.context.getConnectionVisitor());
+                    for (Root_meta_core_runtime_ConnectionStore value : values)
+                    {
+                        Root_meta_core_runtime_Connection realConnection = value._connection();
+                        this.storeConnectionsPairs.add(Tuples.pair(value, realConnection));
+                        value._connection(mockedCompileConnection);
+                        closeableMockedConnections.getTwo().forEach(closeableConsumer);
+                    }
+                }
+            }
+        }
+
+        private Pair<Connection, List<Closeable>> buildTestConnection(Root_meta_core_runtime_Connection connection, Map<Store, EmbeddedData> storeEmbeddedDataMap)
+        {
+            if (storeEmbeddedDataMap.size() == 1 && connection instanceof Root_meta_external_store_model_PureModelConnection)
+            {
+                EmbeddedData embeddedData = storeEmbeddedDataMap.values().stream().findFirst().get();
+                if (embeddedData instanceof ExternalFormatData)
+                {
+                    ExternalFormatData externalFormatData = (ExternalFormatData) embeddedData;
+                    if (connection instanceof Root_meta_external_store_model_JsonModelConnection)
+                    {
+                        String _class = HelperModelBuilder.getElementFullPath(((Root_meta_external_store_model_JsonModelConnection) connection)._class(), this.context.getPureModel().getExecutionSupport());
+                        return new ModelStoreTestConnectionFactory().buildCloseableConnectionFromExternalFormat(externalFormatData, _class);
+                    }
+                    else if (connection instanceof Root_meta_external_store_model_XmlModelConnection)
+                    {
+                        String _class = HelperModelBuilder.getElementFullPath(((Root_meta_external_store_model_XmlModelConnection) connection)._class(), this.context.getPureModel().getExecutionSupport());
+                        return new ModelStoreTestConnectionFactory().buildCloseableConnectionFromExternalFormat(externalFormatData, _class);
+                    }
+                }
+            }
+            return FunctionTestRunner.this.connectionBuilders.collect(f -> f.tryBuildConnectionForStoreData(this.context.getDataElementIndex(), storeEmbeddedDataMap, this.hints)).select(Objects::nonNull).select(Optional::isPresent)
+                    .collect(Optional::get).getFirstOptional().orElseThrow(() -> new UnsupportedOperationException("Unsupported test data for function test suite: " + this.context.getTestSuite()._id()));
+        }
     }
 }

--- a/legend-engine-core/legend-engine-core-testable/legend-engine-test-runner-mapping/src/main/java/org/finos/legend/engine/testable/mapping/extension/MappingTestRunner.java
+++ b/legend-engine-core/legend-engine-core-testable/legend-engine-test-runner-mapping/src/main/java/org/finos/legend/engine/testable/mapping/extension/MappingTestRunner.java
@@ -20,6 +20,8 @@ import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.ListIterate;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.ConnectionFirstPassBuilder;
+import org.finos.legend.engine.language.pure.compiler.toPureGraph.HelperModelBuilder;
+import org.finos.legend.engine.language.pure.compiler.toPureGraph.HelperRuntimeBuilder;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
 import org.finos.legend.engine.plan.execution.PlanExecutor;
 import org.finos.legend.engine.plan.execution.result.Result;
@@ -48,11 +50,14 @@ import org.finos.legend.engine.protocol.pure.v1.model.test.result.TestResult;
 import org.finos.legend.engine.pure.code.core.PureCoreExtensionLoader;
 import org.finos.legend.engine.shared.core.operational.Assert;
 import org.finos.legend.engine.testable.assertion.TestAssertionEvaluator;
+import org.finos.legend.engine.testable.extension.AbstractTestSuiteSessionWithResources;
 import org.finos.legend.engine.testable.extension.TestRunner;
+import org.finos.legend.engine.testable.extension.TestSuiteSession;
 import org.finos.legend.engine.testable.helper.TestResultHelper;
 import org.finos.legend.engine.testable.helper.TestReturnTypeHelper;
 import org.finos.legend.pure.generated.Root_meta_core_runtime_ConnectionStore;
 import org.finos.legend.pure.generated.Root_meta_core_runtime_ConnectionStore_Impl;
+import org.finos.legend.pure.generated.Root_meta_core_runtime_Runtime;
 import org.finos.legend.pure.generated.Root_meta_core_runtime_Runtime_Impl;
 import org.finos.legend.pure.generated.Root_meta_pure_mapping_metamodel_MappingTestSuite;
 import org.finos.legend.pure.generated.Root_meta_pure_test_AtomicTest;
@@ -62,29 +67,24 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
-import java.io.IOException;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.ServiceLoader;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
-
-import static org.finos.legend.engine.language.pure.compiler.toPureGraph.HelperModelBuilder.getElementFullPath;
-import static org.finos.legend.engine.language.pure.compiler.toPureGraph.HelperRuntimeBuilder.getStore;
 
 public class MappingTestRunner implements TestRunner
 {
-
     private static final Logger LOGGER = LoggerFactory.getLogger(MappingTestRunner.class);
-    private Mapping pureMapping;
+
+    private final Mapping pureMapping;
     private final MutableList<PlanGeneratorExtension> extensions;
     private final PlanExecutor executor;
     private final String pureVersion;
-    private final MutableList<ConnectionFactoryExtension> factories = org.eclipse.collections.api.factory.Lists.mutable.withAll(ServiceLoader.load(ConnectionFactoryExtension.class));
-    private TestConnectionBuildParameters hints = TestConnectionBuildParameters.NONE;
+    private final MutableList<ConnectionFactoryExtension> factories;
 
     public MappingTestRunner(Mapping pureMapping, String pureVersion)
     {
@@ -92,6 +92,25 @@ public class MappingTestRunner implements TestRunner
         this.pureVersion = pureVersion;
         this.executor = PlanExecutor.newPlanExecutorBuilder().withAvailableStoreExecutors().build();
         this.extensions = Lists.mutable.withAll(ServiceLoader.load(PlanGeneratorExtension.class));
+        this.factories = Lists.mutable.withAll(ServiceLoader.load(ConnectionFactoryExtension.class));
+    }
+
+    @Override
+    public TestSuiteSession<TestResult> openTestSuiteSession(Root_meta_pure_test_TestSuite testSuite, PureModel pureModel, PureModelContextData data)
+    {
+        return new MappingTestSuiteSession(testSuite, getProtocolSuite(testSuite, pureModel, data), pureModel, data);
+    }
+
+    @Override
+    public boolean supportsDebug()
+    {
+        return true;
+    }
+
+    @Override
+    public TestSuiteSession<TestDebug> openTestSuiteDebugSession(Root_meta_pure_test_TestSuite testSuite, PureModel pureModel, PureModelContextData data)
+    {
+        return new MappingTestSuiteDebugSession(testSuite, getProtocolSuite(testSuite, pureModel, data), pureModel, data);
     }
 
     @Override
@@ -106,100 +125,21 @@ public class MappingTestRunner implements TestRunner
         throw new UnsupportedOperationException("Mapping Test should be executed in context of Mapping Test Suite only");
     }
 
-    @Override
-    public List<TestResult> executeTestSuite(Root_meta_pure_test_TestSuite testSuite, List<String> atomicTestIds, PureModel pureModel, PureModelContextData pureModelContextData)
-    {
-        List<org.finos.legend.engine.protocol.pure.v1.model.test.result.TestResult> results = Lists.mutable.empty();
-        MappingTestRunnerContext context = buildMappingContext(testSuite, pureModel, pureModelContextData);        try
-        {
-            boolean isRelation = TestReturnTypeHelper.isRelationReturnType(context.getMetamodelTestSuite()._query(), pureModel);
-            this.hints = isRelation ? TestConnectionBuildParameters.newBuilder().withIsRelation(true).build() : TestConnectionBuildParameters.NONE;
-            MappingTestSuite mappingTestSuite = ListIterate.detect(context.getMapping().testSuites, ts -> ts.id.equals(testSuite._id()));
-            // build plan, executor args
-            List<MappingTest> mappingTests = mappingTestSuite.tests.stream().filter(t -> t instanceof MappingTest).map(t -> (MappingTest)t).collect(Collectors.toList());
-            // running of each test is catchable and put under a test error
-            for (MappingTest mappingTest : mappingTests)
-            {
-                if (atomicTestIds.contains(mappingTest.id))
-                {
-                    org.finos.legend.engine.protocol.pure.v1.model.test.result.TestResult testResult = executeMappingTest(mappingTest, context);
-                    testResult.testable = context.getMapping().getPath();
-                    testResult.testSuiteId = context.getMetamodelTestSuite()._id();
-                    results.add(testResult);
-                }
-            }
-
-        }
-        catch (Exception e)
-        {
-            // this is to catch any error for the setup of the test suite. we return test error for each test run
-            for (Root_meta_pure_test_AtomicTest testedError: context.getMetamodelTestSuite()._tests())
-            {
-                if (atomicTestIds.contains(testedError._id()) && results.stream().noneMatch(t -> t.atomicTestId.equals(testedError._id())))
-                {
-                    results.add(TestResultHelper.newTestError(testedError._id(), e));
-                }
-            }
-        }
-        return results;
-    }
-
-    @Override
-    public List<TestDebug> debugTestSuite(Root_meta_pure_test_TestSuite testSuite, List<String> atomicTestIds, PureModel pureModel, PureModelContextData pureModelContextData)
-    {
-        List<org.finos.legend.engine.protocol.pure.v1.model.test.result.TestDebug> results = Lists.mutable.empty();
-        MappingTestRunnerContext context = buildMappingContext(testSuite, pureModel, pureModelContextData);
-        try
-        {
-            boolean isRelation = TestReturnTypeHelper.isRelationReturnType(context.getMetamodelTestSuite()._query(), pureModel);
-            this.hints = isRelation ? TestConnectionBuildParameters.newBuilder().withIsRelation(true).build() : TestConnectionBuildParameters.NONE;
-            MappingTestSuite mappingTestSuite = ListIterate.detect(context.getMapping().testSuites, ts -> ts.id.equals(testSuite._id()));
-            // build plan, executor args
-            List<MappingTest> mappingTests = mappingTestSuite.tests.stream().filter(t -> t instanceof MappingTest).map(t -> (MappingTest)t).collect(Collectors.toList());
-            // running of each test is catchable and put under a test error
-            for (MappingTest mappingTest : mappingTests)
-            {
-                if (atomicTestIds.contains(mappingTest.id))
-                {
-                    org.finos.legend.engine.protocol.pure.v1.model.test.result.TestDebug testResult = debugMappingTest(mappingTest, context);
-                    testResult.testable = context.getMapping().getPath();
-                    testResult.testSuiteId = context.getMetamodelTestSuite()._id();
-                    results.add(testResult);
-                }
-            }
-        }
-        catch (Exception e)
-        {
-            // this is to catch any error for the setup of the test suite. we return test error for each test run
-            for (Root_meta_pure_test_AtomicTest testedError: context.getMetamodelTestSuite()._tests())
-            {
-                if (atomicTestIds.contains(testedError._id()) && results.stream().noneMatch(t -> t.atomicTestId.equals(testedError._id())))
-                {
-                    TestExecutionPlanDebug testError = new TestExecutionPlanDebug();
-                    testError.atomicTestId = testedError._id();
-                    testError.error = e.toString();
-                    results.add(testError);
-                }
-            }
-        }
-        return results;
-    }
-
     private MappingTestRunnerContext buildMappingContext(Root_meta_pure_test_TestSuite testSuite, PureModel pureModel, PureModelContextData pureModelContextData)
     {
-        String testablePath = getElementFullPath(this.pureMapping, pureModel.getExecutionSupport());
+        String testablePath = HelperModelBuilder.getElementFullPath(this.pureMapping, pureModel.getExecutionSupport());
         Assert.assertTrue(testSuite instanceof Root_meta_pure_mapping_metamodel_MappingTestSuite, () -> "Test Suite in Mapping expected to be of type Mapping Test Suite");
         Root_meta_pure_mapping_metamodel_MappingTestSuite compiledMappingTestSuite = (Root_meta_pure_mapping_metamodel_MappingTestSuite) testSuite;
         org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.Mapping mapping = ListIterate.detect(pureModelContextData.getElementsOfType(org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.Mapping.class), ele -> ele.getPath().equals(testablePath));
         return new MappingTestRunnerContext(compiledMappingTestSuite, mapping, pureModel, pureModelContextData, extensions.flatCollect(PlanGeneratorExtension::getExtraPlanTransformers), new ConnectionFirstPassBuilder(pureModel.getContext()), PureCoreExtensionLoader.extensions().flatCollect(e -> e.extraPureCoreExtensions(pureModel.getExecutionSupport())));
     }
 
-    private TestResult executeMappingTest(MappingTest mappingTest,  MappingTestRunnerContext context)
+    private TestResult executeMappingTest(MappingTest mappingTest, MappingTestRunnerContext context, TestConnectionBuildParameters hints)
     {
         List<Pair<Connection, List<Closeable>>> connections = Lists.mutable.empty();
         try
         {
-            connections = generateExecutionPlan(mappingTest, context, false);
+            connections = generateExecutionPlan(mappingTest, context, hints, false);
             // execute assertion
             TestAssertion assertion = mappingTest.assertions.get(0);
             PlanExecutor.ExecuteArgs executeArgs = context.getExecuteBuilder().build();
@@ -219,14 +159,14 @@ public class MappingTestRunner implements TestRunner
         }
     }
 
-    private TestDebug debugMappingTest(MappingTest mappingTest,  MappingTestRunnerContext context)
+    private TestDebug debugMappingTest(MappingTest mappingTest, MappingTestRunnerContext context, TestConnectionBuildParameters hints)
     {
         List<Pair<Connection, List<Closeable>>> connections = Lists.mutable.empty();
 
         try
         {
             TestExecutionPlanDebug executionPlanDebug = new TestExecutionPlanDebug();
-            connections = generateExecutionPlan(mappingTest, context, true);
+            connections = generateExecutionPlan(mappingTest, context, hints, true);
             executionPlanDebug.executionPlan = context.getPlan();
             executionPlanDebug.debug = context.getDebug();
             executionPlanDebug.atomicTestId = mappingTest.id;
@@ -234,10 +174,7 @@ public class MappingTestRunner implements TestRunner
         }
         catch (Exception e)
         {
-            TestExecutionPlanDebug executionPlanDebug = new TestExecutionPlanDebug();
-            executionPlanDebug.atomicTestId = mappingTest.id;
-            executionPlanDebug.error = e.toString();
-            return executionPlanDebug;
+            return TestResultHelper.newTestExecutionPlanDebugError(mappingTest.id, e);
         }
         finally
         {
@@ -245,18 +182,18 @@ public class MappingTestRunner implements TestRunner
         }
     }
 
-    private List<Pair<Connection, List<Closeable>>> generateExecutionPlan(MappingTest mappingTest,  MappingTestRunnerContext context, boolean debug)
+    private List<Pair<Connection, List<Closeable>>> generateExecutionPlan(MappingTest mappingTest, MappingTestRunnerContext context, TestConnectionBuildParameters hints, boolean debug)
     {
 
-        Root_meta_core_runtime_Runtime_Impl runtime = new Root_meta_core_runtime_Runtime_Impl("");
+        Root_meta_core_runtime_Runtime runtime = new Root_meta_core_runtime_Runtime_Impl("");
         List<Pair<String, EmbeddedData>> connectionInfo = mappingTest.storeTestData.stream().map(testData -> Tuples.pair(testData.store.path, EmbeddedDataHelper.resolveEmbeddedDataInPMCD(context.getPureModelContextData(), testData.data))).collect(Collectors.toList());
         List<Pair<Connection, List<Closeable>>> connections = connectionInfo.stream()
-                .map(pair -> this.factories.collect(f -> f.tryBuildTestConnectionsForStore(context.getDataElementIndex(), resolveStore(context.getPureModelContextData(), pair.getOne()), pair.getTwo(), this.hints)).select(Objects::nonNull).select(Optional::isPresent)
+                .map(pair -> this.factories.collect(f -> f.tryBuildTestConnectionsForStore(context.getDataElementIndex(), resolveStore(context.getPureModelContextData(), pair.getOne()), pair.getTwo(), hints)).select(Objects::nonNull).select(Optional::isPresent)
                         .collect(Optional::get).getFirstOptional().orElseThrow(() -> new UnsupportedOperationException("Unsupported store type for:'" + pair.getOne() + "' mentioned while running the mapping tests"))).collect(Collectors.toList());
         connections.forEach(connection ->
         {
             Connection conn = connection.getOne();
-            org.finos.legend.pure.m3.coreinstance.meta.pure.store.Store element = getStore(conn.element, conn.elementSourceInformation, context.getPureModel().getContext());
+            org.finos.legend.pure.m3.coreinstance.meta.pure.store.Store element = HelperRuntimeBuilder.getStore(conn.element, conn.elementSourceInformation, context.getPureModel().getContext());
             Root_meta_core_runtime_ConnectionStore connectionStore =
                     new Root_meta_core_runtime_ConnectionStore_Impl("")
                             ._connection(conn.accept(context.getConnectionVisitor()))
@@ -267,30 +204,22 @@ public class MappingTestRunner implements TestRunner
         return connections;
     }
 
-    private void handleGenerationOfPlan(List<Connection> incomingConnections, Root_meta_core_runtime_Runtime_Impl runtime, MappingTestRunnerContext context, boolean debug)
+    private void handleGenerationOfPlan(List<Connection> incomingConnections, Root_meta_core_runtime_Runtime runtime, MappingTestRunnerContext context, boolean debug)
     {
-        SingleExecutionPlan executionPlan = context.getPlan();
-        boolean reusePlan = false;
-        if (context.getConnections() != null)
+        if (context.getPlan() == null || !shouldReusePlan(incomingConnections, context))
         {
-            List<Connection> cachedConnections = context.getConnections();
-            if (cachedConnections.size() == incomingConnections.size())
-            {
-                reusePlan = incomingConnections.stream().allMatch(incomingConnection -> cachedConnections.stream().anyMatch(cachedConn -> cachedConn == incomingConnection));
-            }
-        }
-        if (executionPlan == null || !reusePlan)
-        {
-            List<String> debugger = null;
+            SingleExecutionPlan executionPlan;
+            List<String> debugger;
             if (debug)
             {
-                PlanWithDebug plan = PlanGenerator.generateExecutionPlanDebug(context.getMetamodelTestSuite()._query(), pureMapping, runtime, null, context.getPureModel(), this.pureVersion, PlanPlatform.JAVA, null, context.getRouterExtensions(), context.getExecutionPlanTransformers());
+                PlanWithDebug plan = PlanGenerator.generateExecutionPlanDebug(context.getMetamodelTestSuite()._query(), this.pureMapping, runtime, null, context.getPureModel(), this.pureVersion, PlanPlatform.JAVA, null, context.getRouterExtensions(), context.getExecutionPlanTransformers());
                 executionPlan = plan.plan;
                 debugger = Arrays.asList(plan.debug);
             }
             else
             {
-                executionPlan = PlanGenerator.generateExecutionPlan(context.getMetamodelTestSuite()._query(), pureMapping, runtime, null, context.getPureModel(), this.pureVersion, PlanPlatform.JAVA, null, context.getRouterExtensions(), context.getExecutionPlanTransformers());
+                executionPlan = PlanGenerator.generateExecutionPlan(context.getMetamodelTestSuite()._query(), this.pureMapping, runtime, null, context.getPureModel(), this.pureVersion, PlanPlatform.JAVA, null, context.getRouterExtensions(), context.getExecutionPlanTransformers());
+                debugger = null;
             }
             context.withPlan(executionPlan, debugger);
         }
@@ -298,35 +227,106 @@ public class MappingTestRunner implements TestRunner
         context.withConnections(incomingConnections);
     }
 
+    private boolean shouldReusePlan(List<Connection> incomingConnections, MappingTestRunnerContext context)
+    {
+        List<Connection> cachedConnections = context.getConnections();
+        return (cachedConnections != null) &&
+                (cachedConnections.size() == incomingConnections.size()) &&
+                incomingConnections.stream().allMatch(incomingConnection -> cachedConnections.stream().anyMatch(cachedConn -> cachedConn == incomingConnection));
+    }
+
     private void closeConnections(List<Pair<Connection, List<Closeable>>> connections)
     {
-        List<Closeable> runtimeCloseables = connections.stream().map(x -> x.getTwo()).flatMap(Collection::stream).collect(Collectors.toList());
-        if (runtimeCloseables != null)
+        connections.forEach(p -> p.getTwo().forEach(closeable ->
         {
-            runtimeCloseables.stream().forEach(closeable ->
+            try
             {
-                try
-                {
-                    closeable.close();
-                }
-                catch (IOException e)
-                {
-                    LOGGER.warn("Exception occurred closing closeable resource" + e);
-                }
-            });
-        }
+                closeable.close();
+            }
+            catch (Exception e)
+            {
+                LOGGER.warn("Exception occurred closing closeable resource", e);
+            }
+        }));
     }
 
     private Store resolveStore(PureModelContextData pureModelContextData, String store)
     {
-        if (store.equals("ModelStore"))
+        return store.equals("ModelStore")
+               ? new ModelStore()
+               : (Store) ListIterate.detect(pureModelContextData.getElements(), x -> store.equals(x.getPath()));
+    }
+
+    private MappingTestSuite getProtocolSuite(Root_meta_pure_test_TestSuite testSuite, PureModel pureModel, PureModelContextData data)
+    {
+        String testablePath = HelperModelBuilder.getElementFullPath(this.pureMapping, pureModel.getExecutionSupport());
+        org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.Mapping mapping = (org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.Mapping) ListIterate.detect(data.getElements(), elt -> (elt instanceof org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.Mapping) && testablePath.equals(elt.getPath()));
+        return ListIterate.detect(mapping.testSuites, ts -> ts.id.equals(testSuite._id()));
+    }
+
+    private abstract class BaseMappingTestSuiteSession<TR> extends AbstractTestSuiteSessionWithResources<MappingTestSuite, MappingTest, TR>
+    {
+        MappingTestRunnerContext context;
+        TestConnectionBuildParameters hints;
+
+        private BaseMappingTestSuiteSession(Root_meta_pure_test_TestSuite pureSuite, MappingTestSuite protocolSuite, PureModel pureModel, PureModelContextData pmcd)
         {
-            return new ModelStore();
+            super(pureSuite, protocolSuite, pureModel, pmcd, BaseMappingTestSuiteSession::getTestSuiteTests, BaseMappingTestSuiteSession::getAtomicTestId);
         }
-        else
+
+        @Override
+        protected void initialize(Consumer<? super AutoCloseable> closeableConsumer)
         {
-            return ListIterate.detect(pureModelContextData.getElementsOfType(Store.class), x -> x.getPath().equals(store));
+            this.context = buildMappingContext(this.pureSuite, this.pureModel, this.pmcd);
+
+            boolean isRelation = TestReturnTypeHelper.isRelationReturnType(this.context.getMetamodelTestSuite()._query(), pureModel);
+            this.hints = isRelation ? TestConnectionBuildParameters.newBuilder().withIsRelation(true).build() : TestConnectionBuildParameters.NONE;
         }
     }
 
+    private class MappingTestSuiteSession extends BaseMappingTestSuiteSession<TestResult>
+    {
+        private MappingTestSuiteSession(Root_meta_pure_test_TestSuite pureSuite, MappingTestSuite protocolSuite, PureModel pureModel, PureModelContextData pmcd)
+        {
+            super(pureSuite, protocolSuite, pureModel, pmcd);
+        }
+
+        @Override
+        protected TestResult buildErrorResult(String atomicTestId, Throwable t)
+        {
+            return TestResultHelper.newTestError(this.context.getMapping().getPath(), getTestSuiteId(), atomicTestId, t);
+        }
+
+        @Override
+        protected TestResult runAtomicTest(MappingTest atomicTest)
+        {
+            TestResult testResult = executeMappingTest(atomicTest, this.context, this.hints);
+            testResult.testable = this.context.getMapping().getPath();
+            testResult.testSuiteId = getTestSuiteId();
+            return testResult;
+        }
+    }
+
+    private class MappingTestSuiteDebugSession extends BaseMappingTestSuiteSession<TestDebug>
+    {
+        private MappingTestSuiteDebugSession(Root_meta_pure_test_TestSuite pureSuite, MappingTestSuite protocolSuite, PureModel pureModel, PureModelContextData pmcd)
+        {
+            super(pureSuite, protocolSuite, pureModel, pmcd);
+        }
+
+        @Override
+        protected TestDebug buildErrorResult(String atomicTestId, Throwable t)
+        {
+            return TestResultHelper.newTestExecutionPlanDebugError(this.context.getMapping().getPath(), getTestSuiteId(), atomicTestId, t);
+        }
+
+        @Override
+        protected TestDebug runAtomicTest(MappingTest atomicTest)
+        {
+            TestDebug testResult = debugMappingTest(atomicTest, this.context, this.hints);
+            testResult.testable = this.context.getMapping().getPath();
+            testResult.testSuiteId = getTestSuiteId();
+            return testResult;
+        }
+    }
 }

--- a/legend-engine-core/legend-engine-core-testable/legend-engine-testable/src/main/java/org/finos/legend/engine/testable/extension/AbstractTestSuiteSession.java
+++ b/legend-engine-core/legend-engine-core-testable/legend-engine-testable/src/main/java/org/finos/legend/engine/testable/extension/AbstractTestSuiteSession.java
@@ -1,0 +1,100 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.testable.extension;
+
+import org.eclipse.collections.impl.utility.LazyIterate;
+import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
+import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
+import org.finos.legend.engine.protocol.pure.v1.model.test.AtomicTest;
+import org.finos.legend.engine.protocol.pure.v1.model.test.TestSuite;
+import org.finos.legend.pure.generated.Root_meta_pure_test_TestSuite;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+
+public abstract class AbstractTestSuiteSession<S, T, R> implements TestSuiteSession<R>
+{
+    protected final Root_meta_pure_test_TestSuite pureSuite;
+    protected final S protocolSuite;
+    protected final PureModel pureModel;
+    protected final PureModelContextData pmcd;
+    private final Map<String, T> testsById;
+
+    protected AbstractTestSuiteSession(Root_meta_pure_test_TestSuite pureSuite, S protocolSuite, PureModel pureModel, PureModelContextData pmcd, Function<? super S, ? extends Iterable<? extends T>> getAtomicTests, Function<? super T, ? extends String> getAtomicTestId)
+    {
+        this.pureSuite = Objects.requireNonNull(pureSuite);
+        this.protocolSuite = Objects.requireNonNull(protocolSuite);
+        this.pureModel = Objects.requireNonNull(pureModel);
+        this.pmcd = Objects.requireNonNull(pmcd);
+        this.testsById = indexTests(pureSuite._id(), this.protocolSuite, getAtomicTests, getAtomicTestId);
+    }
+
+    @Override
+    public String getTestSuiteId()
+    {
+        return this.pureSuite._id();
+    }
+
+    @Override
+    public Collection<String> getAtomicTestIds()
+    {
+        return this.testsById.keySet();
+    }
+
+    @Override
+    public boolean isAtomicTestId(String id)
+    {
+        return this.testsById.containsKey(id);
+    }
+
+    protected T getAtomicTest(String id)
+    {
+        return this.testsById.get(id);
+    }
+
+    private static <S, T> Map<String, T> indexTests(String suiteId, S suite, Function<? super S, ? extends Iterable<? extends T>> getTests, Function<? super T, ? extends String> getTestId)
+    {
+        Iterable<? extends T> atomicTests = getTests.apply(suite);
+        if (atomicTests == null)
+        {
+            return Collections.emptyMap();
+        }
+        Map<String, T> map = new LinkedHashMap<>();
+        atomicTests.forEach(t ->
+        {
+            String testId = getTestId.apply(t);
+            if (map.put(testId, t) != null)
+            {
+                throw new IllegalStateException("Duplicate atomic tests in suite " + suiteId + " for id: " + testId);
+            }
+        });
+        return map.isEmpty() ? Collections.emptyMap() : Collections.unmodifiableMap(map);
+    }
+
+    @SuppressWarnings("unchecked")
+    protected static <T extends AtomicTest> Iterable<T> getTestSuiteTests(TestSuite testSuite)
+    {
+        return LazyIterate.collect(testSuite.tests, t -> (T) t);
+    }
+
+    protected static String getAtomicTestId(AtomicTest atomicTest)
+    {
+        return atomicTest.id;
+    }
+}

--- a/legend-engine-core/legend-engine-core-testable/legend-engine-testable/src/main/java/org/finos/legend/engine/testable/extension/AbstractTestSuiteSessionWithResources.java
+++ b/legend-engine-core/legend-engine-core-testable/legend-engine-testable/src/main/java/org/finos/legend/engine/testable/extension/AbstractTestSuiteSessionWithResources.java
@@ -1,0 +1,148 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.testable.extension;
+
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.list.MutableList;
+import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
+import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
+import org.finos.legend.pure.generated.Root_meta_pure_test_TestSuite;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+public abstract class AbstractTestSuiteSessionWithResources<S, T, R> extends AbstractTestSuiteSession<S, T, R>
+{
+    private static final int UNINITIALIZED = 0;
+    private static final int INITIALIZED = 1;
+    private static final int INIT_ERROR = 2;
+    private static final int CLOSED = 3;
+
+    private int state = UNINITIALIZED;
+    private RuntimeException initError;
+    private final MutableList<AutoCloseable> closeables = Lists.mutable.empty();
+
+    protected AbstractTestSuiteSessionWithResources(Root_meta_pure_test_TestSuite pureSuite, S protocolSuite, PureModel pureModel, PureModelContextData pmcd, Function<? super S, ? extends Iterable<? extends T>> getAtomicTests, Function<? super T, ? extends String> getAtomicTestId)
+    {
+        super(pureSuite, protocolSuite, pureModel, pmcd, getAtomicTests, getAtomicTestId);
+    }
+
+    @Override
+    public void initialize()
+    {
+        initialize(true);
+    }
+
+    @Override
+    public R runAtomicTest(String atomicTestId)
+    {
+        T atomicTest = getAtomicTest(atomicTestId);
+        if (atomicTest == null)
+        {
+            return null;
+        }
+        if (initialize(false) == INIT_ERROR)
+        {
+            return buildErrorResult(atomicTestId, this.initError);
+        }
+        try
+        {
+            return runAtomicTest(atomicTest);
+        }
+        catch (Exception e)
+        {
+            return buildErrorResult(atomicTestId, e);
+        }
+    }
+
+    @Override
+    public synchronized void close()
+    {
+        if (this.state != CLOSED)
+        {
+            MutableList<Exception> exceptions = Lists.mutable.empty();
+            this.closeables.forEach(c ->
+            {
+                try
+                {
+                    c.close();
+                }
+                catch (Exception e)
+                {
+                    exceptions.add(e);
+                }
+            });
+            this.state = CLOSED;
+            if ((exceptions.size() == 1) && (exceptions.get(0) instanceof RuntimeException))
+            {
+                throw (RuntimeException) exceptions.get(0);
+            }
+            if (exceptions.notEmpty())
+            {
+                RuntimeException e = new RuntimeException("Multiple exceptions closing test suite session for '" + getTestSuiteId() + "': " + exceptions.size() + " exceptions");
+                exceptions.forEach(e::addSuppressed);
+                throw e;
+            }
+        }
+    }
+
+    private synchronized int initialize(boolean throwOnInitError)
+    {
+        switch (this.state)
+        {
+            case UNINITIALIZED:
+            {
+                try
+                {
+                    initialize(this.closeables::add);
+                    this.state = INITIALIZED;
+                }
+                catch (Throwable t)
+                {
+                    this.initError = new RuntimeException("Error initializing test suite session for '" + getTestSuiteId() + "'", t);
+                    this.state = INIT_ERROR;
+                    if (throwOnInitError)
+                    {
+                        if (t instanceof Error)
+                        {
+                            throw (Error) t;
+                        }
+                        throw this.initError;
+                    }
+                }
+                break;
+            }
+            case INIT_ERROR:
+            {
+                if (throwOnInitError)
+                {
+                    throw this.initError;
+                }
+                break;
+            }
+            case CLOSED:
+            {
+                throw new IllegalStateException("Session is closed");
+            }
+        }
+        return this.state;
+    }
+
+    protected abstract void initialize(Consumer<? super AutoCloseable> closeableConsumer) throws Exception;
+
+    protected abstract R runAtomicTest(T atomicTest);
+
+    protected abstract R buildErrorResult(String atomicTestId, Throwable t);
+}

--- a/legend-engine-core/legend-engine-core-testable/legend-engine-testable/src/main/java/org/finos/legend/engine/testable/extension/TestRunner.java
+++ b/legend-engine-core/legend-engine-core-testable/legend-engine-testable/src/main/java/org/finos/legend/engine/testable/extension/TestRunner.java
@@ -14,6 +14,7 @@
 
 package org.finos.legend.engine.testable.extension;
 
+import org.eclipse.collections.impl.utility.ListIterate;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
 import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
 import org.finos.legend.engine.protocol.pure.v1.model.test.result.TestDebug;
@@ -26,9 +27,19 @@ import java.util.List;
 
 public interface TestRunner
 {
-    TestResult executeAtomicTest(Root_meta_pure_test_AtomicTest atomicTest, PureModel pureModel, PureModelContextData data);
+    default TestResult executeAtomicTest(Root_meta_pure_test_AtomicTest atomicTest, PureModel pureModel, PureModelContextData data)
+    {
+        throw new UnsupportedOperationException("Atomic tests should be run in the context of a test suite");
+    }
 
-    List<TestResult> executeTestSuite(Root_meta_pure_test_TestSuite testSuite, List<String> atomicTestIds, PureModel pureModel, PureModelContextData data);
+    default List<TestResult> executeTestSuite(Root_meta_pure_test_TestSuite testSuite, List<String> atomicTestIds, PureModel pureModel, PureModelContextData data)
+    {
+        try (TestSuiteSession<TestResult> session = openTestSuiteSession(testSuite, pureModel, data))
+        {
+            session.initialize();
+            return ListIterate.collect(atomicTestIds, session::runAtomicTest);
+        }
+    }
 
     default TestDebug debugAtomicTest(Root_meta_pure_test_AtomicTest atomicTest, PureModel pureModel, PureModelContextData data)
     {
@@ -37,6 +48,50 @@ public interface TestRunner
 
     default List<TestDebug> debugTestSuite(Root_meta_pure_test_TestSuite testSuite, List<String> atomicTestIds, PureModel pureModel, PureModelContextData data)
     {
-        return Collections.emptyList();
+        if (!supportsDebug())
+        {
+            return Collections.emptyList();
+        }
+        try (TestSuiteSession<TestDebug> session = openTestSuiteDebugSession(testSuite, pureModel, data))
+        {
+            session.initialize();
+            return ListIterate.collect(atomicTestIds, session::runAtomicTest);
+        }
+    }
+
+    /**
+     * Open a session that manages resources for a test suite so the caller
+     * can run many atomic tests without re-initializing against it without
+     * re-paying that setup cost per test. The caller owns the returned
+     * session and MUST close it (try-with-resources) so that any suite
+     * resources are cleaned up at the end.
+     */
+    TestSuiteSession<TestResult> openTestSuiteSession(Root_meta_pure_test_TestSuite testSuite, PureModel pureModel, PureModelContextData data);
+
+    /**
+     * Return whether the runner supports debug mode. If so, then a debug
+     * session may be created by calling {@link #openTestSuiteDebugSession}.
+     * Otherwise, that method with throw an {@link UnsupportedOperationException}.
+     *
+     * @return whether the runner supports debug
+     * @see #openTestSuiteDebugSession
+     */
+    default boolean supportsDebug()
+    {
+        return false;
+    }
+
+    /**
+     * If the runner supports debug, then this will return a test suite debug session.
+     * (See {@link #openTestSuiteSession} for more information about test suite sessions.)
+     * If the runner does not support debug, this will throw an {@link UnsupportedOperationException}.
+     *
+     * @return test suite debug session
+     * @see #supportsDebug
+     * @see #openTestSuiteSession
+     */
+    default TestSuiteSession<TestDebug> openTestSuiteDebugSession(Root_meta_pure_test_TestSuite testSuite, PureModel pureModel, PureModelContextData data)
+    {
+        throw new UnsupportedOperationException("Debug is not supported");
     }
 }

--- a/legend-engine-core/legend-engine-core-testable/legend-engine-testable/src/main/java/org/finos/legend/engine/testable/extension/TestSuiteSession.java
+++ b/legend-engine-core/legend-engine-core-testable/legend-engine-testable/src/main/java/org/finos/legend/engine/testable/extension/TestSuiteSession.java
@@ -1,0 +1,84 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.testable.extension;
+
+import java.util.Collection;
+
+/**
+ * <p>Session to manage resources that are created when {@link #initialize}
+ * is called and persist throughout all atomic test runs until {@link #close}
+ * is called.</p>
+ *
+ * <p>Obtained via {@link TestRunner#openTestSuiteSession}. The caller owns
+ * the session lifetime and must close it (try-with-resources) so that
+ * runtime and connection resources are released. After {@link #close} the
+ * session must not be used again. If {@link #initialize} is not explicitly
+ * called, initialization will be performed automatically when the first test
+ * is run.</p>
+ *
+ * <p>The contract over multiple {@link #runAtomicTest} calls matches the
+ * single-call contract of {@link TestRunner#executeTestSuite}: each
+ * atomic-test result is independent, a failure in one does not abort the
+ * session, and the runner returns a per-test error rather than throwing
+ * for an individual test failure.</p>
+ */
+public interface TestSuiteSession<TR> extends AutoCloseable
+{
+    /**
+     * Get the id of the test suite.
+     *
+     * @return test suite id
+     */
+    String getTestSuiteId();
+
+    /**
+     * Get the ids of the atomic tests in the suite
+     *
+     * @return ids of atomic tests in the suite
+     */
+    Collection<String> getAtomicTestIds();
+
+    /**
+     * Return whether the given string is an id for an atomic test in the suite.
+     *
+     * @param id id string
+     * @return whether id is an atomic test id for the suite
+     */
+    boolean isAtomicTestId(String id);
+
+    /**
+     * Perform any initialization necessary before running tests from the suite. Should
+     * be called before calling {@link #runAtomicTest} for the first time. Idempotent:
+     * once initialized, subsequent calls have no effect.
+     */
+    void initialize();
+
+    /**
+     * Run one atomic test against the cached suite-level setup.
+     *
+     * @param atomicTestId id of an atomic test in the suite the session was opened for
+     * @return result of executing that atomic test, or {@code null} if no
+     * such test exists in the suite
+     */
+    TR runAtomicTest(String atomicTestId);
+
+    /**
+     * Release any resources held by the session (connections, plan
+     * executor handles, runtime closeables, etc). Idempotent: safe to call
+     * more than once. The session must not be used after close.
+     */
+    @Override
+    void close();
+}

--- a/legend-engine-core/legend-engine-core-testable/legend-engine-testable/src/main/java/org/finos/legend/engine/testable/helper/TestResultHelper.java
+++ b/legend-engine-core/legend-engine-core-testable/legend-engine-testable/src/main/java/org/finos/legend/engine/testable/helper/TestResultHelper.java
@@ -14,10 +14,13 @@
 
 package org.finos.legend.engine.testable.helper;
 
+import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.ExecutionPlan;
 import org.finos.legend.engine.protocol.pure.v1.model.test.result.TestError;
+import org.finos.legend.engine.protocol.pure.v1.model.test.result.TestExecutionPlanDebug;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.List;
 
 public class TestResultHelper
 {
@@ -32,6 +35,28 @@ public class TestResultHelper
         error.testable = testable;
         error.testSuiteId = testSuiteId;
         error.atomicTestId = atomicTestId;
+        error.error = toErrorString(t);
+        return error;
+    }
+
+    public static TestExecutionPlanDebug newTestExecutionPlanDebugError(String atomicTestId, Throwable t)
+    {
+        return newTestExecutionPlanDebugError(null, null, atomicTestId, t);
+    }
+
+    public static TestExecutionPlanDebug newTestExecutionPlanDebugError(String testable, String testSuiteId, String atomicTestId, Throwable t)
+    {
+        return newTestExecutionPlanDebugError(testable, testSuiteId, atomicTestId, null, null, t);
+    }
+
+    public static TestExecutionPlanDebug newTestExecutionPlanDebugError(String testable, String testSuiteId, String atomicTestId, ExecutionPlan executionPlan, List<String> debug, Throwable t)
+    {
+        TestExecutionPlanDebug error = new TestExecutionPlanDebug();
+        error.testable = testable;
+        error.testSuiteId = testSuiteId;
+        error.atomicTestId = atomicTestId;
+        error.executionPlan = executionPlan;
+        error.debug = debug;
         error.error = toErrorString(t);
         return error;
     }

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-test-runner/pom.xml
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-test-runner/pom.xml
@@ -69,10 +69,6 @@
         </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
-            <artifactId>legend-engine-executionPlan-execution</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-protocol-pure</artifactId>
         </dependency>
         <dependency>

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-test-runner/src/main/java/org/finos/legend/engine/testable/persistence/extension/PersistenceTestRunner.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-test-runner/src/main/java/org/finos/legend/engine/testable/persistence/extension/PersistenceTestRunner.java
@@ -14,7 +14,9 @@
 
 package org.finos.legend.engine.testable.persistence.extension;
 
+import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.impl.utility.ListIterate;
+import org.finos.legend.engine.language.pure.compiler.toPureGraph.HelperModelBuilder;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
 import org.finos.legend.engine.persistence.components.common.Datasets;
 import org.finos.legend.engine.persistence.components.ingestmode.IngestMode;
@@ -24,7 +26,6 @@ import org.finos.legend.engine.persistence.components.relational.api.IngestorRes
 import org.finos.legend.engine.persistence.components.relational.api.RelationalIngestor;
 import org.finos.legend.engine.persistence.components.relational.h2.H2Sink;
 import org.finos.legend.engine.persistence.components.relational.jdbc.JdbcConnection;
-import org.finos.legend.engine.plan.execution.PlanExecutor;
 import org.finos.legend.engine.protocol.pure.dsl.path.valuespecification.constant.classInstance.Path;
 import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
 import org.finos.legend.engine.protocol.pure.v1.model.data.ExternalFormatData;
@@ -40,6 +41,7 @@ import org.finos.legend.engine.protocol.pure.v1.model.test.assertion.status.Asse
 import org.finos.legend.engine.protocol.pure.v1.model.test.result.TestExecuted;
 import org.finos.legend.engine.protocol.pure.v1.model.test.result.TestResult;
 import org.finos.legend.engine.testable.extension.TestRunner;
+import org.finos.legend.engine.testable.extension.TestSuiteSession;
 import org.finos.legend.engine.testable.helper.TestResultHelper;
 import org.finos.legend.engine.testable.persistence.assertion.PersistenceTestAssertionEvaluator;
 import org.finos.legend.engine.testable.persistence.exception.PersistenceException;
@@ -50,12 +52,9 @@ import org.finos.legend.pure.generated.Root_meta_pure_test_AtomicTest;
 import org.finos.legend.pure.generated.Root_meta_pure_test_TestSuite;
 
 import java.sql.Connection;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import static org.finos.legend.engine.language.pure.compiler.toPureGraph.HelperModelBuilder.getElementFullPath;
 
 public class PersistenceTestRunner implements TestRunner
 {
@@ -63,50 +62,46 @@ public class PersistenceTestRunner implements TestRunner
     public static final boolean STATS_COLLECTION_DEFAULT = true;
     public static final boolean SCHEMA_EVOLUTION_DEFAULT = false;
 
-    private Root_meta_pure_persistence_metamodel_Persistence purePersistence;
-    private PlanExecutor planExecutor;
-    private String pureVersion;
+    private final Root_meta_pure_persistence_metamodel_Persistence purePersistence;
 
     public PersistenceTestRunner(Root_meta_pure_persistence_metamodel_Persistence purePersistence, String pureVersion)
     {
         this.purePersistence = purePersistence;
-        this.planExecutor = PlanExecutor.newPlanExecutorWithAvailableStoreExecutors();
-        this.pureVersion = pureVersion;
     }
 
     @Override
     public TestResult executeAtomicTest(Root_meta_pure_test_AtomicTest atomicTest, PureModel pureModel, PureModelContextData data)
     {
-        TestResult result;
-        Persistence persistence = ListIterate.detect(data.getElementsOfType(Persistence.class), ele -> ele.getPath().equals(getElementFullPath(purePersistence, pureModel.getExecutionSupport())));
+        Persistence persistence = ListIterate.detect(data.getElementsOfType(Persistence.class), ele -> ele.getPath().equals(HelperModelBuilder.getElementFullPath(this.purePersistence, pureModel.getExecutionSupport())));
         PersistenceTest persistenceTest = persistence.tests.stream().filter(test -> test.id.equals(atomicTest._id())).findFirst().get();
         Path graphFetchPath = persistenceTest.graphFetchPath;
         List<PersistenceTestBatch> testBatches = persistenceTest.testBatches;
 
         PersistenceTestH2Connection persistenceTestH2Connection = new PersistenceTestH2Connection();
         Connection connection = persistenceTestH2Connection.getConnection();
-        boolean isPersistenceSpecModelV1 = persistence.persister != null ? true : false;
+        boolean isPersistenceSpecModelV1 = persistence.persister != null;
 
         try
         {
             validatePersistenceSpec(persistence);
-            List<AssertionStatus> assertStatuses = new ArrayList<>();
+            List<AssertionStatus> assertStatuses = Lists.mutable.empty();
             Dataset targetDataset;
             Set<String> fieldsToIgnore;
             boolean isTransactionMilestoningTimeBased;
-            ServiceOutputTarget serviceOutputTarget = null;
+            ServiceOutputTarget serviceOutputTarget;
 
             // Test runner flow for v1
             if (isPersistenceSpecModelV1)
             {
-                targetDataset = DatasetMapper.getTargetDataset(purePersistence);
+                targetDataset = DatasetMapper.getTargetDataset(this.purePersistence);
+                serviceOutputTarget = null;
                 fieldsToIgnore = IngestModeMapper.getFieldsToIgnore(persistence);
                 isTransactionMilestoningTimeBased = IngestModeMapper.isTransactionMilestoningTimeBased(persistence);
             }
             // Test runner flow for v2
             else
             {
-                targetDataset = org.finos.legend.engine.testable.persistence.mapper.v2.DatasetMapper.getTargetDatasetV2(purePersistence, graphFetchPath);
+                targetDataset = org.finos.legend.engine.testable.persistence.mapper.v2.DatasetMapper.getTargetDatasetV2(this.purePersistence, graphFetchPath);
                 serviceOutputTarget = org.finos.legend.engine.testable.persistence.mapper.v2.IngestModeMapper.getServiceOutputTarget(persistence, graphFetchPath);
                 fieldsToIgnore = org.finos.legend.engine.testable.persistence.mapper.v2.IngestModeMapper.getFieldsToIgnoreForComparison(serviceOutputTarget);
                 isTransactionMilestoningTimeBased = org.finos.legend.engine.testable.persistence.mapper.v2.IngestModeMapper.isTransactionMilestoningTimeBased(serviceOutputTarget);
@@ -154,30 +149,28 @@ public class PersistenceTestRunner implements TestRunner
                 }
             }
             // Construct the Test Result
-            result = constructTestResult(atomicTest._id(), persistence.getPath(), assertStatuses);
+            return constructTestResult(atomicTest._id(), persistence.getPath(), assertStatuses);
         }
         catch (Exception exception)
         {
-            result = TestResultHelper.newTestError(null, "", atomicTest._id(), exception);
+            return TestResultHelper.newTestError(null, "", atomicTest._id(), exception);
         }
         finally
         {
             persistenceTestH2Connection.closeConnection();
         }
-        return result;
     }
 
     private void validatePersistenceSpec(Persistence persistence) throws PersistenceException
     {
-        if ((persistence.persister != null && persistence.serviceOutputTargets != null && persistence.serviceOutputTargets.size() > 0)
+        if ((persistence.persister != null && persistence.serviceOutputTargets != null && !persistence.serviceOutputTargets.isEmpty())
                 || (persistence.persister == null && persistence.serviceOutputTargets == null))
         {
             throw new PersistenceException("Persistence spec should contain either persister or serviceOutputTarget blocks ");
         }
     }
 
-    private IngestorResult invokePersistence(Dataset targetDataset, Persistence persistence, String testData,
-                                             Connection connection) throws Exception
+    private IngestorResult invokePersistence(Dataset targetDataset, Persistence persistence, String testData, Connection connection) throws Exception
     {
         Datasets enrichedDatasets = DatasetMapper.enrichAndDeriveDatasets(persistence, targetDataset, testData);
         IngestMode ingestMode = IngestModeMapper.from(persistence);
@@ -190,12 +183,10 @@ public class PersistenceTestRunner implements TestRunner
                 .enableSchemaEvolution(SCHEMA_EVOLUTION_DEFAULT)
                 .build();
 
-        IngestorResult result = ingestor.performFullIngestion(JdbcConnection.of(connection), enrichedDatasets).get(0);
-        return result;
+        return ingestor.performFullIngestion(JdbcConnection.of(connection), enrichedDatasets).get(0);
     }
 
-    private IngestorResult invokePersistence(Dataset targetDataset, ServiceOutputTarget serviceOutputTarget, String testData,
-                                             Connection connection) throws Exception
+    private IngestorResult invokePersistence(Dataset targetDataset, ServiceOutputTarget serviceOutputTarget, String testData, Connection connection) throws Exception
     {
         Datasets enrichedDatasets = org.finos.legend.engine.testable.persistence.mapper.v2.DatasetMapper.enrichAndDeriveDatasets(serviceOutputTarget, targetDataset, testData);
         IngestMode ingestMode = org.finos.legend.engine.testable.persistence.mapper.v2.IngestModeMapper.from(serviceOutputTarget);
@@ -208,8 +199,7 @@ public class PersistenceTestRunner implements TestRunner
                 .enableSchemaEvolution(SCHEMA_EVOLUTION_DEFAULT)
                 .build();
 
-        IngestorResult result = ingestor.performFullIngestion(JdbcConnection.of(connection), enrichedDatasets).get(0);
-        return result;
+        return ingestor.performFullIngestion(JdbcConnection.of(connection), enrichedDatasets).get(0);
     }
 
     private TestResult constructTestResult(String atomicTestId, String testable, List<AssertionStatus> assertionStatuses)
@@ -227,8 +217,7 @@ public class PersistenceTestRunner implements TestRunner
         if (conTestData.data instanceof ExternalFormatData)
         {
             ExternalFormatData externalFormatData = (ExternalFormatData) conTestData.data;
-            String testDataString = externalFormatData.data;
-            return testDataString;
+            return externalFormatData.data;
         }
         else
         {
@@ -237,7 +226,7 @@ public class PersistenceTestRunner implements TestRunner
     }
 
     @Override
-    public List<TestResult> executeTestSuite(Root_meta_pure_test_TestSuite testSuite, List<String> atomicTestIds, PureModel pureModel, PureModelContextData data)
+    public TestSuiteSession<TestResult> openTestSuiteSession(Root_meta_pure_test_TestSuite testSuite, PureModel pureModel, PureModelContextData data)
     {
         throw new UnsupportedOperationException("TestSuite is not supported for Persistence");
     }

--- a/legend-engine-xts-service/legend-engine-test-runner-service/src/main/java/org/finos/legend/engine/testable/service/extension/ServiceTestRunner.java
+++ b/legend-engine-xts-service/legend-engine-test-runner-service/src/main/java/org/finos/legend/engine/testable/service/extension/ServiceTestRunner.java
@@ -25,8 +25,10 @@ import org.eclipse.collections.api.factory.Sets;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.set.MutableSet;
+import org.eclipse.collections.api.set.SetIterable;
 import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.utility.ListIterate;
+import org.finos.legend.engine.language.pure.compiler.toPureGraph.HelperModelBuilder;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
 import org.finos.legend.engine.language.pure.dsl.service.generation.ServicePlanGenerator;
 import org.finos.legend.engine.plan.execution.PlanExecutor;
@@ -52,7 +54,6 @@ import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service.Service;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service.ServiceTest;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service.ServiceTestSuite;
-import org.finos.legend.engine.protocol.pure.v1.model.test.AtomicTest;
 import org.finos.legend.engine.protocol.pure.v1.model.test.Test;
 import org.finos.legend.engine.protocol.pure.v1.model.test.assertion.TestAssertion;
 import org.finos.legend.engine.protocol.pure.v1.model.test.assertion.status.AssertFail;
@@ -64,7 +65,9 @@ import org.finos.legend.engine.pure.code.core.PureCoreExtensionLoader;
 import org.finos.legend.engine.shared.core.identity.Identity;
 import org.finos.legend.engine.shared.core.operational.errorManagement.EngineException;
 import org.finos.legend.engine.testable.assertion.TestAssertionEvaluator;
+import org.finos.legend.engine.testable.extension.AbstractTestSuiteSessionWithResources;
 import org.finos.legend.engine.testable.extension.TestRunner;
+import org.finos.legend.engine.testable.extension.TestSuiteSession;
 import org.finos.legend.engine.testable.helper.TestResultHelper;
 import org.finos.legend.engine.testable.helper.TestReturnTypeHelper;
 import org.finos.legend.engine.testable.service.result.MultiExecutionServiceTestResult;
@@ -74,32 +77,25 @@ import org.finos.legend.pure.generated.Root_meta_legend_service_metamodel_Servic
 import org.finos.legend.pure.generated.Root_meta_pure_extension_Extension;
 import org.finos.legend.pure.generated.Root_meta_pure_test_AtomicTest;
 import org.finos.legend.pure.generated.Root_meta_pure_test_TestSuite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
-import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.ServiceLoader;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.finos.legend.engine.language.pure.compiler.toPureGraph.HelperModelBuilder.getElementFullPath;
-
 public class ServiceTestRunner implements TestRunner
 {
-    private static final Logger LOGGER = LoggerFactory.getLogger(ServiceTestRunner.class);
+    private final Root_meta_legend_service_metamodel_Service pureService;
 
-    private Root_meta_legend_service_metamodel_Service pureService;
+    private final MutableList<PlanGeneratorExtension> extensions;
+    private final PlanExecutor planExecutor;
 
-    private MutableList<PlanGeneratorExtension> extensions;
-    private PlanExecutor planExecutor;
-
-    private String pureVersion;
+    private final String pureVersion;
 
     public ServiceTestRunner(Root_meta_legend_service_metamodel_Service pureService, String pureVersion)
     {
@@ -115,191 +111,67 @@ public class ServiceTestRunner implements TestRunner
         throw new UnsupportedOperationException("Service Test should be executed in context of Service Test Suite only");
     }
 
+    /**
+     * Open a per-suite session that caches the execution plan and any
+     * runtime closeables across {@link TestSuiteSession#runAtomicTest}
+     * calls. Dispatches by execution type:
+     * <ul>
+     *   <li>{@link PureSingleExecution}: one plan, shared by every atomic test in the suite.</li>
+     *   <li>{@link PureMultiExecution} with {@code executionParameters}: one plan per env key,
+     *       built for every key that any test in the suite could use; each atomic test runs
+     *       once per applicable env and returns a {@link MultiExecutionServiceTestResult}.</li>
+     *   <li>{@link PureMultiExecution} with executionEnvironment reference: one composite plan
+     *       generated for the keys resolved from every test's parameters; each atomic test
+     *       picks its own plan from the composite.</li>
+     * </ul>
+     */
     @Override
-    public List<TestResult> executeTestSuite(Root_meta_pure_test_TestSuite testSuite, List<String> atomicTestIds, PureModel pureModel, PureModelContextData data)
+    public TestSuiteSession<TestResult> openTestSuiteSession(Root_meta_pure_test_TestSuite testSuite, PureModel pureModel, PureModelContextData data)
     {
-        TestConnectionBuildParameters hints = TestConnectionBuildParameters.NONE;
+        Service protocolService = ListIterate.detect(data.getElementsOfType(Service.class), ele -> ele.getPath().equals(HelperModelBuilder.getElementFullPath(this.pureService, pureModel.getExecutionSupport())));
+        if (protocolService == null)
+        {
+            throw new IllegalArgumentException("Service not found: " + HelperModelBuilder.getElementFullPath(this.pureService, pureModel.getExecutionSupport()));
+        }
+        ServiceTestSuite protocolSuite = ListIterate.detect(protocolService.testSuites, ts -> ts.id.equals(testSuite._id()));
+        if (protocolSuite == null)
+        {
+            throw new IllegalArgumentException("Test suite '" + testSuite._id() + "' not found in service");
+        }
+        if (protocolService.execution instanceof PureSingleExecution)
+        {
+            return new SingleExecutionTestSuiteSession(testSuite, protocolSuite, pureModel, data, (PureSingleExecution) protocolService.execution);
+        }
+        if (protocolService.execution instanceof PureMultiExecution)
+        {
+            PureMultiExecution multiExecution = (PureMultiExecution) protocolService.execution;
+            if (multiExecution.executionParameters != null && !multiExecution.executionParameters.isEmpty())
+            {
+                return new MultiExecutionParametersTestSuiteSession(testSuite, protocolSuite, pureModel, data, multiExecution);
+            }
+            return new MultiExecutionEnvironmentTestSuiteSession(testSuite, protocolSuite, pureModel, data, multiExecution);
+        }
+        throw new UnsupportedOperationException("Execution type : " + protocolService.execution.getClass().getSimpleName() + " not supported with ServiceTestRunner");
+    }
+
+    private TestConnectionBuildParameters computeHints(PureModel pureModel)
+    {
         try
         {
-            if (pureService._execution() instanceof Root_meta_legend_service_metamodel_PureExecution)
+            if (this.pureService._execution() instanceof Root_meta_legend_service_metamodel_PureExecution)
             {
-                Root_meta_legend_service_metamodel_PureExecution pureExecution = (Root_meta_legend_service_metamodel_PureExecution) pureService._execution();
+                Root_meta_legend_service_metamodel_PureExecution pureExecution = (Root_meta_legend_service_metamodel_PureExecution) this.pureService._execution();
                 if (TestReturnTypeHelper.isRelationReturnType(pureExecution._func(), pureModel))
                 {
-                    hints = TestConnectionBuildParameters.newBuilder().withIsRelation(true).build();
+                    return TestConnectionBuildParameters.newBuilder().withIsRelation(true).build();
                 }
             }
         }
-        catch (Exception e)
+        catch (Exception ignored)
         {
             // If we can't determine the return type, default to H2
         }
-
-        return executeTestSuiteInternal(testSuite, atomicTestIds, pureModel, data, hints);
-    }
-
-    private List<TestResult> executeTestSuiteInternal(Root_meta_pure_test_TestSuite testSuite, List<String> atomicTestIds, PureModel pureModel, PureModelContextData data, TestConnectionBuildParameters hints)
-    {
-        RichIterable<? extends Root_meta_pure_extension_Extension> routerExtensions = PureCoreExtensionLoader.extensions().flatCollect(e -> e.extraPureCoreExtensions(pureModel.getExecutionSupport()));
-        MutableList<PlanTransformer> planTransformers = extensions.flatCollect(PlanGeneratorExtension::getExtraPlanTransformers);
-
-        Service service = ListIterate.detect(data.getElementsOfType(Service.class), ele -> ele.getPath().equals(getElementFullPath(pureService, pureModel.getExecutionSupport())));
-        ServiceTestSuite suite = ListIterate.detect(service.testSuites, ts -> ts.id.equals(testSuite._id()));
-        if (service.execution instanceof PureMultiExecution)
-        {
-            Map<String, MultiExecutionServiceTestResult> testResultsByTestId = Maps.mutable.empty();
-            List<AtomicTest> atomicTestsInScope = ListIterate.select(suite.tests, t -> atomicTestIds.contains(t.id));
-            for (AtomicTest test : atomicTestsInScope)
-            {
-                MultiExecutionServiceTestResult multiExecutionServiceTestResult = new MultiExecutionServiceTestResult();
-                multiExecutionServiceTestResult.testable = getElementFullPath(pureService, pureModel.getExecutionSupport());
-                multiExecutionServiceTestResult.atomicTestId = test.id;
-                multiExecutionServiceTestResult.testSuiteId = suite.id;
-
-                testResultsByTestId.put(test.id, multiExecutionServiceTestResult);
-            }
-            if (((PureMultiExecution) service.execution).executionParameters != null && !((PureMultiExecution) service.execution).executionParameters.isEmpty())
-            {
-                return executeMultiExecutionParametersTestSuite(atomicTestIds, pureModel, data, routerExtensions, planTransformers, service, suite, testResultsByTestId, atomicTestsInScope, hints);
-            }
-            return executeMultiExecutionEnvironmentTestSuite((PureMultiExecution) service.execution, suite, atomicTestIds, pureModel, data, routerExtensions, planTransformers, testResultsByTestId, hints);
-        }
-        else if (service.execution instanceof PureSingleExecution)
-        {
-            return executeSingleExecutionTestSuite((PureSingleExecution) service.execution, suite, atomicTestIds, pureModel, data, routerExtensions, planTransformers, hints);
-        }
-        else
-        {
-            throw new UnsupportedOperationException("Execution type : " + service.execution.getClass().getSimpleName() + " not supported with ServiceTestRunner");
-        }
-    }
-
-    private List<TestResult> executeMultiExecutionParametersTestSuite(List<String> atomicTestIds, PureModel pureModel, PureModelContextData data, RichIterable<? extends Root_meta_pure_extension_Extension> routerExtensions, MutableList<PlanTransformer> planTransformers, Service service, ServiceTestSuite suite, Map<String, MultiExecutionServiceTestResult> testResultsByTestId, List<AtomicTest> atomicTestsInScope, TestConnectionBuildParameters hints)
-    {
-        Pair<Runtime,List<Closeable>> runtimeWithCloseables = null;
-        MutableMap<String, Pair<Runtime, List<Closeable>>> runtimeWithKeyMap = Maps.mutable.empty();
-        MutableSet<String> allValidEnvIdsInTestSuite = Sets.mutable.empty();
-        List<AtomicTest> testsForEachValidEnv = Lists.mutable.empty();
-
-        for (AtomicTest test: atomicTestsInScope)
-        {
-            if (((ServiceTest) test).keys.isEmpty())
-            {
-                allValidEnvIdsInTestSuite.addAll(((PureMultiExecution) service.execution).executionParameters.stream().map(x -> x.key).collect(Collectors.toList()));
-            }
-            else
-            {
-                allValidEnvIdsInTestSuite.addAll(((ServiceTest) test).keys);
-            }
-        }
-        List<KeyedExecutionParameter> allValidEnvInTestSuite = ((PureMultiExecution) service.execution).executionParameters.stream().filter(s -> allValidEnvIdsInTestSuite.contains(s.key)).collect(Collectors.toList());
-        try
-        {
-            for (KeyedExecutionParameter param : allValidEnvInTestSuite)
-            {
-
-                testsForEachValidEnv = atomicTestsInScope.stream().filter(test -> ((ServiceTest) test).keys.contains(param.key) || ((ServiceTest) test).keys.isEmpty()).collect(Collectors.toList());
-                for (AtomicTest test: testsForEachValidEnv)
-                {
-                    PureSingleExecution pureSingleExecution = new PureSingleExecution();
-                    pureSingleExecution.func = ((PureMultiExecution) service.execution).func;
-                    pureSingleExecution.mapping = param.mapping;
-                    if (runtimeWithKeyMap.containsKey(param.key))
-                    {
-                        pureSingleExecution.runtime = runtimeWithKeyMap.get(param.key).getOne();
-                    }
-                    else
-                    {
-                        runtimeWithCloseables = TestRuntimeBuilder.getTestRuntimeAndClosableResources(param.runtime, suite.testData, data, hints);
-                        runtimeWithKeyMap.put(param.key, runtimeWithCloseables);
-                        pureSingleExecution.runtime = runtimeWithCloseables.getOne();
-                    }
-                    pureSingleExecution.executionOptions = param.executionOptions;
-                    List<TestResult> testResultsForKey = executeSingleExecutionTestSuite(pureSingleExecution, suite, Collections.singletonList(test.id), pureModel, data, routerExtensions, planTransformers, hints);
-                    testResultsByTestId.get(test.id).addTestResult(param.key, testResultsForKey.get(0));
-                }
-            }
-        }
-        finally
-        {
-            for (Pair<Runtime, List<Closeable>> runtimeWIthCloseablePair: runtimeWithKeyMap.values())
-            {
-                if (runtimeWIthCloseablePair != null)
-                {
-                    runtimeWIthCloseablePair.getTwo().forEach(closeable ->
-                    {
-                        try
-                        {
-                            closeable.close();
-                        }
-                        catch (IOException e)
-                        {
-                            LOGGER.warn("Exception occurred closing closeable resource" + e);
-                        }
-                    });
-                }
-            }
-        }
-        return new ArrayList<>(testResultsByTestId.values());
-    }
-
-    private List<org.finos.legend.engine.protocol.pure.v1.model.test.result.TestResult> executeMultiExecutionEnvironmentTestSuite(PureMultiExecution execution, ServiceTestSuite suite, List<String> testIds, PureModel pureModel, PureModelContextData data, RichIterable<? extends Root_meta_pure_extension_Extension> routerExtensions, MutableList<PlanTransformer> planTransformers, Map<String, MultiExecutionServiceTestResult> testResultsByTestId, TestConnectionBuildParameters hints)
-    {
-        List<Closeable> closeables = null;
-        PureMultiExecution multiExecution = shallowCopyMultiExecution(execution, data);
-        String execkey;
-        try
-        {
-            execkey = ((Root_meta_legend_service_metamodel_PureMultiExecution) pureService._execution())._executionKey();
-            Map<String, String> validKeyMap = getAllValidKeysForExecEnv(execkey, suite, testIds);
-            List<Closeable> tempCloseables = Lists.mutable.empty();
-            multiExecution.func.body.stream().forEach(valSpec -> valSpec.accept(new TestValueSpecificationBuilder(new ArrayList<>(validKeyMap.values()), tempCloseables, suite.testData, data)));
-            closeables = tempCloseables;
-            ExecutionPlan executionPlan = ServicePlanGenerator.generateCompositeExecutionPlan(multiExecution, null, pureModel, pureVersion, PlanPlatform.JAVA, null, routerExtensions, planTransformers);
-            CompositeExecutionPlan compositeExecutionPlan = (CompositeExecutionPlan) executionPlan;
-            for (Test test : suite.tests)
-            {
-                if (testIds.contains(test.id))
-                {
-                    String key = validKeyMap.get(test.id);
-                    try
-                    {
-                        SingleExecutionPlan execPlan = compositeExecutionPlan.executionPlans.get(key);
-                        JavaHelper.compilePlan(execPlan, Identity.getAnonymousIdentity());
-                        org.finos.legend.engine.protocol.pure.v1.model.test.result.TestResult testResult = executeServiceTest((ServiceTest) test, execPlan);
-                        testResult.testable = getElementFullPath(pureService, pureModel.getExecutionSupport());
-                        testResult.testSuiteId = suite.id;
-                        testResultsByTestId.get(test.id).addTestResult(key, testResult);
-                    }
-                    catch (Exception exception)
-                    {
-                        throw new RuntimeException("Exception occurred while executing service test suites.\n", exception);
-                    }
-                }
-            }
-        }
-        catch (Exception e)
-        {
-            throw new RuntimeException("Exception occurred executing service test suites.\n", e);
-        }
-        finally
-        {
-            if (closeables != null)
-            {
-                closeables.stream().forEach(closeable ->
-                {
-                    try
-                    {
-                        closeable.close();
-                    }
-                    catch (IOException e)
-                    {
-                        LOGGER.warn("Exception occurred closing closeable resource" + e);
-                    }
-                });
-            }
-        }
-        return new ArrayList<>(testResultsByTestId.values());
+        return TestConnectionBuildParameters.NONE;
     }
 
     private Map<String, String> getAllValidKeysForExecEnv(String execKey, ServiceTestSuite suite, List<String> testIds)
@@ -328,67 +200,7 @@ public class ServiceTestRunner implements TestRunner
         return testWithKey;
     }
 
-    private List<org.finos.legend.engine.protocol.pure.v1.model.test.result.TestResult> executeSingleExecutionTestSuite(PureSingleExecution execution, ServiceTestSuite suite, List<String> testIds, PureModel pureModel, PureModelContextData data, RichIterable<? extends Root_meta_pure_extension_Extension> routerExtensions, MutableList<PlanTransformer> planTransformers, TestConnectionBuildParameters hints)
-    {
-        List<org.finos.legend.engine.protocol.pure.v1.model.test.result.TestResult> results = Lists.mutable.empty();
-        Pair<Runtime, List<Closeable>> runtimeWithCloseables = null;
-        PureSingleExecution testPureSingleExecution = shallowCopySingleExecution(execution);
-        try
-        {
-            if (execution.runtime != null)
-            {
-                runtimeWithCloseables = TestRuntimeBuilder.getTestRuntimeAndClosableResources(execution.runtime, suite.testData, data, hints);
-                Runtime testSuiteRuntime = runtimeWithCloseables.getOne();
-                testPureSingleExecution.runtime = testSuiteRuntime;
-            }
-            else
-            {
-                MutableList<Closeable> closeables = Lists.mutable.empty();
-                testPureSingleExecution.func.body.stream().forEach(func -> func.accept(new TestValueSpecificationBuilder(closeables, suite.testData, data)));
-            }
-
-            ExecutionPlan executionPlan = ServicePlanGenerator.generateExecutionPlan(testPureSingleExecution, null, pureModel, pureVersion, PlanPlatform.JAVA, null, routerExtensions, planTransformers);
-            SingleExecutionPlan singleExecutionPlan = (SingleExecutionPlan) executionPlan;
-            JavaHelper.compilePlan(singleExecutionPlan, Identity.getAnonymousIdentity());
-
-            for (Test test : suite.tests)
-            {
-                if (testIds.contains(test.id))
-                {
-                    org.finos.legend.engine.protocol.pure.v1.model.test.result.TestResult testResult = executeServiceTest((ServiceTest) test, singleExecutionPlan);
-                    testResult.testable = getElementFullPath(pureService, pureModel.getExecutionSupport());
-                    testResult.testSuiteId = suite.id;
-
-                    results.add(testResult);
-                }
-            }
-        }
-        catch (Exception e)
-        {
-            throw new RuntimeException("Exception occurred executing service test suites.\n", e);
-        }
-        finally
-        {
-            if (runtimeWithCloseables != null)
-            {
-                runtimeWithCloseables.getTwo().forEach(closeable ->
-                {
-                    try
-                    {
-                        closeable.close();
-                    }
-                    catch (IOException e)
-                    {
-                        LOGGER.warn("Exception occurred closing closeable resource" + e);
-                    }
-                });
-            }
-        }
-
-        return results;
-    }
-
-    private org.finos.legend.engine.protocol.pure.v1.model.test.result.TestResult executeServiceTest(ServiceTest serviceTest, SingleExecutionPlan executionPlan)
+    private TestResult executeServiceTest(ServiceTest serviceTest, SingleExecutionPlan executionPlan)
     {
         SerializationFormat testSerializationFormat = getSerializationFormatForTest(serviceTest);
 
@@ -429,13 +241,13 @@ public class ServiceTestRunner implements TestRunner
                 if (status instanceof EqualToJsonAssertFail)
                 {
                     span.log("ASSERTION: " + assertion.id + " FAILED");
-                    span.log("EXPECTED: " + ((EqualToJsonAssertFail)status).expected);
-                    span.log("ACTUAL: " + ((EqualToJsonAssertFail)status).actual);
+                    span.log("EXPECTED: " + ((EqualToJsonAssertFail) status).expected);
+                    span.log("ACTUAL: " + ((EqualToJsonAssertFail) status).actual);
                 }
                 else if (status instanceof AssertFail)
                 {
                     span.log("ASSERTION: " + assertion.id + " FAILED");
-                    span.log("MESSAGE: " + ((AssertFail)status).message);
+                    span.log("MESSAGE: " + ((AssertFail) status).message);
                 }
                 else
                 {
@@ -460,17 +272,13 @@ public class ServiceTestRunner implements TestRunner
         {
             return SerializationFormat.defaultFormat;
         }
-        else
+        try
         {
-            try
-            {
-                return SerializationFormat.valueOf(serviceTest.serializationFormat);
-            }
-            catch (IllegalArgumentException exception)
-            {
-                throw new UnsupportedOperationException("Unsupported serialization format '" + serviceTest.serializationFormat
-                        + "'." + "Supported formats are:" + Stream.of(SerializationFormat.values()).map(SerializationFormat::name).collect(Collectors.joining(",")));
-            }
+            return SerializationFormat.valueOf(serviceTest.serializationFormat);
+        }
+        catch (IllegalArgumentException exception)
+        {
+            throw new UnsupportedOperationException("Unsupported serialization format '" + serviceTest.serializationFormat + "'. Supported formats are:" + Stream.of(SerializationFormat.values()).map(SerializationFormat::name).collect(Collectors.joining(",")));
         }
     }
 
@@ -483,11 +291,226 @@ public class ServiceTestRunner implements TestRunner
         return shallowCopy;
     }
 
-    private static PureMultiExecution shallowCopyMultiExecution(PureMultiExecution pureMultiExecution, PureModelContextData data)
+    private static PureMultiExecution shallowCopyMultiExecution(PureMultiExecution pureMultiExecution)
     {
         PureMultiExecution shallowCopy = new PureMultiExecution();
         shallowCopy.func = pureMultiExecution.func;
         shallowCopy.executionKey = pureMultiExecution.executionKey;
         return shallowCopy;
+    }
+
+    private String testablePath(PureModel pureModel)
+    {
+        return HelperModelBuilder.getElementFullPath(this.pureService, pureModel.getExecutionSupport());
+    }
+
+    private abstract class ServiceTestSuiteSession extends AbstractTestSuiteSessionWithResources<ServiceTestSuite, ServiceTest, TestResult>
+    {
+        private ServiceTestSuiteSession(Root_meta_pure_test_TestSuite pureSuite, ServiceTestSuite protocolSuite, PureModel pureModel, PureModelContextData pmcd)
+        {
+            super(pureSuite, protocolSuite, pureModel, pmcd, ServiceTestSuiteSession::getTestSuiteTests, ServiceTestSuiteSession::getAtomicTestId);
+        }
+
+        @Override
+        protected TestResult buildErrorResult(String atomicTestId, Throwable t)
+        {
+            return TestResultHelper.newTestError(testablePath(this.pureModel), getTestSuiteId(), atomicTestId, t);
+        }
+
+        protected TestResult runSingleExecTest(ServiceTest atomicTest, SingleExecutionPlan executionPlan)
+        {
+            TestResult testResult = executeServiceTest(atomicTest, executionPlan);
+            testResult.testable = testablePath(this.pureModel);
+            testResult.testSuiteId = getTestSuiteId();
+            return testResult;
+        }
+    }
+
+    /**
+     * Lift the runtime build, plan generation, and plan compile into a
+     * session that lives across atomic-test invocations.
+     * {@link #runAtomicTest} becomes a lookup of the protocol test by id
+     * plus the existing {@code executeServiceTest} call against the cached
+     * plan.
+     */
+    private class SingleExecutionTestSuiteSession extends ServiceTestSuiteSession
+    {
+        private final PureSingleExecution execution;
+        private SingleExecutionPlan plan;
+
+        SingleExecutionTestSuiteSession(Root_meta_pure_test_TestSuite pureSuite, ServiceTestSuite protocolSuite, PureModel pureModel, PureModelContextData pmcd, PureSingleExecution execution)
+        {
+            super(pureSuite, protocolSuite, pureModel, pmcd);
+            this.execution = execution;
+        }
+
+        @Override
+        protected void initialize(Consumer<? super AutoCloseable> closeableConsumer) throws Exception
+        {
+            TestConnectionBuildParameters hints = computeHints(this.pureModel);
+            RichIterable<? extends Root_meta_pure_extension_Extension> routerExtensions = PureCoreExtensionLoader.extensions().flatCollect(e -> e.extraPureCoreExtensions(this.pureModel.getExecutionSupport()));
+            MutableList<PlanTransformer> planTransformers = ServiceTestRunner.this.extensions.flatCollect(PlanGeneratorExtension::getExtraPlanTransformers);
+            PureSingleExecution testPureSingleExecution = shallowCopySingleExecution(this.execution);
+            if (this.execution.runtime != null)
+            {
+                Pair<Runtime, List<Closeable>> runtimeWithCloseables = TestRuntimeBuilder.getTestRuntimeAndClosableResources(this.execution.runtime, this.protocolSuite.testData, this.pmcd, hints);
+                testPureSingleExecution.runtime = runtimeWithCloseables.getOne();
+                runtimeWithCloseables.getTwo().forEach(closeableConsumer);
+            }
+            else
+            {
+                MutableList<Closeable> closeables = Lists.mutable.empty();
+                testPureSingleExecution.func.body.forEach(func -> func.accept(new TestValueSpecificationBuilder(closeables, this.protocolSuite.testData, this.pmcd)));
+                closeables.forEach(closeableConsumer);
+            }
+            ExecutionPlan executionPlan = ServicePlanGenerator.generateExecutionPlan(testPureSingleExecution, null, this.pureModel, ServiceTestRunner.this.pureVersion, PlanPlatform.JAVA, null, routerExtensions, planTransformers);
+            SingleExecutionPlan singleExecutionPlan = (SingleExecutionPlan) executionPlan;
+            JavaHelper.compilePlan(singleExecutionPlan, Identity.getAnonymousIdentity());
+            this.plan = singleExecutionPlan;
+        }
+
+        @Override
+        protected TestResult runAtomicTest(ServiceTest atomicTest)
+        {
+            return runSingleExecTest(atomicTest, this.plan);
+        }
+    }
+
+    /**
+     * Multi-execution session for services configured with explicit
+     * {@code executionParameters}. Builds one plan per env key referenced
+     * by any test in the suite (so the session can serve any test the
+     * caller picks). Each atomic test runs once per applicable env;
+     * results are bundled into a {@link MultiExecutionServiceTestResult}.
+     */
+    private class MultiExecutionParametersTestSuiteSession extends ServiceTestSuiteSession
+    {
+        private final PureMultiExecution execution;
+        private final MutableMap<String, SingleExecutionPlan> plansByKey = Maps.mutable.empty();
+
+        MultiExecutionParametersTestSuiteSession(Root_meta_pure_test_TestSuite pureSuite, ServiceTestSuite protocolSuite, PureModel pureModel, PureModelContextData pmcd, PureMultiExecution execution)
+        {
+            super(pureSuite, protocolSuite, pureModel, pmcd);
+            this.execution = execution;
+        }
+
+        @Override
+        protected void initialize(Consumer<? super AutoCloseable> closeableConsumer) throws Exception
+        {
+            TestConnectionBuildParameters hints = computeHints(this.pureModel);
+            RichIterable<? extends Root_meta_pure_extension_Extension> routerExtensions = PureCoreExtensionLoader.extensions().flatCollect(e -> e.extraPureCoreExtensions(this.pureModel.getExecutionSupport()));
+            MutableList<PlanTransformer> planTransformers = ServiceTestRunner.this.extensions.flatCollect(PlanGeneratorExtension::getExtraPlanTransformers);
+
+            MutableSet<String> envIdsInSuite = Sets.mutable.empty();
+            for (Test test : this.protocolSuite.tests)
+            {
+                if (test instanceof ServiceTest)
+                {
+                    List<String> testKeys = ((ServiceTest) test).keys;
+                    if (testKeys == null || testKeys.isEmpty())
+                    {
+                        ListIterate.collect(this.execution.executionParameters, p -> p.key, envIdsInSuite);
+                    }
+                    else
+                    {
+                        envIdsInSuite.addAll(testKeys);
+                    }
+                }
+            }
+
+            for (KeyedExecutionParameter param : this.execution.executionParameters)
+            {
+                if (envIdsInSuite.contains(param.key))
+                {
+                    PureSingleExecution pureSingleExecution = new PureSingleExecution();
+                    pureSingleExecution.func = this.execution.func;
+                    pureSingleExecution.mapping = param.mapping;
+                    Pair<Runtime, List<Closeable>> runtimeWithCloseables = TestRuntimeBuilder.getTestRuntimeAndClosableResources(param.runtime, this.protocolSuite.testData, this.pmcd, hints);
+                    pureSingleExecution.runtime = runtimeWithCloseables.getOne();
+                    pureSingleExecution.executionOptions = param.executionOptions;
+                    runtimeWithCloseables.getTwo().forEach(closeableConsumer);
+                    ExecutionPlan executionPlan = ServicePlanGenerator.generateExecutionPlan(pureSingleExecution, null, this.pureModel, ServiceTestRunner.this.pureVersion, PlanPlatform.JAVA, null, routerExtensions, planTransformers);
+                    SingleExecutionPlan singleExecutionPlan = (SingleExecutionPlan) executionPlan;
+                    JavaHelper.compilePlan(singleExecutionPlan, Identity.getAnonymousIdentity());
+                    this.plansByKey.put(param.key, singleExecutionPlan);
+                }
+            }
+        }
+
+        @Override
+        protected TestResult runAtomicTest(ServiceTest atomicTest)
+        {
+            MultiExecutionServiceTestResult multiResult = new MultiExecutionServiceTestResult();
+            multiResult.testable = testablePath(this.pureModel);
+            multiResult.atomicTestId = atomicTest.id;
+            multiResult.testSuiteId = getTestSuiteId();
+            SetIterable<String> testKeys = ((atomicTest.keys == null) || atomicTest.keys.isEmpty()) ? Sets.immutable.empty() : Sets.mutable.withAll(atomicTest.keys);
+            this.execution.executionParameters.forEach(param ->
+            {
+                if (testKeys.isEmpty() || testKeys.contains(param.key))
+                {
+                    SingleExecutionPlan plan = this.plansByKey.get(param.key);
+                    if (plan != null)
+                    {
+                        multiResult.addTestResult(param.key, runSingleExecTest(atomicTest, plan));
+                    }
+                }
+            });
+            return multiResult;
+        }
+    }
+
+    /**
+     * Multi-execution session for services that reference an
+     * executionEnvironment. Generates one composite plan covering every
+     * key resolved from the suite's tests; each atomic test picks its own
+     * plan from the composite by the key carried in its parameters.
+     */
+    private class MultiExecutionEnvironmentTestSuiteSession extends ServiceTestSuiteSession
+    {
+        private final PureMultiExecution execution;
+        private CompositeExecutionPlan compositePlan;
+        private Map<String, String> validKeyMap;
+
+        MultiExecutionEnvironmentTestSuiteSession(Root_meta_pure_test_TestSuite pureSuite, ServiceTestSuite protocolSuite, PureModel pureModel, PureModelContextData pmcd, PureMultiExecution execution)
+        {
+            super(pureSuite, protocolSuite, pureModel, pmcd);
+            this.execution = execution;
+        }
+
+        @Override
+        protected void initialize(Consumer<? super AutoCloseable> closeableConsumer) throws Exception
+        {
+            RichIterable<? extends Root_meta_pure_extension_Extension> routerExtensions = PureCoreExtensionLoader.extensions().flatCollect(e -> e.extraPureCoreExtensions(this.pureModel.getExecutionSupport()));
+            MutableList<PlanTransformer> planTransformers = ServiceTestRunner.this.extensions.flatCollect(PlanGeneratorExtension::getExtraPlanTransformers);
+            String execKey = ((Root_meta_legend_service_metamodel_PureMultiExecution) ServiceTestRunner.this.pureService._execution())._executionKey();
+            List<String> allTestIds = this.protocolSuite.tests.stream().map(t -> t.id).collect(Collectors.toList());
+            this.validKeyMap = getAllValidKeysForExecEnv(execKey, this.protocolSuite, allTestIds);
+            PureMultiExecution multiExecution = shallowCopyMultiExecution(this.execution);
+            List<Closeable> tempCloseables = Lists.mutable.empty();
+            multiExecution.func.body.forEach(valSpec -> valSpec.accept(new TestValueSpecificationBuilder(new ArrayList<>(this.validKeyMap.values()), tempCloseables, this.protocolSuite.testData, this.pmcd)));
+            tempCloseables.forEach(closeableConsumer);
+            this.compositePlan = ServicePlanGenerator.generateCompositeExecutionPlan(multiExecution, null, this.pureModel, ServiceTestRunner.this.pureVersion, PlanPlatform.JAVA, null, routerExtensions, planTransformers);
+            for (String key : Sets.mutable.withAll(this.validKeyMap.values()))
+            {
+                SingleExecutionPlan execPlan = this.compositePlan.executionPlans.get(key);
+                if (execPlan != null)
+                {
+                    JavaHelper.compilePlan(execPlan, Identity.getAnonymousIdentity());
+                }
+            }
+        }
+
+        @Override
+        protected TestResult runAtomicTest(ServiceTest atomicTest)
+        {
+            MultiExecutionServiceTestResult multiResult = new MultiExecutionServiceTestResult();
+            multiResult.testable = testablePath(this.pureModel);
+            multiResult.atomicTestId = atomicTest.id;
+            multiResult.testSuiteId = getTestSuiteId();
+            String key = this.validKeyMap.get(atomicTest.id);
+            multiResult.addTestResult(key, runSingleExecTest(atomicTest, this.compositePlan.executionPlans.get(key)));
+            return multiResult;
+        }
     }
 }


### PR DESCRIPTION
Update Testable framework to support TestSuiteSession. This allows more granular control over running the atomic tests while handling suite-level resource management.