### PR TITLE
Improve closeable handling in AbstractTestSuiteSessionWithResources

### DIFF
--- a/legend-engine-core/legend-engine-core-testable/legend-engine-test-runner-function/src/main/java/org/finos/legend/engine/testable/function/extension/FunctionTestRunner.java
+++ b/legend-engine-core/legend-engine-core-testable/legend-engine-test-runner-function/src/main/java/org/finos/legend/engine/testable/function/extension/FunctionTestRunner.java
@@ -19,6 +19,7 @@ import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.ListIterate;
@@ -46,7 +47,6 @@ import org.finos.legend.engine.protocol.pure.v1.model.data.ExternalFormatData;
 import org.finos.legend.engine.protocol.pure.v1.model.data.relation.RelationElementsData;
 import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.SingleExecutionPlan;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.connection.Connection;
-import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain.ParameterValue;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.function.FunctionTest;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.function.FunctionTestData;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.function.FunctionTestSuite;
@@ -77,10 +77,8 @@ import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.Concre
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.FunctionDefinition;
 
 import java.io.Closeable;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.ServiceLoader;
@@ -173,8 +171,8 @@ public class FunctionTestRunner implements TestRunner
                     FunctionTestRunner.this.extensions.flatCollect(PlanGeneratorExtension::getExtraPlanTransformers),
                     new ConnectionFirstPassBuilder(this.pureModel.getContext()),
                     PureCoreExtensionLoader.extensions().flatCollect(e -> e.extraPureCoreExtensions(this.pureModel.getExecutionSupport())));
-            closeableConsumer.accept((AutoCloseable) () -> this.storeConnectionsPairs.forEach(p -> p.getOne()._connection(p.getTwo())));
-            setup(closeableConsumer);
+            registerCloseable(() -> this.storeConnectionsPairs.forEach(p -> p.getOne()._connection(p.getTwo())));
+            setup();
         }
 
         @Override
@@ -200,13 +198,11 @@ public class FunctionTestRunner implements TestRunner
                 SingleExecutionPlan executionPlan = PlanGenerator.generateExecutionPlan(effectiveFunction, null, null, null, this.context.getPureModel(), FunctionTestRunner.this.pureVersion, PlanPlatform.JAVA, null, this.context.getRouterExtensions(), this.context.getExecutionPlanTransformers());
                 TestAssertion assertion = functionTest.assertions.get(0);
                 PlanExecutor.ExecuteArgsBuilder executeArgs = this.context.getExecuteBuilder().withPlan(executionPlan);
-                Map<String, Object> parameters = Maps.mutable.empty();
+                MutableMap<String, Object> parameters = Maps.mutable.empty();
                 if (functionTest.parameters != null)
                 {
-                    for (ParameterValue parameterValue : functionTest.parameters)
-                    {
-                        parameters.put(parameterValue.name, parameterValue.value.accept(new PrimitiveValueSpecificationToObjectVisitor()));
-                    }
+                    PrimitiveValueSpecificationToObjectVisitor visitor = new PrimitiveValueSpecificationToObjectVisitor();
+                    functionTest.parameters.forEach(pv -> parameters.put(pv.name, pv.value.accept(visitor)));
                 }
                 executeArgs.withParams(parameters);
                 Result result = FunctionTestRunner.this.executor.executeWithArgs(executeArgs.build());
@@ -221,7 +217,7 @@ public class FunctionTestRunner implements TestRunner
             }
         }
 
-        private void setup(Consumer<? super AutoCloseable> closeableConsumer)
+        private void setup()
         {
             Root_meta_legend_function_metamodel_FunctionTestSuite functionTestSuite = this.context.getTestSuite();
             FunctionTestSuite protocolFunctionSuite = this.context.getProtocolSuite();
@@ -234,8 +230,8 @@ public class FunctionTestRunner implements TestRunner
                 return;
             }
             Root_meta_core_runtime_Runtime runtime = getRuntimesInFunction(this.context.getPureModel());
-            List<FunctionTestData> storeTestData = new ArrayList<>();
-            List<FunctionTestData> nonStoreRelationTestData = new ArrayList<>();
+            MutableList<FunctionTestData> storeTestData = Lists.mutable.empty();
+            MutableList<FunctionTestData> nonStoreRelationTestData = Lists.mutable.empty();
             protocolFunctionSuite.testData.forEach(testData ->
             {
                 try
@@ -248,15 +244,15 @@ public class FunctionTestRunner implements TestRunner
                     nonStoreRelationTestData.add(testData);
                 }
             });
