### PR TITLE
Avoid duplicated fromJson by renaming native meta::json::fromJson to fromJsonNative

### DIFF
--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/HelperConnectionBuilder.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/HelperConnectionBuilder.java
@@ -48,7 +48,7 @@ public class HelperConnectionBuilder
     public static MutableMap<Class<?>, org.finos.legend.pure.m3.coreinstance.meta.pure.functions.collection.List<Root_meta_pure_metamodel_type_Any_Impl>> processModelInput(ModelStringInput modelInput, CompileContext context, boolean deserializeInstances, ExecutionSupport executionSupport)
     {
         Class<?> _class = context.resolveClass(modelInput._class);
-        RichIterable<?> values = deserializeInstances ? ListIterate.collect(modelInput.instances, i -> core_external_format_json_jsonExtension.Root_meta_json_fromJson_String_1__Class_1__T_1_(cleanInstanceString(i), _class, executionSupport)) : Lists.immutable.withAll(modelInput.instances);
+        RichIterable<?> values = deserializeInstances ? ListIterate.collect(modelInput.instances, i -> core_external_format_json_jsonExtension.Root_meta_json_fromJsonNative_String_1__Class_1__T_1_(cleanInstanceString(i), _class, executionSupport)) : Lists.immutable.withAll(modelInput.instances);
         org.finos.legend.pure.m3.coreinstance.meta.pure.functions.collection.List pureList = new Root_meta_pure_functions_collection_List_Impl<>("");
         pureList._values(values);
         return Maps.mutable.with(_class, pureList);

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/external/format/json/jsonExtension.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/external/format/json/jsonExtension.pure
@@ -19,9 +19,9 @@ function meta::json::fromJsonDeprecated<T>(string:String[1], clazz:Class<T>[1]):
     fromJsonDeprecated($string, $clazz, ^JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));
 }
 
-function meta::json::fromJson<T>(string:String[1], clazz:Class<T>[1]):T[1]
+function meta::json::fromJsonNative<T>(string:String[1], clazz:Class<T>[1]):T[1]
 {
-    fromJson($string, $clazz, ^JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));
+    fromJsonNative($string, $clazz, ^JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));
 }
 
 function meta::json::toJsonBeta(instance: Any[*]):String[1]

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/external/format/json/tests/testFromJson2.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/external/format/json/tests/testFromJson2.pure
@@ -29,7 +29,7 @@ function <<test.Test>> meta::json::tests::fromJson::simpleStringTests():Boolean[
 {
    let example = ^SimpleString(string='foo');
    let exampleJson = '{"string":"foo"}';
-   assertLogicallyEqual($example, $exampleJson -> fromJson(SimpleString));
+   assertLogicallyEqual($example, $exampleJson -> fromJsonNative(SimpleString));
 }
 
 Class meta::json::tests::fromJson::SimpleInteger
@@ -41,7 +41,7 @@ function <<test.Test>> meta::json::tests::fromJson::simpleIntegerTests():Boolean
 {
    let example = ^SimpleInteger(integer=3);
    let exampleJson = '{"integer":3}';
-   assertLogicallyEqual($example, $exampleJson -> fromJson(SimpleInteger));
+   assertLogicallyEqual($example, $exampleJson -> fromJsonNative(SimpleInteger));
 }
 
 Class meta::json::tests::fromJson::SimpleFloat
@@ -53,7 +53,7 @@ function <<test.Test>> meta::json::tests::fromJson::simpleFloatTests():Boolean[1
 {
    let example = ^SimpleFloat(float=3.14);
    let exampleJson = '{"float":3.14}';
-   assertLogicallyEqual($example, $exampleJson -> fromJson(SimpleFloat));
+   assertLogicallyEqual($example, $exampleJson -> fromJsonNative(SimpleFloat));
 }
 
 Class meta::json::tests::fromJson::SimpleBoolean
@@ -65,11 +65,11 @@ function <<test.Test>> meta::json::tests::fromJson::simpleBooleanTests():Boolean
 {
    let trueExample = ^SimpleBoolean(boolean=true);
    let trueExampleJson = '{"boolean":true}';
-   assertLogicallyEqual($trueExample, $trueExampleJson -> fromJson(SimpleBoolean));
+   assertLogicallyEqual($trueExample, $trueExampleJson -> fromJsonNative(SimpleBoolean));
    
    let falseExample = ^SimpleBoolean(boolean=false);
    let falseExampleJson = '{"boolean":false}';
-   assertLogicallyEqual($falseExample, $falseExampleJson -> fromJson(SimpleBoolean));
+   assertLogicallyEqual($falseExample, $falseExampleJson -> fromJsonNative(SimpleBoolean));
 }
 
 Class meta::json::tests::fromJson::SimpleNull
@@ -81,7 +81,7 @@ function <<test.Test>> meta::json::tests::fromJson::simpleNullTests():Boolean[1]
 {
    let example = ^SimpleNull(null=[]);
    let exampleJson = '{"null":null}';
-   assertLogicallyEqual($example, $exampleJson -> fromJson(SimpleNull));
+   assertLogicallyEqual($example, $exampleJson -> fromJsonNative(SimpleNull));
 }
 
 Class meta::json::tests::fromJson::SimpleArray
@@ -93,7 +93,7 @@ function <<test.Test>> meta::json::tests::fromJson::simpleArrayTests():Boolean[1
 {
    let example = ^SimpleArray(array=['1','2']);
    let exampleJson = '{"array":["1","2"]}';
-   assertLogicallyEqual($example, $exampleJson -> fromJson(SimpleArray));
+   assertLogicallyEqual($example, $exampleJson -> fromJsonNative(SimpleArray));
 }
 
 Enum meta::json::tests::fromJson::TestingEnum
@@ -110,7 +110,7 @@ function <<test.Test>> meta::json::tests::fromJson::simpleEnumTests():Boolean[1]
 {
    let example = ^SimpleEnum(enum=TestingEnum.Value1);
    let exampleJson = '{"enum":"meta::json::tests::fromJson::TestingEnum.Value1"}';
-   assertLogicallyEqual($example, $exampleJson -> fromJson(SimpleEnum));
+   assertLogicallyEqual($example, $exampleJson -> fromJsonNative(SimpleEnum));
 }
 
 Class meta::json::tests::fromJson::OptionalField
@@ -122,14 +122,14 @@ function <<test.Test>> meta::json::tests::fromJson::optionalFieldTest_Without():
 {
    let example = ^OptionalField();
    let exampleJson = '{}';
-   assertLogicallyEqual($example, $exampleJson -> fromJson(OptionalField));
+   assertLogicallyEqual($example, $exampleJson -> fromJsonNative(OptionalField));
 }
 
 function <<test.Test>> meta::json::tests::fromJson::optionalFieldTest_With():Boolean[1]
 {
    let example = ^OptionalField(field='with');
    let exampleJson = '{"field":"with"}';
-   assertLogicallyEqual($example, $exampleJson -> fromJson(OptionalField));
+   assertLogicallyEqual($example, $exampleJson -> fromJsonNative(OptionalField));
 }
 
 Class meta::json::tests::fromJson::ExactlyTwo
@@ -141,7 +141,7 @@ function <<test.Test>> meta::json::tests::fromJson::exactlyTwoTest():Boolean[1]
 {
    let example = ^ExactlyTwo(field=['one','two']);
    let exampleJson = '{"field":["one","two"]}';
-   assertLogicallyEqual($example, $exampleJson -> fromJson(ExactlyTwo));
+   assertLogicallyEqual($example, $exampleJson -> fromJsonNative(ExactlyTwo));
 }
 
 Class meta::json::tests::fromJson::Many
@@ -153,7 +153,7 @@ function <<test.Test>> meta::json::tests::fromJson::manyTest():Boolean[1]
 {
    let example = ^Many(field=['one','two','more']);
    let exampleJson = '{"field":["one","two","more"]}';
-   assertLogicallyEqual($example, $exampleJson -> fromJson(Many));
+   assertLogicallyEqual($example, $exampleJson -> fromJsonNative(Many));
 }
 
 Class <<access.private>> meta::json::tests::fromJson::Child
@@ -170,7 +170,7 @@ function <<test.Test>> meta::json::tests::fromJson::simpleInheritenceTest():Bool
 {  
    let example = ^ExtendedChild(a='a', b=1);
    let exampleJson = '{"a" : "a", "b" : 1}';
-   assertLogicallyEqual($example, $exampleJson -> fromJson(ExtendedChild));
+   assertLogicallyEqual($example, $exampleJson -> fromJsonNative(ExtendedChild));
 }   
 
 Class <<access.private>> meta::json::tests::fromJson::Parent
@@ -182,7 +182,7 @@ function <<test.Test>> meta::json::tests::fromJson::simpleCompositionTest():Bool
 {  
    let example = ^Parent(b=^Child(a='a'));
    let exampleJson = '{"b":{"a":"a"}}';
-   assertLogicallyEqual($example, $exampleJson -> fromJson(Parent));
+   assertLogicallyEqual($example, $exampleJson -> fromJsonNative(Parent));
 }
 
 Class <<access.private>> meta::json::tests::fromJson::EmptyParent {}
@@ -201,21 +201,21 @@ function <<test.Test>> meta::json::tests::fromJson::arrayPropertySubclass():Bool
 {  
    let example = ^SS(s='a');
    let exampleJson = '{"s":"a"}';
-   assertLogicallyEqual($example, $exampleJson -> fromJson(SS));
+   assertLogicallyEqual($example, $exampleJson -> fromJsonNative(SS));
 }
 
 function <<test.Test>> meta::json::tests::fromJson::arrayPropertySubclass2():Boolean[1]
 {  
    let example = ^SSS(s=['a']);
    let exampleJson = '{"s":["a"]}';
-   assertLogicallyEqual($example, $exampleJson -> fromJson(SSS));
+   assertLogicallyEqual($example, $exampleJson -> fromJsonNative(SSS));
 }
 
 function <<test.Test>> meta::json::tests::fromJson::arrayPropertySubclass3():Boolean[1]
 {  
    let example = ^SSS(s=['a','b']);
    let exampleJson = '{"s":["a","b"]}';
-   assertLogicallyEqual($example, $exampleJson -> fromJson(SSS));
+   assertLogicallyEqual($example, $exampleJson -> fromJsonNative(SSS));
 }
 
 Class <<access.private>> meta::json::tests::fromJson::OwnerOfAmbigousChildren
@@ -242,7 +242,7 @@ function <<test.Test>> meta::json::tests::fromJson::ambiguityResolvedByHint():Bo
    let config = ^JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=true);
    let example = ^OwnerOfAmbigousChildren(a=^AmbigousChild1(b=10));
    let exampleJson = '{"a" : { "@type": "AmbigousChild1", "b" : 10 } }';
-   assertLogicallyEqual($example, $exampleJson -> fromJson(OwnerOfAmbigousChildren, $config));
+   assertLogicallyEqual($example, $exampleJson -> fromJsonNative(OwnerOfAmbigousChildren, $config));
 }   
 
 function <<test.Test>> meta::json::tests::fromJson::notStrictJson():Boolean[1]
@@ -250,7 +250,7 @@ function <<test.Test>> meta::json::tests::fromJson::notStrictJson():Boolean[1]
    let config = ^JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false);
    let example = ^OwnerOfAmbigousChildren(a=^AmbigousChild1(b=10));
    let exampleJson = '{"a" : { "@type": "AmbigousChild1", "b" : 10 }, "c" : 42 }';
