### PR TITLE
Fix router inlining clobbering arguments on parameter-name collision

### DIFF
--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/router_test.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/router_test.pure
@@ -1,0 +1,140 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::pure::executionPlan::*;
+import meta::pure::metamodel::serialization::grammar::*;
+import meta::pure::router::tests::*;
+
+function <<test.Test>> meta::pure::router::tests::testRouterScopeCorrectlyFunctionParameters():Boolean[1]
+{
+  let ctx = ^GContext(space='');
+
+  let cfg = ^Configuration(fullPath=false, extensions = ^GrammarExtension(
+    extraInstanceValueHandlers = [
+      {x:PlanVarPlaceHolder[1] | '$' + $x.name}
+    ]
+  ));
+
+  let expected = 'businessDate: Date[1]|let prevBusinessDate = $businessDate->adjust(-1, meta::pure::functions::date::DurationUnit.DAYS);\n' + 
+                 '                      $businessDate->dayOfMonth() - $prevBusinessDate->dayOfMonth();\n';
+
+  let a = routeFunction(topLevelFunctionToTestWithoutClashingParameters_Date_1__Any_1_, []);
+  let grammar = $a->evaluateAndDeactivate()->printFunctionDefinition($cfg, $ctx);
+  assertEquals($expected, $grammar);
+
+  let a2 = routeFunction(topLevelFunctionToTestWithClashingParameters_Date_1__Any_1_, []);
+  let grammar2 = $a2->evaluateAndDeactivate()->printFunctionDefinition($cfg, $ctx);
+  assertEquals($expected, $grammar2);
+}
+
+function <<access.private>> meta::pure::router::tests::topLevelFunctionToTestWithoutClashingParameters(businessDate: Date[1]): Any[1]
+{
+    let prevBusinessDate = $businessDate->adjust(-1, DurationUnit.DAYS);
+    $businessDate->topLevelFunctionToTestWithoutClashingParametersProcessingFunc($prevBusinessDate);
+}
+
+function <<access.private>> meta::pure::router::tests::topLevelFunctionToTestWithoutClashingParametersProcessingFunc(businessDate: Date[1], prevBusinessDate: Date[1]): Any[1]
+{
+    $businessDate->getDay_distinctParameterName() - $prevBusinessDate->getDay_distinctParameterName();
+}
+
+function <<access.private>> meta::pure::router::tests::getDay_distinctParameterName(d: Date[1]): Integer[1]
+{
+    $d->dayOfMonth();
+}
+
+function <<access.private>> meta::pure::router::tests::topLevelFunctionToTestWithClashingParameters(businessDate: Date[1]): Any[1]
+{
+    let prevBusinessDate = $businessDate->adjust(-1, DurationUnit.DAYS);
+    $businessDate->topLevelFunctionToTestWithClashingParametersProcessingFunc($prevBusinessDate);
+}
+
+function <<access.private>> meta::pure::router::tests::topLevelFunctionToTestWithClashingParametersProcessingFunc(businessDate: Date[1], prevBusinessDate: Date[1]): Any[1]
+{
+    $businessDate->getDay_clashingParameterName() - $prevBusinessDate->getDay_clashingParameterName();
+}
+
+function <<access.private>> meta::pure::router::tests::getDay_clashingParameterName(businessDate: Date[1]): Integer[1]
+{
+    $businessDate->dayOfMonth();
+}
+
+// Regression: a nested call passes arguments in swapped order against same-named parameters.
+// The inlined function's own parameter bindings must shadow the enclosing scope, otherwise the
+// name-keyed scope silently un-swaps the arguments.
+function <<test.Test>> meta::pure::router::tests::testRouterScopeCorrectlyWithSwappedFunctionParameters():Boolean[1]
+{
+  let ctx = ^GContext(space='');
+
+  let cfg = ^Configuration(fullPath=false, extensions = ^GrammarExtension(
+    extraInstanceValueHandlers = [
+      {x:PlanVarPlaceHolder[1] | '$' + $x.name}
+    ]
+  ));
+
+  let expected = 'businessDate: Date[1]|let prevBusinessDate = $businessDate->adjust(-1, meta::pure::functions::date::DurationUnit.DAYS);\n' +
+                 '                      $prevBusinessDate->dayOfMonth() - $businessDate->dayOfMonth();\n';
+
+  let a = routeFunction(topLevelFunctionToTestWithSwappedParameters_Date_1__Any_1_, []);
+  let grammar = $a->evaluateAndDeactivate()->printFunctionDefinition($cfg, $ctx);
+  assertEquals($expected, $grammar);
+}
+
+function <<access.private>> meta::pure::router::tests::topLevelFunctionToTestWithSwappedParameters(businessDate: Date[1]): Any[1]
+{
+    let prevBusinessDate = $businessDate->adjust(-1, DurationUnit.DAYS);
+    $businessDate->topLevelFunctionToTestWithSwappedParametersProcessingFunc($prevBusinessDate);
+}
+
+function <<access.private>> meta::pure::router::tests::topLevelFunctionToTestWithSwappedParametersProcessingFunc(businessDate: Date[1], prevBusinessDate: Date[1]): Any[1]
+{
+    // pass prevBusinessDate into the businessDate parameter and vice versa
+    topLevelFunctionToTestWithSwappedParametersDiff($prevBusinessDate, $businessDate);
+}
+
+function <<access.private>> meta::pure::router::tests::topLevelFunctionToTestWithSwappedParametersDiff(businessDate: Date[1], prevBusinessDate: Date[1]): Integer[1]
+{
+    $businessDate->dayOfMonth() - $prevBusinessDate->dayOfMonth();
+}
+
+// Regression: confirms the inlining scope is correctly scoped per expression. The merged variable
+// map is a local argument to routeValueSpecification and is never stored back into the RoutingState
+// threaded across expressions, so one expression's inlining cannot corrupt a later one. The clashing
+// call is made twice - once in a middle let, once as the return expression - and both must
+// independently resolve $businessDate and $prevBusinessDate to the correct values.
+function <<test.Test>> meta::pure::router::tests::testRouterScopeDoesNotLeakAcrossExpressions():Boolean[1]
+{
+  let ctx = ^GContext(space='');
+
+  let cfg = ^Configuration(fullPath=false, extensions = ^GrammarExtension(
+    extraInstanceValueHandlers = [
+      {x:PlanVarPlaceHolder[1] | '$' + $x.name}
+    ]
+  ));
+
+  let expected = 'businessDate: Date[1]|let prevBusinessDate = $businessDate->adjust(-1, meta::pure::functions::date::DurationUnit.DAYS);\n' +
+                 '                      let firstResult = $businessDate->dayOfMonth() - $prevBusinessDate->dayOfMonth();\n' +
+                 '                      $businessDate->dayOfMonth() - $prevBusinessDate->dayOfMonth();\n';
+
+  let a = routeFunction(topLevelFunctionToTestWithClashingParametersAcrossExpressions_Date_1__Any_1_, []);
+  let grammar = $a->evaluateAndDeactivate()->printFunctionDefinition($cfg, $ctx);
+  assertEquals($expected, $grammar);
+}
+
+function <<access.private>> meta::pure::router::tests::topLevelFunctionToTestWithClashingParametersAcrossExpressions(businessDate: Date[1]): Any[1]
+{
+    let prevBusinessDate = $businessDate->adjust(-1, DurationUnit.DAYS);
+    let firstResult = $businessDate->topLevelFunctionToTestWithClashingParametersProcessingFunc($prevBusinessDate);
+    $businessDate->topLevelFunctionToTestWithClashingParametersProcessingFunc($prevBusinessDate);
+}

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/routing/router_routing.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/routing/router_routing.pure
@@ -548,7 +548,7 @@ function meta::pure::router::routing::routeFunctionExpressionFunctionDefinition(
                     ^$lastSecondPass(shouldBeRouted = $shouldBeRouted, value=$possiblyWrapperd, pathPrefix=$state.pathPrefix);,
                   | let newVars = $fullRes->mapVariables(newMap([]->cast(@Pair<VariableExpression, ValueSpecification>), VariableExpression->classPropertyByName('name')->cast(@Property<VariableExpression,String|1>)),$inScopeVars);
                     assert($f->cast(@FunctionDefinition<Any>).expressionSequence->size() <= 1, | 'Function ' +$f->cast(@FunctionDefinition<Any>)->elementToPath() + ' is not yet supported as functions with more than one expression can not be routed');
-                    ^$lastSecondPass(value=$f->cast(@FunctionDefinition<Any>).expressionSequence->at(0))->routeValueSpecification($executionContext, $newVars->putAll($vars), $inScopeVars, $extensions, $debug);
+                    ^$lastSecondPass(value=$f->cast(@FunctionDefinition<Any>).expressionSequence->at(0))->routeValueSpecification($executionContext, $vars->putAll($newVars), $inScopeVars, $extensions, $debug);
               );
         );
   );

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/serialization/toPureGrammar.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/serialization/toPureGrammar.pure
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import meta::pure::router::utils::*;
+import meta::pure::router::metamodel::clustering::*;
 import meta::pure::store::*;
 import meta::core::runtime::*;
 import meta::pure::metamodel::relation::*;