-            if (!storeTestData.isEmpty() && !nonStoreRelationTestData.isEmpty())
+            if (storeTestData.notEmpty() && nonStoreRelationTestData.notEmpty())
             {
                 throw new IllegalStateException("Error in function testSuite " + this.context.getTestSuite()._id() + ". The combination of store and non-store relation test data is not supported");
             }
-            if (!storeTestData.isEmpty())
+            if (storeTestData.notEmpty())
             {
-                setupStoreTestData(storeTestData, runtime, closeableConsumer);
+                setupStoreTestData(storeTestData, runtime);
             }
-            else if (!nonStoreRelationTestData.isEmpty())
+            else if (nonStoreRelationTestData.notEmpty())
             {
                 setupNonStoreRelationTestData(nonStoreRelationTestData);
             }
@@ -264,7 +260,7 @@ public class FunctionTestRunner implements TestRunner
 
         private void setupNonStoreRelationTestData(List<FunctionTestData> nonStoreRelationTestData)
         {
-            Map<org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement, RelationElementsData> relationData = Maps.mutable.empty();
+            MutableMap<org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement, RelationElementsData> relationData = Maps.mutable.empty();
             nonStoreRelationTestData.forEach(testData ->
             {
                 org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement element = this.context.getPureModel().getPackageableElement(testData.packageableElementPointer.path, testData.packageableElementPointer.sourceInformation);
@@ -276,7 +272,8 @@ public class FunctionTestRunner implements TestRunner
                     relationData.put(element, (RelationElementsData) data);
                 }
             });
-            List<FunctionDefinition<?>> modifiedFunctions = new ArrayList<>(FunctionTestRunner.this.connectionAndDatabaseBuilders.collect(f -> f.rewriteFunctionForTestDataExecution(FunctionTestRunner.this.functionDefinition, relationData, this.context.getPureModel())).select(Objects::nonNull));
+            MutableList<FunctionDefinition<?>> modifiedFunctions = FunctionTestRunner.this.connectionAndDatabaseBuilders.collect(f -> f.rewriteFunctionForTestDataExecution(FunctionTestRunner.this.functionDefinition, relationData, this.context.getPureModel()));
+            modifiedFunctions.removeIf(Objects::isNull);
             if (modifiedFunctions.size() > 1)
             {
                 throw new IllegalStateException("Error in function testSuite " + this.context.getTestSuite()._id() + ". The combination of accessors used is not supported");
@@ -288,41 +285,29 @@ public class FunctionTestRunner implements TestRunner
             this.modifiedFunctionDefinition = modifiedFunctions.get(0);
         }
 
