### PR TITLE
Add dq persistence strategy grammar as interface

### DIFF
--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/DataQualityCompilerExtension.java
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/DataQualityCompilerExtension.java
@@ -30,6 +30,7 @@ import org.finos.legend.engine.language.pure.compiler.toPureGraph.handlers.Handl
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.handlers.inference.ParametersInference;
 import org.finos.legend.engine.protocol.dataquality.metamodel.DataQuality;
 import org.finos.legend.engine.protocol.dataquality.metamodel.DataQualityExecutionContext;
+import org.finos.legend.engine.protocol.dataquality.metamodel.DataQualityPersistenceStrategy;
 import org.finos.legend.engine.protocol.dataquality.metamodel.DataQualityPropertyGraphFetchTree;
 import org.finos.legend.engine.protocol.dataquality.metamodel.DataQualityRelationComparison;
 import org.finos.legend.engine.protocol.dataquality.metamodel.DataQualityRootGraphFetchTree;
@@ -61,6 +62,7 @@ import org.finos.legend.pure.generated.Root_meta_external_dataquality_MD5HashStr
 import org.finos.legend.pure.generated.Root_meta_external_dataquality_DataQualityRootGraphFetchTree;
 import org.finos.legend.pure.generated.Root_meta_external_dataquality_DataQualityRootGraphFetchTree_Impl;
 import org.finos.legend.pure.generated.Root_meta_external_dataquality_DataQuality_Impl;
+import org.finos.legend.pure.generated.Root_meta_external_dataquality_DataQualityPersistenceStrategy;
 import org.finos.legend.pure.generated.Root_meta_external_dataquality_DataSpaceDataQualityExecutionContext;
 import org.finos.legend.pure.generated.Root_meta_external_dataquality_DataSpaceDataQualityExecutionContext_Impl;
 import org.finos.legend.pure.generated.Root_meta_external_dataquality_MappingAndRuntimeDataQualityExecutionContext;
@@ -86,7 +88,6 @@ import org.finos.legend.pure.m4.coreinstance.SourceInformation;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -202,10 +203,26 @@ public class DataQualityCompilerExtension implements CompilerExtension
                     LambdaFunction<?> relationValidationQuery = buildRelationLambda(dataqualityRelationValidation.query, compileContext);
                     metamodel._query(relationValidationQuery);
                     metamodel._validations(buildDataQualityRelationValidations(dataqualityRelationValidation.validations, dataqualityRelationValidation.query, relationValidationQuery, SourceInformationHelper.toM3SourceInformation(dataqualityRelationValidation.sourceInformation), compileContext));
+                    if (dataqualityRelationValidation.persistenceStrategy != null)
+                    {
+                        metamodel._persistenceStrategy(buildPersistenceStrategy(dataqualityRelationValidation.persistenceStrategy, compileContext));
+                    }
                     metamodel._validate(true, SourceInformationHelper.toM3SourceInformation(dataqualityRelationValidation.sourceInformation), compileContext.getExecutionSupport());
                 },
                 this::dataQualityRelationValidationPrerequisiteElementsPass
         );
