### PR TITLE
Limit query param for recon source, recon target and dq query

### DIFF
--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-api/src/main/java/org/finos/legend/engine/language/dataquality/api/DataQualityExecute.java
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-api/src/main/java/org/finos/legend/engine/language/dataquality/api/DataQualityExecute.java
@@ -395,8 +395,9 @@ public class DataQualityExecute
 
         if (input.runSourceQuery)
         {
-            // return source query results directly
-            dqLambdaFunction = sourceLambdaFunction;
+            // return source query results directly, with optional limit
+            Long queryLimit = input.queryLimit == null ? null : input.queryLimit.longValue();
+            dqLambdaFunction = DataQualityLambdaGenerator.extendLambdaWithLimit(pureModel, sourceLambdaFunction, queryLimit);
             if (input.sourceLambdaParameterValues != null)
             {
                 input.sourceLambdaParameterValues.forEach(p -> lambdaParameterMap.put(p.name, p.value.accept(new PrimitiveValueSpecificationToObjectVisitor())));
@@ -404,8 +405,9 @@ public class DataQualityExecute
         }
         else if (input.runTargetQuery)
         {
-            // return target query results directly
-            dqLambdaFunction = targetLambdaFunction;
+            // return target query results directly, with optional limit
+            Long queryLimit = input.queryLimit == null ? null : input.queryLimit.longValue();
+            dqLambdaFunction = DataQualityLambdaGenerator.extendLambdaWithLimit(pureModel, targetLambdaFunction, queryLimit);
             if (input.targetLambdaParameterValues != null)
             {
                 input.targetLambdaParameterValues.forEach(p -> lambdaParameterMap.put(p.name, p.value.accept(new PrimitiveValueSpecificationToObjectVisitor())));
@@ -520,7 +522,12 @@ public class DataQualityExecute
         {
             return DataQualityLambdaGenerator.generateRelationValidationMainQueryRowCount(pureModel, dataQualityExecuteInput.packagePath);
         }
-        return DataQualityLambdaGenerator.generateLambda(pureModel, dataQualityExecuteInput.packagePath, dataQualityExecuteInput.getValidationNames(), dataQualityExecuteInput.runQuery, dataQualityExecuteInput.defectsLimit, dataQualityExecuteInput.enrichDQColumns, dataQualityExecuteInput.includeTotalDefectCount, queryType);
+        org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction dqLambdaFunction = DataQualityLambdaGenerator.generateLambda(pureModel, dataQualityExecuteInput.packagePath, dataQualityExecuteInput.getValidationNames(), dataQualityExecuteInput.runQuery, dataQualityExecuteInput.defectsLimit, dataQualityExecuteInput.enrichDQColumns, dataQualityExecuteInput.includeTotalDefectCount, queryType);
+        if (Boolean.TRUE.equals(dataQualityExecuteInput.runQuery))
+        {
+            return DataQualityLambdaGenerator.extendLambdaWithLimit(pureModel, dqLambdaFunction, dataQualityExecuteInput.queryLimit);
+        }
+        return dqLambdaFunction;
     }
 
     @POST

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-api/src/main/java/org/finos/legend/engine/language/dataquality/api/DataQualityExecuteTrialInput.java
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-api/src/main/java/org/finos/legend/engine/language/dataquality/api/DataQualityExecuteTrialInput.java
@@ -33,7 +33,8 @@ public class DataQualityExecuteTrialInput
     public PureModelContext model;
     @JsonProperty
     public String packagePath;
-    public Integer defectsLimit;
+    public Long defectsLimit;
+    public Long queryLimit;
     public boolean includeTotalDefectCount = false;
     public List<ParameterValue> lambdaParameterValues;
     @Deprecated

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-api/src/main/java/org/finos/legend/engine/language/dataquality/api/DataQualityReconInput.java
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-api/src/main/java/org/finos/legend/engine/language/dataquality/api/DataQualityReconInput.java
@@ -42,6 +42,7 @@ public class DataQualityReconInput
     public boolean runSourceQuery = false;
     public boolean runTargetQuery = false;
     public Long defectLimit; //optional limit on the number of defect rows returned
+    public Long queryLimit; //optional limit on the number of rows fetched from source and target queries
     public List<ParameterValue> sourceLambdaParameterValues; //parameter values for the source lambda
     public List<ParameterValue> targetLambdaParameterValues; //parameter values for the target lambda
 

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-generation/src/main/java/org/finos/legend/engine/generation/dataquality/DataQualityLambdaGenerator.java
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-generation/src/main/java/org/finos/legend/engine/generation/dataquality/DataQualityLambdaGenerator.java
@@ -43,13 +43,13 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 public class DataQualityLambdaGenerator
 {
 
-    public static org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction<Object> generateLambda(PureModel pureModel, String qualifiedPath, Set<String> validationNames, Boolean runQuery, Integer resultLimit, boolean enrichDQColumns, boolean includeTotalDefectCount, String queryType)
+    public static org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction<Object> generateLambda(PureModel pureModel, String qualifiedPath, Set<String> validationNames, Boolean runQuery, Long resultLimit, boolean enrichDQColumns, boolean includeTotalDefectCount, String queryType)
     {
         PackageableElement packageableElement = pureModel.getPackageableElement(qualifiedPath);
         return generateLambda(pureModel, packageableElement, validationNames, runQuery, resultLimit, enrichDQColumns, includeTotalDefectCount, queryType);
     }
 
-    public static org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction<Object> generateLambda(PureModel pureModel, PackageableElement packageableElement, Set<String> validationNames, Boolean runQuery, Integer resultLimit, boolean enrichDQColumns, boolean includeTotalDefectCount, String queryType)
+    public static org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction<Object> generateLambda(PureModel pureModel, PackageableElement packageableElement, Set<String> validationNames, Boolean runQuery, Long resultLimit, boolean enrichDQColumns, boolean includeTotalDefectCount, String queryType)
     {
         if (packageableElement instanceof Root_meta_external_dataquality_DataQuality)
         {
@@ -67,7 +67,7 @@ public class DataQualityLambdaGenerator
         return core_dataquality_generation_dataquality.Root_meta_external_dataquality_generateDataQualityQuery_DataQuality_1__Integer_$0_1$__LambdaFunction_1_(packageableElement, Objects.isNull(queryLimit) ? null : queryLimit.longValue(), pureModel.getExecutionSupport());
     }
 
-    private static org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction<Object> generateRelationValidationLambda(PureModel pureModel, Root_meta_external_dataquality_DataQualityRelationValidation packageableElement, Set<String> validationNames, Boolean runQuery, Integer resultLimit, boolean enrichDQColumns, boolean includeTotalDefectCount, String queryType)
+    private static org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction<Object> generateRelationValidationLambda(PureModel pureModel, Root_meta_external_dataquality_DataQualityRelationValidation packageableElement, Set<String> validationNames, Boolean runQuery, Long resultLimit, boolean enrichDQColumns, boolean includeTotalDefectCount, String queryType)
     {
         if (isNotBlank(queryType) && !core_dataquality_generation_dataquality.Root_meta_external_dataquality_isEndingWithFromFunction_FunctionDefinition_1__Boolean_1_(packageableElement._query(), pureModel.getExecutionSupport()))
         {
@@ -77,7 +77,16 @@ public class DataQualityLambdaGenerator
         {
             return (org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction<Object>) packageableElement._query();
         }
-        return (org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction<Object>) core_dataquality_generation_dataquality.Root_meta_external_dataquality_generateDataqualityRelationValidationLambda_DataQualityRelationValidation_1__String_MANY__Integer_$0_1$__Boolean_1__Boolean_1__Boolean_1__Boolean_1__LambdaFunction_1_(packageableElement, Sets.immutable.ofAll(validationNames), Objects.isNull(resultLimit) ? null : resultLimit.longValue(), enrichDQColumns, false, false, includeTotalDefectCount, pureModel.getExecutionSupport());
+        return (org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction<Object>) core_dataquality_generation_dataquality.Root_meta_external_dataquality_generateDataqualityRelationValidationLambda_DataQualityRelationValidation_1__String_MANY__Integer_$0_1$__Boolean_1__Boolean_1__Boolean_1__Boolean_1__LambdaFunction_1_(packageableElement, Sets.immutable.ofAll(validationNames), resultLimit, enrichDQColumns, false, false, includeTotalDefectCount, pureModel.getExecutionSupport());
+    }
+
+    public static org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction<?> extendLambdaWithLimit(PureModel pureModel, org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction<?> lambda, Long queryLimit)
+    {
+        if (queryLimit == null)
+        {
+            return lambda;
+        }
+        return core_dataquality_generation_dataquality.Root_meta_external_dataquality_extendLambdaWithLimit_LambdaFunction_1__Integer_$0_1$__LambdaFunction_1_(lambda, queryLimit, pureModel.getExecutionSupport());
     }
 
     public static LambdaFunction transformLambda(org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction<?> lambda, PureModel pureModel, Function<PureModel, RichIterable<? extends Root_meta_pure_extension_Extension>> extensions)

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure-test/src/main/resources/core_dataquality_test/dataquality_test.pure
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure-test/src/main/resources/core_dataquality_test/dataquality_test.pure
@@ -1023,3 +1023,78 @@ function <<test.Test>> meta::external::dataquality::tests::testFromFunctionListI
 
   assertEmpty($missingFuncs->map(pe|$pe->elementToPath()));
 }
+
+// Tests for extendLambdaWithLimit
+
+function <<test.Test>> meta::external::dataquality::tests::testExtendLambdaWithLimit_noLimit_returnsUnchanged():Boolean[1]
+{
+   let dqDef = '###DataQualityValidation' +
+      '      DataQualityRelationValidation meta::external::dataquality::tests::domain::RelationValidation' +
+      '      {' +
+      '        query: #>{meta::external::dataquality::tests::domain::db.personTable}#->select(~[FIRSTNAME, LASTNAME])->from(meta::external::dataquality::tests::domain::DataQualityRuntime);' +
+      '        validations: [' +
+      '          {' +
+      '             name: \'validFirstName\';' +
+      '             description: \'first name should not be empty\';' +
+      '             assertion: row|$row.FIRSTNAME->isNotEmpty();' +
+      '             type: ROW_LEVEL;' +
+      '          }' +
+      '         ];' +
+      '      }';
+   let dqRelVal = $dqDef->loadDataQualityRelationValidation();
+   let originalLambda = $dqRelVal.query;
+   let result = meta::external::dataquality::extendLambdaWithLimit($originalLambda, []);
+   let config = grammarConfig();
+   assertEquals(
+      $originalLambda->meta::pure::metamodel::serialization::grammar::printFunctionDefinition($config, ^meta::pure::metamodel::serialization::grammar::GContext(space='')),
+      $result->meta::pure::metamodel::serialization::grammar::printFunctionDefinition($config, ^meta::pure::metamodel::serialization::grammar::GContext(space=''))
+   );
+}
+
+function <<test.Test>> meta::external::dataquality::tests::testExtendLambdaWithLimit_relationWithFrom_appliesLimit():Boolean[1]
+{
+   let dqDef = '###DataQualityValidation' +
+      '      DataQualityRelationValidation meta::external::dataquality::tests::domain::RelationValidation' +
+      '      {' +
+      '        query: #>{meta::external::dataquality::tests::domain::db.personTable}#->select(~[FIRSTNAME, LASTNAME])->from(meta::external::dataquality::tests::domain::DataQualityRuntime);' +
+      '        validations: [' +
+      '          {' +
+      '             name: \'validFirstName\';' +
+      '             description: \'first name should not be empty\';' +
+      '             assertion: row|$row.FIRSTNAME->isNotEmpty();' +
+      '             type: ROW_LEVEL;' +
+      '          }' +
+      '         ];' +
+      '      }';
+   let dqRelVal = $dqDef->loadDataQualityRelationValidation();
+   let originalLambda = $dqRelVal.query;
+   let result = meta::external::dataquality::extendLambdaWithLimit($originalLambda, 50);
+   let config = grammarConfig();
+   let ctx = ^meta::pure::metamodel::serialization::grammar::GContext(space='');
+   let originalStr = $originalLambda->meta::pure::metamodel::serialization::grammar::printFunctionDefinition($config, $ctx);
+   let resultStr = $result->meta::pure::metamodel::serialization::grammar::printFunctionDefinition($config, $ctx);
+   // limit should be injected inside the from (on the relation expression), not after it
+   let expectedStr = $originalStr->replace('->meta::pure::mapping::from', '->meta::pure::functions::relation::limit(50)->meta::pure::mapping::from');
+   assertEquals($expectedStr, $resultStr);
+}
+
+function <<test.Test>> meta::external::dataquality::tests::testExtendLambdaWithLimit_classBasedWithFrom_appliesTake():Boolean[1]
+{
+   let dataQuality = loadDataQuality(
+      '$[' +
+      '      meta::external::dataquality::tests::domain::Person<mustBeOfLegalAge>{' +
+      '        name,' +
+      '        age' +
+      '      }' +
+      ']$'
+   );
+   let lambdaWithFrom = meta::external::dataquality::generateDataQualityQuery($dataQuality, [], true);
+   let result = meta::external::dataquality::extendLambdaWithLimit($lambdaWithFrom, 25);
+   let config = grammarConfig();
+   let ctx = ^meta::pure::metamodel::serialization::grammar::GContext(space='');
+   let originalStr = $lambdaWithFrom->meta::pure::metamodel::serialization::grammar::printFunctionDefinition($config, $ctx);
+   let resultStr = $result->meta::pure::metamodel::serialization::grammar::printFunctionDefinition($config, $ctx);
+   // take should be injected inside the from (on the class expression), not after it
+   let expectedStr = $originalStr->replace('->meta::pure::mapping::from', '->meta::pure::functions::collection::take(25)->meta::pure::mapping::from');
+   assertEquals($expectedStr, $resultStr);
+}

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure/src/main/resources/core_dataquality/generation/dataquality.pure
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure/src/main/resources/core_dataquality/generation/dataquality.pure
@@ -1077,6 +1077,32 @@ function meta::external::dataquality::buildRelationFilterExpressionForRowLevelVa
    )->evaluateAndDeactivate();
 }
 
+function meta::external::dataquality::extendLambdaWithLimit(lambda: LambdaFunction<Any>[1], queryLimit: Integer[0..1]): LambdaFunction<Any>[1]
+{
+   if ($queryLimit->isEmpty(),
+       | $lambda,
+       | let hasFrom = $lambda->isEndingWithFromFunction();
+         let lastExpr = $lambda.expressionSequence->evaluateAndDeactivate()->last()->toOne();
+         if ($hasFrom,
+             | let fromExpr = $lastExpr->cast(@SimpleFunctionExpression);
+               let innerExpr = $fromExpr.parametersValues->evaluateAndDeactivate()->at(0)->evaluateAndDeactivate();
+               let isRelation = $innerExpr.genericType.rawType->toOne()->subTypeOf(Relation);
+               let withLimit = if ($isRelation,
+                   | $innerExpr->buildRelationLimitFilterExpression($queryLimit->toOne(), $innerExpr.genericType),
+                   | $innerExpr->buildLimitFilterExpression($queryLimit->toOne(), $innerExpr.genericType)
+               );
+               let newFromExpr = ^$fromExpr(parametersValues = $withLimit->concatenate($fromExpr.parametersValues->evaluateAndDeactivate()->tail()))->evaluateAndDeactivate();
+               ^$lambda(expressionSequence = $lambda.expressionSequence->evaluateAndDeactivate()->init()->concatenate($newFromExpr)->toOneMany());,
+             | let isRelation = $lastExpr.genericType.rawType->toOne()->subTypeOf(Relation);
+               let withLimit = if ($isRelation,
+                   | $lastExpr->buildRelationLimitFilterExpression($queryLimit->toOne(), $lastExpr.genericType),
+                   | $lastExpr->buildLimitFilterExpression($queryLimit->toOne(), $lastExpr.genericType)
+               );
+               ^$lambda(expressionSequence = $lambda.expressionSequence->evaluateAndDeactivate()->init()->concatenate($withLimit)->toOneMany());
+         );
+   );
+}
+
 function meta::external::dataquality::buildLimitFilterExpression(f: ValueSpecification[1], limit: Integer[1], returnType:GenericType[1]):FunctionExpression[1]
 {
   ^SimpleFunctionExpression(func=take_T_MANY__Integer_1__T_MANY_,


### PR DESCRIPTION
Added query param so limit can be applied to recon source query, recon target query and dq base query

#### What type of PR is this?
- Improvement