@@ -118,6 +120,7 @@ function meta::pure::metamodel::serialization::grammar::printValueSpecification(
                     f:Float[1] | $f->toRepresentation(),
                     s:String[1] | $s->toRepresentation(),
                     b:Boolean[1] | $b->toRepresentation(),
+                    c:ClusteredValueSpecification[1] | $c->byPassValueSpecificationWrapper()->printValueSpecification($configuration, $context),
                     a:Any[1] | 'UNKNOWN: ' + $a->type()->toOne()->id()
                 ]
              );

--- a/legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-PCT/src/test/java/org/finos/legend/engine/pure/code/core/java/binding/Test_JAVA_GrammarFunction_PCT.java
+++ b/legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-PCT/src/test/java/org/finos/legend/engine/pure/code/core/java/binding/Test_JAVA_GrammarFunction_PCT.java
@@ -39,12 +39,6 @@ public class Test_JAVA_GrammarFunction_PCT extends PCTReportConfiguration
             one("meta::pure::functions::boolean::tests::equality::equal::testEqualNonPrimitive_Function_1__Boolean_1_", "\"Unhandled value type: meta::pure::functions::boolean::tests::equalitymodel::SideClass\""),
             one("meta::pure::functions::boolean::tests::equality::equal::testEqualVarIdentity_Function_1__Boolean_1_", "\"Unhandled value type: meta::pure::functions::boolean::tests::equalitymodel::BottomClass\""),
 
