### PR TITLE
Improve MappingTestRunner plan generation

### DIFF
--- a/legend-engine-config/legend-engine-configuration/legend-engine-configuration-plan-generation-serialization/src/main/java/org/finos/legend/engine/plan/generation/extension/VersionPlanTransformer.java
+++ b/legend-engine-config/legend-engine-configuration/legend-engine-configuration-plan-generation-serialization/src/main/java/org/finos/legend/engine/plan/generation/extension/VersionPlanTransformer.java
@@ -41,13 +41,19 @@ public class VersionPlanTransformer implements PlanTransformer
     {
         try
         {
-            Class cl = Class.forName("org.finos.legend.pure.generated.core_pure_protocol_" + version + "_transfers_executionPlan");
-            Method method = cl.getMethod("Root_meta_protocols_pure_" + version + "_transformation_fromPureGraph_executionPlan_transformPlan_ExecutionPlan_1__Extension_MANY__ExecutionPlan_1_", Root_meta_pure_executionPlan_ExecutionPlan.class, RichIterable.class, org.finos.legend.pure.m3.execution.ExecutionSupport.class);
+            Class<?> cl = Class.forName("org.finos.legend.pure.generated.core_pure_protocol_" + version + "_transfers_executionPlan");
+            Method method = cl.getMethod("Root_meta_protocols_pure_" + version + "_transformation_fromPureGraph_executionPlan_transformPlan_ExecutionPlan_1__Extension_MANY__ExecutionPlan_1_", Root_meta_pure_executionPlan_ExecutionPlan.class, RichIterable.class, ExecutionSupport.class);
             return method.invoke(null, purePlan, extensions, executionSupport);
         }
-        catch (ClassNotFoundException | NoSuchMethodException | InvocationTargetException | IllegalAccessException e)
+        catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException e)
         {
             throw new RuntimeException(e);
+        }
+        catch (InvocationTargetException e)
+        {
+            Throwable cause = e.getCause();
+            String message = (cause == null) ? null : cause.getMessage();
+            throw (message == null) ? new RuntimeException(e) : new RuntimeException(message, e);
         }
     }
 }

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/test/ModelStoreTestConnectionFactory.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/test/ModelStoreTestConnectionFactory.java
@@ -14,19 +14,26 @@
 
 package org.finos.legend.engine.language.pure.compiler.toPureGraph.test;
 
+import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.tuple.Tuples;
+import org.finos.legend.engine.protocol.pure.m3.valuespecification.ValueSpecification;
+import org.finos.legend.engine.protocol.pure.m3.valuespecification.constant.PackageableElementPtr;
 import org.finos.legend.engine.protocol.pure.v1.extension.ConnectionFactoryExtension;
-import org.finos.legend.engine.protocol.pure.v1.model.data.*;
+import org.finos.legend.engine.protocol.pure.v1.model.data.EmbeddedData;
+import org.finos.legend.engine.protocol.pure.v1.model.data.EmbeddedDataHelper;
+import org.finos.legend.engine.protocol.pure.v1.model.data.ExternalFormatData;
+import org.finos.legend.engine.protocol.pure.v1.model.data.ModelEmbeddedTestData;
+import org.finos.legend.engine.protocol.pure.v1.model.data.ModelInstanceTestData;
+import org.finos.legend.engine.protocol.pure.v1.model.data.ModelStoreData;
+import org.finos.legend.engine.protocol.pure.v1.model.data.ModelTestData;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.connection.Connection;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.data.DataElement;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.Store;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.modelToModel.ModelStore;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.modelToModel.connection.JsonModelConnection;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.modelToModel.connection.XmlModelConnection;
-import org.finos.legend.engine.protocol.pure.m3.valuespecification.ValueSpecification;
-import org.finos.legend.engine.protocol.pure.m3.valuespecification.constant.PackageableElementPtr;
 import org.finos.legend.engine.shared.core.url.InputStreamProvider;
 import org.finos.legend.engine.shared.core.url.StreamProviderHolder;
 
@@ -35,7 +42,11 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 // TO BE MOVED TO MODEL STORE MODULE ONCE CREATED
 public class ModelStoreTestConnectionFactory implements ConnectionFactoryExtension
@@ -43,7 +54,7 @@ public class ModelStoreTestConnectionFactory implements ConnectionFactoryExtensi
     @Override
     public MutableList<String> group()
     {
-        return org.eclipse.collections.impl.factory.Lists.mutable.with("Store", "M2M");
+        return Lists.mutable.with("Store", "M2M");
     }
 
     public static final String MODEL_STORE = "ModelStore";
@@ -55,7 +66,6 @@ public class ModelStoreTestConnectionFactory implements ConnectionFactoryExtensi
 
     private static JsonModelConnection jsonModelConnection = new JsonModelConnection();
     private static XmlModelConnection xmlModelConnection = new XmlModelConnection();
-
 
     public Pair<Connection, List<Closeable>> buildCloseableConnectionFromExternalFormat(ExternalFormatData externalFormatData, String _class)
     {
@@ -138,7 +148,7 @@ public class ModelStoreTestConnectionFactory implements ConnectionFactoryExtensi
     }
 
     @Override
-    public Optional<Pair<Connection, List<Closeable>>> tryBuildTestConnectionsForStore(Map<String, DataElement>  dataElements, Store store, EmbeddedData testData)
+    public Optional<Pair<Connection, List<Closeable>>> tryBuildTestConnectionsForStore(Map<String, DataElement> dataElements, Store store, EmbeddedData testData)
     {
         if (store instanceof ModelStore && testData instanceof ModelStoreData)
         {
@@ -200,5 +210,4 @@ public class ModelStoreTestConnectionFactory implements ConnectionFactoryExtensi
     {
         return DATA_PROTOCOL_NAME + ":" + type + ";base64," + Base64.getEncoder().encodeToString(externalFormatData.data.getBytes(StandardCharsets.UTF_8));
     }
-
 }

--- a/legend-engine-core/legend-engine-core-testable/legend-engine-test-runner-mapping/src/main/java/org/finos/legend/engine/testable/mapping/extension/MappingTestRunner.java
+++ b/legend-engine-core/legend-engine-core-testable/legend-engine-test-runner-mapping/src/main/java/org/finos/legend/engine/testable/mapping/extension/MappingTestRunner.java
@@ -14,10 +14,15 @@
 
 package org.finos.legend.engine.testable.mapping.extension;
 
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.api.set.SetIterable;
 import org.eclipse.collections.api.tuple.Pair;
+import org.eclipse.collections.impl.block.factory.HashingStrategies;
+import org.eclipse.collections.impl.set.strategy.mutable.UnifiedSetWithHashingStrategy;
 import org.eclipse.collections.impl.tuple.Tuples;
+import org.eclipse.collections.impl.utility.Iterate;
 import org.eclipse.collections.impl.utility.ListIterate;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.ConnectionFirstPassBuilder;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.HelperModelBuilder;
@@ -30,6 +35,7 @@ import org.finos.legend.engine.plan.generation.PlanGenerator;
 import org.finos.legend.engine.plan.generation.PlanWithDebug;
 import org.finos.legend.engine.plan.generation.extension.PlanGeneratorExtension;
 import org.finos.legend.engine.plan.platform.PlanPlatform;
+import org.finos.legend.engine.protocol.pure.PureClientVersions;
 import org.finos.legend.engine.protocol.pure.v1.extension.ConnectionFactoryExtension;
 import org.finos.legend.engine.protocol.pure.v1.extension.TestConnectionBuildParameters;
 import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
@@ -59,6 +65,7 @@ import org.finos.legend.pure.generated.Root_meta_core_runtime_ConnectionStore;
 import org.finos.legend.pure.generated.Root_meta_core_runtime_ConnectionStore_Impl;
 import org.finos.legend.pure.generated.Root_meta_core_runtime_Runtime;
 import org.finos.legend.pure.generated.Root_meta_core_runtime_Runtime_Impl;
+import org.finos.legend.pure.generated.Root_meta_pure_extension_Extension;
 import org.finos.legend.pure.generated.Root_meta_pure_mapping_metamodel_MappingTestSuite;
 import org.finos.legend.pure.generated.Root_meta_pure_test_AtomicTest;
 import org.finos.legend.pure.generated.Root_meta_pure_test_TestSuite;
@@ -68,14 +75,42 @@ import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 
+/**
+ * {@link TestRunner} for Mapping test suites.
+ *
+ * <p><b>Plan management.</b> The execution plan for a test is determined by the
+ * suite's query, the mapping, and the test connections (and therefore the
+ * runtime) built from the test's store test data. When every test in the suite
+ * yields equivalent connections (a common case - e.g., all tests reference the
+ * same DataElement, or all bind ModelStore data, whose plans do not embed the
+ * data content), one plan serves the whole suite: it is generated during
+ * session initialization, so its cost is reported as suite setup rather than
+ * disappearing into the first test run. Otherwise, plans are generated lazily as
+ * tests run and cached, keyed on connection identity: a test reuses a cached plan
+ * when its connections are the same instances as an earlier test's, so a suite
+ * whose tests fall into a few connection groups still shares a plan within each
+ * group rather than regenerating one per test. Connections are rebuilt for every
+ * test execution in either mode: they are cheap, and some (notably ModelStore's)
+ * pass the test's data to the execution through thread-local state bound when the
+ * connection is built.
+ *
+ * <p><b>Thread safety.</b> A session's shared state is written only during
+ * {@code initialize()} (synchronized by the session base class) and is
+ * read-only afterward; the shared router extensions are pre-warmed there (see
+ * {@code buildMappingContext}); the per-test path works entirely on local
+ * state. Atomic tests of one session can therefore be run concurrently, within
+ * the limits of the connection factories - {@code ModelStoreTestConnectionFactory}
+ * in particular still mutates shared connection instances while building, which
+ * is benign when concurrent tests bind the same model class and content type
+ * (the usual case) but is not generally thread-safe.
+ */
 public class MappingTestRunner implements TestRunner
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(MappingTestRunner.class);
@@ -131,19 +166,32 @@ public class MappingTestRunner implements TestRunner
         Assert.assertTrue(testSuite instanceof Root_meta_pure_mapping_metamodel_MappingTestSuite, () -> "Test Suite in Mapping expected to be of type Mapping Test Suite");
         Root_meta_pure_mapping_metamodel_MappingTestSuite compiledMappingTestSuite = (Root_meta_pure_mapping_metamodel_MappingTestSuite) testSuite;
         org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.Mapping mapping = ListIterate.detect(pureModelContextData.getElementsOfType(org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.Mapping.class), ele -> ele.getPath().equals(testablePath));
-        return new MappingTestRunnerContext(compiledMappingTestSuite, mapping, pureModel, pureModelContextData, extensions.flatCollect(PlanGeneratorExtension::getExtraPlanTransformers), new ConnectionFirstPassBuilder(pureModel.getContext()), PureCoreExtensionLoader.extensions().flatCollect(e -> e.extraPureCoreExtensions(pureModel.getExecutionSupport())));
+        RichIterable<? extends Root_meta_pure_extension_Extension> routerExtensions = PureCoreExtensionLoader.extensions().flatCollect(e -> e.extraPureCoreExtensions(pureModel.getExecutionSupport()));
+        // This is a workaround for the fact that meta::pure::extension::Extension.serializerExtension(String[1]) is not thread safe
+        String resolvedPureVersion = (this.pureVersion == null) ? PureClientVersions.production : this.pureVersion;
+        routerExtensions.forEach(ext -> ext.serializerExtension(resolvedPureVersion, pureModel.getExecutionSupport()));
+        return new MappingTestRunnerContext(compiledMappingTestSuite, mapping, pureModel, pureModelContextData, this.extensions.flatCollect(PlanGeneratorExtension::getExtraPlanTransformers), routerExtensions);
     }
 