-        private void setupStoreTestData(List<FunctionTestData> functionTestData, Root_meta_core_runtime_Runtime runtime, Consumer<? super AutoCloseable> closeableConsumer)
+        private void setupStoreTestData(List<FunctionTestData> functionTestData, Root_meta_core_runtime_Runtime runtime)
         {
             if (runtime == null)
             {
                 return;
             }
-            Map<Root_meta_core_runtime_Connection, List<Root_meta_core_runtime_ConnectionStore>> connectionMap = Maps.mutable.empty();
-            runtime._connectionStores().forEach(connectionStores ->
+            MutableMap<Root_meta_core_runtime_Connection, MutableList<Root_meta_core_runtime_ConnectionStore>> connectionMap = Maps.mutable.empty();
+            runtime._connectionStores().forEach(cStores -> connectionMap.getIfAbsentPut(cStores._connection(), Lists.mutable::empty).add(cStores));
+            connectionMap.forEachKeyValue((connection, connectionStores) ->
             {
-                List<Root_meta_core_runtime_ConnectionStore> stores = connectionMap.get(connectionStores._connection());
-                if (stores == null)
-                {
-                    stores = Lists.mutable.empty();
-                    connectionMap.putIfAbsent(connectionStores._connection(), stores);
-                }
-                stores.add(connectionStores);
-            });
-            for (Map.Entry<Root_meta_core_runtime_Connection, List<Root_meta_core_runtime_ConnectionStore>> entry : connectionMap.entrySet())
-            {
-                Root_meta_core_runtime_Connection key = entry.getKey();
-                List<Root_meta_core_runtime_ConnectionStore> values = entry.getValue();
-                Map<Store, EmbeddedData> storeTestDataList = Maps.mutable.empty();
-                entry.getValue().forEach(connectionStore ->
+                MutableMap<Store, EmbeddedData> storeTestDataList = Maps.mutable.empty();
+                connectionStores.forEach(connectionStore ->
                 {
                     Object element = connectionStore._element();
                     if (element instanceof org.finos.legend.pure.m3.coreinstance.meta.pure.store.Store)
                     {
                         org.finos.legend.pure.m3.coreinstance.meta.pure.store.Store metamodelStore = (org.finos.legend.pure.m3.coreinstance.meta.pure.store.Store) element;
                         String connectionStorePath = HelperModelBuilder.getElementFullPath(metamodelStore, this.context.getPureModel().getExecutionSupport());
-                        Optional<FunctionTestData> optionalStoreTestData = functionTestData.stream().filter(
-                                pTestData ->
-                                {
-                                    String testDataStorePath = HelperModelBuilder.getElementFullPath(StoreProviderCompilerHelper.getStoreFromPackageableElementPointer(pTestData.packageableElementPointer, this.context.getPureModel().getContext()), this.context.getPureModel().getExecutionSupport());
-                                    return testDataStorePath.equals(connectionStorePath);
-                                }).findFirst();
+                        Optional<FunctionTestData> optionalStoreTestData = functionTestData.stream().filter(pTestData ->
+                        {
+                            String testDataStorePath = HelperModelBuilder.getElementFullPath(StoreProviderCompilerHelper.getStoreFromPackageableElementPointer(pTestData.packageableElementPointer, this.context.getPureModel().getContext()), this.context.getPureModel().getExecutionSupport());
+                            return connectionStorePath.equals(testDataStorePath);
+                        }).findFirst();
                         if (optionalStoreTestData.isPresent())
                         {
                             FunctionTestData resolvedStoreTestData = optionalStoreTestData.get();
@@ -335,27 +320,27 @@ public class FunctionTestRunner implements TestRunner
                         }
                     }
                 });
-                if (!storeTestDataList.isEmpty())
+                if (storeTestDataList.notEmpty())
                 {
-                    Pair<Connection, List<Closeable>> closeableMockedConnections = buildTestConnection(key, storeTestDataList);
+                    Pair<Connection, List<Closeable>> closeableMockedConnections = buildTestConnection(connection, storeTestDataList);
                     Connection mockedConnection = closeableMockedConnections.getOne();
                     Root_meta_core_runtime_Connection mockedCompileConnection = mockedConnection.accept(this.context.getConnectionVisitor());
-                    for (Root_meta_core_runtime_ConnectionStore value : values)
+                    connectionStores.forEach(connectionStore ->
                     {
-                        Root_meta_core_runtime_Connection realConnection = value._connection();
-                        this.storeConnectionsPairs.add(Tuples.pair(value, realConnection));
-                        value._connection(mockedCompileConnection);
-                        closeableMockedConnections.getTwo().forEach(closeableConsumer);
-                    }
+                        Root_meta_core_runtime_Connection realConnection = connectionStore._connection();
+                        this.storeConnectionsPairs.add(Tuples.pair(connectionStore, realConnection));
+                        connectionStore._connection(mockedCompileConnection);
+                        registerCloseables(closeableMockedConnections.getTwo());
+                    });
                 }
-            }
+            });
         }
 
-        private Pair<Connection, List<Closeable>> buildTestConnection(Root_meta_core_runtime_Connection connection, Map<Store, EmbeddedData> storeEmbeddedDataMap)
+        private Pair<Connection, List<Closeable>> buildTestConnection(Root_meta_core_runtime_Connection connection, MutableMap<Store, EmbeddedData> storeEmbeddedDataMap)
         {
             if (storeEmbeddedDataMap.size() == 1 && connection instanceof Root_meta_external_store_model_PureModelConnection)
             {
-                EmbeddedData embeddedData = storeEmbeddedDataMap.values().stream().findFirst().get();
+                EmbeddedData embeddedData = storeEmbeddedDataMap.getAny();
                 if (embeddedData instanceof ExternalFormatData)
                 {
                     ExternalFormatData externalFormatData = (ExternalFormatData) embeddedData;
@@ -371,8 +356,15 @@ public class FunctionTestRunner implements TestRunner
                     }
                 }
             }
-            return FunctionTestRunner.this.connectionBuilders.collect(f -> f.tryBuildConnectionForStoreData(this.context.getDataElementIndex(), storeEmbeddedDataMap, this.hints)).select(Objects::nonNull).select(Optional::isPresent)
-                    .collect(Optional::get).getFirstOptional().orElseThrow(() -> new UnsupportedOperationException("Unsupported test data for function test suite: " + this.context.getTestSuite()._id()));
+            for (ConnectionFactoryExtension factory : FunctionTestRunner.this.connectionBuilders)
+            {
+                Optional<Pair<Connection, List<Closeable>>> optional = factory.tryBuildConnectionForStoreData(this.context.getDataElementIndex(), storeEmbeddedDataMap, this.hints);
+                if ((optional != null) && optional.isPresent())
+                {
+                    return optional.get();
+                }
+            }
+            throw new UnsupportedOperationException("Unsupported test data for function test suite: " + this.context.getTestSuite()._id());
         }
     }
 }