+    }
+
+    private static Root_meta_external_dataquality_DataQualityPersistenceStrategy buildPersistenceStrategy(DataQualityPersistenceStrategy persistenceStrategy, CompileContext context)
+    {
+        return IDataQualityCompilerExtension.getExtensions(context)
+                .map(IDataQualityCompilerExtension::getExtraDataQualityPersistenceStrategyProcessors)
+                .flatMap(List::stream)
+                .map(processor -> processor.value(persistenceStrategy, context))
+                .filter(Objects::nonNull)
+                .findAny()
+                .orElseThrow(() -> new EngineException("Can't compile persistence strategy ", persistenceStrategy.sourceInformation, EngineErrorType.COMPILATION));
+
     }
 
     private Set<PackageableElementPointer> dataQualityRelationComparisonPrerequisiteElementsPass(DataQualityRelationComparison relationComparison, CompileContext compileContext)

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/IDataQualityCompilerExtension.java
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/IDataQualityCompilerExtension.java
@@ -1,0 +1,57 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.language.pure.compiler.toPureGraph;
+
+import org.eclipse.collections.api.block.function.Function2;
+import org.eclipse.collections.impl.utility.ListIterate;
+import org.finos.legend.engine.language.pure.compiler.toPureGraph.extension.CompilerExtension;
+import org.finos.legend.engine.protocol.dataquality.metamodel.DataQualityPersistenceStrategy;
+import org.finos.legend.engine.protocol.pure.v1.model.context.EngineErrorType;
+import org.finos.legend.engine.shared.core.operational.errorManagement.EngineException;
+import org.finos.legend.pure.generated.Root_meta_external_dataquality_DataQualityPersistenceStrategy;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+public interface IDataQualityCompilerExtension extends CompilerExtension
+{
+    static Stream<IDataQualityCompilerExtension> getExtensions(CompileContext context)
+    {
+        return context.getCompilerExtensions()
+                .getExtensions()
+                .stream()
+                .filter(IDataQualityCompilerExtension.class::isInstance)
+                .map(IDataQualityCompilerExtension.class::cast);
+    }
+
+    static Root_meta_external_dataquality_DataQualityPersistenceStrategy process(
+            DataQualityPersistenceStrategy persistenceStrategy,
+            List<Function2<DataQualityPersistenceStrategy, CompileContext, Root_meta_external_dataquality_DataQualityPersistenceStrategy>> processors,
+            CompileContext context)
+    {
+        return ListIterate
+                .collect(processors, processor -> processor.value(persistenceStrategy, context))
+                .select(Objects::nonNull)
+                .getFirstOptional()
+                .orElseThrow(() -> new EngineException("Unsupported persistenceStrategy type '" + persistenceStrategy.getClass() + "'", persistenceStrategy.sourceInformation, EngineErrorType.COMPILATION));
+    }
+
+    default List<Function2<DataQualityPersistenceStrategy, CompileContext, Root_meta_external_dataquality_DataQualityPersistenceStrategy>> getExtraDataQualityPersistenceStrategyProcessors()
+    {
+        return Collections.emptyList();
+    }
+}

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-grammar/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/DataQualityLexerGrammar.g4
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-grammar/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/DataQualityLexerGrammar.g4
@@ -42,3 +42,6 @@ RECON_SOURCE_HASH_COLUMN:                'sourceHashColumn';
 RECON_TARGET_HASH_COLUMN:                'targetHashColumn';
 RECON_AGGREGATED_HASH:                   'aggregatedHash';
 RECON_EXPECTED_MATCH:                    'expectedMatch';
+
+// -------------------- PERSISTENCE STRATEGY ----------------------------------------------
+PERSISTENCE_STRATEGY:                    'persistenceStrategy';

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-grammar/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/DataQualityParserGrammar.g4
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-grammar/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/DataQualityParserGrammar.g4
@@ -37,6 +37,7 @@ identifier:                             VALID_STRING | STRING
                                         | RECON_TARGET_HASH_COLUMN
                                         | RECON_AGGREGATED_HASH
                                         | RECON_EXPECTED_MATCH
+                                        | PERSISTENCE_STRATEGY
 ;
 
 
@@ -126,6 +127,7 @@ relationValidationDefinition:           DATAQUALITYRELATIONVALIDATION stereotype
                                              (
                                                  relationFunc
                                                  | validations
+                                                 | persistenceStrategy
                                              )*
                                         BRACE_CLOSE
 ;
@@ -154,6 +156,9 @@ validationType:                        VALIDATION_TYPE COLON validationTypeVal S
 validationTypeVal:                     VALIDATION_TYPE_ROW | VALIDATION_TYPE_AGG
 ;
 
