### PR TITLE
Improve EMIT handling of atomic tests without test suites in Testables

### DIFF
--- a/docs/emit/emit.md
+++ b/docs/emit/emit.md
@@ -405,7 +405,7 @@ This phase covers both types of file generation:
 
 ### 4.6 Phase 5: Test Execution
 
-- **Run Testable tests**: Find all `Testable` elements in the compiled `PureModel` (e.g., services, mappings, functions with test suites).
+- **Run Testable tests**: Find all `Testable` elements in the compiled `PureModel`. A Testable's tests may be grouped into **test suites** (services, mappings, functions) or be **top-level atomic tests** with no enclosing suite (e.g., `Persistence`); both shapes are discovered and executed.
 - **Run Legacy Mapping tests**: Find `Mapping` elements with legacy `MappingTest` / `MappingTestSuite` elements.
 - **Run Legacy Service tests**: Find `Service` elements with legacy `ServiceTest` elements.
 - **Dependency Exclusion**: Only execute tests for elements defined in the primary `model`. Any test defined in an element loaded via `dependencies` MUST be ignored.
@@ -485,6 +485,10 @@ It then yields one `DynamicTest` per granular operation, with descriptive names:
 - `[service-simple] Plan: demo::PersonService`
 - `[service-simple] Legacy Mapping Test: demo::PersonMapping / legacyTest_1`
 - `[service-simple] Legacy Service Test: demo::PersonService`
+
+For a Testable whose tests are **top-level atomic tests** (no enclosing suite — e.g., a `Persistence`), the test task carries no suite segment between the testable and the atomic-test id:
+
+- `[persistence-snapshot] Test: demo::MyPersistence / test_1`
 
 Because each `DynamicTest` is a distinct JUnit test, IDEs and build servers (like Maven Surefire) report granular pass/fail statuses, durations, and diffs natively.
 

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/main/java/org/finos/legend/engine/test/emit/junit/EMITTestSuiteBuilder.java
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit-junit/src/main/java/org/finos/legend/engine/test/emit/junit/EMITTestSuiteBuilder.java
@@ -412,20 +412,43 @@ public final class EMITTestSuiteBuilder
     }
 
     /**
-     * Group the test candidates by {@code (testablePath, suiteId)} and yield
-     * one {@link DynamicTest} per atomic test. Each group opens a single
-     * {@link TestSuiteSession} lazily (so empty/filtered groups pay no
-     * setup) and closes it when its sub-stream is exhausted (so every
-     * runtime / connection resource the session held is released
-     * regardless of test outcome). Suite-level setup — plan generation,
-     * runtime build — is therefore paid once per suite instead of once per
-     * atomic test.
+     * Yield one {@link DynamicTest} per atomic test, mirroring the engine's own
+     * {@code TestRunner} split between standalone atomic tests and suite members:
+     * <ul>
+     *   <li><b>Suite-less atomic tests</b> ({@code suiteId == null}) are run
+     *       standalone via {@link EMITTasks#runTest}. There is no suite, hence no
+     *       per-suite setup to amortize and no {@link TestSuiteSession} to
+     *       open.</li>
+     *   <li><b>Suite members</b> are grouped by {@code (testablePath, suiteId)};
+     *       each group opens a single {@link TestSuiteSession} lazily (so
+     *       empty/filtered groups pay no setup) and closes it when its sub-stream
+     *       is exhausted (so every runtime / connection resource the session held
+     *       is released regardless of test outcome). Suite-level setup — plan
+     *       generation, runtime build — is therefore paid once per suite instead
+     *       of once per atomic test.</li>
+     * </ul>
+     * Standalone atomic tests are emitted before suite tests.
      */
     private static Stream<DynamicNode> sessionGroupedTestStream(boolean verboseNames, String label, String containerName, EMITModel model, List<TestCandidate> testCandidates)
     {
-        Map<String, List<TestCandidate>> groups = new LinkedHashMap<>();
-        testCandidates.forEach(candidate -> groups.computeIfAbsent(candidate.testablePath + "\0" + ((candidate.suiteId == null) ? "" : candidate.suiteId), k -> new ArrayList<>()).add(candidate));
-        return groups.values().stream().flatMap(group -> sessionGroupStream(verboseNames, label, containerName, model, group));
+        List<TestCandidate> standalone = new ArrayList<>();
+        Map<String, List<TestCandidate>> suiteGroups = new LinkedHashMap<>();
+        testCandidates.forEach(candidate ->
+        {
+            if (candidate.suiteId == null)
+            {
+                standalone.add(candidate);
+            }
+            else
+            {
+                suiteGroups.computeIfAbsent(candidate.testablePath + "\0" + candidate.suiteId, k -> new ArrayList<>()).add(candidate);
+            }
+        });
+        Stream<DynamicNode> standaloneStream = standalone.stream().map(candidate -> test(
+                () -> EMITTasks.assertTestPassed(EMITTasks.runTest(candidate.testablePath, null, candidate.atomicTestId, model.getPmcd(), model.getPureModel())),
+                verboseNames, label, containerName, candidate.testablePath + " / " + candidate.atomicTestId));
+        Stream<DynamicNode> suiteStream = suiteGroups.values().stream().flatMap(group -> sessionGroupStream(verboseNames, label, containerName, model, group));
+        return Stream.concat(standaloneStream, suiteStream);
     }
 
     private static Stream<DynamicNode> sessionGroupStream(boolean verboseNames, String label, String containerName, EMITModel model, List<TestCandidate> group)