-            // GreaterThan
-            one("meta::pure::functions::boolean::tests::inequalities::greaterThan::testGreaterThan_Boolean_Function_1__Boolean_1_", "\"Assert failed\""),
-
-            // GreaterThanEqual
-            one("meta::pure::functions::boolean::tests::inequalities::greaterThanEqual::testGreaterThanEqual_Boolean_Function_1__Boolean_1_", "\"Assert failed\""),
-
             // Filter
             one("meta::pure::functions::collection::tests::filter::testFilterInstance_Function_1__Boolean_1_", "\"Unhandled value type: meta::pure::functions::collection::tests::model::CO_Person\""),
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-clickhouse/legend-engine-xt-relationalStore-clickhouse-PCT/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/clickhouse/pct/Test_Relational_ClickHouse_GrammarFunctions_PCT.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-clickhouse/legend-engine-xt-relationalStore-clickhouse-PCT/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/clickhouse/pct/Test_Relational_ClickHouse_GrammarFunctions_PCT.java
@@ -72,13 +72,11 @@ public class Test_Relational_ClickHouse_GrammarFunctions_PCT extends PCTReportCo
             one("meta::pure::functions::boolean::tests::equality::equal::testEqualNonPrimitive_Function_1__Boolean_1_", "\"Filter expressions are only supported for Primitives and Enums. Filter contains a parameter of type SideClass\""),
 
             // GreaterThan
-            one("meta::pure::functions::boolean::tests::inequalities::greaterThan::testGreaterThan_Boolean_Function_1__Boolean_1_", "Assert failure at (resource:/platform/pure/essential/tests/assert.pure line:26 column:5), \"Assert failed\""),
             one("meta::pure::functions::boolean::tests::inequalities::greaterThan::testGreaterThan_Date_Function_1__Boolean_1_", "class java.lang.Long cannot be cast to class java.lang.Boolean (java.lang.Long and java.lang.Boolean are in module java.base of loader 'bootstrap')"),
             one("meta::pure::functions::boolean::tests::inequalities::greaterThan::testGreaterThan_Number_Function_1__Boolean_1_", "class java.lang.Long cannot be cast to class java.lang.Boolean (java.lang.Long and java.lang.Boolean are in module java.base of loader 'bootstrap')"),
             one("meta::pure::functions::boolean::tests::inequalities::greaterThan::testGreaterThan_String_Function_1__Boolean_1_", "class java.lang.Long cannot be cast to class java.lang.Boolean (java.lang.Long and java.lang.Boolean are in module java.base of loader 'bootstrap')"),
 
             // GreaterThanEqual