+// --------------------------- Persistence Strategy ----------------------------------------------------------
+persistenceStrategy:                   PERSISTENCE_STRATEGY COLON islandDefinition SEMI_COLON
+;
 
 // -------------------- Relation Comparison Definition ------------------------------------
 relationComparisonDefinition:   DATAQUALITYRELATIONCOMPARISON qualifiedName

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-grammar/src/main/java/org/finos/legend/engine/language/dataquality/grammar/from/DataQualityTreeWalker.java
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-grammar/src/main/java/org/finos/legend/engine/language/dataquality/grammar/from/DataQualityTreeWalker.java
@@ -411,6 +411,12 @@ public class DataQualityTreeWalker
                 dataqualityRelationValidation.sourceInformation);
         dataqualityRelationValidation.validations = visitValidations(validationsContext, dataqualityRelationValidation.sourceInformation);
 
+        DataQualityParserGrammar.PersistenceStrategyContext persistenceStrategyContext = PureGrammarParserUtility.validateAndExtractOptionalField(relationValidationDefinitionContext.persistenceStrategy(), "persistenceStrategy", dataqualityRelationValidation.sourceInformation);
+        if (Objects.nonNull(persistenceStrategyContext))
+        {
+            dataqualityRelationValidation.persistenceStrategy = IDataQualityGrammarParserExtension.parsePersistenceStrategy(persistenceStrategyContext.islandDefinition(), this.walkerSourceInformation, this.parserContext.getPureGrammarParserExtensions());
+        }
+
         return dataqualityRelationValidation;
     }
 

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-grammar/src/main/java/org/finos/legend/engine/language/dataquality/grammar/from/IDataQualityGrammarParserExtension.java
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-grammar/src/main/java/org/finos/legend/engine/language/dataquality/grammar/from/IDataQualityGrammarParserExtension.java
@@ -1,0 +1,83 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.language.dataquality.grammar.from;
+
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.tree.TerminalNode;
+import org.finos.legend.engine.language.pure.grammar.from.ParseTreeWalkerSourceInformation;
+import org.finos.legend.engine.language.pure.grammar.from.PureIslandGrammarSourceCode;
+import org.finos.legend.engine.language.pure.grammar.from.extension.PureGrammarParserExtension;
+import org.finos.legend.engine.language.pure.grammar.from.extension.PureGrammarParserExtensions;
+import org.finos.legend.engine.protocol.dataquality.metamodel.DataQualityPersistenceStrategy;
+import org.finos.legend.engine.protocol.pure.m3.SourceInformation;
+import org.finos.legend.engine.protocol.pure.v1.model.context.EngineErrorType;
+import org.finos.legend.engine.shared.core.operational.Assert;
+import org.finos.legend.engine.shared.core.operational.errorManagement.EngineException;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+import org.eclipse.collections.api.block.function.Function;
+
+public interface IDataQualityGrammarParserExtension extends PureGrammarParserExtension
+{
+    static Stream<IDataQualityGrammarParserExtension> getExtensions(PureGrammarParserExtensions context)
+    {
+        return context.getExtensions()
+                .stream()
+                .filter(IDataQualityGrammarParserExtension.class::isInstance)
+                .map(IDataQualityGrammarParserExtension.class::cast);
+    }
+
+    default List<Function<PureIslandGrammarSourceCode, DataQualityPersistenceStrategy>> getExtraDataQualityPersistenceStrategyParsers()
+    {
+        return Collections.emptyList();
+    }
+
+    static DataQualityPersistenceStrategy parsePersistenceStrategy(ParserRuleContext ctx, ParseTreeWalkerSourceInformation walkerSourceInformation, PureGrammarParserExtensions context)
+    {
+        return parseIsland(ctx, walkerSourceInformation, IDataQualityGrammarParserExtension.getExtensions(context).map(IDataQualityGrammarParserExtension::getExtraDataQualityPersistenceStrategyParsers).flatMap(List::stream));
+    }
+
+    static DataQualityPersistenceStrategy parseIsland(ParserRuleContext ctx, ParseTreeWalkerSourceInformation walkerSourceInformation, Stream<Function<PureIslandGrammarSourceCode, DataQualityPersistenceStrategy>> processors)
+    {
+        Assert.assertTrue(ctx.getChildCount() == 2, () -> "Wrong number of token on persistence strategy island", walkerSourceInformation.getSourceInformation(ctx), EngineErrorType.PARSER);
+        TerminalNode islandOpenToken = (TerminalNode) ctx.getChild(0);
+        String islandOpen = islandOpenToken.getText();
+        String type = islandOpen.substring(1, islandOpen.length() - 1).trim();
+
+        Assert.assertTrue(!type.isEmpty(), () -> "Missing persistence strategy type.  Expect '# TYPE_HERE { ... }#'", walkerSourceInformation.getSourceInformation(islandOpenToken.getSymbol()), EngineErrorType.PARSER);
+
+        ParserRuleContext islandContentContext = (ParserRuleContext) ctx.getChild(1);
+        islandContentContext.removeLastChild();
+        String islandCode = islandContentContext.getText();
+
+        // prepare island grammar walker source information
+        int startLine = islandOpenToken.getSymbol().getLine();
+        int lineOffset = walkerSourceInformation.getLineOffset() + startLine - 1;
+        // only add current walker source information column offset if this is the first line
+        int columnOffset = (startLine == 1 ? walkerSourceInformation.getColumnOffset() : 0) + islandOpenToken.getSymbol().getCharPositionInLine() + islandOpenToken.getSymbol().getText().length();
+        ParseTreeWalkerSourceInformation subWalkerSourceInformation = new ParseTreeWalkerSourceInformation.Builder(walkerSourceInformation.getSourceId(), lineOffset, columnOffset).withReturnSourceInfo(walkerSourceInformation.getReturnSourceInfo()).build();
+        SourceInformation sourceInformation = walkerSourceInformation.getSourceInformation(ctx);
+
+        PureIslandGrammarSourceCode code = new PureIslandGrammarSourceCode(islandCode, type, sourceInformation, subWalkerSourceInformation);
+
+        return processors.map(processor -> processor.apply(code))
+                .filter(Objects::nonNull)
+                .findAny()
+                .orElseThrow(() -> new EngineException("Unsupported Persistence Strategy type '" + code.type + "'", code.sourceInformation, EngineErrorType.PARSER));
+    }
+}

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-grammar/src/main/java/org/finos/legend/engine/language/dataquality/grammar/to/DataQualityGrammarComposerExtension.java
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-grammar/src/main/java/org/finos/legend/engine/language/dataquality/grammar/to/DataQualityGrammarComposerExtension.java
@@ -96,7 +96,17 @@ public class DataQualityGrammarComposerExtension implements PureGrammarComposerE
                 "{\n" +
                 "   query: " + renderRelationQuery(dataqualityRelationValidation, context) +
                 "   validations: " + renderValidations(dataqualityRelationValidation.validations, context) +
