### PR TITLE
Rename meta::analytics::quality::model::rule to meta::analytics::quality::profiles::rule

### DIFF
--- a/legend-engine-xts-analytics/legend-engine-xts-analytics-quality/legend-engine-xt-analytics-quality-pure/src/main/resources/core_analytics_quality/associationChecks.pure
+++ b/legend-engine-xts-analytics/legend-engine-xts-analytics-quality/legend-engine-xt-analytics-quality-pure/src/main/resources/core_analytics_quality/associationChecks.pure
@@ -1,6 +1,7 @@
-import meta::analytics::quality::model::*;
 import meta::analytics::quality::*;
+import meta::analytics::quality::model::*;
 import meta::analytics::quality::model::domain::*;
+import meta::analytics::quality::profiles::*;
 
 function meta::analytics::quality::model::domain::associationRules():Rule<Association>[*]
 {

--- a/legend-engine-xts-analytics/legend-engine-xts-analytics-quality/legend-engine-xt-analytics-quality-pure/src/main/resources/core_analytics_quality/checksEngine.pure
+++ b/legend-engine-xts-analytics/legend-engine-xts-analytics-quality/legend-engine-xt-analytics-quality-pure/src/main/resources/core_analytics_quality/checksEngine.pure
@@ -1,7 +1,8 @@
 import meta::analytics::quality::model::*;
 import meta::analytics::quality::model::domain::*;
-import meta::relational::tests::*;
+import meta::analytics::quality::profiles::*;
 import meta::pure::runtime::*;
+import meta::relational::tests::*;
 
 
 Enum meta::analytics::quality::model::Severity
@@ -25,7 +26,7 @@ Class meta::analytics::quality::model::Rule<T>
 
 }
 