-   assertLogicallyEqual($example, $exampleJson -> fromJson(OwnerOfAmbigousChildren, $config));
+   assertLogicallyEqual($example, $exampleJson -> fromJsonNative(OwnerOfAmbigousChildren, $config));
 }  
 
 Class <<access.private>> meta::json::tests::fromJson::Assoc_class1
@@ -271,7 +271,7 @@ Association meta::json::tests::fromJson::Assoc1
 
 function <<test.Test>> meta::json::tests::fromJson::associationOneToOne():Any[1]
 {
-   let exampleJson = '{"a":3,"ASSOC2":{"b":2,"ASSOC1":{"a":3}}}' -> fromJson(Assoc_class1);   
+   let exampleJson = '{"a":3,"ASSOC2":{"b":2,"ASSOC1":{"a":3}}}' -> fromJsonNative(Assoc_class1);   
 }
 
 Class <<access.private>> meta::json::tests::fromJson::HasAssocProp
@@ -281,7 +281,7 @@ Class <<access.private>> meta::json::tests::fromJson::HasAssocProp
 
 function <<test.Test>> {test.excludePlatform = 'Interpreted'} meta::json::tests::fromJson::associationHasAssocProperty():Any[1]
 {
-   let exampleJson = '{"c": {"a":3,"ASSOC2":{"b":2,"ASSOC1":{"a":3}}}}' -> fromJson(HasAssocProp);
+   let exampleJson = '{"c": {"a":3,"ASSOC2":{"b":2,"ASSOC1":{"a":3}}}}' -> fromJsonNative(HasAssocProp);
 }
 
 Class <<access.private>> meta::json::tests::fromJson::Assoc_class3 {}
@@ -294,7 +294,7 @@ Association meta::json::tests::fromJson::Assoc2
 
 function <<test.Test>> meta::json::tests::fromJson::associationOptional():Any[1]
 {
-   let exampleJson = '{}' -> fromJson(Assoc_class3);   
+   let exampleJson = '{}' -> fromJsonNative(Assoc_class3);   
 }
 
 Class <<access.private>> meta::json::tests::fromJson::Assoc_class5 {}
@@ -307,8 +307,8 @@ Association meta::json::tests::fromJson::Assoc3
 
 function <<test.Test>> meta::json::tests::fromJson::associationOneToMany():Any[1]
 {
-   '{}' -> fromJson(Assoc_class5);
-   '{"ASSOC6":{"ASSOC5":{}}}' -> fromJson(Assoc_class5);
+   '{}' -> fromJsonNative(Assoc_class5);
+   '{"ASSOC6":{"ASSOC5":{}}}' -> fromJsonNative(Assoc_class5);
 }
 
 Class <<access.private>> meta::json::tests::fromJson::Assoc_class7 {}