+                renderPersistenceStrategy(dataqualityRelationValidation, context) +
                 "}";
+    }
+
+    private static String renderPersistenceStrategy(DataqualityRelationValidation dataqualityRelationValidation, PureGrammarComposerContext context)
+    {
+        if (Objects.isNull(dataqualityRelationValidation.persistenceStrategy))
+        {
+            return "";
+        }
+        return "   persistenceStrategy: " + IDataQualityGrammarComposerExtension.renderPersistenceStrategy(dataqualityRelationValidation.persistenceStrategy, 1, context) + ";\n";
     }
 
     private static String renderDataQualityRelationComparison(DataQualityRelationComparison relationComparison, PureGrammarComposerContext context)

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-grammar/src/main/java/org/finos/legend/engine/language/dataquality/grammar/to/IDataQualityGrammarComposerExtension.java
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-grammar/src/main/java/org/finos/legend/engine/language/dataquality/grammar/to/IDataQualityGrammarComposerExtension.java
@@ -1,0 +1,52 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.language.dataquality.grammar.to;
+
+import org.eclipse.collections.api.block.function.Function3;
+import org.finos.legend.engine.language.pure.grammar.to.PureGrammarComposerContext;
+import org.finos.legend.engine.language.pure.grammar.to.extension.PureGrammarComposerExtension;
+import org.finos.legend.engine.protocol.dataquality.metamodel.DataQualityPersistenceStrategy;
+import org.finos.legend.engine.shared.core.operational.errorManagement.EngineException;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+public interface IDataQualityGrammarComposerExtension extends PureGrammarComposerExtension
+{
+    static Stream<IDataQualityGrammarComposerExtension> getExtensions(PureGrammarComposerContext context)
+    {
+        return context.extensions.stream()
+                .filter(IDataQualityGrammarComposerExtension.class::isInstance)
+                .map(IDataQualityGrammarComposerExtension.class::cast);
+    }
+
+    default List<Function3<DataQualityPersistenceStrategy, Integer, PureGrammarComposerContext, String>> getExtraDataQualityPersistenceStrategyComposers()
+    {
+        return Collections.emptyList();
+    }
+
+    static String renderPersistenceStrategy(DataQualityPersistenceStrategy persistenceStrategy, int indentLevel, PureGrammarComposerContext context)
+    {
+        return IDataQualityGrammarComposerExtension.getExtensions(context)
+                .map(IDataQualityGrammarComposerExtension::getExtraDataQualityPersistenceStrategyComposers)
+                .flatMap(List::stream)
+                .map(x -> x.value(persistenceStrategy, indentLevel, context))
+                .filter(Objects::nonNull)
+                .findAny()
+                .orElseThrow(() -> new EngineException("No renderer found for " + persistenceStrategy.getClass()));
+    }
+}

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-protocol/src/main/java/org/finos/legend/engine/protocol/dataquality/metamodel/DataQualityPersistenceStrategy.java
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-protocol/src/main/java/org/finos/legend/engine/protocol/dataquality/metamodel/DataQualityPersistenceStrategy.java
@@ -1,0 +1,24 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.protocol.dataquality.metamodel;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.finos.legend.engine.protocol.pure.m3.SourceInformation;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "_type")
+public abstract class DataQualityPersistenceStrategy
+{
+    public SourceInformation sourceInformation;
+}

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-protocol/src/main/java/org/finos/legend/engine/protocol/dataquality/metamodel/DataQualityProtocolExtension.java
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-protocol/src/main/java/org/finos/legend/engine/protocol/dataquality/metamodel/DataQualityProtocolExtension.java
@@ -55,6 +55,8 @@ public class DataQualityProtocolExtension implements PureProtocolExtension
                         .build(),
                 ProtocolSubTypeInfo.newBuilder(PackageableElement.class)
                         .withSubtype(DataQualityRelationComparison.class, "dataQualityRelationComparison")