-            one("meta::pure::functions::boolean::tests::inequalities::greaterThanEqual::testGreaterThanEqual_Boolean_Function_1__Boolean_1_", "Assert failure at (resource:/platform/pure/essential/tests/assert.pure line:26 column:5), \"Assert failed\""),
             one("meta::pure::functions::boolean::tests::inequalities::greaterThanEqual::testGreaterThanEqual_Date_Function_1__Boolean_1_", "class java.lang.Long cannot be cast to class java.lang.Boolean (java.lang.Long and java.lang.Boolean are in module java.base of loader 'bootstrap')"),
             one("meta::pure::functions::boolean::tests::inequalities::greaterThanEqual::testGreaterThanEqual_Number_Function_1__Boolean_1_", "class java.lang.Long cannot be cast to class java.lang.Boolean (java.lang.Long and java.lang.Boolean are in module java.base of loader 'bootstrap')"),
             one("meta::pure::functions::boolean::tests::inequalities::greaterThanEqual::testGreaterThanEqual_String_Function_1__Boolean_1_", "class java.lang.Long cannot be cast to class java.lang.Boolean (java.lang.Long and java.lang.Boolean are in module java.base of loader 'bootstrap')"),

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-databricks/legend-engine-xt-relationalStore-databricks-PCT/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/databricks/pct/Test_Relational_Databricks_GrammarFunctions_PCT.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-databricks/legend-engine-xt-relationalStore-databricks-PCT/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/databricks/pct/Test_Relational_Databricks_GrammarFunctions_PCT.java
@@ -58,10 +58,6 @@ public class Test_Relational_Databricks_GrammarFunctions_PCT extends PCTReportCo
             one("meta::pure::functions::boolean::tests::equality::equal::testEqualPrimitiveExtension_Function_1__Boolean_1_", "Filter expressions are only supported for Primitives and Enums. Filter contains a parameter of type SideClass", AdapterQualifier.unsupportedFeature),
             one("meta::pure::functions::boolean::tests::equality::equal::testEqualVarIdentity_Function_1__Boolean_1_", "\"Filter expressions are only supported for Primitives and Enums. Filter contains a parameter of type BottomClass\"", AdapterQualifier.unsupportedFeature),
 
-            //inequalities
-            one("meta::pure::functions::boolean::tests::inequalities::greaterThan::testGreaterThan_Boolean_Function_1__Boolean_1_", "\"Assert failed\""),
-            one("meta::pure::functions::boolean::tests::inequalities::greaterThanEqual::testGreaterThanEqual_Boolean_Function_1__Boolean_1_", "\"Assert failed\""),
-
             //filter
             one("meta::pure::functions::collection::tests::filter::testFilterInstance_Function_1__Boolean_1_", "Error dynamically evaluating value specification (from /platform/pure/grammar/functions/collection/iteration/filter.pure:49cc46-50); error compiling generated Java code", AdapterQualifier.unsupportedFeature),
             one("meta::pure::functions::collection::tests::filter::testFilterLiteralFromVar_Function_1__Boolean_1_", "[unsupported-api] relational lambda processing not supported for Database Type: Databricks"),

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-duckdb/legend-engine-xt-relationalStore-duckdb-PCT/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/duckdb/pct/Test_Relational_DuckDB_GrammarFunctions_PCT.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-duckdb/legend-engine-xt-relationalStore-duckdb-PCT/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/duckdb/pct/Test_Relational_DuckDB_GrammarFunctions_PCT.java
@@ -54,12 +54,6 @@ public class Test_Relational_DuckDB_GrammarFunctions_PCT extends PCTReportConfig
             one("meta::pure::functions::boolean::tests::equality::equal::testEqualDateStrictYear_Function_1__Boolean_1_", "\"DuckDB doesn't support YEAR and YEAR-MONTH\"", AdapterQualifier.unsupportedFeature),
             one("meta::pure::functions::boolean::tests::equality::equal::testEqualPrimitiveExtension_Function_1__Boolean_1_", "\"Filter expressions are only supported for Primitives and Enums. Filter contains a parameter of type SideClass\"", AdapterQualifier.unsupportedFeature),
 