@@ -321,6 +321,6 @@ Association meta::json::tests::fromJson::Assoc4
 
 function <<test.Test>> meta::json::tests::fromJson::associationOneToThreeExactly():Any[1]
 {
-   '{"ASSOC8":[{"ASSOC7":{}},{"ASSOC7":{}},{"ASSOC7":{}}]}' -> fromJson(Assoc_class7);
+   '{"ASSOC8":[{"ASSOC7":{}},{"ASSOC7":{}},{"ASSOC7":{}}]}' -> fromJsonNative(Assoc_class7);
 }
 

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/external/format/json/tests/testToJson2.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/external/format/json/tests/testToJson2.pure
@@ -17,7 +17,7 @@ import meta::json::tests::toJson::*;
 
 function <<access.private>> meta::json::tests::toJson::deserializeBackAndCompare<T>(json: String[1], clazz: Class<T>[1], originalInstance: Any[1]):Boolean[1]
 {
-   $json->fromJson($clazz)->propertyComparator($originalInstance, []);
+   $json->fromJsonNative($clazz)->propertyComparator($originalInstance, []);
 }
 
 

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-json/legend-engine-pure-functions-json-pure/src/main/resources/core_functions_json/json.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-json/legend-engine-pure-functions-json-pure/src/main/resources/core_functions_json/json.pure
@@ -18,7 +18,7 @@ native function meta::json::escape(string:String[1]):String[1];
 
 native function meta::json::parseJSON(string:String[1]):meta::json::JSONElement[1];
 
-native function meta::json::fromJson<T>(string:String[1], clazz:Class<T>[1], config:JSONDeserializationConfig[1]):T[1];
+native function meta::json::fromJsonNative<T>(string:String[1], clazz:Class<T>[1], config:JSONDeserializationConfig[1]):T[1];
 
 native function meta::json::fromJsonDeprecated<T>(string:String[1], clazz:Class<T>[1], config:JSONDeserializationConfig[1]):T[1];
 

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-json/legend-engine-pure-functions-json-pure/src/test/java/org/finos/legend/engine/runtime/java/extension/external/json/natives/AbstractTestFromJson.java
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-json/legend-engine-pure-functions-json-pure/src/test/java/org/finos/legend/engine/runtime/java/extension/external/json/natives/AbstractTestFromJson.java
@@ -409,7 +409,7 @@ public abstract class AbstractTestFromJson extends AbstractPureTestWithCoreCompi
                 "{\n" +
                 // this json describes a Firm with one employee, but the association states all Firms must have exactly 7 employees.
                 "    let json = '{\"employees\":[{\"employer\":{\"employees\":[{}]}}]}';\n" +
-                "    $json -> fromJson(Firm, ^meta::json::JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
+                "    $json -> fromJsonNative(Firm, ^meta::json::JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
                 "}\n";
         String testFunction = "Association():Any[*]";
         String exceptionMessage = "Error populating property 'employees' on class 'meta::pure::functions::json::tests::Firm': \n" +
@@ -440,7 +440,7 @@ public abstract class AbstractTestFromJson extends AbstractPureTestWithCoreCompi
                 "function Association():Any[*]\n" +
                 "{\n" +
                 "    let json = '{\"firms\": {\"employees\":[{\"employer\":{\"employees\":{}}}]}}';\n" +
-                "    $json -> fromJson(OfficeBuilding, ^JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
+                "    $json -> fromJsonNative(OfficeBuilding, ^JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
                 "}\n";
         String testFunction = "Association():Any[*]";
         String exceptionMessage = "Error populating property 'firms' on class 'meta::pure::functions::json::tests::OfficeBuilding': \n" +
@@ -476,7 +476,7 @@ public abstract class AbstractTestFromJson extends AbstractPureTestWithCoreCompi
                 "function Association():Any[*]\n" +
                 "{\n" +
                 "    let json = '{\"occupant\": {\"building\": {\"occupant\": {}}, \"employees\":[{\"employer\":{\"employees\":{}}}]}}';\n" +
-                "    $json -> fromJson(OfficeBuilding, ^meta::json::JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
+                "    $json -> fromJsonNative(OfficeBuilding, ^meta::json::JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
                 "}\n";
         String testFunction = "Association():Any[*]";
         String exceptionMessage = "Error populating property 'occupant' on class 'meta::pure::functions::json::tests::OfficeBuilding': \n" +
@@ -502,7 +502,7 @@ public abstract class AbstractTestFromJson extends AbstractPureTestWithCoreCompi
                 "function mimic():Any[*]\n" +
                 "{\n" +
                 "    let json = '{\"check\": \"passes here\", \"bar\": {\"foo\": {\"check\": \"and here\", \"bar\": {}}}}';\n" +
-                "    $json -> fromJson(Foo, ^JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
+                "    $json -> fromJsonNative(Foo, ^JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
                 "}";
         String testFunction = "mimic():Any[*]";
         assertPassesExecution(sourceCode, testFunction);
@@ -531,7 +531,7 @@ public abstract class AbstractTestFromJson extends AbstractPureTestWithCoreCompi
                 "function foo():Any[*]\n" +
                 "{\n" +
                 "    let json = '{\"buildings\": {\"occupant\": {\"building\": {}}}}';\n" +
-                "    $json -> fromJson(Campus, ^JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
+                "    $json -> fromJsonNative(Campus, ^JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
                 "}";
         String testFunction = "foo():Any[*]";
         assertPassesExecution(sourceCode, testFunction);
@@ -556,7 +556,7 @@ public abstract class AbstractTestFromJson extends AbstractPureTestWithCoreCompi
                 "function foo():Any[*]\n" +
                 "{\n" +
                 "    let json = '{\"str\": \"bar\", \"b\": {\"a\": {\"str\": \"foo\"}}}';\n" +
-                "    let o = $json -> fromJson(C, ^meta::json::JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
+                "    let o = $json -> fromJsonNative(C, ^meta::json::JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
                 "    assert($o.str == 'bar', |'');\n" +
                 "}";
         String testFunction = "foo():Any[*]";
@@ -583,7 +583,7 @@ public abstract class AbstractTestFromJson extends AbstractPureTestWithCoreCompi
                 "{\n" +
                 "    let config = ^JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=true);\n\n" +
                 "    let json = '{\"str\": \"foo\", \"b\": {\"a\": {\"str\": \"foo\"}}}';\n" +
-                "    let o = $json -> fromJson(C, $config);\n" +
+                "    let o = $json -> fromJsonNative(C, $config);\n" +
                 "}";
         String testFunction = "foo():Any[*]";
         String expectedException = "Error populating property 'b' on class 'meta::pure::functions::json::tests::C': \n" +
@@ -604,7 +604,7 @@ public abstract class AbstractTestFromJson extends AbstractPureTestWithCoreCompi
                 "function InRangeToOne():Any[*]\n" +
                 "{\n" +
                 "    let json = '{}';\n" +
-                "    $json -> fromJson(must, ^JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
+                "    $json -> fromJsonNative(must, ^JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
                 "}";
         String testFunction = "InRangeToOne():Any[*]";
         String expectedException = "Error populating property 'testField' on class 'meta::pure::functions::json::tests::must': \n" +