+                        .build(),
+                ProtocolSubTypeInfo.newBuilder(DataQualityPersistenceStrategy.class)
                         .build()
         ));
     }

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-protocol/src/main/java/org/finos/legend/engine/protocol/dataquality/metamodel/DataqualityRelationValidation.java
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-protocol/src/main/java/org/finos/legend/engine/protocol/dataquality/metamodel/DataqualityRelationValidation.java
@@ -34,4 +34,5 @@ public class DataqualityRelationValidation extends ModelGenerationSpecification
 
     public LambdaFunction query;
     public List<RelationValidation> validations = Collections.emptyList();
+    public DataQualityPersistenceStrategy persistenceStrategy;
 }

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure/src/main/resources/core_dataquality/metamodel/metamodel.pure
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure/src/main/resources/core_dataquality/metamodel/metamodel.pure
@@ -53,6 +53,11 @@ Class meta::external::dataquality::DataQualityRelationValidation extends Package
 {
   query: LambdaFunction<Any>[1];                                         // should return a relation - enforced in compiler
   validations: RelationValidation[*];
+  persistenceStrategy: DataQualityPersistenceStrategy[0..1];
+}
+
+Class <<typemodifiers.abstract>> meta::external::dataquality::DataQualityPersistenceStrategy
+{
 }
 
 Class meta::external::dataquality::RelationValidation


### PR DESCRIPTION
#### What type of PR is this?

- Improvement

#### What does this PR do / why is it needed ?

- New field on Data Quality Relation Validation called persistence strategy
- This will be added as an interface so that any downstream projects can add their own implementations of this