@@ -436,7 +459,7 @@ public final class EMITTestSuiteBuilder
                 .<DynamicNode>map(candidate -> test(
                         () -> EMITTasks.assertTestPassed(lazy.get().runAtomicTest(candidate.atomicTestId)),
                         verboseNames, label, containerName,
-                        candidate.testablePath + ((candidate.suiteId == null) ? "" : (" / " + candidate.suiteId)) + " / " + candidate.atomicTestId))
+                        candidate.testablePath + " / " + candidate.suiteId + " / " + candidate.atomicTestId))
                 .onClose(lazy::close);
     }
 

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/main/java/org/finos/legend/engine/test/emit/EMITTasks.java
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/main/java/org/finos/legend/engine/test/emit/EMITTasks.java
@@ -88,8 +88,6 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.ServiceLoader;
@@ -351,54 +349,16 @@ public final class EMITTasks
      * re-paying that setup cost per test. The caller owns the session
      * lifetime and MUST close it.
      *
-     * <p>For a top-level atomic test ({@code suiteId == null}), no
-     * amortization is possible and the returned session simply delegates
-     * each {@link TestSuiteSession#runAtomicTest} call back to
-     * {@link #runTest}.</p>
+     * <p>{@code suiteId} must identify a real {@link Root_meta_pure_test_TestSuite}
+     * on the testable. Suite-less top-level atomic tests have no suite whose
+     * setup could be amortized; they are run standalone via {@link #runTest}
+     * (which dispatches to the runner's {@code executeAtomicTest}). Accordingly
+     * this method rejects a null {@code suiteId} rather than fabricating a
+     * session for a suite that does not exist.</p>
      */
     public static TestSuiteSession<TestResult> openTestSession(String testablePath, String suiteId, PureModelContextData pmcd, PureModel pureModel)
     {
-        if (suiteId == null)
-        {
-            return new TestSuiteSession<TestResult>()
-            {
-                @Override
-                public String getTestSuiteId()
-                {
-                    return null;
-                }
-
-                @Override
-                public Collection<String> getAtomicTestIds()
-                {
-                    return Collections.emptyList();
-                }
-
-                @Override
-                public boolean isAtomicTestId(String id)
-                {
-                    return false;
-                }
-
-                @Override
-                public void initialize()
-                {
-                    // no initialization
-                }
-
-                @Override
-                public TestResult runAtomicTest(String atomicTestId)
-                {
-                    return runTest(testablePath, getTestSuiteId(), atomicTestId, pmcd, pureModel);
-                }
-
-                @Override
-                public void close()
-                {
-                    // nothing to close
-                }
-            };
-        }
+        Objects.requireNonNull(suiteId, "openTestSession requires a non-null suiteId; suite-less atomic tests are run standalone via runTest");
         org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement element;
         try
         {
@@ -413,7 +373,8 @@ public final class EMITTasks
             throw new EMITException(EMITPhase.TEST_EXECUTION, "Element '" + testablePath + "' is not a testable element");
         }
         Testable testable = (Testable) element;
-        Root_meta_pure_test_TestSuite suite = (Root_meta_pure_test_TestSuite) testable._tests().detect(t -> (t instanceof Root_meta_pure_test_TestSuite) && suiteId.equals(((Root_meta_pure_test_TestSuite) t)._id()));
+
+        Root_meta_pure_test_TestSuite suite = (Root_meta_pure_test_TestSuite) testable._tests().detect(t -> (t instanceof Root_meta_pure_test_TestSuite) && suiteId.equals(t._id()));
         if (suite == null)
         {
             throw new EMITException(EMITPhase.TEST_EXECUTION, "Test suite '" + suiteId + "' not found on testable '" + testablePath + "'");

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/java/org/finos/legend/engine/test/emit/TestEMITTaskSessions.java
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/java/org/finos/legend/engine/test/emit/TestEMITTaskSessions.java
@@ -151,6 +151,17 @@ public class TestEMITTaskSessions
                 () -> "Message should explain the testable-element rejection; got: " + ex.getMessage());
     }
 
+    @Test
+    void openTestSessionRejectsNullSuiteId()
+    {
+        // A session is a per-suite amortization handle, so it requires a real suite id. Suite-less
+        // top-level atomic tests (e.g. Persistence) have no suite to amortize and are run standalone
+        // via EMITTasks.runTest, not through a fabricated "no-suite" session.
+        Assertions.assertThrows(NullPointerException.class,
+                () -> EMITTasks.openTestSession(TESTABLE_PATH, null, pmcd, pureModel),
+                "openTestSession must reject a null suiteId rather than fabricating a suite-less session");
+    }
+
     private static void assertPasses(TestResult result, String label)
     {
         Assertions.assertNotNull(result, () -> "Expected a TestResult for " + label + " but got null");


### PR DESCRIPTION
Improve EMIT handling of atomic tests without test suites in Testables. Previously, a fictitious test suite session would be created. Now, however, the atomic tests are run directly through the usual methods.