### PR TITLE
Preval - stop on from/with function

### DIFF
--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/vX_X_X/transfers/valueSpecification.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/vX_X_X/transfers/valueSpecification.pure
@@ -568,6 +568,13 @@ function <<access.private>> meta::protocols::pure::vX_X_X::transformation::fromP
                                     runtime = $r->meta::protocols::pure::vX_X_X::transformation::fromPureGraph::runtime::transformRuntime($extensions)
                                 )
                       ),
+
+                  f:meta::pure::runtime::PackageableRuntime[1]|
+                     ^meta::protocols::pure::vX_X_X::metamodel::m3::valuespecification::constant::PackageableElementPtr
+                     (
+                        _type = 'packageableElementPtr',
+                        fullPath = $f->elementToPath()
+                     ),                           
                  l:List<Any>[1]|
                       ^meta::protocols::pure::vX_X_X::metamodel::m3::valuespecification::AppliedFunction
                       (
@@ -856,6 +863,8 @@ function meta::protocols::pure::vX_X_X::transformation::fromPureGraph::toPureGra
                                                    ->concatenate([
                                                       pair(meta::pure::mapping::from_TabularDataSet_1__Mapping_1__Runtime_1__TabularDataSet_1_.name->toOne(), meta::pure::mapping::from_TabularDataSet_1__Mapping_1__Runtime_1__TabularDataSet_1_),
                                                       pair(meta::pure::mapping::from_TabularDataSet_1__Mapping_1__Runtime_1__ExecutionContext_1__TabularDataSet_1_.name->toOne(), meta::pure::mapping::from_TabularDataSet_1__Mapping_1__Runtime_1__ExecutionContext_1__TabularDataSet_1_),
+                                                      pair(meta::pure::mapping::from_TabularDataSet_1__Mapping_1__PackageableRuntime_1__TabularDataSet_1_.name->toOne(), meta::pure::mapping::from_TabularDataSet_1__Mapping_1__PackageableRuntime_1__TabularDataSet_1_),
+                                                      pair(meta::pure::mapping::from_T_m__PackageableRuntime_1__T_m_.name->toOne(), meta::pure::mapping::from_T_m__PackageableRuntime_1__T_m_->cast(@ConcreteFunctionDefinition<Any>)),
                                                       pair(meta::core::runtime::currentUserId__String_1_.name->toOne(), meta::core::runtime::currentUserId__String_1_),
                                                       pair(meta::pure::functions::hash::hash_String_1__HashType_1__String_1_.name->toOne(), meta::pure::functions::hash::hash_String_1__HashType_1__String_1_)
                                                    ])

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/preeval/preeval.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/preeval/preeval.pure
@@ -960,21 +960,8 @@ function <<access.private>> meta::pure::router::preeval::stopPreeval(value : Any
             p : meta::external::format::shared::ExternalFormatExternalizeConfig[1] | true,
             p : meta::external::format::shared::ExternalFormatInternalizeConfig[1] | true,
             f : FunctionExpression[1]| $f.func->in([
-              letFunction_String_1__T_m__T_m_,
-              //this is the subset of from/with functions which are not marked as NotImplemented which already triggers no preval
-              meta::pure::mapping::from_T_m__PackageableRuntime_1__T_m_,
-              meta::pure::mapping::from_T_m__Mapping_1__PackageableRuntime_1__T_m_,          
-              meta::pure::mapping::from_TabularDataSet_1__Mapping_1__PackageableRuntime_1__TabularDataSet_1_,
-              meta::pure::mapping::from_TabularDataSet_1__Mapping_1__PackageableRuntime_1__ExecutionContext_1__TabularDataSet_1_,
-              meta::pure::mapping::from_FunctionDefinition_1__Mapping_1__PackageableRuntime_1__T_m_,
-              meta::pure::mapping::from_FunctionDefinition_1__Mapping_1__Runtime_1__T_m_,
-              meta::pure::mapping::from_FunctionDefinition_1__PackageableRuntime_1__T_m_,
-              meta::pure::mapping::from_FunctionDefinition_1__Runtime_1__T_m_,              
-              meta::pure::mapping::with_T_m__PackageableRuntime_1__T_m_,
-              meta::pure::mapping::with_T_m__Mapping_1__PackageableRuntime_1__T_m_,
-              meta::pure::mapping::with_T_m__Runtime_1__T_m_,
-              meta::pure::mapping::with_T_m__Mapping_1__Runtime_1__T_m_                    
-            ]),
+              letFunction_String_1__T_m__T_m_
+            ]->concatenate(fromFunctionsToStop())),
             a : meta::pure::metamodel::relation::AggColSpecArray<Any, Any, Any>[1] | true,
             f : meta::pure::metamodel::relation::FuncColSpecArray<Any, Any>[1] | true,
             a : Any[*]| $a->type()
@@ -983,6 +970,25 @@ function <<access.private>> meta::pure::router::preeval::stopPreeval(value : Any
                               o:Any[1]|false
                           ])
           ]);