-            // GreaterThan
-            one("meta::pure::functions::boolean::tests::inequalities::greaterThan::testGreaterThan_Boolean_Function_1__Boolean_1_", "\"Assert failed\""),
-
-            // GreaterThanEqual
-            one("meta::pure::functions::boolean::tests::inequalities::greaterThanEqual::testGreaterThanEqual_Boolean_Function_1__Boolean_1_", "\"Assert failed\""),
-
             // Filter
             one("meta::pure::functions::collection::tests::filter::testFilterInstance_Function_1__Boolean_1_", "Error dynamically evaluating value specification (from /platform/pure/grammar/functions/collection/iteration/filter.pure:49cc46-50); error compiling generated Java code", AdapterQualifier.unsupportedFeature),
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-h2/legend-engine-xt-relationalStore-h2-PCT/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/h2/pct/Test_Relational_H2_GrammarFunctions_PCT.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-h2/legend-engine-xt-relationalStore-h2-PCT/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/h2/pct/Test_Relational_H2_GrammarFunctions_PCT.java
@@ -60,12 +60,6 @@ public class Test_Relational_H2_GrammarFunctions_PCT extends PCTReportConfigurat
             one("meta::pure::functions::boolean::tests::equality::equal::testEqualVarIdentity_Function_1__Boolean_1_", "\"Filter expressions are only supported for Primitives and Enums. Filter contains a parameter of type BottomClass\"", AdapterQualifier.unsupportedFeature),
             one("meta::pure::functions::boolean::tests::equality::equal::testEqualPrimitiveExtension_Function_1__Boolean_1_", "\"Filter expressions are only supported for Primitives and Enums. Filter contains a parameter of type SideClass\"", AdapterQualifier.unsupportedFeature),
 
-            // GreaterThan
-            one("meta::pure::functions::boolean::tests::inequalities::greaterThan::testGreaterThan_Boolean_Function_1__Boolean_1_", "\"Assert failed\""),
-
-            // GreaterThanEqual
-            one("meta::pure::functions::boolean::tests::inequalities::greaterThanEqual::testGreaterThanEqual_Boolean_Function_1__Boolean_1_", "\"Assert failed\""),
-
             // Filter
             one("meta::pure::functions::collection::tests::filter::testFilterInstance_Function_1__Boolean_1_", "Error dynamically evaluating value specification (from /platform/pure/grammar/functions/collection/iteration/filter.pure:49cc46-50); error compiling generated Java code", AdapterQualifier.unsupportedFeature),
             one("meta::pure::functions::collection::tests::filter::testFilterLiteralFromVar_Function_1__Boolean_1_", "Match failure: FilterRelationalLambdaObject instanceOf FilterRelationalLambda"),

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-postgres/legend-engine-xt-relationalStore-postgres-PCT/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/postgres/pct/Test_Relational_Postgres_GrammarFunctions_PCT.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-postgres/legend-engine-xt-relationalStore-postgres-PCT/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/postgres/pct/Test_Relational_Postgres_GrammarFunctions_PCT.java
@@ -54,12 +54,6 @@ public class Test_Relational_Postgres_GrammarFunctions_PCT extends PCTReportConf
             one("meta::pure::functions::boolean::tests::equality::equal::testEqualDateStrictYear_Function_1__Boolean_1_", "\"Ensure the target system understands Year or Year-month semantic.\"", AdapterQualifier.unsupportedFeature),
             one("meta::pure::functions::boolean::tests::equality::equal::testEqualPrimitiveExtension_Function_1__Boolean_1_", "\"Filter expressions are only supported for Primitives and Enums. Filter contains a parameter of type SideClass\"", AdapterQualifier.unsupportedFeature),
 