-    private TestResult executeMappingTest(MappingTest mappingTest, MappingTestRunnerContext context, TestConnectionBuildParameters hints)
+    private TestResult executeMappingTest(MappingTest mappingTest, MappingTestRunnerContext context, TestConnectionBuildParameters hints, GeneratedPlan sharedPlan)
     {
-        List<Pair<Connection, List<Closeable>>> connections = Lists.mutable.empty();
+        MutableList<Closeable> testOwnedCloseables = null;
         try
         {
-            connections = generateExecutionPlan(mappingTest, context, hints, false);
+            // Connections are built for every execution even when the plan is shared: some test
+            // connections (notably ModelStore's) hand the test's data to the execution out of band,
+            // through a thread-local stream bound when the connection is built, so each execution
+            // needs connections freshly built on its own thread.
+            Pair<MutableList<Connection>, MutableList<Closeable>> connections = buildTestConnections(resolveStoreTestData(mappingTest, context), context, hints);
+            testOwnedCloseables = connections.getTwo();
+            // No suite-wide shared plan: reuse a plan cached for these connection instances, or
+            // generate and cache one. Tests whose connections match (by identity) share the plan.
+            SingleExecutionPlan plan = (sharedPlan != null)
+                    ? sharedPlan.plan
+                    : context.getOrComputePlan(connections.getOne(), () -> generatePlan(buildRuntime(connections.getOne(), context), context, false)).plan;
             // execute assertion
             TestAssertion assertion = mappingTest.assertions.get(0);
-            PlanExecutor.ExecuteArgs executeArgs = context.getExecuteBuilder().build();
-            Result result = this.executor.executeWithArgs(executeArgs);
+            Result result = this.executor.executeWithArgs(PlanExecutor.withArgs().withPlan(plan).build());
             AssertionStatus assertionResult = assertion.accept(new TestAssertionEvaluator(result, SerializationFormat.RAW));
             TestExecuted testResult = new TestExecuted(Collections.singletonList(assertionResult));
             testResult.atomicTestId = mappingTest.id;
@@ -155,20 +203,29 @@ public class MappingTestRunner implements TestRunner
         }
         finally
         {
-            this.closeConnections(connections);
+            closeAll(testOwnedCloseables);
         }
     }
 
-    private TestDebug debugMappingTest(MappingTest mappingTest, MappingTestRunnerContext context, TestConnectionBuildParameters hints)
+    private TestDebug debugMappingTest(MappingTest mappingTest, MappingTestRunnerContext context, TestConnectionBuildParameters hints, GeneratedPlan sharedPlan)
     {
-        List<Pair<Connection, List<Closeable>>> connections = Lists.mutable.empty();
-
+        MutableList<Closeable> testOwnedCloseables = null;
         try
         {
+            GeneratedPlan plan;
+            if (sharedPlan != null)
+            {
+                plan = sharedPlan;
+            }
+            else
+            {
+                Pair<MutableList<Connection>, MutableList<Closeable>> connections = buildTestConnections(resolveStoreTestData(mappingTest, context), context, hints);
+                testOwnedCloseables = connections.getTwo();
+                plan = context.getOrComputePlan(connections.getOne(), () -> generatePlan(buildRuntime(connections.getOne(), context), context, true));
+            }
             TestExecutionPlanDebug executionPlanDebug = new TestExecutionPlanDebug();
-            connections = generateExecutionPlan(mappingTest, context, hints, true);
-            executionPlanDebug.executionPlan = context.getPlan();
-            executionPlanDebug.debug = context.getDebug();
+            executionPlanDebug.executionPlan = plan.plan;
+            executionPlanDebug.debug = plan.debug;
             executionPlanDebug.atomicTestId = mappingTest.id;
             return executionPlanDebug;
         }
@@ -178,83 +235,70 @@ public class MappingTestRunner implements TestRunner
         }
         finally
         {
-            this.closeConnections(connections);
+            closeAll(testOwnedCloseables);
         }
     }
 
-    private List<Pair<Connection, List<Closeable>>> generateExecutionPlan(MappingTest mappingTest, MappingTestRunnerContext context, TestConnectionBuildParameters hints, boolean debug)
+    /**
+     * Resolve a test's store test data to {@code (store path, resolved data)} bindings. Data
+     * element references are resolved to the referenced {@code DataElement}'s data instance,
+     * so two tests referencing the same data element yield identical bindings.
+     */
+    private List<Pair<String, EmbeddedData>> resolveStoreTestData(MappingTest mappingTest, MappingTestRunnerContext context)
     {
+        return ListIterate.collect(mappingTest.storeTestData, testData -> Tuples.pair(testData.store.path, EmbeddedDataHelper.resolveEmbeddedDataInPMCD(context.getPureModelContextData(), testData.data)));
+    }
 