+}
+
+//this is the subset of from/with functions which are not marked as NotImplemented which already triggers no preval
+function meta::pure::router::preeval::fromFunctionsToStop():ConcreteFunctionDefinition<Any>[*]
+{
+  [
+    meta::pure::mapping::from_T_m__PackageableRuntime_1__T_m_,
+    meta::pure::mapping::from_T_m__Mapping_1__PackageableRuntime_1__T_m_,
+    meta::pure::mapping::from_TabularDataSet_1__Mapping_1__PackageableRuntime_1__TabularDataSet_1_,
+    meta::pure::mapping::from_TabularDataSet_1__Mapping_1__PackageableRuntime_1__ExecutionContext_1__TabularDataSet_1_,
+    meta::pure::mapping::from_FunctionDefinition_1__Mapping_1__PackageableRuntime_1__T_m_,
+    meta::pure::mapping::from_FunctionDefinition_1__Mapping_1__Runtime_1__T_m_,
+    meta::pure::mapping::from_FunctionDefinition_1__PackageableRuntime_1__T_m_,
+    meta::pure::mapping::from_FunctionDefinition_1__Runtime_1__T_m_,
+    meta::pure::mapping::with_T_m__PackageableRuntime_1__T_m_,
+    meta::pure::mapping::with_T_m__Mapping_1__PackageableRuntime_1__T_m_,
+    meta::pure::mapping::with_T_m__Runtime_1__T_m_,
+    meta::pure::mapping::with_T_m__Mapping_1__Runtime_1__T_m_
+  ]
 }
 
 function <<access.public>> meta::pure::router::preeval::isSimpleType(c : Class<Any>[1]) : Boolean[1]

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/preeval/preeval.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/preeval/preeval.pure
@@ -959,7 +959,22 @@ function <<access.private>> meta::pure::router::preeval::stopPreeval(value : Any
             p : meta::pure::graphFetch::execution::AlloySerializationConfig[1]| true,
             p : meta::external::format::shared::ExternalFormatExternalizeConfig[1] | true,
             p : meta::external::format::shared::ExternalFormatInternalizeConfig[1] | true,
-            f : FunctionExpression[1]| $f.func->in([letFunction_String_1__T_m__T_m_]),
+            f : FunctionExpression[1]| $f.func->in([
+              letFunction_String_1__T_m__T_m_,
+              //this is the subset of from/with functions which are not marked as NotImplemented which already triggers no preval
+              meta::pure::mapping::from_T_m__PackageableRuntime_1__T_m_,
+              meta::pure::mapping::from_T_m__Mapping_1__PackageableRuntime_1__T_m_,          
+              meta::pure::mapping::from_TabularDataSet_1__Mapping_1__PackageableRuntime_1__TabularDataSet_1_,
+              meta::pure::mapping::from_TabularDataSet_1__Mapping_1__PackageableRuntime_1__ExecutionContext_1__TabularDataSet_1_,
+              meta::pure::mapping::from_FunctionDefinition_1__Mapping_1__PackageableRuntime_1__T_m_,
+              meta::pure::mapping::from_FunctionDefinition_1__Mapping_1__Runtime_1__T_m_,
+              meta::pure::mapping::from_FunctionDefinition_1__PackageableRuntime_1__T_m_,
+              meta::pure::mapping::from_FunctionDefinition_1__Runtime_1__T_m_,              
+              meta::pure::mapping::with_T_m__PackageableRuntime_1__T_m_,
+              meta::pure::mapping::with_T_m__Mapping_1__PackageableRuntime_1__T_m_,
+              meta::pure::mapping::with_T_m__Runtime_1__T_m_,
+              meta::pure::mapping::with_T_m__Mapping_1__Runtime_1__T_m_                    
+            ]),
             a : meta::pure::metamodel::relation::AggColSpecArray<Any, Any, Any>[1] | true,
             f : meta::pure::metamodel::relation::FuncColSpecArray<Any, Any>[1] | true,
             a : Any[*]| $a->type()

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/preeval/tests.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/preeval/tests.pure
@@ -1640,7 +1640,7 @@ function <<test.Test>> meta::pure::router::preeval::tests::testFromWith():Boolea
 
 function <<test.Test>> meta::pure::router::preeval::tests::testFromStopFunctions():Boolean[1]
 {
-  let funcs = meta::pure::mapping->packageFunctionsRecursive()->filter(f | $f.functionName->in(['from', 'to']));
+  let funcs = meta::pure::mapping->packageFunctionsRecursive()->filter(f | $f.functionName->in(['from', 'with']));
   let stopped = fromFunctionsToStop();
 
   let difference = $funcs->filter(f | !($f->hasStereotype('NotImplementedFunction', functionType) || $f->in($stopped)));

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/preeval/tests.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/preeval/tests.pure
@@ -1576,6 +1576,16 @@ function meta::pure::router::preeval::tests::getTestRuntimeWithModelConnection(s
   ^Runtime(connectionStores=^ConnectionStore(element = 'DummyStore', connection=^meta::external::store::model::ModelConnection(instances=newMap(pair($sourceClass, list($inputs))))));
 }
 
+function <<access.private>> meta::pure::router::preeval::tests::getDummyPackageableRuntime():meta::pure::runtime::PackageableRuntime[1]
+{
+  ^meta::pure::runtime::PackageableRuntime(runtimeValue = getDummyRuntime());
+}
+
+function <<access.private>> meta::pure::router::preeval::tests::getDummyRuntime():EngineRuntime[1]
+{
+  ^EngineRuntime(connectionStores = ^meta::core::runtime::ConnectionStore(element = '', connection = ^meta::external::store::model::ModelConnection(instances = newMap(pair(ConnectionStore, list(''))))));
+}
+
 function <<test.Test>> meta::pure::router::preeval::tests::testGetGenericType():Boolean[1]
 {
   let input    = { |
@@ -1609,6 +1619,25 @@ function <<test.Test>> meta::pure::router::preeval::tests::testInline():Boolean[
   assertRoundTrip($input, $expected);
 }
 
+function <<test.Test>> meta::pure::router::preeval::tests::testFromWith():Boolean[1]
+{
+  let packageableRuntime = getDummyPackageableRuntime();
+  let runtime = getDummyRuntime();
+
+  assertRoundTrip({| meta::pure::router::preeval::tests::Person.all()->from($packageableRuntime) });
+  assertRoundTrip({| meta::pure::router::preeval::tests::Person.all()->from(emptyMapping, $packageableRuntime) });
+  assertRoundTrip({| meta::pure::router::preeval::tests::Person.all()->project(x | $x.firstName, 'name')->from(emptyMapping, $packageableRuntime) });
+  assertRoundTrip({| |meta::pure::router::preeval::tests::Person.all()->from($packageableRuntime) });
+  assertRoundTrip({| |meta::pure::router::preeval::tests::Person.all()->from(emptyMapping, $packageableRuntime) });
+  assertRoundTrip({| |meta::pure::router::preeval::tests::Person.all()->from($runtime) });
+  assertRoundTrip({| |meta::pure::router::preeval::tests::Person.all()->from(emptyMapping, $runtime) });  
+
+  assertRoundTrip({| meta::pure::router::preeval::tests::Person.all()->with($packageableRuntime) });
+  assertRoundTrip({| meta::pure::router::preeval::tests::Person.all()->with(emptyMapping, $packageableRuntime) });  
+  assertRoundTrip({| meta::pure::router::preeval::tests::Person.all()->with($runtime) });
+  assertRoundTrip({| meta::pure::router::preeval::tests::Person.all()->with(emptyMapping, $runtime) });    
+}
+
 function <<access.private>> meta::pure::router::preeval::tests::myTestFuncThatDoesEval<P>(value:P[1]):Boolean[1]
 {
   meta::pure::router::preeval::tests::myTestFuncThatDoesSomething_P_1__Boolean_1_->eval($value)
@@ -1622,6 +1651,11 @@ function <<access.private>> meta::pure::router::preeval::tests::myTestFuncThatDe
 function <<access.private>> meta::pure::router::preeval::tests::myTestFuncThatDoesSomething<P>(k:P[1]):Boolean[1]
 {
   $k == 1;
+}
+
+function <<access.private>> meta::pure::router::preeval::tests::assertRoundTrip(input : FunctionDefinition<Any>[1]):Boolean[1]
+{
+  assertRoundTrip($input, $input, noDebug())
 }
 
 function <<access.private>> meta::pure::router::preeval::tests::assertRoundTrip(input : FunctionDefinition<Any>[1], expectedOrig : FunctionDefinition<Any>[1]):Boolean[1]
@@ -1705,3 +1739,9 @@ function <<access.private>> meta::pure::router::preeval::tests::assertRoundTrip(
 
   true;
 }
+
+
+###Mapping
+
+Mapping meta::pure::router::preeval::tests::emptyMapping
+()

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/preeval/tests.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/preeval/tests.pure
@@ -1638,6 +1638,16 @@ function <<test.Test>> meta::pure::router::preeval::tests::testFromWith():Boolea
   assertRoundTrip({| meta::pure::router::preeval::tests::Person.all()->with(emptyMapping, $runtime) });    
 }
 
+function <<test.Test>> meta::pure::router::preeval::tests::testFromStopFunctions():Boolean[1]
+{
+  let funcs = meta::pure::mapping->packageFunctionsRecursive()->filter(f | $f.functionName->in(['from', 'to']));
+  let stopped = fromFunctionsToStop();
+
+  let difference = $funcs->filter(f | !($f->hasStereotype('NotImplementedFunction', functionType) || $f->in($stopped)));
+
+  assert($difference->isEmpty(), | 'from/with functions missing from preval stop functions ' + $difference->map(d | $d->elementToPath())->joinStrings(', '));
+}
+
 function <<access.private>> meta::pure::router::preeval::tests::myTestFuncThatDoesEval<P>(value:P[1]):Boolean[1]
 {
   meta::pure::router::preeval::tests::myTestFuncThatDoesSomething_P_1__Boolean_1_->eval($value)


### PR DESCRIPTION
#### What type of PR is this?
Bug Fix

#### What does this PR do / why is it needed ?
a number of the from/with functions have implementation which end up getting prevaled to a different from/with function. This can have effect downstream in routing where froms can be handled differently

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
