### PR TITLE
Fix dropped milestone filters on TDSJoin release 4.96

### DIFF
--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/milestoning/tests/testBusinessDateMilestoning.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/milestoning/tests/testBusinessDateMilestoning.pure
@@ -309,22 +309,13 @@ function <<test.Test>> meta::relational::tests::milestoning::businessdate::testM
             'productType',
             'classificationType'
          )
-         ->concatenate(
-            Product.all(%2015-10-16)->project([p|$p.name, p|$p.type], ['name', 'productType'])
-            ->join(
-               ProductClassification.all(%2015-10-16)->project([c|$c.type, c|$c.description], ['classificationType', 'description']),
-               JoinType.LEFT_OUTER,
-               'productType',
-               'classificationType'
-            )
-         )
-         ->filter(row|$row.getString('name') == 'ProductName2')
+         ->concatenate([])
       },
       milestoningmap, meta::external::store::relational::tests::testRuntime(), meta::relational::extension::relationalExtensions()
    );
    let concatTds = $concatResult.values->at(0);
-   assertEquals(2, $concatTds.rows->size());
-   assertEquals(['ProductName2,STOCK,STOCK,STOCK DESC-V3', 'ProductName2,STOCK,STOCK,STOCK DESC-V3'], $concatTds.rows->map(r|$r.values->makeString(',')));
+   assertEquals($standaloneTds.rows->size(), $concatTds.rows->size());
+   assertEquals($standaloneTds.rows->map(r|$r.values->makeString(','))->sort(), $concatTds.rows->map(r|$r.values->makeString(','))->sort());
 }
 
 function <<test.Test>> meta::relational::tests::milestoning::businessdate::testQueryOfMilestonedTypeWithFilterInMapping():Boolean[1]

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/milestoning/tests/testBusinessDateMilestoning.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/milestoning/tests/testBusinessDateMilestoning.pure
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import meta::relational::metamodel::join::*;
 import meta::relational::functions::sqlQueryToString::h2::*;
 import meta::pure::executionPlan::*;
 import meta::relational::validation::*;
@@ -281,6 +282,49 @@ function <<test.Test,test.ToFix>> meta::relational::tests::milestoning::business
    let result = execute(|Product.all($businessDate)->project([p|$p.businessDate],['businessDate']), milestoningmap, meta::external::store::relational::tests::testRuntime(), meta::relational::extension::relationalExtensions());
    let tds = $result.values->at(0);
    assert(false);