-        Root_meta_core_runtime_Runtime runtime = new Root_meta_core_runtime_Runtime_Impl("");
-        List<Pair<String, EmbeddedData>> connectionInfo = mappingTest.storeTestData.stream().map(testData -> Tuples.pair(testData.store.path, EmbeddedDataHelper.resolveEmbeddedDataInPMCD(context.getPureModelContextData(), testData.data))).collect(Collectors.toList());
-        List<Pair<Connection, List<Closeable>>> connections = connectionInfo.stream()
-                .map(pair -> this.factories.collect(f -> f.tryBuildTestConnectionsForStore(context.getDataElementIndex(), resolveStore(context.getPureModelContextData(), pair.getOne()), pair.getTwo(), hints)).select(Objects::nonNull).select(Optional::isPresent)
-                        .collect(Optional::get).getFirstOptional().orElseThrow(() -> new UnsupportedOperationException("Unsupported store type for:'" + pair.getOne() + "' mentioned while running the mapping tests"))).collect(Collectors.toList());
-        connections.forEach(connection ->
+    private Pair<MutableList<Connection>, MutableList<Closeable>> buildTestConnections(List<Pair<String, EmbeddedData>> storeTestData, MappingTestRunnerContext context, TestConnectionBuildParameters hints)
+    {
+        MutableList<Connection> connections = Lists.mutable.empty();
+        MutableList<Closeable> closeables = Lists.mutable.empty();
+        storeTestData.forEach(pair ->
         {
-            Connection conn = connection.getOne();
+            String storePath = pair.getOne();
+            EmbeddedData embeddedData = pair.getTwo();
+            for (ConnectionFactoryExtension factory : this.factories)
+            {
+                Optional<Pair<Connection, List<Closeable>>> optional = factory.tryBuildTestConnectionsForStore(context.getDataElementIndex(), resolveStore(context.getPureModelContextData(), storePath), embeddedData, hints);
+                if ((optional != null) && optional.isPresent())
+                {
+                    Pair<Connection, List<Closeable>> connectionWithCloseables = optional.get();
+                    connections.add(connectionWithCloseables.getOne());
+                    closeables.addAll(connectionWithCloseables.getTwo());
+                    return;
+                }
+            }
+            throw new UnsupportedOperationException("Unsupported store type for:'" + storePath + "' mentioned while running the mapping tests");
+        });
+        return Tuples.pair(connections, closeables);
+    }
+
+    private Root_meta_core_runtime_Runtime buildRuntime(Iterable<? extends Connection> connections, MappingTestRunnerContext context)
+    {
+        Root_meta_core_runtime_Runtime runtime = new Root_meta_core_runtime_Runtime_Impl("");
+        ConnectionFirstPassBuilder connectionVisitor = new ConnectionFirstPassBuilder(context.getPureModel().getContext());
+        connections.forEach(conn ->
+        {
             org.finos.legend.pure.m3.coreinstance.meta.pure.store.Store element = HelperRuntimeBuilder.getStore(conn.element, conn.elementSourceInformation, context.getPureModel().getContext());
             Root_meta_core_runtime_ConnectionStore connectionStore =
                     new Root_meta_core_runtime_ConnectionStore_Impl("")
-                            ._connection(conn.accept(context.getConnectionVisitor()))
+                            ._connection(conn.accept(connectionVisitor))
                             ._element(element);
             runtime._connectionStoresAdd(connectionStore);
         });
-        handleGenerationOfPlan(connections.stream().map(Pair::getOne).collect(Collectors.toList()), runtime, context, debug);
-        return connections;
+        return runtime;
     }
 
-    private void handleGenerationOfPlan(List<Connection> incomingConnections, Root_meta_core_runtime_Runtime runtime, MappingTestRunnerContext context, boolean debug)
+    private GeneratedPlan generatePlan(Root_meta_core_runtime_Runtime runtime, MappingTestRunnerContext context, boolean debug)
     {
-        if (context.getPlan() == null || !shouldReusePlan(incomingConnections, context))
+        // The context's router extensions are safe to share across concurrent generations
+        // because buildMappingContext pre-warmed their per-version serializer extensions.
+        if (debug)
         {
-            SingleExecutionPlan executionPlan;
-            List<String> debugger;
-            if (debug)
-            {
-                PlanWithDebug plan = PlanGenerator.generateExecutionPlanDebug(context.getMetamodelTestSuite()._query(), this.pureMapping, runtime, null, context.getPureModel(), this.pureVersion, PlanPlatform.JAVA, null, context.getRouterExtensions(), context.getExecutionPlanTransformers());
-                executionPlan = plan.plan;
-                debugger = Arrays.asList(plan.debug);
-            }
-            else
-            {
-                executionPlan = PlanGenerator.generateExecutionPlan(context.getMetamodelTestSuite()._query(), this.pureMapping, runtime, null, context.getPureModel(), this.pureVersion, PlanPlatform.JAVA, null, context.getRouterExtensions(), context.getExecutionPlanTransformers());
-                debugger = null;
-            }
-            context.withPlan(executionPlan, debugger);
+            PlanWithDebug plan = PlanGenerator.generateExecutionPlanDebug(context.getMetamodelTestSuite()._query(), this.pureMapping, runtime, null, context.getPureModel(), this.pureVersion, PlanPlatform.JAVA, null, context.getRouterExtensions(), context.getExecutionPlanTransformers());
+            return new GeneratedPlan(plan.plan, Arrays.asList(plan.debug));
         }
-        // set new connections
-        context.withConnections(incomingConnections);
-    }
-
-    private boolean shouldReusePlan(List<Connection> incomingConnections, MappingTestRunnerContext context)
-    {
-        List<Connection> cachedConnections = context.getConnections();
-        return (cachedConnections != null) &&
-                (cachedConnections.size() == incomingConnections.size()) &&
-                incomingConnections.stream().allMatch(incomingConnection -> cachedConnections.stream().anyMatch(cachedConn -> cachedConn == incomingConnection));
-    }
-
-    private void closeConnections(List<Pair<Connection, List<Closeable>>> connections)
-    {
-        connections.forEach(p -> p.getTwo().forEach(closeable ->
-        {
-            try
-            {
-                closeable.close();
-            }
-            catch (Exception e)
-            {
-                LOGGER.warn("Exception occurred closing closeable resource", e);
-            }
-        }));
-    }
-
-    private Store resolveStore(PureModelContextData pureModelContextData, String store)
-    {
-        return store.equals("ModelStore")
-               ? new ModelStore()
-               : (Store) ListIterate.detect(pureModelContextData.getElements(), x -> store.equals(x.getPath()));
+        return new GeneratedPlan(PlanGenerator.generateExecutionPlan(context.getMetamodelTestSuite()._query(), this.pureMapping, runtime, null, context.getPureModel(), this.pureVersion, PlanPlatform.JAVA, null, context.getRouterExtensions(), context.getExecutionPlanTransformers()), null);
     }
 
     private MappingTestSuite getProtocolSuite(Root_meta_pure_test_TestSuite testSuite, PureModel pureModel, PureModelContextData data)
@@ -264,23 +308,137 @@ public class MappingTestRunner implements TestRunner
         return ListIterate.detect(mapping.testSuites, ts -> ts.id.equals(testSuite._id()));
     }
 
+    private static void closeAll(Iterable<? extends AutoCloseable> closeables)
+    {
+        if (closeables != null)
+        {
+            closeables.forEach(c ->
+            {
+                try
+                {
+                    c.close();
+                }
+                catch (Exception e)
+                {
+                    LOGGER.warn("Exception occurred closing closeable resource", e);
+                }
+            });
+        }
+    }
+
+    private Store resolveStore(PureModelContextData pureModelContextData, String store)
+    {
+        return store.equals("ModelStore")
+               ? new ModelStore()
+               : (Store) ListIterate.detect(pureModelContextData.getElements(), x -> store.equals(x.getPath()));
+    }
+
+    /**
+     * An execution plan together with its debug output ({@code null} unless generated in
+     * debug mode). Immutable; a single instance is reused across tests whose connections
+     * are the same instances.
+     */
+    static final class GeneratedPlan
+    {
+        final SingleExecutionPlan plan;
+        final List<String> debug;
+
+        GeneratedPlan(SingleExecutionPlan plan, List<String> debug)
+        {
+            this.plan = plan;
+            this.debug = debug;
+        }
+    }
+
     private abstract class BaseMappingTestSuiteSession<TR> extends AbstractTestSuiteSessionWithResources<MappingTestSuite, MappingTest, TR>
     {
+        private final boolean debug;
         MappingTestRunnerContext context;
         TestConnectionBuildParameters hints;
+        /**
+         * Non-null when one plan serves every test in the suite, in which case it is
+         * generated during initialization (from connections built and closed there).
+         * Null when the suite's tests do not all share one plan; each test then obtains
+         * its plan from a connection-keyed plan cache as it runs, so tests with matching
+         * connections still share. Either way connections are rebuilt per test execution.
+         * Written only during the (synchronized) initialization, read-only afterward.
+         */
+        GeneratedPlan sharedPlan;
 
-        private BaseMappingTestSuiteSession(Root_meta_pure_test_TestSuite pureSuite, MappingTestSuite protocolSuite, PureModel pureModel, PureModelContextData pmcd)
+        private BaseMappingTestSuiteSession(Root_meta_pure_test_TestSuite pureSuite, MappingTestSuite protocolSuite, PureModel pureModel, PureModelContextData pmcd, boolean debug)
         {
             super(pureSuite, protocolSuite, pureModel, pmcd, BaseMappingTestSuiteSession::getTestSuiteTests, BaseMappingTestSuiteSession::getAtomicTestId);
+            this.debug = debug;
         }
 
         @Override
         protected void initialize(Consumer<? super AutoCloseable> closeableConsumer)
         {
             this.context = buildMappingContext(this.pureSuite, this.pureModel, this.pmcd);
+            this.hints = TestReturnTypeHelper.isRelationReturnType(this.context.getMetamodelTestSuite()._query(), pureModel)
+                         ? TestConnectionBuildParameters.newBuilder().withIsRelation(true).build()
+                         : TestConnectionBuildParameters.NONE;
+            this.sharedPlan = computeSharedPlan(closeableConsumer);
+        }
 
-            boolean isRelation = TestReturnTypeHelper.isRelationReturnType(this.context.getMetamodelTestSuite()._query(), pureModel);
-            this.hints = isRelation ? TestConnectionBuildParameters.newBuilder().withIsRelation(true).build() : TestConnectionBuildParameters.NONE;
+        /**
+         * A single plan to serve every test in the suite, or {@code null} when no such plan is
+         * valid - in which case each test generates its own plan as it runs. A shared plan is
+         * generated here from one set of connections that are closed at the end of initialization,
+         * so it is valid only if it embeds no per-build connection state: that holds exactly when
+         * the suite's test connections are stable across rebuilds. Stability is checked by
+         * rebuilding every test's connections (the first test included, so a single-test suite is
+         * checked too) and confirming each rebuild yields the same connection instances as the
+         * plan's - the same connection-identity criterion the per-test path used historically.
+         * ModelStore's singleton connections satisfy it; freshly-built service-store / MongoDB
+         * connections, which carry a dynamically allocated local server address, do not.
+         */
+        private GeneratedPlan computeSharedPlan(Consumer<? super AutoCloseable> closeableConsumer)
+        {
+            Collection<String> atomicTestIds = getAtomicTestIds();
+            if (atomicTestIds.isEmpty())
+            {
+                return null;
+            }
+
+            MutableList<Closeable> planCloseables = null;
+            try
+            {
+                Pair<MutableList<Connection>, MutableList<Closeable>> planConnections = buildTestConnections(resolveStoreTestData(getAtomicTest(Iterate.getFirst(atomicTestIds)), this.context), this.context, this.hints);
+                planCloseables = planConnections.getTwo();
+                SetIterable<Connection> connectionSet = UnifiedSetWithHashingStrategy.newSet(HashingStrategies.identityStrategy(), planConnections.getOne());
+                for (String atomicTestId : atomicTestIds)
+                {
+                    Pair<MutableList<Connection>, MutableList<Closeable>> rebuilt = buildTestConnections(resolveStoreTestData(getAtomicTest(atomicTestId), this.context), this.context, this.hints);
+                    try
+                    {
+                        if ((connectionSet.size() != rebuilt.getOne().size()) || !rebuilt.getOne().allSatisfy(connectionSet::contains))
+                        {
+                            return null;
+                        }
+                    }
+                    finally
+                    {
+                        closeAll(rebuilt.getTwo());
+                    }
+                }
+                GeneratedPlan plan = generatePlan(buildRuntime(planConnections.getOne(), this.context), this.context, this.debug);
+                if (planCloseables != null)
+                {
+                    planCloseables.forEach(closeableConsumer);
+                    planCloseables = null;
+                }
+                return plan;
+            }
+            catch (Exception e)
+            {
+                LOGGER.warn("Unable to generate a shared plan for the suite; falling back to per-test plan generation", e);
+                return null;
+            }
+            finally
+            {
+                closeAll(planCloseables);
+            }
         }
     }
 