-Profile meta::analytics::quality::model::rule
+Profile meta::analytics::quality::profiles::rule
 {
     stereotypes: [skipTests];
     tags: [rule, severity, category, description, ignore];
@@ -93,7 +94,7 @@ function meta::analytics::quality::model::domain::createRule<T>(ruleFunctionB: F
     let description = $ruleFunction->value4Tag('description', rule).value->toOne();
     let severity = Severity->extractEnumValue($tags->filter(t | $t.tag == rule->tag('severity'))->map(t | $t.value)->toOne()->toString());
     let category = Category->extractEnumValue($tags->filter(t | $t.tag == rule->tag('category'))->map(t | $t.value)->toOne()->toString());
-    let skipTestsTag = $ruleFunction->hasStereotype('skipTests',meta::analytics::quality::model::rule);
+    let skipTestsTag = $ruleFunction->hasStereotype('skipTests',meta::analytics::quality::profiles::rule);
     ^Rule<T>(id=$rule,func=$ruleFunctionB,severity=$severity,category=$category,description=$description,hasSkipTestsFlag=$skipTestsTag);
 }
 

--- a/legend-engine-xts-analytics/legend-engine-xts-analytics-quality/legend-engine-xt-analytics-quality-pure/src/main/resources/core_analytics_quality/classChecks.pure
+++ b/legend-engine-xts-analytics/legend-engine-xts-analytics-quality/legend-engine-xt-analytics-quality-pure/src/main/resources/core_analytics_quality/classChecks.pure
@@ -1,6 +1,7 @@
-import meta::analytics::quality::model::*;
 import meta::analytics::quality::*;
+import meta::analytics::quality::model::*;
 import meta::analytics::quality::model::domain::*;
+import meta::analytics::quality::profiles::*;
 
 
 function meta::analytics::quality::model::domain::classRules():Rule<Class<Any>>[*]

--- a/legend-engine-xts-analytics/legend-engine-xts-analytics-quality/legend-engine-xt-analytics-quality-pure/src/main/resources/core_analytics_quality/enumerationChecks.pure
+++ b/legend-engine-xts-analytics/legend-engine-xts-analytics-quality/legend-engine-xt-analytics-quality-pure/src/main/resources/core_analytics_quality/enumerationChecks.pure
@@ -1,6 +1,7 @@
 import meta::analytics::quality::*;
 import meta::analytics::quality::model::*;
 import meta::analytics::quality::model::domain::*;
+import meta::analytics::quality::profiles::*;
 
 function meta::analytics::quality::model::domain::enumerationRules():Rule<Enumeration<Any>>[*]
 {

--- a/legend-engine-xts-analytics/legend-engine-xts-analytics-quality/legend-engine-xt-analytics-quality-pure/src/main/resources/core_analytics_quality/functionChecks.pure
+++ b/legend-engine-xts-analytics/legend-engine-xts-analytics-quality/legend-engine-xt-analytics-quality-pure/src/main/resources/core_analytics_quality/functionChecks.pure
@@ -1,9 +1,10 @@
 import meta::analytics::quality::*;
 import meta::analytics::quality::model::*;
+import meta::analytics::quality::model::domain::*;
+import meta::analytics::quality::profiles::*;
 import meta::pure::functions::collection::*;
 import meta::pure::functions::meta::applications::*;
 import meta::pure::metamodel::serialization::grammar::*;
-import meta::analytics::quality::model::domain::*;
 
 function meta::analytics::quality::model::domain::functionRules():Rule<List<FunctionDefinition<Any>>>[*]
 {

--- a/legend-engine-xts-analytics/legend-engine-xts-analytics-quality/legend-engine-xt-analytics-quality-pure/src/main/resources/core_analytics_quality/propertyChecks.pure
+++ b/legend-engine-xts-analytics/legend-engine-xts-analytics-quality/legend-engine-xt-analytics-quality-pure/src/main/resources/core_analytics_quality/propertyChecks.pure
@@ -1,6 +1,7 @@
-import meta::analytics::quality::model::*;
 import meta::analytics::quality::*;
+import meta::analytics::quality::model::*;
 import meta::analytics::quality::model::domain::*;
+import meta::analytics::quality::profiles::*;
 
 function meta::analytics::quality::model::domain::propertyRules():Rule<AbstractProperty<Any>>[*]
 {

--- a/legend-engine-xts-analytics/legend-engine-xts-analytics-quality/legend-engine-xt-analytics-quality-pure/src/main/resources/core_analytics_quality/tests/functionChecksTest.pure
+++ b/legend-engine-xts-analytics/legend-engine-xts-analytics-quality/legend-engine-xt-analytics-quality-pure/src/main/resources/core_analytics_quality/tests/functionChecksTest.pure
@@ -1,6 +1,7 @@
 import meta::analytics::quality::tests::*;
 import meta::analytics::quality::model::*;
 import meta::analytics::quality::model::domain::*;
+import meta::analytics::quality::profiles::*;
 import meta::relational::runtime::*;
 import meta::analytics::quality::model::domain::tests::*;
 

--- a/legend-engine-xts-analytics/legend-engine-xts-analytics-quality/legend-engine-xt-analytics-quality-pure/src/main/resources/core_analytics_quality/tests/testQuality.pure
+++ b/legend-engine-xts-analytics/legend-engine-xts-analytics-quality/legend-engine-xt-analytics-quality-pure/src/main/resources/core_analytics_quality/tests/testQuality.pure
@@ -2,6 +2,7 @@ import apps::pure::quality::tests::*;
 import meta::relational::tests::*;
 import meta::relational::runtime::*;
 import meta::analytics::quality::model::*;
+import meta::analytics::quality::profiles::*;
 
 Class meta::analytics::quality::model::domain::tests::myTestClass
 {


### PR DESCRIPTION
Rename meta::analytics::quality::model::rule to meta::analytics::quality::profiles::rule to reduce confusion, as meta::analytics::quality::model::rule and meta::analytics::quality::model::Rule differ only in case.