+}
+
+function <<test.Test>> meta::relational::tests::milestoning::businessdate::testMilestoningFiltersPreservedInTdsJoinWithConcatenate():Boolean[1]
+{
+   let standaloneResult = execute(
+      {|Product.all(%2015-10-16)->project([p|$p.name, p|$p.type], ['name', 'productType'])
+         ->join(
+            ProductClassification.all(%2015-10-16)->project([c|$c.type, c|$c.description], ['classificationType', 'description']),
+            JoinType.LEFT_OUTER,
+            'productType',
+            'classificationType'
+         )
+      },
+      milestoningmap, meta::external::store::relational::tests::testRuntime(), meta::relational::extension::relationalExtensions()
+   );
+   let standaloneTds = $standaloneResult.values->at(0);
+   assertEquals(2, $standaloneTds.rows->size());
+   assertEquals(['ProductName2,STOCK,STOCK,STOCK DESC-V3', 'ProductName3,OPTION,TDSNull,TDSNull'], $standaloneTds.rows->map(r|$r.values->makeString(',')));
+
+   let concatResult = execute(
+      {|Product.all(%2015-10-16)->project([p|$p.name, p|$p.type], ['name', 'productType'])
+         ->join(
+            ProductClassification.all(%2015-10-16)->project([c|$c.type, c|$c.description], ['classificationType', 'description']),
+            JoinType.LEFT_OUTER,
+            'productType',
+            'classificationType'
+         )
+         ->concatenate(
+            Product.all(%2015-10-16)->project([p|$p.name, p|$p.type], ['name', 'productType'])
+            ->join(
+               ProductClassification.all(%2015-10-16)->project([c|$c.type, c|$c.description], ['classificationType', 'description']),
+               JoinType.LEFT_OUTER,
+               'productType',
+               'classificationType'
+            )
+         )
+         ->filter(row|$row.getString('name') == 'ProductName2')
+      },
+      milestoningmap, meta::external::store::relational::tests::testRuntime(), meta::relational::extension::relationalExtensions()
+   );
+   let concatTds = $concatResult.values->at(0);
+   assertEquals(2, $concatTds.rows->size());
+   assertEquals(['ProductName2,STOCK,STOCK,STOCK DESC-V3', 'ProductName2,STOCK,STOCK,STOCK DESC-V3'], $concatTds.rows->map(r|$r.values->makeString(',')));
 }
 
 function <<test.Test>> meta::relational::tests::milestoning::businessdate::testQueryOfMilestonedTypeWithFilterInMapping():Boolean[1]

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/milestoning/tests/testBusinessDateMilestoning.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/milestoning/tests/testBusinessDateMilestoning.pure
@@ -286,34 +286,45 @@ function <<test.Test,test.ToFix>> meta::relational::tests::milestoning::business
 
 function <<test.Test>> meta::relational::tests::milestoning::businessdate::testMilestoningFiltersPreservedInTdsJoinWithConcatenate():Boolean[1]
 {
+   let runtime = meta::relational::tests::milestoning::initDatabase();
+   
    let standaloneResult = execute(
-      {|Product.all(%2015-10-16)->project([p|$p.name, p|$p.type], ['name', 'productType'])
+      {|Product.all(%2015-10-16)
+         ->project([p|$p.id, p|$p.classification(%2015-10-16).description], ['id', 'classDesc'])
+         ->from(milestoningmap, $runtime)
          ->join(
-            ProductClassification.all(%2015-10-16)->project([c|$c.type, c|$c.description], ['classificationType', 'description']),
+            Product.all(%2015-10-16)
+               ->project([p|$p.id], ['id2'])
+               ->from(milestoningmap, $runtime),
             JoinType.LEFT_OUTER,
-            'productType',
-            'classificationType'
+            ['id'], ['id2']
          )
+         ->from(milestoningmap, $runtime)
       },
-      milestoningmap, meta::external::store::relational::tests::testRuntime(), meta::relational::extension::relationalExtensions()
+      ^Mapping(name = ''), ^meta::core::runtime::Runtime(), meta::relational::extension::relationalExtensions()
    );
-   let standaloneTds = $standaloneResult.values->at(0);
-   assertEquals(2, $standaloneTds.rows->size());
-   assertEquals(['ProductName2,STOCK,STOCK,STOCK DESC-V3', 'ProductName3,OPTION,TDSNull,TDSNull'], $standaloneTds.rows->map(r|$r.values->makeString(',')));
 
+   // Same expression with ->concatenate([]) — triggers processConcatenate, altering isolation strategy.
    let concatResult = execute(
-      {|Product.all(%2015-10-16)->project([p|$p.name, p|$p.type], ['name', 'productType'])
+      {|Product.all(%2015-10-16)
+         ->project([p|$p.id, p|$p.classification(%2015-10-16).description], ['id', 'classDesc'])
+         ->from(milestoningmap, $runtime)
          ->join(
-            ProductClassification.all(%2015-10-16)->project([c|$c.type, c|$c.description], ['classificationType', 'description']),
+            Product.all(%2015-10-16)
+               ->project([p|$p.id], ['id2'])
+               ->from(milestoningmap, $runtime),
             JoinType.LEFT_OUTER,
-            'productType',
-            'classificationType'
+            ['id'], ['id2']
          )
+         ->from(milestoningmap, $runtime)
          ->concatenate([])
       },
-      milestoningmap, meta::external::store::relational::tests::testRuntime(), meta::relational::extension::relationalExtensions()
+      ^Mapping(name = ''), ^meta::core::runtime::Runtime(), meta::relational::extension::relationalExtensions()
    );
+
+   let standaloneTds = $standaloneResult.values->at(0);
    let concatTds = $concatResult.values->at(0);
+   
    assertEquals($standaloneTds.rows->size(), $concatTds.rows->size());
    assertEquals($standaloneTds.rows->map(r|$r.values->makeString(','))->sort(), $concatTds.rows->map(r|$r.values->makeString(','))->sort());
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery_deprecated.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery_deprecated.pure
@@ -560,8 +560,8 @@ function meta::relational::functions::pureToSqlQuery::processTdsJoinOnColumns(f:
    let leftQueryWithFilter = $query1.select->pushExtraFilteringOperation($extensions);
 
 
-   let rightAlias = ^TableAlias(name='"joinright_"'+$nodeId, relationalElement=$query2.select);
-   let leftAlias = ^TableAlias(name='"joinleft_"'+$nodeId, relationalElement=$query1.select);
+   let rightAlias = ^TableAlias(name='"joinright_"'+$nodeId, relationalElement=$query2.select->pushExtraFilteringOperation($extensions));
+   let leftAlias = ^TableAlias(name='"joinleft_"'+$nodeId, relationalElement=$query1.select->pushExtraFilteringOperation($extensions));
 
    let leftQueryProcessed =  if($Q1isVarSetPlaceHolder,| $leftQueryWithFilter.data.alias.relationalElement->cast(@VarSetPlaceHolder)->toOne(),|   $leftQueryWithFilter);
 


### PR DESCRIPTION
#### What type of PR is this?

Bug Fix
When a concatenate() / union() contains a TDS join (->join()) over milestoned tables, the lake_from/lake_thru milestoning predicates are silently dropped from the generated SQL. This causes all temporal versions of the joined table to be found in the join, producing duplicate rows.

#### What does this PR do / why is it needed ?

<!--
Describe change being introduced by this PR.
-->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