@@ -288,7 +446,7 @@ public class MappingTestRunner implements TestRunner
     {
         private MappingTestSuiteSession(Root_meta_pure_test_TestSuite pureSuite, MappingTestSuite protocolSuite, PureModel pureModel, PureModelContextData pmcd)
         {
-            super(pureSuite, protocolSuite, pureModel, pmcd);
+            super(pureSuite, protocolSuite, pureModel, pmcd, false);
         }
 
         @Override
@@ -300,7 +458,7 @@ public class MappingTestRunner implements TestRunner
         @Override
         protected TestResult runAtomicTest(MappingTest atomicTest)
         {
-            TestResult testResult = executeMappingTest(atomicTest, this.context, this.hints);
+            TestResult testResult = executeMappingTest(atomicTest, this.context, this.hints, this.sharedPlan);
             testResult.testable = this.context.getMapping().getPath();
             testResult.testSuiteId = getTestSuiteId();
             return testResult;
@@ -311,7 +469,7 @@ public class MappingTestRunner implements TestRunner
     {
         private MappingTestSuiteDebugSession(Root_meta_pure_test_TestSuite pureSuite, MappingTestSuite protocolSuite, PureModel pureModel, PureModelContextData pmcd)
         {
-            super(pureSuite, protocolSuite, pureModel, pmcd);
+            super(pureSuite, protocolSuite, pureModel, pmcd, true);
         }
 
         @Override
@@ -323,7 +481,7 @@ public class MappingTestRunner implements TestRunner
         @Override
         protected TestDebug runAtomicTest(MappingTest atomicTest)
         {
-            TestDebug testResult = debugMappingTest(atomicTest, this.context, this.hints);
+            TestDebug testResult = debugMappingTest(atomicTest, this.context, this.hints, this.sharedPlan);
             testResult.testable = this.context.getMapping().getPath();
             testResult.testSuiteId = getTestSuiteId();
             return testResult;

--- a/legend-engine-core/legend-engine-core-testable/legend-engine-test-runner-mapping/src/main/java/org/finos/legend/engine/testable/mapping/extension/MappingTestRunnerContext.java
+++ b/legend-engine-core/legend-engine-core-testable/legend-engine-test-runner-mapping/src/main/java/org/finos/legend/engine/testable/mapping/extension/MappingTestRunnerContext.java
@@ -15,129 +15,114 @@
 package org.finos.legend.engine.testable.mapping.extension;
 
 import org.eclipse.collections.api.RichIterable;
+import org.eclipse.collections.api.block.function.Function0;
 import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.api.map.ConcurrentMutableMap;
+import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.set.SetIterable;
+import org.eclipse.collections.impl.block.factory.HashingStrategies;
+import org.eclipse.collections.impl.map.mutable.ConcurrentHashMap;
+import org.eclipse.collections.impl.set.strategy.mutable.UnifiedSetWithHashingStrategy;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
-import org.finos.legend.engine.plan.execution.PlanExecutor;
 import org.finos.legend.engine.plan.generation.transformers.PlanTransformer;
 import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
-import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.SingleExecutionPlan;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.connection.Connection;
-import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.connection.ConnectionVisitor;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.data.DataElement;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.Mapping;
 import org.finos.legend.pure.generated.Root_meta_pure_extension_Extension;
 import org.finos.legend.pure.generated.Root_meta_pure_mapping_metamodel_MappingTestSuite;
-import org.finos.legend.pure.generated.Root_meta_core_runtime_Connection;
 
-import java.util.List;
+import java.util.Collection;
 import java.util.Map;
 
+/**
+ * Per-suite context for {@link MappingTestRunner}: the compiled and protocol
+ * views of the suite plus the loaded plan-generation extensions. Its only
+ * mutable state is a thread-safe, lazily-populated cache of execution plans
+ * keyed on connection identity, used when the suite has no single shared plan
+ * (see {@code MappingTestRunner}'s class Javadoc for the plan management
+ * strategy); it is otherwise safe to share across threads.
+ */
 class MappingTestRunnerContext
 {
     private final PureModel pureModel;
     private final PureModelContextData pureModelContextData;
     private final MutableList<PlanTransformer> executionPlanTransformers;
-    private final ConnectionVisitor<Root_meta_core_runtime_Connection> connectionVisitor;
     private final Root_meta_pure_mapping_metamodel_MappingTestSuite metamodelTestSuite;
     private final RichIterable<? extends Root_meta_pure_extension_Extension> routerExtensions;
-    private final org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.Mapping mapping;
-    private final PlanExecutor.ExecuteArgsBuilder executeBuilder;
+    private final Mapping mapping;
     private final Map<String, DataElement> dataElementIndex;
-    private SingleExecutionPlan plan;
-    private List<String> debug;
-    private List<Connection> connections;
+    private final ConcurrentMutableMap<SetIterable<Connection>, MappingTestRunner.GeneratedPlan> planCache = ConcurrentHashMap.newMap();
 
-    public MappingTestRunnerContext(Root_meta_pure_mapping_metamodel_MappingTestSuite metamodelTestSuite, org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.Mapping mapping, PureModel pureModel, PureModelContextData pureModelContextData, MutableList<PlanTransformer> executionPlanTransformers,
-                                    ConnectionVisitor<Root_meta_core_runtime_Connection> connectionVisitor, RichIterable<? extends Root_meta_pure_extension_Extension> routerExtensions)
+    MappingTestRunnerContext(Root_meta_pure_mapping_metamodel_MappingTestSuite metamodelTestSuite, Mapping mapping, PureModel pureModel, PureModelContextData pureModelContextData, MutableList<PlanTransformer> executionPlanTransformers, RichIterable<? extends Root_meta_pure_extension_Extension> routerExtensions)
     {
         this.pureModel = pureModel;
         this.pureModelContextData = pureModelContextData;
-        this.dataElementIndex = this.buildDataElementIndex(pureModelContextData);
+        this.dataElementIndex = buildDataElementIndex(pureModelContextData);
         this.mapping = mapping;
         this.executionPlanTransformers = executionPlanTransformers;
-        this.connectionVisitor = connectionVisitor;
         this.metamodelTestSuite = metamodelTestSuite;
         this.routerExtensions = routerExtensions;
-        this.executeBuilder = PlanExecutor.withArgs();
     }
 
     private Map<String, DataElement> buildDataElementIndex(PureModelContextData pureModelContextData)
     {
-        Map<String, DataElement> result = Maps.mutable.empty();
-        pureModelContextData.getElementsOfType(DataElement.class).forEach(d -> result.put(d.getPath(), d));
-        return result;
+        MutableMap<String, DataElement> result = Maps.mutable.empty();
+        pureModelContextData.getElements().forEach(e ->
+        {
+            if (e instanceof DataElement)
+            {
+                result.put(e.getPath(), (DataElement) e);
+            }
+        });
+        return result.asUnmodifiable();
     }
 
-    public void withConnections(List<Connection> connections)
+    PureModel getPureModel()
     {
-        this.connections = connections;
+        return this.pureModel;
     }
 
-    public List<Connection> getConnections()
+    Mapping getMapping()
     {
-        return connections;
+        return this.mapping;
     }
 
-    public PureModel getPureModel()
+    PureModelContextData getPureModelContextData()
     {
-        return pureModel;
+        return this.pureModelContextData;
     }
 
-    public Mapping getMapping()
+    Map<String, DataElement> getDataElementIndex()
     {
-        return mapping;
+        return this.dataElementIndex;
     }
 
-    public PureModelContextData getPureModelContextData()
+    RichIterable<? extends Root_meta_pure_extension_Extension> getRouterExtensions()
     {
-        return pureModelContextData;
+        return this.routerExtensions;
     }
 
-    public PlanExecutor.ExecuteArgsBuilder getExecuteBuilder()
+    MutableList<PlanTransformer> getExecutionPlanTransformers()
     {
-        return executeBuilder;
+        return this.executionPlanTransformers;
     }
 
-    public Map<String, DataElement> getDataElementIndex()
+    Root_meta_pure_mapping_metamodel_MappingTestSuite getMetamodelTestSuite()
     {
-        return dataElementIndex;
+        return this.metamodelTestSuite;
     }
 
-    public SingleExecutionPlan getPlan()
+    /**
+     * Return the plan cached for these connection instances, generating and caching one (via
+     * {@code planSupplier}) on a miss. Tests whose connections are the same instances - the
+     * criterion by which a plan may be reused - share a plan; tests with differing connections
+     * each get their own. Thread-safe: a plan is generated at most once per distinct set of
+     * connection instances even under concurrent atomic-test execution.
+     */
+    MappingTestRunner.GeneratedPlan getOrComputePlan(Collection<? extends Connection> connections, Function0<MappingTestRunner.GeneratedPlan> planSupplier)
     {
-        return plan;
-    }
-
-    public List<String> getDebug()
-    {
-        return this.debug;
-    }
-
-    public void withPlan(SingleExecutionPlan plan, List<String> debug)
-    {
-        this.executeBuilder.withPlan(plan);
-        this.debug = debug;
-        this.plan = plan;
-    }
-
-    public ConnectionVisitor<Root_meta_core_runtime_Connection> getConnectionVisitor()
-    {
-        return connectionVisitor;
-    }
-
-    public RichIterable<? extends Root_meta_pure_extension_Extension> getRouterExtensions()
-    {
-        return routerExtensions;
-    }
-
-    public MutableList<PlanTransformer> getExecutionPlanTransformers()
-    {
-        return executionPlanTransformers;
-    }
-
-    public Root_meta_pure_mapping_metamodel_MappingTestSuite getMetamodelTestSuite()
-    {
-        return metamodelTestSuite;
+        return this.planCache.getIfAbsentPut(UnifiedSetWithHashingStrategy.newSet(HashingStrategies.identityStrategy(), connections), planSupplier);
     }
 }

--- a/legend-engine-core/legend-engine-core-testable/legend-engine-test-runner-mapping/src/main/java/org/finos/legend/engine/testable/mapping/extension/MappingTestableRunnerExtension.java
+++ b/legend-engine-core/legend-engine-core-testable/legend-engine-test-runner-mapping/src/main/java/org/finos/legend/engine/testable/mapping/extension/MappingTestableRunnerExtension.java
@@ -14,10 +14,10 @@
 
 package org.finos.legend.engine.testable.mapping.extension;
 
+import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.MutableList;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
 import org.finos.legend.engine.protocol.pure.m3.PackageableElement;
-import org.finos.legend.engine.protocol.pure.m3.function.Function;
 import org.finos.legend.engine.protocol.pure.v1.CorePureProtocolExtension;
 import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
 import org.finos.legend.engine.protocol.pure.v1.model.test.result.TestResult;
@@ -37,7 +37,7 @@ public class MappingTestableRunnerExtension implements TestableRunnerExtension
     @Override
     public MutableList<String> group()
     {
-        return org.eclipse.collections.impl.factory.Lists.mutable.with("PackageableElement", "Mapping");
+        return Lists.mutable.with("PackageableElement", "Mapping");
     }
 
     @Override
@@ -80,9 +80,9 @@ public class MappingTestableRunnerExtension implements TestableRunnerExtension
 
         return testable._tests().flatCollect(testSuite ->
         {
-            List<String> atomicTestIds = ((Root_meta_pure_test_TestSuite) testSuite)._tests().collect(TestAccessor::_id).toList();
+            List<String> atomicTestIds = ((Root_meta_pure_test_TestSuite) testSuite)._tests().collect(TestAccessor::_id, Lists.mutable.empty());
             return testRunner.executeTestSuite((Root_meta_pure_test_TestSuite) testSuite, atomicTestIds, pureModel, pureModelContextData);
-        }).toList();
+        }, Lists.mutable.empty());
     }
 
     public void setPureVersion(String pureVersion)

--- a/legend-engine-core/legend-engine-core-testable/legend-engine-test-runner-mapping/src/test/java/org/finos/legend/engine/testable/mapping/extension/TestMappingTestRunner.java
+++ b/legend-engine-core/legend-engine-core-testable/legend-engine-test-runner-mapping/src/test/java/org/finos/legend/engine/testable/mapping/extension/TestMappingTestRunner.java
@@ -15,29 +15,45 @@
 package org.finos.legend.engine.testable.mapping.extension;
 
 import net.javacrumbs.jsonunit.JsonAssert;
+import org.eclipse.collections.api.block.function.Function0;
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.factory.Maps;
+import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.api.tuple.Pair;
+import org.eclipse.collections.impl.utility.ListIterate;
 import org.finos.legend.engine.language.pure.compiler.Compiler;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
+import org.finos.legend.engine.language.pure.compiler.toPureGraph.test.ModelStoreTestConnectionFactory;
 import org.finos.legend.engine.language.pure.grammar.from.PureGrammarParser;
 import org.finos.legend.engine.protocol.pure.PureClientVersions;
 import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
+import org.finos.legend.engine.protocol.pure.v1.model.data.ExternalFormatData;
+import org.finos.legend.engine.protocol.pure.v1.model.data.ModelEmbeddedTestData;
+import org.finos.legend.engine.protocol.pure.v1.model.data.ModelStoreData;
+import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.ExecutionPlan;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.connection.Connection;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.modelToModel.ModelStore;
 import org.finos.legend.engine.protocol.pure.v1.model.test.assertion.status.AssertionStatus;
 import org.finos.legend.engine.protocol.pure.v1.model.test.assertion.status.EqualToJsonAssertFail;
-import org.finos.legend.engine.protocol.pure.v1.model.test.result.*;
+import org.finos.legend.engine.protocol.pure.v1.model.test.result.TestDebug;
+import org.finos.legend.engine.protocol.pure.v1.model.test.result.TestExecuted;
+import org.finos.legend.engine.protocol.pure.v1.model.test.result.TestExecutionPlanDebug;
+import org.finos.legend.engine.protocol.pure.v1.model.test.result.TestExecutionStatus;
+import org.finos.legend.engine.protocol.pure.v1.model.test.result.TestResult;
 import org.finos.legend.engine.shared.core.deployment.DeploymentMode;
 import org.finos.legend.engine.shared.core.identity.Identity;
-import org.finos.legend.engine.shared.core.identity.factory.*;
 import org.finos.legend.engine.testable.extension.TestRunner;
 import org.finos.legend.pure.generated.Root_meta_pure_test_TestSuite;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.testable.TestAccessor;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.Closeable;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class TestMappingTestRunner
 {
-
     private String getGrammar1MappingSuite(String TEST_SUITE_GRAMMAR)
     {
         return "###Pure\n" +
@@ -177,6 +193,71 @@ public class TestMappingTestRunner
             "  ]");
 
 
+    String TEST_SUITE_SHARED_DATA = getGrammar1MappingSuite("  testSuites:\n" +
+            "  [\n" +
+            "    testSuite1:\n" +
+            "    {\n" +
+            "      function: |test::changedModel.all()->graphFetch(#{test::changedModel{id,name}}#)->serialize(#{test::changedModel{id,name}}#);\n" +
+            "      tests:\n" +
+            "      [\n" +
+            "        test1:\n" +
+            "        {\n" +
+            "          data:\n" +
+            "          [\n" +
+            "           ModelStore: ModelStore\n" +
+            "            #{\n" +
+            "               test::model:\n" +
+            "                Reference\n" +
+            "                #{\n" +
+            "                  test::data::MyData\n" +
+            "                }#\n" +
+            "            }#\n" +
+            "          ];\n" +
+            "          asserts:\n" +
+            "          [\n" +
+            "            assert1:\n" +
+            "              EqualToJson\n" +
+            "              #{\n" +
+            "                expected :\n" +
+            "                  ExternalFormat\n" +
+            "                  #{\n" +
+            "                    contentType: 'application/json';\n" +
+            "                    data: '{\"id\" : 77, \"name\" : \"john doe\"}';\n" +
+            "                  }#;\n" +
+            "              }#\n" +
+            "          ];\n" +
+            "        },\n" +
+            "        test2:\n" +
+            "        {\n" +
+            "          data:\n" +
+            "          [\n" +
+            "           ModelStore: ModelStore\n" +
+            "            #{\n" +
+            "               test::model:\n" +
+            "                Reference\n" +
+            "                #{\n" +
+            "                  test::data::MyData\n" +
+            "                }#\n" +
+            "            }#\n" +
+            "          ];\n" +
+            "          asserts:\n" +
+            "          [\n" +
+            "            assert1:\n" +
+            "              EqualToJson\n" +
+            "              #{\n" +
+            "                expected :\n" +
+            "                  ExternalFormat\n" +
+            "                  #{\n" +
+            "                    contentType: 'application/json';\n" +
+            "                    data: '{\"name\" : \"john doe\", \"id\" : 77}';\n" +
+            "                  }#;\n" +
+            "              }#\n" +
+            "          ];\n" +
+            "        }\n" +
+            "      ];\n" +
+            "    }\n" +
+            "  ]");
+
     String grammar2 = "###Data\n" +
             "Data test::data::MyTestData\n" +
             "{\n" +
@@ -282,7 +363,6 @@ public class TestMappingTestRunner
             "    }\n" +
             "  ]\n" +
             ")\n";
-
 
 
     String multiInputWithReferenceM2M = "###Data\n" +
@@ -596,7 +676,6 @@ public class TestMappingTestRunner
             ")\n";
 
 
-
     @Test
     public void testMappingTestSuiteForM2MUsecase()
     {
@@ -624,12 +703,12 @@ public class TestMappingTestRunner
         PureModelContextData modelDataWithReferenceData = PureGrammarParser.newInstance().parseModel(TEST_SUITE_1);
         PureModel pureModelWithReferenceData = Compiler.compile(modelDataWithReferenceData, DeploymentMode.TEST, Identity.getAnonymousIdentity().getName());
         org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.Mapping mappingToTest = (org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.Mapping) pureModelWithReferenceData.getPackageableElement("test::modelToModelMapping");
-        TestRunner runner =  mappingTestableRunnerExtension.getTestRunner(mappingToTest);
+        TestRunner runner = mappingTestableRunnerExtension.getTestRunner(mappingToTest);
         List<TestDebug> debugLists = mappingToTest._tests().flatCollect(testSuite ->
         {
-            List<String> atomicTestIds = ((Root_meta_pure_test_TestSuite) testSuite)._tests().collect(TestAccessor::_id).toList();
+            List<String> atomicTestIds = ((Root_meta_pure_test_TestSuite) testSuite)._tests().collect(TestAccessor::_id, Lists.mutable.empty());
             return runner.debugTestSuite((Root_meta_pure_test_TestSuite) testSuite, atomicTestIds, pureModelWithReferenceData, modelDataWithReferenceData);
-        }).toList();
+        }, Lists.mutable.empty());
         Assert.assertEquals(1, debugLists.size());
         Assert.assertEquals("test::modelToModelMapping", debugLists.get(0).testable);
         Assert.assertEquals("testSuite1", debugLists.get(0).testSuiteId);
@@ -714,6 +793,240 @@ public class TestMappingTestRunner
     }
 
     @Test