@@ -635,7 +635,7 @@ public abstract class AbstractTestFromJson extends AbstractPureTestWithCoreCompi
                 "function missing():Any[*]\n" +
                 "{\n" +
                 "    let json = '{}';\n" +
-                "    $json -> fromJson(MissingData, ^meta::json::JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
+                "    $json -> fromJsonNative(MissingData, ^meta::json::JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
                 "}";
         String testFunc = "missing():Any[*]";
         String expectedException = "Error populating property 'missing' on class 'meta::pure::functions::json::tests::MissingData': \n" +
@@ -656,7 +656,7 @@ public abstract class AbstractTestFromJson extends AbstractPureTestWithCoreCompi
                 "{\n" +
                 "    let json = '{\"testField\": 1,\"secondProperty\":2}';\n" +
                 "    let config = ^JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=true);\n" +
-                "    $json -> fromJson(failUnknown, $config);\n" +
+                "    $json -> fromJsonNative(failUnknown, $config);\n" +
                 "}";
         String testFunc = "failUnknown():Any[*]";
         String expectedException = "Property 'secondProperty' can't be found in class meta::pure::functions::json::tests::failUnknown. ";
@@ -676,7 +676,7 @@ public abstract class AbstractTestFromJson extends AbstractPureTestWithCoreCompi
                 "{\n" +
                 "  let json = '{\"testField\": 1,\"__TYPE\":\"failUnknown\"}';\n" +
                 "  let config = ^JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=true);\n" +
-                "  $json -> fromJson(failUnknown, $config);\n" +
+                "  $json -> fromJsonNative(failUnknown, $config);\n" +
                 "}";
         String testFunc = "TypeKey():Any[*]";
         String expectedException = "Property '__TYPE' can't be found in class meta::pure::functions::json::tests::failUnknown. ";
@@ -695,7 +695,7 @@ public abstract class AbstractTestFromJson extends AbstractPureTestWithCoreCompi
                 "\n" +
                 "function go():Any[*]\n" +
                 "{\n" +
-                "  let json='{ \"a\": \"fred\" }'->meta::json::fromJson(meta::pure::functions::json::tests::A, ^meta::json::JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
+                "  let json='{ \"a\": \"fred\" }'->meta::json::fromJsonNative(meta::pure::functions::json::tests::A, ^meta::json::JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
                 "  assert(!$json->isEmpty(), |'');\n" +
                 "  assert('fred' == $json.a, |'');\n" +
                 "}";
@@ -721,7 +721,7 @@ public abstract class AbstractTestFromJson extends AbstractPureTestWithCoreCompi
                 "function go():Any[*]\n" +
                 "{\n" +
                 "  let config = ^JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=true, constraintsHandler=^ConstraintsOverride(constraintsManager=myFunc_Any_1__Any_1_));\n" +
-                "  let json='{ \"a\": \"fred\" }'->meta::json::fromJson(meta::pure::functions::json::tests::A, $config);\n" +
+                "  let json='{ \"a\": \"fred\" }'->meta::json::fromJsonNative(meta::pure::functions::json::tests::A, $config);\n" +
                 "  assert(!$json->isEmpty(), |''); \n" +
                 "  assert('fred' == $json.a, |''); \n" +
                 "}";
@@ -742,7 +742,7 @@ public abstract class AbstractTestFromJson extends AbstractPureTestWithCoreCompi
                 "}\n" +
                 "function go():Any[*]\n" +
                 "{\n" +
-                "  let json='{ \"str\": \"fred\", \"a\": {} }'->meta::json::fromJson(meta::pure::functions::json::tests::B, ^JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
+                "  let json='{ \"str\": \"fred\", \"a\": {} }'->meta::json::fromJsonNative(meta::pure::functions::json::tests::B, ^JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
                 "  assert(!$json->isEmpty(), |'');\n" +
                 "  assert('fred' == $json.str, |'');\n" +
                 "}";
@@ -767,7 +767,7 @@ public abstract class AbstractTestFromJson extends AbstractPureTestWithCoreCompi
                 "}\n" +
                 "function go():Any[*]\n" +
                 "{\n" +
-                "  let json='{ \"b\": {\"a\": \"fred\" } }'->meta::json::fromJson(meta::pure::functions::json::tests::B, ^meta::json::JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
+                "  let json='{ \"b\": {\"a\": \"fred\" } }'->meta::json::fromJsonNative(meta::pure::functions::json::tests::B, ^meta::json::JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
                 "  assert(!$json->isEmpty(), |'');\n" +
                 "  assert('fred' == $json.b.a, |'');\n" +
                 "}";
@@ -792,7 +792,7 @@ public abstract class AbstractTestFromJson extends AbstractPureTestWithCoreCompi
                 "}\n" +
                 "function go():Any[*]\n" +
                 "{\n" +
-                "  let json='{ \"b\": {\"a\": \"fred\" } }'->meta::json::fromJson(meta::pure::functions::json::tests::B, ^meta::json::JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
+                "  let json='{ \"b\": {\"a\": \"fred\" } }'->meta::json::fromJsonNative(meta::pure::functions::json::tests::B, ^meta::json::JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
                 "  assert(!$json->isEmpty(), |'');\n" +
                 "  assert('fred' == $json.b.a, |'');\n" +
                 "}";
@@ -820,7 +820,7 @@ public abstract class AbstractTestFromJson extends AbstractPureTestWithCoreCompi
                 "}\n" +
                 "function go():Any[*]\n" +
                 "{\n" +
-                "  let json='{ \"string\": \"dave\", \"B\": {\"string\": \"fred\", \"A\": { \"string\": \"dave\" } } }'->meta::json::fromJson(meta::pure::functions::json::tests::a, ^meta::json::JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
+                "  let json='{ \"string\": \"dave\", \"B\": {\"string\": \"fred\", \"A\": { \"string\": \"dave\" } } }'->meta::json::fromJsonNative(meta::pure::functions::json::tests::a, ^meta::json::JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
                 "}";
         String testFunc = "go():Any[*]";
         String expectedException = "Error populating property 'B' on class 'meta::pure::functions::json::tests::a': \n" +
@@ -851,7 +851,7 @@ public abstract class AbstractTestFromJson extends AbstractPureTestWithCoreCompi
                 "}\n" +
                 "function go():Any[*]\n" +
                 "{\n" +
-                "    '" + json + "' -> fromJson(Foo, ^JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
+                "    '" + json + "' -> fromJsonNative(Foo, ^JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
                 "}";
         String testFunc = "go():Any[*]";
         assertPassesExecution(sourceCode, testFunc);
@@ -869,7 +869,7 @@ public abstract class AbstractTestFromJson extends AbstractPureTestWithCoreCompi
                 "}\n" +
                 "function foo():Any[*]\n" +
                 "{\n" +
-                "   let fromJson = '{\"@id\": 1, \"str\": \"one\", \"FOO\": {\"@id\": 1, \"str\": \"two\", \"FOO\": 1}}' -> fromJson(Foo, ^JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
+                "   let fromJson = '{\"@id\": 1, \"str\": \"one\", \"FOO\": {\"@id\": 1, \"str\": \"two\", \"FOO\": 1}}' -> fromJsonNative(Foo, ^JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
                 "   assert($fromJson.FOO.FOO == [], |'');\n" +
                 "}";
         String testFunc = "foo():Any[*]";
