### PR TITLE
Add optional clientVersion param to compile endpoint

### DIFF
--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler-http-api/src/main/java/org/finos/legend/engine/language/pure/compiler/api/Compile.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler-http-api/src/main/java/org/finos/legend/engine/language/pure/compiler/api/Compile.java
@@ -48,6 +48,7 @@ import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -78,7 +79,7 @@ public class Compile
     @ApiOperation(value = "Loads the model and then compiles. It performs no action. Mostly used for testing")
     @Consumes({MediaType.APPLICATION_JSON, APPLICATION_ZLIB})
     @Prometheus(name = "compile model", doc = "Pure model compilation duration summary")
-    public Response compile(PureModelContext model, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm, @Context UriInfo uriInfo)
+    public Response compile(PureModelContext model, @ApiParam("Optional client version. When omitted, falls back to the serializer version if a Pointer, otherwise null.") @QueryParam("clientVersion") String clientVersion, @ApiParam(hidden = true) @Pac4JProfileManager ProfileManager<CommonProfile> pm, @Context UriInfo uriInfo)
     {
         MutableList<CommonProfile> profiles = ProfileManagerHelper.extractProfiles(pm);
         Identity identity = Identity.makeIdentity(profiles);
@@ -86,7 +87,10 @@ public class Compile
         try (Scope scope = GlobalTracer.get().buildSpan("Service: compile").startActive(true))
         {
             CompilerExtensions.logAvailableExtensions();
-            Pair<PureModelContextData, PureModel> res = modelManager.loadModelAndData(model, model instanceof PureModelContextPointer ? ((PureModelContextPointer) model).serializer.version : null, identity, null);
+            String effectiveClientVersion = clientVersion != null
+                    ? clientVersion
+                    : (model instanceof PureModelContextPointer ? ((PureModelContextPointer) model).serializer.version : null);
+            Pair<PureModelContextData, PureModel> res = modelManager.loadModelAndData(model, effectiveClientVersion, identity, null);
             long end = System.currentTimeMillis();
             MetricsHandler.observe("compile model", start, end);
             MetricsHandler.observeRequest(uriInfo != null ? uriInfo.getPath() : null, start, end);

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler-http-api/src/test/java/org/finos/legend/engine/language/pure/compiler/api/test/TestCompileApi.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler-http-api/src/test/java/org/finos/legend/engine/language/pure/compiler/api/test/TestCompileApi.java
@@ -16,12 +16,18 @@ package org.finos.legend.engine.language.pure.compiler.api.test;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.opentracing.Span;
 import net.javacrumbs.jsonunit.JsonAssert;
 import org.finos.legend.engine.language.pure.compiler.api.Compile;
 import org.finos.legend.engine.language.pure.compiler.api.LambdaReturnTypeInput;
 import org.finos.legend.engine.language.pure.grammar.from.PureGrammarParser;
+import org.finos.legend.engine.language.pure.modelManager.ModelLoader;
 import org.finos.legend.engine.language.pure.modelManager.ModelManager;
+import org.finos.legend.engine.protocol.pure.v1.model.context.AlloySDLC;
+import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContext;
+import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextCombination;
 import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
+import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextPointer;
 import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextText;
 import org.finos.legend.engine.protocol.pure.m3.valuespecification.constant.PackageableType;
 import org.finos.legend.engine.protocol.pure.m3.relation.RelationType;
@@ -29,9 +35,11 @@ import org.finos.legend.engine.protocol.pure.m3.relation.Column;
 import org.finos.legend.engine.protocol.pure.m3.function.LambdaFunction;
 import org.finos.legend.engine.shared.core.ObjectMapperFactory;
 import org.finos.legend.engine.shared.core.deployment.DeploymentMode;
+import org.finos.legend.engine.shared.core.identity.Identity;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.Objects;
 import java.util.Scanner;
 
@@ -80,7 +88,7 @@ public class TestCompileApi
         try
         {
             PureModelContextData pureModelContextData = objectMapper.readValue(pureModelContextDataJsonStr, PureModelContextData.class);
-            Object response = compileApi.compile(pureModelContextData, null, null).getEntity();
+            Object response = compileApi.compile(pureModelContextData, null, null, null).getEntity();
             actual = objectMapper.writeValueAsString(response);
             if (compilationResult != null)
             {
@@ -188,6 +196,62 @@ public class TestCompileApi
         Assert.assertEquals("test::SampleProfile", ageColumn.taggedValues.get(0).tag.profile);
         Assert.assertEquals("doc", ageColumn.taggedValues.get(0).tag.value);
         Assert.assertEquals("age documentation", ageColumn.taggedValues.get(0).value);
+    }
+
+    @Test
+    public void testCompileCombinationWithPointersUsesQueryParamClientVersion() throws JsonProcessingException
+    {
+        // Stub loader: succeeds only if Compile.compile() propagated a non-null clientVersion. This is the
+        // assertion path that used to trip the bug (SDLCLoader rejects null clientVersion).
+        ModelLoader loader = new ModelLoader()
+        {
+            @Override
+            public boolean supports(PureModelContext context)
+            {
+                return context instanceof PureModelContextPointer;
+            }
+
+            @Override
+            public PureModelContextData load(Identity identity, PureModelContext context, String clientVersion, Span parentSpan)
+            {
+                Assert.assertEquals("Compile endpoint must forward the supplied clientVersion when resolving pointers", "v1_33_0", clientVersion);
+                return PureGrammarParser.newInstance().parseModel("Class loaded::FromPointer { y: Integer[1]; }");
+            }
+
+            @Override
+            public void setModelManager(ModelManager modelManager)
+            {
+            }
+
+            @Override
+            public boolean shouldCache(PureModelContext context)
+            {
+                return false;
+            }
+
+            @Override
+            public PureModelContext cacheKey(PureModelContext context, Identity identity)
+            {
+                return context;
+            }
+        };
+
+        AlloySDLC sdlc = new AlloySDLC();
+        sdlc.groupId = "org.example";
+        sdlc.artifactId = "some-published-model";
+        sdlc.version = "1.0.0";
+        PureModelContextPointer pointer = new PureModelContextPointer();
+        pointer.sdlcInfo = sdlc;
+
+        PureModelContextText text = new PureModelContextText();
+        text.code = "Class my::A { x: String[1]; }";
+
+        PureModelContextCombination combination = new PureModelContextCombination();
+        combination.contexts = Arrays.asList(text, pointer);
+
+        Compile api = new Compile(new ModelManager(DeploymentMode.TEST, loader));
+        Object response = api.compile(combination, "v1_33_0", null, null).getEntity();
+        Assert.assertEquals("{\"message\":\"OK\",\"defects\":[]}", objectMapper.writeValueAsString(response));
     }
 
 }


### PR DESCRIPTION
#### What type of PR is this?

Improvement

#### What does this PR do / why is it needed ?

##### Why?
`POST /api/pure/v1/compilation/compile` could not compile a `PureModelContextCombination` whose inner contexts contained any `PureModelContextPointer`. The endpoint only extracted `clientVersion` when the top-level model was a `PureModelContextPointer`; in every other case it forwarded null to `ModelManager.loadModelAndData`, which then tripped `SDLCLoader.load`'s assertion:

```
Client version should be set when pulling metadata from the metadata repository
```

Consequence: every client has to pre-resolve all dependency pointers against the metadata server itself and submit a fully-inlined PMCD - exactly the work `ModelManager` was designed to do server-side. This duplicates effort, blows up the request payload (tens of MB for non-trivial workspaces), and bypasses the engine's `pureModelContextCache`.

##### What's Changed?
`Compile.compile` now accepts an optional `clientVersion` query parameter and forwards it to `ModelManager.loadModelAndData` regardless of the top-level context type.

This is a **strict superset** of the previous behaviour: existing callers passing `PureModelContextData`, `PureModelContextText`, or a top-level `PureModelContextPointer` need no changes. Clients that want server-side resolution of pointers inside a `PureModelContextCombination` simply add `?clientVersion=vX_X_X` to the request.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


#### Other notes for reviewers:

An argument could be made that the default of `null` should be changed to `PureClientVersions.production` in line with how some other endpoints handle PMCs. Will review the impact of this seperately.

#### Does this PR introduce a user-facing change?
<!--
-->