--- a/legend-engine-core/legend-engine-core-testable/legend-engine-test-runner-mapping/src/main/java/org/finos/legend/engine/testable/mapping/extension/MappingTestRunner.java
+++ b/legend-engine-core/legend-engine-core-testable/legend-engine-test-runner-mapping/src/main/java/org/finos/legend/engine/testable/mapping/extension/MappingTestRunner.java
@@ -378,7 +378,7 @@ public class MappingTestRunner implements TestRunner
             this.hints = TestReturnTypeHelper.isRelationReturnType(this.context.getMetamodelTestSuite()._query(), pureModel)
                          ? TestConnectionBuildParameters.newBuilder().withIsRelation(true).build()
                          : TestConnectionBuildParameters.NONE;
-            this.sharedPlan = computeSharedPlan(closeableConsumer);
+            this.sharedPlan = computeSharedPlan();
         }
 
         /**
@@ -393,7 +393,7 @@ public class MappingTestRunner implements TestRunner
          * ModelStore's singleton connections satisfy it; freshly-built service-store / MongoDB
          * connections, which carry a dynamically allocated local server address, do not.
          */
-        private GeneratedPlan computeSharedPlan(Consumer<? super AutoCloseable> closeableConsumer)
+        private GeneratedPlan computeSharedPlan()
         {
             Collection<String> atomicTestIds = getAtomicTestIds();
             if (atomicTestIds.isEmpty())
@@ -425,7 +425,7 @@ public class MappingTestRunner implements TestRunner
                 GeneratedPlan plan = generatePlan(buildRuntime(planConnections.getOne(), this.context), this.context, this.debug);
                 if (planCloseables != null)
                 {
-                    planCloseables.forEach(closeableConsumer);
+                    registerCloseables(planCloseables);
                     planCloseables = null;
                 }
                 return plan;

--- a/legend-engine-core/legend-engine-core-testable/legend-engine-testable/src/main/java/org/finos/legend/engine/testable/extension/AbstractTestSuiteSessionWithResources.java
+++ b/legend-engine-core/legend-engine-core-testable/legend-engine-testable/src/main/java/org/finos/legend/engine/testable/extension/AbstractTestSuiteSessionWithResources.java
@@ -20,6 +20,7 @@ import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
 import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
 import org.finos.legend.pure.generated.Root_meta_pure_test_TestSuite;
 
+import java.util.Collection;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -75,15 +76,19 @@ public abstract class AbstractTestSuiteSessionWithResources<S, T, R> extends Abs
             MutableList<Exception> exceptions = Lists.mutable.empty();
             this.closeables.forEach(c ->
             {
-                try
+                if (c != null)
                 {
-                    c.close();
-                }
-                catch (Exception e)
-                {
-                    exceptions.add(e);
+                    try
+                    {
+                        c.close();
+                    }
+                    catch (Exception e)
+                    {
+                        exceptions.add(e);
+                    }
                 }
             });
+            this.closeables.clear();
             this.state = CLOSED;
             if ((exceptions.size() == 1) && (exceptions.get(0) instanceof RuntimeException))
             {
@@ -106,7 +111,7 @@ public abstract class AbstractTestSuiteSessionWithResources<S, T, R> extends Abs
             {
                 try
                 {
-                    initialize(this.closeables::add);
+                    initialize(this::registerCloseable);
                     this.state = INITIALIZED;
                 }
                 catch (Throwable t)
@@ -138,6 +143,33 @@ public abstract class AbstractTestSuiteSessionWithResources<S, T, R> extends Abs
             }
         }
         return this.state;
+    }
+
+    protected synchronized void registerCloseable(AutoCloseable closeable)
+    {
+        if (this.state == CLOSED)
+        {
+            throw new IllegalStateException("Session is closed");
+        }
+        this.closeables.add(closeable);
+    }
+
+    protected synchronized void registerCloseables(Collection<? extends AutoCloseable> closeables)
+    {
+        if (this.state == CLOSED)
+        {
+            throw new IllegalStateException("Session is closed");
+        }
+        this.closeables.addAll(closeables);
+    }
+
+    protected synchronized void registerCloseables(Iterable<? extends AutoCloseable> closeables)
+    {
+        if (this.state == CLOSED)
+        {
+            throw new IllegalStateException("Session is closed");
+        }
+        this.closeables.addAllIterable(closeables);
     }
 
     protected abstract void initialize(Consumer<? super AutoCloseable> closeableConsumer) throws Exception;