@@ -894,7 +894,7 @@ public abstract class AbstractTestFromJson extends AbstractPureTestWithCoreCompi
                 "function foo():Any[*]\n" +
                 "{\n" +
                 "  let json = '{\"@id\": 1, \"str\": \"foo\", \"b\": {\"a\": 1}}';\n" +
-                "  let o = $json -> fromJson(_A, ^JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
+                "  let o = $json -> fromJsonNative(_A, ^JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
                 "  let _b = $o.b;\n" +
                 "  assert($_b == $_b.a.b, |'');\n" +
                 "}";
@@ -919,7 +919,7 @@ public abstract class AbstractTestFromJson extends AbstractPureTestWithCoreCompi
                 "function foo():Any[*]\n" +
                 "{\n" +
                 "  let json = '{\"@id\": 1, \"str\": \"foo\", \"two\": {\"one\": 1}}';\n" +
-                "  let one = $json -> fromJson(ClassOne, ^meta::json::JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
+                "  let one = $json -> fromJsonNative(ClassOne, ^meta::json::JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
                 "  let two = $one.two;\n" +
                 "  assert($two.one == [], |'');\n" +
                 "}";
@@ -945,7 +945,7 @@ public abstract class AbstractTestFromJson extends AbstractPureTestWithCoreCompi
                 "function foo():Any[*]\n" +
                 "{\n" +
                 "  let json = '{\"str\": \"foo\", \"b\": {}}';\n" +
-                "  let o = $json -> fromJson(A, ^JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
+                "  let o = $json -> fromJsonNative(A, ^JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
                 "  let _b = $o.b -> toOne();\n" +
                 "  assert($_b == $_b.a.b, |'');\n" +
                 "}";
@@ -974,7 +974,7 @@ public abstract class AbstractTestFromJson extends AbstractPureTestWithCoreCompi
                 "function foo():Any[*]\n" +
                 "{\n" +
                 "   let json = '{\"a\": [{\"@type\": \"B\", \"float\": 4167}, {\"@type\": \"C\", \"string\": \"foo\"}]}';\n" +
-                "   let o = $json -> fromJson(Parent, ^meta::json::JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
+                "   let o = $json -> fromJsonNative(Parent, ^meta::json::JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
                 "   assert(4167.0 == $o.a -> first() -> cast(@B).float, |'');\n" +
                 "}";
         String testFunc = "foo():Any[*]";
@@ -994,7 +994,7 @@ public abstract class AbstractTestFromJson extends AbstractPureTestWithCoreCompi
                 "{\n" +
                 "   let config = ^JSONDeserializationConfig(typeKeyName='__TYPE', failOnUnknownProperties=true);\n" +
                 "   let json = '{\"__TYPE\": \"B\", \"float\": 4167}';\n" +
-                "   let o = $json -> fromJson(B, $config);\n" +
+                "   let o = $json -> fromJsonNative(B, $config);\n" +
                 "   assert(4167.0 == $o.float, |'');\n" +
                 "}";
         String testFunc = "foo():Any[*]";
@@ -1015,7 +1015,7 @@ public abstract class AbstractTestFromJson extends AbstractPureTestWithCoreCompi
                 "function go():Any[*]\n" +
                 "{\n" +
                 "   let json = '{\"a\": {\"float\": 4167}}';\n" +
-                "   let o = $json -> fromJson(Parent, ^meta::json::JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
+                "   let o = $json -> fromJsonNative(Parent, ^meta::json::JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
                 "}";
         String testFunc = "go():Any[*]";
         assertPassesExecution(sourceCode, testFunc);
@@ -1031,7 +1031,7 @@ public abstract class AbstractTestFromJson extends AbstractPureTestWithCoreCompi
                 "}\n" +
                 "function go():Any[*]\n" +
                 "{\n" +
-                "  let json='{}'->fromJson(meta::pure::functions::json::tests::a, ^meta::json::JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
+                "  let json='{}'->fromJsonNative(meta::pure::functions::json::tests::a, ^meta::json::JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
                 "}";
         String testFunc = "go():Any[*]";
         String expectedException = "Error populating property 'string' on class 'meta::pure::functions::json::tests::a': \n" +
@@ -1049,7 +1049,7 @@ public abstract class AbstractTestFromJson extends AbstractPureTestWithCoreCompi
                 "}\n" +
                 "function go():Any[*]\n" +
                 "{\n\n" +
-                "  let json='{\"string\": [\"foo\", \"bar\"]}'->fromJson(meta::pure::functions::json::tests::a, ^JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
+                "  let json='{\"string\": [\"foo\", \"bar\"]}'->fromJsonNative(meta::pure::functions::json::tests::a, ^JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
                 "}";
         String testFunc = "go():Any[*]";
         assertPassesExecution(sourceCode, testFunc);
@@ -1064,7 +1064,7 @@ public abstract class AbstractTestFromJson extends AbstractPureTestWithCoreCompi
                 "}\n" +
                 "function go():Any[*]\n" +
                 "{\n" +
-                "  '{\"@type\": \"Foo\"}'->fromJson(meta::pure::functions::json::tests::Foo, ^JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
+                "  '{\"@type\": \"Foo\"}'->fromJsonNative(meta::pure::functions::json::tests::Foo, ^JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
                 "}";
         String testFunc = "go():Any[*]";
         assertPassesExecution(sourceCode, testFunc);
@@ -1084,7 +1084,7 @@ public abstract class AbstractTestFromJson extends AbstractPureTestWithCoreCompi
                 "}\n" +
                 "function go():Any[*]\n" +
                 "{\n" +
-                "  '{\"e\": \"Foo\"}'->fromJson(meta::pure::functions::json::tests::Foo, ^meta::json::JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
+                "  '{\"e\": \"Foo\"}'->fromJsonNative(meta::pure::functions::json::tests::Foo, ^meta::json::JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
                 "}";
         String testFunc = "go():Any[*]";
         assertPassesExecution(sourceCode, testFunc);
@@ -1098,7 +1098,7 @@ public abstract class AbstractTestFromJson extends AbstractPureTestWithCoreCompi
                 "Class meta::json::test::Bar {}\n" +
                 "function go():Any[*]\n" +
                 "{\n" +
-                "  '{\"@type\": \"Foo\"}'->fromJson(meta::json::test::Bar, ^meta::json::JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
+                "  '{\"@type\": \"Foo\"}'->fromJsonNative(meta::json::test::Bar, ^meta::json::JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
                 "}";
         String testFunc = "go():Any[*]";
         String expectedException = "Could not find a sub-type of \"meta::json::test::Bar\" with name \"Foo\".";
@@ -1112,7 +1112,7 @@ public abstract class AbstractTestFromJson extends AbstractPureTestWithCoreCompi
                 "Class meta::json::test::Foo {}\n" +
                 "function go():Any[*]\n" +
                 "{\n" +
-                "  '[]'->fromJson(meta::json::test::Foo, ^meta::json::JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
+                "  '[]'->fromJsonNative(meta::json::test::Foo, ^meta::json::JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
                 "}";
         String testFunc = "go():Any[*]";
         String expectedException = "Can only deserialize root-level JSONObjects i.e. serialized single instances of PURE classes. Cannot deserialize collections of multiple PURE objects.";