-            // GreaterThan
-            one("meta::pure::functions::boolean::tests::inequalities::greaterThan::testGreaterThan_Boolean_Function_1__Boolean_1_", "\"Assert failed\""),
-
-            // GreaterThanEqual
-            one("meta::pure::functions::boolean::tests::inequalities::greaterThanEqual::testGreaterThanEqual_Boolean_Function_1__Boolean_1_", "\"Assert failed\""),
-
             // Filter
             one("meta::pure::functions::collection::tests::filter::testFilterInstance_Function_1__Boolean_1_", "Error dynamically evaluating value specification (from /platform/pure/grammar/functions/collection/iteration/filter.pure:49cc46-50); error compiling generated Java code"),
             one("meta::pure::functions::collection::tests::filter::testFilterLiteralFromVar_Function_1__Boolean_1_", "[unsupported-api] relational lambda processing not supported for Database Type: Postgres"),

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-PCT/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/snowflake/pct/Test_Relational_Snowflake_GrammarFunctions_PCT.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-PCT/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/snowflake/pct/Test_Relational_Snowflake_GrammarFunctions_PCT.java
@@ -55,12 +55,6 @@ public class Test_Relational_Snowflake_GrammarFunctions_PCT extends PCTReportCon
             one("meta::pure::functions::boolean::tests::equality::equal::testEqualNonPrimitive_Function_1__Boolean_1_", "\"Filter expressions are only supported for Primitives and Enums. Filter contains a parameter of type SideClass\"", AdapterQualifier.unsupportedFeature),
             one("meta::pure::functions::boolean::tests::equality::equal::testEqualVarIdentity_Function_1__Boolean_1_", "\"Filter expressions are only supported for Primitives and Enums. Filter contains a parameter of type BottomClass\"", AdapterQualifier.unsupportedFeature),
 
-            // GreaterThan
-            one("meta::pure::functions::boolean::tests::inequalities::greaterThan::testGreaterThan_Boolean_Function_1__Boolean_1_", "\"Assert failed\""),
-
-            // GreaterThanEqual
-            one("meta::pure::functions::boolean::tests::inequalities::greaterThanEqual::testGreaterThanEqual_Boolean_Function_1__Boolean_1_", "\"Assert failed\""),
-
             // Filter
             one("meta::pure::functions::collection::tests::filter::testFilterInstance_Function_1__Boolean_1_", "Error dynamically evaluating value specification (from /platform/pure/grammar/functions/collection/iteration/filter.pure:49cc46-50); error compiling generated Java code"),
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-spanner/legend-engine-xt-relationalStore-spanner-PCT/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/spanner/pct/Test_Relational_Spanner_GrammarFunctions_PCT.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-spanner/legend-engine-xt-relationalStore-spanner-PCT/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/spanner/pct/Test_Relational_Spanner_GrammarFunctions_PCT.java
@@ -63,12 +63,6 @@ public class Test_Relational_Spanner_GrammarFunctions_PCT extends PCTReportConfi
             one("meta::pure::functions::boolean::tests::equality::equal::testEqualVarIdentity_Function_1__Boolean_1_", "\"Filter expressions are only supported for Primitives and Enums. Filter contains a parameter of type BottomClass\"", AdapterQualifier.unsupportedFeature),
             one("meta::pure::functions::boolean::tests::equality::equal::testEqualEnum_Function_1__Boolean_1_", "\"Assert failed\""),
 
-            //greaterThan
-            one("meta::pure::functions::boolean::tests::inequalities::greaterThan::testGreaterThan_Boolean_Function_1__Boolean_1_", "\"Assert failed\""),
-
-            //greaterThanEqual
-            one("meta::pure::functions::boolean::tests::inequalities::greaterThanEqual::testGreaterThanEqual_Boolean_Function_1__Boolean_1_", "\"Assert failed\""),
-
             //filter
             one("meta::pure::functions::collection::tests::filter::testFilterInstance_Function_1__Boolean_1_", "Error dynamically evaluating value specification (from /platform/pure/grammar/functions/collection/iteration/filter.pure:49cc46-50); error compiling generated Java code"),
             one("meta::pure::functions::collection::tests::filter::testFilterLiteralFromVar_Function_1__Boolean_1_", "[unsupported-api] relational lambda processing not supported for Database Type: Spanner"),

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-trino/legend-engine-xt-relationalStore-trino-PCT/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/trino/pct/Test_Relational_Trino_GrammarFunctions_PCT.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-trino/legend-engine-xt-relationalStore-trino-PCT/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/trino/pct/Test_Relational_Trino_GrammarFunctions_PCT.java
@@ -54,12 +54,6 @@ public class Test_Relational_Trino_GrammarFunctions_PCT extends PCTReportConfigu
             one("meta::pure::functions::boolean::tests::equality::equal::testEqualPrimitiveExtension_Function_1__Boolean_1_", "\"Filter expressions are only supported for Primitives and Enums. Filter contains a parameter of type SideClass\""),
             one("meta::pure::functions::boolean::tests::equality::equal::testEqualVarIdentity_Function_1__Boolean_1_", "\"Filter expressions are only supported for Primitives and Enums. Filter contains a parameter of type BottomClass\""),
 
