### PR TITLE
Fix compilation issue java M2M indexof

### DIFF
--- a/legend-engine-core/legend-engine-core-query-pure-http-api/src/test/java/org/finos/legend/engine/query/pure/api/test/inMemory/TestM2MGrammarCompileAndExecute.java
+++ b/legend-engine-core/legend-engine-core-query-pure-http-api/src/test/java/org/finos/legend/engine/query/pure/api/test/inMemory/TestM2MGrammarCompileAndExecute.java
@@ -308,6 +308,51 @@ public class TestM2MGrammarCompileAndExecute
         assertEquals("{\"builder\":{\"_type\":\"json\"},\"values\":{\"enum\":\"Target Enum@$#_*[]{}()\"}}", jsonResult2);
     }
 
+    @Test
+    public void testM2MIndexOfMapsToInteger() throws IOException
+    {
+        // Regression test for the M2M Java code-generation bug where the Pure j_invoke return
+        // type declared for indexOf was the element type of the collection (e.g. String) instead
+        // of an integer. Mapping the result into an Integer-typed property failed to compile the
+        // generated Java. See essential/collection.pure (indexOf fc2).
+        PureModelContextData contextData = PureGrammarParser.newInstance().parseModel("" +
+                "Class test::S_Item\n" +
+                "{\n" +
+                "   name : String[1];\n" +
+                "}\n" +
+                "\n" +
+                "Class test::Item\n" +
+                "{\n" +
+                "   name : String[1];\n" +
+                "   idx  : Integer[0..1];\n" +
+                "}\n" +
+                "\n" +
+                "###Mapping\n" +
+                "Mapping test::itemMapping\n" +
+                "(\n" +
+                "   *test::Item : Pure\n" +
+                "   {\n" +
+                "     ~src test::S_Item\n" +
+                "     name : $src.name,\n" +
+                "     idx  : ['a', 'b', 'c']->indexOf($src.name)\n" +
+                "   }\n" +
+                ")\n"
+        );
+
+        ClassInstance fetchTree = rootGFT("test::Item", propertyGFT("name"), propertyGFT("idx"));
+        LambdaFunction lambda = lambda(apply(SERIALIZE, apply(GRAPH_FETCH, apply(GET_ALL, clazz("test::Item")), fetchTree), fetchTree));
+
+        ExecuteInput input = new ExecuteInput();
+        input.clientVersion = "vX_X_X";
+        input.model = contextData;
+        input.mapping = "test::itemMapping";
+        input.function = lambda;
+        input.runtime = runtimeValue(jsonModelConnection("test::S_Item", "{\"name\":\"b\"}"));
+        input.context = context();
+        String json = responseAsString(runTest(input));
+        assertEquals("{\"builder\":{\"_type\":\"json\"},\"values\":{\"name\":\"b\",\"idx\":1}}", json);
+    }
+
     private Response runTest(ExecuteInput input)
     {
         ModelManager modelManager = new ModelManager(DeploymentMode.TEST);

--- a/legend-engine-xts-java/legend-engine-xt-javaGeneration-conventions-essential-pure/src/main/resources/core_external_language_java_conventions_essential/essential/collection.pure
+++ b/legend-engine-xts-java/legend-engine-xt-javaGeneration-conventions-essential-pure/src/main/resources/core_external_language_java_conventions_essential/essential/collection.pure
@@ -42,7 +42,7 @@ function meta::external::language::java::generation::essential::collection::regi
          fc3(contains_Z_MANY__Z_1__Function_1__Boolean_1_,                       {ctx,collection,obj,eqlf      | $library->j_invoke('contains', [$collection, $obj, $eqlf], javaBoolean())}),
 
          fc2(at_T_MANY__Integer_1__T_1_,                                         {ctx,collection,index         | $library->j_invoke('at', [$collection, $index], if($collection.type->isJavaList(), |$collection.type->elementTypeOfJavaList(), |$collection.type))}),
-         fc2(indexOf_T_MANY__T_1__Integer_1_,                                    {ctx,collection,obj           | $library->j_invoke('indexOf', [$collection, $obj], if($collection.type->isJavaList(), |$collection.type->elementTypeOfJavaList(), |$collection.type))}),
+         fc2(indexOf_T_MANY__T_1__Integer_1_,                                    {ctx,collection,obj           | $library->j_invoke('indexOf', [$collection, $obj], javaIntBoxed())->j_invoke('longValue', [], javaLong())}),
 
          fc3(fold_T_MANY__Function_1__V_m__V_m_,                                 {ctx,collection,acc,identity  | javaFold($ctx, $collection, $acc, $identity, $library) }),
 


### PR DESCRIPTION
#### What type of PR is this?
- Bug Fix


#### What does this PR do / why is it needed ?

This PR fixes a runtime compilation issue in M2M when using index of and assigning the result to an integer model property


#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
No