@@ -1129,7 +1129,7 @@ public abstract class AbstractTestFromJson extends AbstractPureTestWithCoreCompi
                 "}\n" +
                 "function go():Any[*]\n" +
                 "{\n" +
-                "  '{\"_type\":\"z\",\"name\":\"bla\"}'->fromJson(meta::json::test::Foo, ^meta::json::JSONDeserializationConfig(failOnUnknownProperties=true, typeKeyName='_type', typeLookup = [pair('z','meta::json::test::Foo')]));\n" +
+                "  '{\"_type\":\"z\",\"name\":\"bla\"}'->fromJsonNative(meta::json::test::Foo, ^meta::json::JSONDeserializationConfig(failOnUnknownProperties=true, typeKeyName='_type', typeLookup = [pair('z','meta::json::test::Foo')]));\n" +
                 "}";
         String testFunc = "go():Any[*]";
         assertPassesExecution(sourceCode, testFunc);
@@ -1151,7 +1151,7 @@ public abstract class AbstractTestFromJson extends AbstractPureTestWithCoreCompi
                 "}\n" +
                 "function testUnitToJson():Any[*]\n" +
                 "{\n" +
-                "   let res ='{\"myWeight\":{\"unit\":[{\"unitId\":\"pkg::Mass~Kilogram\",\"exponentValue\":1}],\"value\":5.5}}'\n->meta::json::fromJson(A, ^meta::json::JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
+                "   let res ='{\"myWeight\":{\"unit\":[{\"unitId\":\"pkg::Mass~Kilogram\",\"exponentValue\":1}],\"value\":5.5}}'\n->meta::json::fromJsonNative(A, ^meta::json::JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
                 "   $res.myWeight;\n" +
                 "}\n";
         String testFunc = "testUnitToJson():Any[*]";
@@ -1176,7 +1176,7 @@ public abstract class AbstractTestFromJson extends AbstractPureTestWithCoreCompi
                 "}\n" +
                 "function testUnitToJson():Any[*]\n" +
                 "{\n" +
-                "   let res ='{\"myWeight\":[{\"unit\":[{\"unitId\":\"pkg::Mass~Kilogram\",\"exponentValue\":1}],\"value\":5},{\"unit\":[{\"unitId\":\"pkg::Mass~Kilogram\",\"exponentValue\":1}],\"value\":1}]}'\n->meta::json::fromJson(A, ^meta::json::JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
+                "   let res ='{\"myWeight\":[{\"unit\":[{\"unitId\":\"pkg::Mass~Kilogram\",\"exponentValue\":1}],\"value\":5},{\"unit\":[{\"unitId\":\"pkg::Mass~Kilogram\",\"exponentValue\":1}],\"value\":1}]}'\n->meta::json::fromJsonNative(A, ^meta::json::JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
                 "   $res.myWeight->at(0);\n" +
                 "}\n";
         String testFunc = "testUnitToJson():Any[*]";
@@ -1201,7 +1201,7 @@ public abstract class AbstractTestFromJson extends AbstractPureTestWithCoreCompi
                 "}\n" +
                 "function testUnitToJson():Any[*]\n" +
                 "{\n" +
-                "   let res ='{\"myWeight\":{\"unit\":[{\"unitId\":\"pkg::Mass~Kilogram\",\"exponentValue\":1}],\"value\":5.5}}'\n->meta::json::fromJson(A, ^meta::json::JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
+                "   let res ='{\"myWeight\":{\"unit\":[{\"unitId\":\"pkg::Mass~Kilogram\",\"exponentValue\":1}],\"value\":5.5}}'\n->meta::json::fromJsonNative(A, ^meta::json::JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
                 "   $res.myWeight;\n" +
                 "}\n";
         String testFunc = "testUnitToJson():Any[*]";
@@ -1227,7 +1227,7 @@ public abstract class AbstractTestFromJson extends AbstractPureTestWithCoreCompi
                 "}\n" +
                 "function testUnitToJsonWithType():Any[*]\n" +
                 "{\n" +
-                "   let res ='{\"__TYPE\":\"A\",\"myWeight\":{\"unit\":[{\"unitId\":\"pkg::Mass~Kilogram\",\"exponentValue\":1}],\"value\":5.5}, \"myOptionalWeight\":[]}'->meta::json::fromJson(A, ^meta::json::JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
+                "   let res ='{\"__TYPE\":\"A\",\"myWeight\":{\"unit\":[{\"unitId\":\"pkg::Mass~Kilogram\",\"exponentValue\":1}],\"value\":5.5}, \"myOptionalWeight\":[]}'->meta::json::fromJsonNative(A, ^meta::json::JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
                 "   $res.myWeight;\n" +
                 "}\n";
         String testFunc = "testUnitToJsonWithType():Any[*]";
@@ -1252,7 +1252,7 @@ public abstract class AbstractTestFromJson extends AbstractPureTestWithCoreCompi
                 "}\n" +
                 "function testUnitToJsonWithType():Any[*]\n" +
                 "{\n" +
-                "   let res ='{\"__TYPE\":\"A\",\"myWeight\":{\"unit\":[{\"unitId\":\"badtype\",\"exponentValue\":1}],\"value\":5.5}}'->meta::json::fromJson(A, ^meta::json::JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
+                "   let res ='{\"__TYPE\":\"A\",\"myWeight\":{\"unit\":[{\"unitId\":\"badtype\",\"exponentValue\":1}],\"value\":5.5}}'->meta::json::fromJsonNative(A, ^meta::json::JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
                 "   $res.myWeight;\n" +
                 "}\n";
         String testFunc = "testUnitToJsonWithType():Any[*]";
@@ -1277,7 +1277,7 @@ public abstract class AbstractTestFromJson extends AbstractPureTestWithCoreCompi
                 "}\n" +
                 "function testUnitToJsonWithType():Any[*]\n" +
                 "{\n" +
-                "   let res ='{\"__TYPE\":\"A\",\"myWeight\":{\"unit\":[{\"unitId\":\"pkg::Mass~Kilogram\",\"exponentValue\":1}],\"value\":\"5.5\"}}'->meta::json::fromJson(A, ^meta::json::JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
+                "   let res ='{\"__TYPE\":\"A\",\"myWeight\":{\"unit\":[{\"unitId\":\"pkg::Mass~Kilogram\",\"exponentValue\":1}],\"value\":\"5.5\"}}'->meta::json::fromJsonNative(A, ^meta::json::JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
                 "   $res.myWeight;\n" +
                 "}\n";
         String testFunc = "testUnitToJsonWithType():Any[*]";
@@ -1302,7 +1302,7 @@ public abstract class AbstractTestFromJson extends AbstractPureTestWithCoreCompi
                 "}\n" +
                 "function testUnitToJsonWithType():Any[*]\n" +
                 "{\n" +
-                "   let res ='{\"__TYPE\":\"A\",\"myWeight\":{\"unit\":[{\"unitId\":\"pkg::Mass~Kilogram\",\"exponentValue\":3}],\"value\":5}}'->meta::json::fromJson(A, ^meta::json::JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
+                "   let res ='{\"__TYPE\":\"A\",\"myWeight\":{\"unit\":[{\"unitId\":\"pkg::Mass~Kilogram\",\"exponentValue\":3}],\"value\":5}}'->meta::json::fromJsonNative(A, ^meta::json::JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
                 "}\n";
         String testFunc = "testUnitToJsonWithType():Any[*]";
         String expectedException = "Error populating property 'myWeight' on class 'A': \n" +