+    public void testSharedStoreTestDataSuiteSharesOnePlanAcrossTests()
+    {
+        MappingTestableRunnerExtension mappingTestableRunnerExtension = new MappingTestableRunnerExtension();
+        mappingTestableRunnerExtension.setPureVersion(PureClientVersions.production);
+
+        PureModelContextData modelData = PureGrammarParser.newInstance().parseModel(TEST_SUITE_SHARED_DATA);
+        PureModel pureModel = Compiler.compile(modelData, DeploymentMode.TEST, Identity.getAnonymousIdentity().getName());
+        org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.Mapping mappingToTest = (org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.Mapping) pureModel.getPackageableElement("test::modelToModelMapping");
+
+        // Both tests reference the same DataElement, so one plan serves the suite: it is generated
+        // during session initialization and shared, which the debug session exposes as the same
+        // plan instance on every test.
+        TestRunner runner = mappingTestableRunnerExtension.getTestRunner(mappingToTest);
+        List<TestDebug> debugs = mappingToTest._tests().flatCollect(testSuite ->
+        {
+            List<String> atomicTestIds = ((Root_meta_pure_test_TestSuite) testSuite)._tests().collect(TestAccessor::_id, Lists.mutable.empty());
+            return runner.debugTestSuite((Root_meta_pure_test_TestSuite) testSuite, atomicTestIds, pureModel, modelData);
+        }, Lists.mutable.empty());
+        Assert.assertEquals(2, debugs.size());
+        ExecutionPlan plan1 = ((TestExecutionPlanDebug) debugs.get(0)).executionPlan;
+        ExecutionPlan plan2 = ((TestExecutionPlanDebug) debugs.get(1)).executionPlan;
+        Assert.assertNotNull(plan1);
+        Assert.assertSame("tests sharing store test data should share the plan generated during session initialization", plan1, plan2);
+
+        // And both tests pass against the shared plan.
+        List<TestResult> results = mappingTestableRunnerExtension.executeAllTest(mappingToTest, pureModel, modelData);
+        Assert.assertEquals(2, results.size());
+        results.forEach(result -> Assert.assertTrue("expected " + result.atomicTestId + " to pass", hasTestPassed(result)));
+    }
+
+    @Test
+    public void testM2MDifferingDataStillSharesOnePlan()
+    {
+        MappingTestableRunnerExtension mappingTestableRunnerExtension = new MappingTestableRunnerExtension();
+        mappingTestableRunnerExtension.setPureVersion(PureClientVersions.production);
+
+        PureModelContextData modelData = PureGrammarParser.newInstance().parseModel(TEST_SUITE_2);
+        PureModel pureModel = Compiler.compile(modelData, DeploymentMode.TEST, Identity.getAnonymousIdentity().getName());
+        org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.Mapping mappingToTest = (org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.Mapping) pureModel.getPackageableElement("test::modelToModelMapping");
+
+        // test1 references a DataElement while test2 carries different inline data, but both bind
+        // the same model class with JSON data — and ModelStore plans do not embed the data content
+        // (it reaches the execution out of band), so one plan still serves the whole suite.
+        TestRunner runner = mappingTestableRunnerExtension.getTestRunner(mappingToTest);
+        List<TestDebug> debugs = mappingToTest._tests().flatCollect(testSuite ->
+        {
+            List<String> atomicTestIds = ((Root_meta_pure_test_TestSuite) testSuite)._tests().collect(TestAccessor::_id, Lists.mutable.empty());
+            return runner.debugTestSuite((Root_meta_pure_test_TestSuite) testSuite, atomicTestIds, pureModel, modelData);
+        }, Lists.mutable.empty());
+        Assert.assertEquals(2, debugs.size());
+        ExecutionPlan plan1 = ((TestExecutionPlanDebug) debugs.get(0)).executionPlan;
+        ExecutionPlan plan2 = ((TestExecutionPlanDebug) debugs.get(1)).executionPlan;
+        Assert.assertNotNull(plan1);
+        Assert.assertSame("ModelStore tests differing only in data content should share the plan generated during session initialization", plan1, plan2);
+    }
+
+    @Test
+    public void testM2MDifferingDataShapeStillSharesOnePlan()
+    {
+        MappingTestableRunnerExtension mappingTestableRunnerExtension = new MappingTestableRunnerExtension();
+        mappingTestableRunnerExtension.setPureVersion(PureClientVersions.production);
+
+        // test2's ModelStore data binds two model classes where test1's binds one, but plan sharing
+        // is decided by connection identity, not data shape: both tests resolve to the same singleton
+        // ModelStore connection (JSON), whose plan does not embed the data, so one plan still serves
+        // the whole suite.
+        String suiteGrammar = getGrammar1MappingSuite("  testSuites:\n" +
+                "  [\n" +
+                "    testSuite1:\n" +
+                "    {\n" +
+                "      function: |test::changedModel.all()->graphFetch(#{test::changedModel{id,name}}#)->serialize(#{test::changedModel{id,name}}#);\n" +
+                "      tests:\n" +
+                "      [\n" +
+                "        test1:\n" +
+                "        {\n" +
+                "          data:\n" +
+                "          [\n" +
+                "           ModelStore: ModelStore\n" +
+                "            #{\n" +
+                "               test::model:\n" +
+                "               ExternalFormat\n" +
+                "               #{\n" +
+                "                 contentType: 'application/json';\n" +
+                "                 data: '{\"name\":\"john doe\",\"id\":\"77\"}';\n" +
+                "               }#\n" +
+                "            }#\n" +
+                "          ];\n" +
+                "          asserts:\n" +
+                "          [\n" +
+                "            assert1:\n" +
+                "              EqualToJson\n" +
+                "              #{\n" +
+                "                expected :\n" +
+                "                  ExternalFormat\n" +
+                "                  #{\n" +
+                "                    contentType: 'application/json';\n" +
+                "                    data: '{\"id\" : 77, \"name\" : \"john doe\"}';\n" +
+                "                  }#;\n" +
+                "              }#\n" +
+                "          ];\n" +
+                "        },\n" +
+                "        test2:\n" +
+                "        {\n" +
+                "          data:\n" +
+                "          [\n" +
+                "           ModelStore: ModelStore\n" +
+                "            #{\n" +
+                "               test::model:\n" +
+                "               ExternalFormat\n" +
+                "               #{\n" +
+                "                 contentType: 'application/json';\n" +
+                "                 data: '{\"name\":\"john doe\",\"id\":\"77\"}';\n" +
+                "               }#,\n" +
+                "               test::changedModel:\n" +
+                "               ExternalFormat\n" +
+                "               #{\n" +
+                "                 contentType: 'application/json';\n" +
+                "                 data: '{\"name\":\"john doe\",\"id\":77}';\n" +
+                "               }#\n" +
+                "            }#\n" +
+                "          ];\n" +
+                "          asserts:\n" +
+                "          [\n" +
+                "            assert1:\n" +
+                "              EqualToJson\n" +
+                "              #{\n" +
+                "                expected :\n" +
+                "                  ExternalFormat\n" +
+                "                  #{\n" +
+                "                    contentType: 'application/json';\n" +
+                "                    data: '{\"id\" : 77, \"name\" : \"john doe\"}';\n" +
+                "                  }#;\n" +
+                "              }#\n" +
+                "          ];\n" +
+                "        }\n" +
+                "      ];\n" +
+                "    }\n" +
+                "  ]");
+
+        PureModelContextData modelData = PureGrammarParser.newInstance().parseModel(suiteGrammar);
+        PureModel pureModel = Compiler.compile(modelData, DeploymentMode.TEST, Identity.getAnonymousIdentity().getName());
+        org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.Mapping mappingToTest = (org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.Mapping) pureModel.getPackageableElement("test::modelToModelMapping");
+
+        TestRunner runner = mappingTestableRunnerExtension.getTestRunner(mappingToTest);
+        List<TestDebug> debugs = mappingToTest._tests().flatCollect(testSuite ->
+        {
+            List<String> atomicTestIds = ((Root_meta_pure_test_TestSuite) testSuite)._tests().collect(TestAccessor::_id, Lists.mutable.empty());
+            return runner.debugTestSuite((Root_meta_pure_test_TestSuite) testSuite, atomicTestIds, pureModel, modelData);
+        }, Lists.mutable.empty());
+        Assert.assertEquals(2, debugs.size());
+        ExecutionPlan plan1 = ((TestExecutionPlanDebug) debugs.get(0)).executionPlan;
+        ExecutionPlan plan2 = ((TestExecutionPlanDebug) debugs.get(1)).executionPlan;
+        Assert.assertNotNull(plan1);
+        Assert.assertNotNull(plan2);
+        Assert.assertSame("ModelStore tests differing only in data shape resolve to the same connection instance and should share the plan generated during session initialization", plan1, plan2);
+    }
+
+    /**
+     * A suite mixing tests that use different connections (here ModelStore JSON vs XML, which
+     * resolve to distinct singleton connections) has no single shared plan, so plans are cached
+     * lazily keyed on connection identity. This drives that cache with the connections such a
+     * suite would build and asserts a plan is generated once per connection group and reused
+     * within it - the partial-sharing benefit the cache exists to provide.
+     */
+    @Test
+    public void testMixedConnectionsSharePlanWithinEachConnectionGroup()
+    {
+        ModelStoreTestConnectionFactory connectionFactory = new ModelStoreTestConnectionFactory();
+        MutableList<Closeable> closeables = Lists.mutable.empty();
+        try
+        {
+            // ModelStore's factory returns a singleton connection per content type, so the two JSON
+            // tests would build the same connection instance, the two XML tests another, and the JSON
+            // and XML instances differ - giving two connection groups across the four tests.
+            Connection json1 = buildModelStoreConnection(connectionFactory, "application/json", "{\"name\":\"john\",\"id\":\"1\"}", closeables);
+            Connection json2 = buildModelStoreConnection(connectionFactory, "application/json", "{\"name\":\"jane\",\"id\":\"2\"}", closeables);
+            Connection xml1 = buildModelStoreConnection(connectionFactory, "application/xml", "<model><name>john</name><id>1</id></model>", closeables);
+            Connection xml2 = buildModelStoreConnection(connectionFactory, "application/xml", "<model><name>jane</name><id>2</id></model>", closeables);
+            Assert.assertSame("ModelStore JSON tests should build the same connection instance", json1, json2);
+            Assert.assertSame("ModelStore XML tests should build the same connection instance", xml1, xml2);
+            Assert.assertNotSame("ModelStore JSON and XML tests should build different connection instances", json1, xml1);
+
+            MappingTestRunnerContext context = new MappingTestRunnerContext(null, null, null, PureModelContextData.newPureModelContextData(), null, null);
+            AtomicInteger generationCount = new AtomicInteger();
+            Function0<MappingTestRunner.GeneratedPlan> planSupplier = () ->
+            {
+                generationCount.incrementAndGet();
+                return new MappingTestRunner.GeneratedPlan(null, null);
+            };
+
+            MappingTestRunner.GeneratedPlan jsonPlan1 = context.getOrComputePlan(Lists.mutable.with(json1), planSupplier);
+            MappingTestRunner.GeneratedPlan jsonPlan2 = context.getOrComputePlan(Lists.mutable.with(json2), planSupplier);
+            MappingTestRunner.GeneratedPlan xmlPlan1 = context.getOrComputePlan(Lists.mutable.with(xml1), planSupplier);
+            MappingTestRunner.GeneratedPlan xmlPlan2 = context.getOrComputePlan(Lists.mutable.with(xml2), planSupplier);
+
+            Assert.assertSame("tests sharing a connection should share a plan", jsonPlan1, jsonPlan2);
+            Assert.assertSame("tests sharing a connection should share a plan", xmlPlan1, xmlPlan2);
+            Assert.assertNotSame("tests using different connections should not share a plan", jsonPlan1, xmlPlan1);
+            Assert.assertEquals("a plan should be generated once per connection group", 2, generationCount.get());
+        }
+        finally
+        {
+            closeables.forEach(closeable ->
+            {
+                try
+                {
+                    closeable.close();
+                }
+                catch (Exception ignored)
+                {
+                    // best effort - clears any thread-local connection state bound on this thread
+                }
+            });
+        }
+    }
+
+    private static Connection buildModelStoreConnection(ModelStoreTestConnectionFactory factory, String contentType, String data, MutableList<Closeable> closeables)
+    {
+        ExternalFormatData externalFormatData = new ExternalFormatData();
+        externalFormatData.contentType = contentType;
+        externalFormatData.data = data;
+        ModelEmbeddedTestData modelTestData = new ModelEmbeddedTestData();
+        modelTestData.model = "test::model";
+        modelTestData.data = externalFormatData;
+        ModelStoreData modelStoreData = new ModelStoreData();
+        modelStoreData.modelData = Lists.mutable.with(modelTestData);
+
+        Pair<Connection, List<Closeable>> built = factory.tryBuildTestConnectionsForStore(Maps.mutable.empty(), new ModelStore(), modelStoreData)
+                .orElseThrow(() -> new AssertionError("ModelStore connection factory should build a connection for " + contentType + " data"));
+        closeables.addAll(built.getTwo());
+        return built.getOne();
+    }
+
+    @Test
     public void testMultiInputsWithDifferentSerializationAndReferences()
     {
         MappingTestableRunnerExtension mappingTestableRunnerExtension = new MappingTestableRunnerExtension();
@@ -726,14 +1039,14 @@ public class TestMappingTestRunner
 
         // basic assertions 2 suites
         Assert.assertEquals(8, mappingTestResults.size());
-        List<TestResult> graphFetchSuite = mappingTestResults.stream().filter(e -> e.testSuiteId.equals("graphFetchSuite")).collect(Collectors.toList());;
+        MutableList<TestResult> graphFetchSuite = ListIterate.select(mappingTestResults, e -> e.testSuiteId.equals("graphFetchSuite"));
         Assert.assertEquals(6, graphFetchSuite.size());
-        List<TestResult> graphFetchCheckedSuite = mappingTestResults.stream().filter(e -> e.testSuiteId.equals("graphFetchChecked")).collect(Collectors.toList());;
+        MutableList<TestResult> graphFetchCheckedSuite = ListIterate.select(mappingTestResults, e -> e.testSuiteId.equals("graphFetchChecked"));
         Assert.assertEquals(2, graphFetchCheckedSuite.size());
 
         // graphFetchSuite
-        Assert.assertEquals(4,graphFetchSuite.stream().filter(this::hasTestPassed).collect(Collectors.toList()).size());
-        Assert.assertEquals(2,graphFetchSuite.stream().filter(e -> !this.hasTestPassed(e)).collect(Collectors.toList()).size());
+        Assert.assertEquals(4, graphFetchSuite.count(this::hasTestPassed));
+        Assert.assertEquals(2, graphFetchSuite.count(e -> !hasTestPassed(e)));
         Assert.assertTrue(hasTestPassed(findTestById(graphFetchSuite, "basicInput")));
         Assert.assertTrue(hasTestPassed(findTestById(graphFetchSuite, "differentInput")));
         Assert.assertTrue(hasTestPassed(findTestById(graphFetchSuite, "dataReferenceOnPerson")));
@@ -758,8 +1071,8 @@ public class TestMappingTestRunner
         testFailingTest(findTestById(graphFetchSuite, "dataReferenceFail"), expected1, actual1);
 
         // graphFetchSuite Checked
-        Assert.assertEquals(1, graphFetchCheckedSuite.stream().filter(this::hasTestPassed).collect(Collectors.toList()).size());
-        Assert.assertEquals(1, graphFetchCheckedSuite.stream().filter(e -> !this.hasTestPassed(e)).collect(Collectors.toList()).size());
+        Assert.assertEquals(1, graphFetchCheckedSuite.count(this::hasTestPassed));
+        Assert.assertEquals(1, graphFetchCheckedSuite.count(e -> !this.hasTestPassed(e)));
         String e = "{}";
         String a = "{\n" +
                 "  \"defects\": [],\n" +
@@ -789,7 +1102,7 @@ public class TestMappingTestRunner
         AssertionStatus status = testExecuted.assertStatuses.get(0);
         if (status instanceof EqualToJsonAssertFail)
         {
-            EqualToJsonAssertFail equalToJsonAssertFail = (EqualToJsonAssertFail)status;
+            EqualToJsonAssertFail equalToJsonAssertFail = (EqualToJsonAssertFail) status;
             JsonAssert.assertJsonEquals(expected, equalToJsonAssertFail.expected);
             JsonAssert.assertJsonEquals(actual, equalToJsonAssertFail.actual);
         }
@@ -806,7 +1119,7 @@ public class TestMappingTestRunner
 
     private TestExecuted guaranteedTestExecuted(TestResult result)
     {
-        if (result instanceof  TestExecuted)
+        if (result instanceof TestExecuted)
         {
             return (TestExecuted) result;
         }
@@ -815,7 +1128,7 @@ public class TestMappingTestRunner
 
     private boolean hasTestPassed(TestResult result)
     {
-        if (result instanceof  TestExecuted)
+        if (result instanceof TestExecuted)
         {
             return ((TestExecuted) result).testExecutionStatus.equals(TestExecutionStatus.PASS);
         }
@@ -823,4 +1136,3 @@ public class TestMappingTestRunner
     }
 
 }
-

--- a/legend-engine-core/legend-engine-core-testable/legend-engine-test-runner-mapping/src/test/java/org/finos/legend/engine/testable/mapping/extension/TestMappingTestSuiteConcurrency.java
+++ b/legend-engine-core/legend-engine-core-testable/legend-engine-test-runner-mapping/src/test/java/org/finos/legend/engine/testable/mapping/extension/TestMappingTestSuiteConcurrency.java
@@ -1,0 +1,241 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.testable.mapping.extension;
+
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.list.MutableList;
+import org.finos.legend.engine.language.pure.compiler.Compiler;
+import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
+import org.finos.legend.engine.language.pure.grammar.from.PureGrammarParser;
+import org.finos.legend.engine.protocol.pure.PureClientVersions;
+import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
+import org.finos.legend.engine.protocol.pure.v1.model.test.result.TestError;
+import org.finos.legend.engine.protocol.pure.v1.model.test.result.TestExecuted;
+import org.finos.legend.engine.protocol.pure.v1.model.test.result.TestExecutionStatus;
+import org.finos.legend.engine.protocol.pure.v1.model.test.result.TestResult;
+import org.finos.legend.engine.shared.core.deployment.DeploymentMode;
+import org.finos.legend.engine.shared.core.identity.Identity;
+import org.finos.legend.engine.testable.extension.TestRunner;
+import org.finos.legend.engine.testable.extension.TestSuiteSession;
+import org.finos.legend.pure.generated.Root_meta_pure_test_TestSuite;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.Mapping;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.testable.TestAccessor;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Runs many atomic tests of a single {@link MappingTestRunner} session concurrently. All shared
+ * session state must be safe to read from concurrent test threads, and the per-test path must
+ * not race through shared mutable plan or executor-argument state. Both grammars end up in
+ * shared-plan mode (ModelStore plans do not depend on the data content), so the second variant
+ * — three tests with three different inline datasets — is the critical one: each concurrent
+ * execution must see its own test's data (passed per execution via thread-local stream bound
+ * during that test's own connection build), with no bleed between threads.
+ */
+public class TestMappingTestSuiteConcurrency
+{
+    private static final int THREADS = 8;
+    private static final int EXECUTIONS = 48;
+    private static final int TIMEOUT_SECONDS = 180;
+
+    private static final String GRAMMAR_BASE = "###Pure\n" +
+            "Class test::model\n" +
+            "{\n" +
+            "    name: String[1];\n" +
+            "    id: String[1];\n" +
+            "}\n" +
+            "\n" +
+            "Class test::changedModel{    name: String[1];    id: Integer[1];}\n" +
+            "###Data\n" +
+            "Data test::data::MyData\n" +
+            "{\n" +
+            "  ExternalFormat\n" +
+            "  #{\n" +
+            "    contentType: 'application/json';\n" +
+            "    data: '{\"name\":\"john doe\",\"id\":\"77\"}';\n" +
+            "  }#\n" +
+            "}\n" +
+            "\n" +
+            "###Mapping\n" +
+            "Mapping test::modelToModelMapping\n" +
+            "(\n" +
+            "    *test::changedModel: Pure\n" +
+            "{\n" +
+            "    ~src test::model\n" +
+            "    name: $src.name,\n" +
+            "    id: $src.id->parseInteger()\n" +
+            "}\n" +
+            "\n";
+
+    private static final String SHARED_DATA_TEST_1 = sharedDataTest("test1");
+    private static final String SHARED_DATA_TEST_2 = sharedDataTest("test2");
+
+    private static final String SHARED_DATA_GRAMMAR = GRAMMAR_BASE +
+            "  testSuites:\n" +
+            "  [\n" +
+            "    testSuite1:\n" +
+            "    {\n" +
+            "      function: |test::changedModel.all()->graphFetch(#{test::changedModel{id,name}}#)->serialize(#{test::changedModel{id,name}}#);\n" +
+            "      tests:\n" +
+            "      [\n" +
+            SHARED_DATA_TEST_1 + ",\n" +
+            SHARED_DATA_TEST_2 + "\n" +
+            "      ];\n" +
+            "    }\n" +
+            "  ]\n" +
+            ")\n";
+
+    private static final String PER_TEST_DATA_GRAMMAR = GRAMMAR_BASE +
+            "  testSuites:\n" +
+            "  [\n" +
+            "    testSuite1:\n" +
+            "    {\n" +
+            "      function: |test::changedModel.all()->graphFetch(#{test::changedModel{id,name}}#)->serialize(#{test::changedModel{id,name}}#);\n" +
+            "      tests:\n" +
+            "      [\n" +
+            inlineDataTest("test1", "jane", "1") + ",\n" +
+            inlineDataTest("test2", "john", "2") + ",\n" +
+            inlineDataTest("test3", "judy", "3") + "\n" +
+            "      ];\n" +
+            "    }\n" +
+            "  ]\n" +
+            ")\n";
+
+    @Test
+    public void testConcurrentAtomicTestsWithSharedPlan() throws Exception
+    {
+        runSuiteTestsConcurrently(SHARED_DATA_GRAMMAR);
+    }
+
+    @Test
+    public void testConcurrentAtomicTestsWithSharedPlanAndPerTestData() throws Exception
+    {
+        runSuiteTestsConcurrently(PER_TEST_DATA_GRAMMAR);
+    }
+
+    private void runSuiteTestsConcurrently(String grammar) throws Exception
+    {
+        PureModelContextData pmcd = PureGrammarParser.newInstance().parseModel(grammar);
+        PureModel pureModel = Compiler.compile(pmcd, DeploymentMode.TEST, Identity.getAnonymousIdentity().getName());
+        Mapping mapping = (Mapping) pureModel.getPackageableElement("test::modelToModelMapping");
+
+        MappingTestableRunnerExtension extension = new MappingTestableRunnerExtension();
+        extension.setPureVersion(PureClientVersions.production);
+        TestRunner runner = extension.getTestRunner(mapping);
+        Root_meta_pure_test_TestSuite suite = (Root_meta_pure_test_TestSuite) mapping._tests().getOnly();
+        MutableList<String> atomicTestIds = suite._tests().collect(TestAccessor::_id, Lists.mutable.empty());
+
+        try (TestSuiteSession<TestResult> session = runner.openTestSuiteSession(suite, pureModel, pmcd))
+        {
+            session.initialize();
+            ExecutorService pool = Executors.newFixedThreadPool(THREADS);
+            try
+            {
+                MutableList<Future<TestResult>> futures = Lists.mutable.empty();
+                for (int i = 0; i < EXECUTIONS; i++)
+                {
+                    String atomicTestId = atomicTestIds.get(i % atomicTestIds.size());
+                    futures.add(pool.submit(() -> session.runAtomicTest(atomicTestId)));
+                }
+                for (Future<TestResult> future : futures)
+                {
+                    TestResult result = future.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+                    Assert.assertTrue(
+                            "Expected TestExecuted, got " + result.getClass().getSimpleName() + " for " + result.atomicTestId
+                                    + ((result instanceof TestError) ? ": " + ((TestError) result).error : ""),
+                            result instanceof TestExecuted);
+                    TestExecuted executed = (TestExecuted) result;
+                    Assert.assertEquals(
+                            "Test " + executed.atomicTestId + " did not PASS" +
+                                    ((executed.assertStatuses != null && !executed.assertStatuses.isEmpty()) ? " / " + executed.assertStatuses.get(0) : ""),
+                            TestExecutionStatus.PASS,
+                            executed.testExecutionStatus);
+                }
+            }
+            finally
+            {
+                pool.shutdownNow();
+            }
+        }
+    }
+
+    private static String sharedDataTest(String testId)
+    {
+        return "        " + testId + ":\n" +
+                "        {\n" +
+                "          data:\n" +
+                "          [\n" +
+                "           ModelStore: ModelStore\n" +
+                "            #{\n" +
+                "               test::model:\n" +
+                "                Reference\n" +
+                "                #{\n" +
+                "                  test::data::MyData\n" +
+                "                }#\n" +
+                "            }#\n" +
+                "          ];\n" +
+                "          asserts:\n" +
+                "          [\n" +
+                "            assert1:\n" +
+                "              EqualToJson\n" +
+                "              #{\n" +
+                "                expected :\n" +
+                "                  ExternalFormat\n" +
+                "                  #{\n" +
+                "                    contentType: 'application/json';\n" +
+                "                    data: '{\"id\" : 77, \"name\" : \"john doe\"}';\n" +
+                "                  }#;\n" +
+                "              }#\n" +
+                "          ];\n" +
+                "        }";
+    }
+
+    private static String inlineDataTest(String testId, String name, String id)
+    {
+        return "        " + testId + ":\n" +
+                "        {\n" +
+                "          data:\n" +
+                "          [\n" +
+                "           ModelStore: ModelStore\n" +
+                "            #{\n" +
+                "               test::model:\n" +
+                "               ExternalFormat\n" +
+                "               #{\n" +
+                "                 contentType: 'application/json';\n" +
+                "                 data: '{\"name\":\"" + name + "\",\"id\":\"" + id + "\"}';\n" +
+                "               }#\n" +
+                "            }#\n" +
+                "          ];\n" +
+                "          asserts:\n" +
+                "          [\n" +
+                "            assert1:\n" +
+                "              EqualToJson\n" +
+                "              #{\n" +
+                "                expected :\n" +
+                "                  ExternalFormat\n" +
+                "                  #{\n" +
+                "                    contentType: 'application/json';\n" +
+                "                    data: '{\"id\" : " + id + ", \"name\" : \"" + name + "\"}';\n" +
+                "                  }#;\n" +
+                "              }#\n" +
+                "          ];\n" +
+                "        }";
+    }
+}

--- a/legend-engine-xts-serviceStore/legend-engine-xt-serviceStore-executionPlan/src/test/java/org/finos/legend/engine/plan/execution/stores/service/testable/mapping/TestMappingTestRunner.java
+++ b/legend-engine-xts-serviceStore/legend-engine-xt-serviceStore-executionPlan/src/test/java/org/finos/legend/engine/plan/execution/stores/service/testable/mapping/TestMappingTestRunner.java
@@ -21,9 +21,9 @@ import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextDa
 import org.finos.legend.engine.protocol.pure.v1.model.test.result.TestExecuted;
 import org.finos.legend.engine.protocol.pure.v1.model.test.result.TestExecutionStatus;
 import org.finos.legend.engine.protocol.pure.v1.model.test.result.TestResult;
+import org.finos.legend.engine.shared.core.ObjectMapperFactory;
 import org.finos.legend.engine.shared.core.deployment.DeploymentMode;
 import org.finos.legend.engine.shared.core.identity.Identity;
-import org.finos.legend.engine.shared.core.identity.factory.*;
 import org.finos.legend.engine.testable.mapping.extension.MappingTestableRunnerExtension;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.Mapping;
 import org.junit.Assert;
@@ -263,12 +263,26 @@ public class TestMappingTestRunner
 
     private TestExecuted guaranteedTestExecuted(TestResult result)
     {
-        if (result instanceof  TestExecuted)
+        if (result instanceof TestExecuted)
         {
             return (TestExecuted) result;
         }
-        throw new RuntimeException("test expected to have been executed");
+        String resultString;
+        if (result == null)
+        {
+            resultString = "null";
+        }
+        else
+        {
+            try
+            {
+                resultString = ObjectMapperFactory.getNewStandardObjectMapperWithPureProtocolExtensionSupports().writeValueAsString(result);
+            }
+            catch (Exception ignore)
+            {
+                resultString = result.toString();
+            }
+        }
+        throw new RuntimeException("test expected to have been executed, got: " + resultString);
     }
-
-
 }


### PR DESCRIPTION
Improve MappingTestRunner so that shared plan generation happens during initialization. Also, improve its thread safety.