-            // GreaterThan
-            one("meta::pure::functions::boolean::tests::inequalities::greaterThan::testGreaterThan_Boolean_Function_1__Boolean_1_", "\"Assert failed\""),
-
-            // GreaterThanEqual
-            one("meta::pure::functions::boolean::tests::inequalities::greaterThanEqual::testGreaterThanEqual_Boolean_Function_1__Boolean_1_", "\"Assert failed\""),
-
             // Filter
             one("meta::pure::functions::collection::tests::filter::testFilterInstance_Function_1__Boolean_1_", "Error dynamically evaluating value specification (from /platform/pure/grammar/functions/collection/iteration/filter.pure:49cc46-50); error compiling generated Java code"),
             one("meta::pure::functions::collection::tests::filter::testFilterLiteralFromVar_Function_1__Boolean_1_", "\"[unsupported-api] relational lambda processing not supported for Database Type: Trino\""),


### PR DESCRIPTION
## Problem

When the router inlines a user-defined function during plan generation, it merges the callee's parameter bindings with the enclosing scope. The merge was written `$newVars->putAll($vars)`, which lets the **outer** scope win on a key (variable name) collision. So when a callee parameter is named the same as a variable already in the caller's scope, the callee's binding is overwritten with the caller's value — silently dropping the real argument.

Minimal reproduction (routes to `$businessDate->dayOfMonth() - $businessDate->dayOfMonth()` instead of `... - $prevBusinessDate->dayOfMonth()`):

```
function topLevel(businessDate: Date[1]): Any[1]
{
    let prevBusinessDate = $businessDate->adjust(-1, DurationUnit.DAYS);
    $businessDate->processing($prevBusinessDate);
}
function processing(businessDate: Date[1], prevBusinessDate: Date[1]): Any[1]
{
    $businessDate->getDay() - $prevBusinessDate->getDay();
}
function getDay(businessDate: Date[1]): Integer[1]   // param name collides with caller var
{
    $businessDate->dayOfMonth();
}
```

## Fix

`router_routing.pure` — flip the merge to `$vars->putAll($newVars)` so the inlined function's own parameters shadow same-named enclosing variables. The convention `X->putAll(Y)` ⇒ `Y` wins on collision is already used the correct way at `router_routing.pure` (QualifiedProperty path) and in `preeval.pure` (`addToScope`, lambda scope); this was the one site with the operands reversed.

## Cross-store correctness bug this also fixes

The standard library defines `greaterThan(Boolean) => lessThan($right, $left)`, and `lessThan`'s parameters are also named `left`/`right`. Pre-fix, the swapped arguments were silently un-swapped by the clobber, so boolean `>` / `>=` returned wrong results on every store that routes the inlined Pure implementation (relational **and** Java platform binding). These were hidden behind `"Assert failed"` PCT expected-failures for `testGreaterThan_Boolean` / `testGreaterThanEqual_Boolean`; the fix makes them pass, so those entries are removed.

- **Removed** (cause = `"Assert failed"`, the shadowing bug): H2, DuckDB, Java binding *(verified locally)*; Postgres, Snowflake, Databricks, Spanner, Trino, ClickHouse *(by inference — the bug is dialect-independent and computed in-engine; **cloud CI is the arbiter**)*.
- **Kept** (unrelated causes): SqlServer (SQL syntax), MemSQL (ClassCast), Deephaven (unsupported `and`/`or`).

## Tests

New router regression tests in `router_test.pure`: parameter-name collision, swapped arguments, and cross-expression scope isolation. (`toPureGrammar.pure` gains a `ClusteredValueSpecification` print case so routed output can be grammar-asserted.)

## Verification (local)

- `Test_Pure_Core` 1094 ✅ · `Test_Pure_Relational` 2676 ✅
- Java-binding full PCT (6 categories) ✅ · DuckDB full PCT (7 categories) ✅ · H2 GrammarFunctions PCT ✅
- Checkstyle ✅ · new tests fail pre-fix / pass post-fix