@@ -1326,7 +1326,7 @@ public abstract class AbstractTestFromJson extends AbstractPureTestWithCoreCompi
                 "}\n" +
                 "function testUnitToJsonWithType():Any[*]\n" +
                 "{\n" +
-                "   let res ='{\"__TYPE\":\"A\",\"myWeight\":{\"unit\":[{\"unitId\":\"pkg::Mass~Kilogram\",\"exponentValue\":1},{\"unitId\":\"pkg::Mass~Gram\",\"exponentValue\":1}],\"value\":5}}'->meta::json::fromJson(A, ^meta::json::JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
+                "   let res ='{\"__TYPE\":\"A\",\"myWeight\":{\"unit\":[{\"unitId\":\"pkg::Mass~Kilogram\",\"exponentValue\":1},{\"unitId\":\"pkg::Mass~Gram\",\"exponentValue\":1}],\"value\":5}}'->meta::json::fromJsonNative(A, ^meta::json::JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
                 "}\n";
         String testFunc = "testUnitToJsonWithType():Any[*]";
         String expectedException = "Error populating property 'myWeight' on class 'A': \n" +
@@ -1361,7 +1361,7 @@ public abstract class AbstractTestFromJson extends AbstractPureTestWithCoreCompi
                 "function " + testName + "():Any[*]\n" +
                 "{\n" +
                 "    let json = '{\"testField\": " + actualJson + "}';\n" +
-                "    $json -> fromJson(" + testName + ", ^JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
+                "    $json -> fromJsonNative(" + testName + ", ^JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
                 "}";
         String testFunction = testName + "():Any[*]";
         String exceptionDetails = "".equals(expectedExceptionSnippet) ? "" : ": \n" + expectedExceptionSnippet;
@@ -1386,7 +1386,7 @@ public abstract class AbstractTestFromJson extends AbstractPureTestWithCoreCompi
                 "function " + testName + "():Any[*]\n" +
                 "{\n" +
                 "    let json = '{\"testField\": " + actualJson + "}';\n" +
-                "    let jsonAsPure = $json -> fromJson(" + testName + ", ^JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
+                "    let jsonAsPure = $json -> fromJsonNative(" + testName + ", ^JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n" +
                 "    assertEquals(" + result + ", $jsonAsPure.testField, 'Output does match expected');\n" +
                 "}";
         String testFunction = testName + "():Any[*]";

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-json/legend-engine-pure-runtime-java-extension-compiled-functions-json/src/main/java/org/finos/legend/pure/runtime/java/extension/external/json/compiled/natives/FromJson.java
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-json/legend-engine-pure-runtime-java-extension-compiled-functions-json/src/main/java/org/finos/legend/pure/runtime/java/extension/external/json/compiled/natives/FromJson.java
@@ -25,7 +25,7 @@ public class FromJson extends AbstractNativeFunctionGeneric
     {
         super("org.finos.legend.pure.generated.JsonGen.fromJson",
                 new Object[]{String.class, org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class.class, "org.finos.legend.pure.generated.Root_meta_json_JSONDeserializationConfig", SourceInformation.class, ExecutionSupport.class},
-                true, true, false, "fromJson_String_1__Class_1__JSONDeserializationConfig_1__T_1_");
+                true, true, false, "fromJsonNative_String_1__Class_1__JSONDeserializationConfig_1__T_1_");
     }
 
     @Override

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-json/legend-engine-pure-runtime-java-extension-interpreted-functions-json/src/main/java/org/finos/legend/pure/runtime/java/extension/external/json/interpreted/JsonExtensionInterpreted.java
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-json/legend-engine-pure-runtime-java-extension-interpreted-functions-json/src/main/java/org/finos/legend/pure/runtime/java/extension/external/json/interpreted/JsonExtensionInterpreted.java
@@ -31,7 +31,7 @@ public class JsonExtensionInterpreted extends BaseInterpretedExtension
         super(Tuples.pair("escape_String_1__String_1_", Escape::new),
                 Tuples.pair("parseJSON_String_1__JSONElement_1_", ParseJSON::new),
                 Tuples.pair("equalJsonStrings_String_1__String_1__Boolean_1_", JsonStringsEqual::new),
-                Tuples.pair("fromJson_String_1__Class_1__JSONDeserializationConfig_1__T_1_", FromJson::new),
+                Tuples.pair("fromJsonNative_String_1__Class_1__JSONDeserializationConfig_1__T_1_", FromJson::new),
                 Tuples.pair("fromJsonDeprecated_String_1__Class_1__JSONDeserializationConfig_1__T_1_", FromJsonDeprecated::new),
                 Tuples.pair("toJsonBeta_Any_MANY__JSONSerializationConfig_1__String_1_", ToJson::new)
         );

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-variant/legend-engine-pure-runtime-java-extension-interpreted-functions-variant/src/main/java/org/finos/legend/pure/runtime/java/extension/external/variant/interpreted/natives/AbstractTo.java
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-variant/legend-engine-pure-runtime-java-extension-interpreted-functions-variant/src/main/java/org/finos/legend/pure/runtime/java/extension/external/variant/interpreted/natives/AbstractTo.java
@@ -209,7 +209,7 @@ public abstract class AbstractTo extends NativeFunction
                 Instance.setValuesForProperty(desConfig, "typeLookup", typeLookup, processorSupport);
                 Instance.setValueForProperty(desConfig, "failOnUnknownProperties", this.repository.newBooleanCoreInstance(false), processorSupport);
 
-                CoreInstance fromJsonToClassFunc = processorSupport.package_getByUserPath("meta::json::fromJson_String_1__Class_1__JSONDeserializationConfig_1__T_1_");
+                CoreInstance fromJsonToClassFunc = processorSupport.package_getByUserPath("meta::json::fromJsonNative_String_1__Class_1__JSONDeserializationConfig_1__T_1_");
                 ListIterable<CoreInstance> arguments = Lists.fixedSize.of(
                         ValueSpecificationBootstrap.wrapValueSpecification(this.repository.newStringCoreInstance(jsonNode.toString()), true, processorSupport),
                         ValueSpecificationBootstrap.wrapValueSpecification(targetRawType, true, processorSupport),

--- a/legend-engine-xts-elasticsearch/legend-engine-xt-elasticsearch-pure-specification-metamodel/src/main/resources/core_elasticsearch_specification_metamodel/metamodel.pure
+++ b/legend-engine-xts-elasticsearch/legend-engine-xt-elasticsearch-pure-specification-metamodel/src/main/resources/core_elasticsearch_specification_metamodel/metamodel.pure
@@ -534,5 +534,5 @@ function meta::external::store::elasticsearch::specification::metamodel::parse(s
       ]
     );
 
-    $specAsJson->fromJson(Model, $jsonDeserializationConfig);
+    $specAsJson->fromJsonNative(Model, $jsonDeserializationConfig);
 }