--- a/legend-engine-xts-service/legend-engine-test-runner-service/src/main/java/org/finos/legend/engine/testable/service/extension/ServiceTestRunner.java
+++ b/legend-engine-xts-service/legend-engine-test-runner-service/src/main/java/org/finos/legend/engine/testable/service/extension/ServiceTestRunner.java
@@ -79,7 +79,6 @@ import org.finos.legend.pure.generated.Root_meta_pure_test_AtomicTest;
 import org.finos.legend.pure.generated.Root_meta_pure_test_TestSuite;
 
 import java.io.Closeable;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -355,13 +354,13 @@ public class ServiceTestRunner implements TestRunner
             {
                 Pair<Runtime, List<Closeable>> runtimeWithCloseables = TestRuntimeBuilder.getTestRuntimeAndClosableResources(this.execution.runtime, this.protocolSuite.testData, this.pmcd, hints);
                 testPureSingleExecution.runtime = runtimeWithCloseables.getOne();
-                runtimeWithCloseables.getTwo().forEach(closeableConsumer);
+                registerCloseables(runtimeWithCloseables.getTwo());
             }
             else
             {
                 MutableList<Closeable> closeables = Lists.mutable.empty();
                 testPureSingleExecution.func.body.forEach(func -> func.accept(new TestValueSpecificationBuilder(closeables, this.protocolSuite.testData, this.pmcd)));
-                closeables.forEach(closeableConsumer);
+                registerCloseables(closeables);
             }
             ExecutionPlan executionPlan = ServicePlanGenerator.generateExecutionPlan(testPureSingleExecution, null, this.pureModel, ServiceTestRunner.this.pureVersion, PlanPlatform.JAVA, null, routerExtensions, planTransformers);
             SingleExecutionPlan singleExecutionPlan = (SingleExecutionPlan) executionPlan;
@@ -428,7 +427,7 @@ public class ServiceTestRunner implements TestRunner
                     Pair<Runtime, List<Closeable>> runtimeWithCloseables = TestRuntimeBuilder.getTestRuntimeAndClosableResources(param.runtime, this.protocolSuite.testData, this.pmcd, hints);
                     pureSingleExecution.runtime = runtimeWithCloseables.getOne();
                     pureSingleExecution.executionOptions = param.executionOptions;
-                    runtimeWithCloseables.getTwo().forEach(closeableConsumer);
+                    registerCloseables(runtimeWithCloseables.getTwo());
                     ExecutionPlan executionPlan = ServicePlanGenerator.generateExecutionPlan(pureSingleExecution, null, this.pureModel, ServiceTestRunner.this.pureVersion, PlanPlatform.JAVA, null, routerExtensions, planTransformers);
                     SingleExecutionPlan singleExecutionPlan = (SingleExecutionPlan) executionPlan;
                     JavaHelper.compilePlan(singleExecutionPlan, Identity.getAnonymousIdentity());
@@ -487,9 +486,12 @@ public class ServiceTestRunner implements TestRunner
             List<String> allTestIds = this.protocolSuite.tests.stream().map(t -> t.id).collect(Collectors.toList());
             this.validKeyMap = getAllValidKeysForExecEnv(execKey, this.protocolSuite, allTestIds);
             PureMultiExecution multiExecution = shallowCopyMultiExecution(this.execution);
-            List<Closeable> tempCloseables = Lists.mutable.empty();
-            multiExecution.func.body.forEach(valSpec -> valSpec.accept(new TestValueSpecificationBuilder(new ArrayList<>(this.validKeyMap.values()), tempCloseables, this.protocolSuite.testData, this.pmcd)));
-            tempCloseables.forEach(closeableConsumer);
+            MutableList<Closeable> tempCloseables = Lists.mutable.empty();
+            multiExecution.func.body.forEach(valSpec -> valSpec.accept(new TestValueSpecificationBuilder(Lists.mutable.withAll(this.validKeyMap.values()), tempCloseables, this.protocolSuite.testData, this.pmcd)));
+            if (tempCloseables.notEmpty())
+            {
+                registerCloseables(tempCloseables);
+            }
             this.compositePlan = ServicePlanGenerator.generateCompositeExecutionPlan(multiExecution, null, this.pureModel, ServiceTestRunner.this.pureVersion, PlanPlatform.JAVA, null, routerExtensions, planTransformers);
             for (String key : Sets.mutable.withAll(this.validKeyMap.values()))
             {


### PR DESCRIPTION
Improve closeable handling in AbstractTestSuiteSessionWithResources by allowing more flexibility in how subclasses can register closeables. Also, disallow registering closeables after the session has been closed.