--- a/legend-engine-xts-graphQL/legend-engine-xt-graphQL-pure/src/main/resources/core_external_query_graphql/binding/toPure/introspection/tests/continents/testContinents.pure
+++ b/legend-engine-xts-graphQL/legend-engine-xt-graphQL-pure/src/main/resources/core_external_query_graphql/binding/toPure/introspection/tests/continents/testContinents.pure
@@ -5,7 +5,7 @@ import meta::pure::metamodel::serialization::grammar::*;
 function <<test.Test>> meta::external::query::graphQL::binding::toPure::introspection::tests::testCountriesFromIntrospection():Boolean[1]
 {
     let str = readFile('/core_external_query_graphql/binding/toPure/introspection/tests/continents/continents.json')->toOne();
-    let res = $str->meta::json::fromJson(__Schema)->meta::external::query::graphQL::binding::toPure::introspection::buildPureTypesFromGraphQLSchema('');
+    let res = $str->meta::json::fromJsonNative(__Schema)->meta::external::query::graphQL::binding::toPure::introspection::buildPureTypesFromGraphQLSchema('');
     assertEquals( 'Enum CacheControlScope\n' +
                   '{\n' +
                   '  PUBLIC,\n' +

--- a/legend-engine-xts-graphQL/legend-engine-xt-graphQL-pure/src/main/resources/core_external_query_graphql/binding/toPure/introspection/tests/simple/testSimple.pure
+++ b/legend-engine-xts-graphQL/legend-engine-xt-graphQL-pure/src/main/resources/core_external_query_graphql/binding/toPure/introspection/tests/simple/testSimple.pure
@@ -5,7 +5,7 @@ import meta::pure::metamodel::serialization::grammar::*;
 function <<test.Test>> meta::external::query::graphQL::binding::toPure::introspection::tests::testPureFromIntrospection():Boolean[1]
 {
     let str = readFile('/core_external_query_graphql/binding/toPure/introspection/tests/simple/introspectionResult.json')->toOne();
-    let res = $str->meta::json::fromJson(__Schema)->meta::external::query::graphQL::binding::toPure::introspection::buildPureTypesFromGraphQLSchema('');
+    let res = $str->meta::json::fromJsonNative(__Schema)->meta::external::query::graphQL::binding::toPure::introspection::buildPureTypesFromGraphQLSchema('');
     assertEquals( 'Class Domain\n' +
                   '{\n' +
                   '  val: String[1];\n' +

--- a/legend-engine-xts-graphQL/legend-engine-xt-graphQL-pure/src/main/resources/core_external_query_graphql/binding/toPure/introspection/tests/travel/testTravelX.pure
+++ b/legend-engine-xts-graphQL/legend-engine-xt-graphQL-pure/src/main/resources/core_external_query_graphql/binding/toPure/introspection/tests/travel/testTravelX.pure
@@ -6,6 +6,6 @@ function <<test.Test>> meta::external::query::graphQL::binding::toPure::introspe
 {
     let str = readFile('/core_external_query_graphql/binding/toPure/introspection/tests/travel/travelx.json')->toOne();
     let expected = readFile('/core_external_query_graphql/binding/toPure/introspection/tests/travel/travelResult.txt', '\n')->toOne();
-    let res = $str->meta::json::fromJson(__Schema)->meta::external::query::graphQL::binding::toPure::introspection::buildPureTypesFromGraphQLSchema('');
+    let res = $str->meta::json::fromJsonNative(__Schema)->meta::external::query::graphQL::binding::toPure::introspection::buildPureTypesFromGraphQLSchema('');
     assertEquals($expected, $res->sortBy(r|$r->elementToPath())->map(r|$r->printType())->joinStrings('\n'));
 }

--- a/legend-engine-xts-java/legend-engine-xt-javaGeneration-pure/src/main/resources/core_external_language_java/generation/conventions.pure
+++ b/legend-engine-xts-java/legend-engine-xt-javaGeneration-pure/src/main/resources/core_external_language_java/generation/conventions.pure
@@ -1262,7 +1262,7 @@ function meta::external::language::java::transform::defaultProhibitedFunctions(e
 
       meta::json::escape_String_1__String_1_,
       meta::json::fromJsonDeprecated_String_1__Class_1__JSONDeserializationConfig_1__T_1_,
-      meta::json::fromJson_String_1__Class_1__JSONDeserializationConfig_1__T_1_,
+      meta::json::fromJsonNative_String_1__Class_1__JSONDeserializationConfig_1__T_1_,
       meta::json::parseJSON_String_1__JSONElement_1_,
       meta::json::toJsonBeta_Any_MANY__JSONSerializationConfig_1__String_1_
    ]->concatenate($extraProhibitedFunctions)->map(f | pair($f, true))->newMap();

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-postgresSql/legend-engine-xt-relationalStore-postgresSqlParser-pure/src/main/resources/core_external_store_relational_postgres_sql_parser/postgresSqlParser.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-postgresSql/legend-engine-xt-relationalStore-postgresSqlParser-pure/src/main/resources/core_external_store_relational_postgres_sql_parser/postgresSqlParser.pure
@@ -22,7 +22,7 @@ native function <<access.private>> meta::external::store::relational::postgresSq
 function meta::external::store::relational::postgresSql::parser::parseSqlStatement(sql: String[1]): Statement[1]
 {
   let statementJson = $sql->parseSqlStatementToJson();
-  $statementJson->fromJson(
+  $statementJson->fromJsonNative(
     Statement,
     ^JSONDeserializationConfig(
       typeKeyName = '_type',


### PR DESCRIPTION
## Problem

`meta::json::fromJson` (lowercase — a 3-arg native plus a 2-arg Pure wrapper) and `meta::json::fromJSON` (uppercase — the 12-overload Pure family) differ **only by case**. legend-pure serializes each element to a `.pelt`/`.pbr` resource keyed by its mangled name (e.g. `meta/json/fromJson_String_1__Class_1__T_1_.pelt` vs `…/fromJSON_String_1__Class_1__T_1_.pelt`). On a **case-insensitive filesystem** these resource paths collide and clobber each other, so a dependent repo can fail to resolve the function — e.g. `core_protocol_generation` failing with `can't find a match for meta::json::fromJSON(String[1], Class<...>[1])` / `cannot find resource …fromJSON_String_1__Class_1__T_1_.pelt`.

## Fix

Rename the lowercase `meta::json::fromJson` family to `meta::json::fromJsonNative` so the two families no longer collide:

- `json.pure` (3-arg native) and `jsonExtension.pure` (2-arg Pure wrapper) definitions
- interpreted + compiled JSON native registrations (`JsonExtensionInterpreted`, `FromJson`)
- the variant `AbstractTo` `package_getByUserPath` lookup
- the compiled-generated call `Root_meta_json_fromJson_…` in `HelperConnectionBuilder`
- the java-generation prohibited-function list (`conventions.pure`)
- the `String->fromJson(Class[,config])` call sites (graphQL introspection tests, postgres SQL parser, elasticsearch metamodel, JSON tests)

The unrelated `meta::external::format::json::functions::fromJson` (`Class->fromJson($data)`) and the no-arg variant `fromJson()` are left untouched.

No behavioural change — pure rename.