### PR TITLE
Improve test for milestoning predicate loss in TDS join with concatenate

### DIFF
--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/milestoning/tests/testBusinessDateMilestoning.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/milestoning/tests/testBusinessDateMilestoning.pure
@@ -289,44 +289,48 @@ function <<test.Test>> meta::relational::tests::milestoning::businessdate::testM
    let runtime = meta::relational::tests::milestoning::initDatabase();
 
    let standaloneResult = execute(
-      {|Product.all(%2015-10-16)
-         ->project([p|$p.id, p|$p.classification(%2015-10-16).description], ['id', 'classDesc'])
-         ->from(milestoningmap, $runtime)
+      {|Order.all()
+         ->filter(o| $o.product(%2015-10-16).stockProductName == 'ProductName2')
+         ->project([o|$o.id], ['id'])
          ->join(
-            Product.all(%2015-10-16)
-               ->project([p|$p.id], ['id2'])
-               ->from(milestoningmap, $runtime),
+            Order.all()
+               ->project([o|$o.id], ['id2']),
             JoinType.LEFT_OUTER,
             ['id'], ['id2']
          )
-         ->from(milestoningmap, $runtime)
       },
-      ^Mapping(name = ''), ^meta::core::runtime::Runtime(), meta::relational::extension::relationalExtensions()
+      milestoningmap, $runtime, meta::relational::extension::relationalExtensions()
    );
+   let standaloneRows = $standaloneResult.values->at(0).rows->size();
+   assertEquals(1, $standaloneRows);
 
-   // Same expression with ->concatenate([]) — triggers processConcatenate, altering isolation strategy.
-   let concatResult = execute(
-      {|Product.all(%2015-10-16)
-         ->project([p|$p.id, p|$p.classification(%2015-10-16).description], ['id', 'classDesc'])
-         ->from(milestoningmap, $runtime)
+   let concatenatedResult = execute(
+      {|Order.all()
+         ->filter(o| $o.product(%2015-10-16).stockProductName == 'ProductName2')
+         ->project([o|$o.id], ['id'])
          ->join(
-            Product.all(%2015-10-16)
-               ->project([p|$p.id], ['id2'])
-               ->from(milestoningmap, $runtime),
+            Order.all()
+               ->project([o|$o.id], ['id2']),
             JoinType.LEFT_OUTER,
             ['id'], ['id2']
          )
-         ->from(milestoningmap, $runtime)
-         ->concatenate([])
+         ->concatenate(
+            Order.all()
+               ->filter(o| 1 == 0)
+               ->project([o|$o.id], ['id'])
+               ->join(
+                  Order.all()
+                     ->project([o|$o.id], ['id2']),
+                  JoinType.LEFT_OUTER,
+                  ['id'], ['id2']
+               )
+         )
       },
-      ^Mapping(name = ''), ^meta::core::runtime::Runtime(), meta::relational::extension::relationalExtensions()
+      milestoningmap, $runtime, meta::relational::extension::relationalExtensions()
    );
+   let concatenatedRows = $concatenatedResult.values->at(0).rows->size();
 
-   let standaloneTds = $standaloneResult.values->at(0);
-   let concatTds = $concatResult.values->at(0);
-
-   assertEquals($standaloneTds.rows->size(), $concatTds.rows->size());
-   assertEquals($standaloneTds.rows->map(r|$r.values->makeString(','))->sort(), $concatTds.rows->map(r|$r.values->makeString(','))->sort());
+   assertEquals($standaloneRows, $concatenatedRows);
 }
 
 function <<test.Test>> meta::relational::tests::milestoning::businessdate::testQueryOfMilestonedTypeWithFilterInMapping():Boolean[1]

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/milestoning/tests/testBusinessDateMilestoning.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/milestoning/tests/testBusinessDateMilestoning.pure
@@ -286,45 +286,47 @@ function <<test.Test,test.ToFix>> meta::relational::tests::milestoning::business
 
 function <<test.Test>> meta::relational::tests::milestoning::businessdate::testMilestoningFiltersPreservedInTdsJoinWithConcatenate():Boolean[1]
 {
-   let standaloneResult = execute(
-      {|Product.all(%2015-10-16)->project([p|$p.name, p|$p.type], ['name', 'productType'])
-         ->join(
-            ProductClassification.all(%2015-10-16)->project([c|$c.type, c|$c.description], ['classificationType', 'description']),
-            JoinType.LEFT_OUTER,
-            'productType',
-            'classificationType'
-         )
-      },
-      milestoningmap, meta::external::store::relational::tests::testRuntime(), meta::relational::extension::relationalExtensions()
-   );
-   let standaloneTds = $standaloneResult.values->at(0);
-   assertEquals(2, $standaloneTds.rows->size());
-   assertEquals(['ProductName2,STOCK,STOCK,STOCK DESC-V3', 'ProductName3,OPTION,TDSNull,TDSNull'], $standaloneTds.rows->map(r|$r.values->makeString(',')));
+   let runtime = meta::relational::tests::milestoning::initDatabase();
 
-   let concatResult = execute(
-      {|Product.all(%2015-10-16)->project([p|$p.name, p|$p.type], ['name', 'productType'])
+   let standaloneResult = execute(
+      {|Product.all(%2015-10-16)
+         ->project([p|$p.id, p|$p.classification(%2015-10-16).description], ['id', 'classDesc'])
+         ->from(milestoningmap, $runtime)
          ->join(
-            ProductClassification.all(%2015-10-16)->project([c|$c.type, c|$c.description], ['classificationType', 'description']),
+            Product.all(%2015-10-16)
+               ->project([p|$p.id], ['id2'])
+               ->from(milestoningmap, $runtime),
             JoinType.LEFT_OUTER,
-            'productType',
-            'classificationType'
+            ['id'], ['id2']
          )
-         ->concatenate(
-            Product.all(%2015-10-16)->project([p|$p.name, p|$p.type], ['name', 'productType'])
-            ->join(
-               ProductClassification.all(%2015-10-16)->project([c|$c.type, c|$c.description], ['classificationType', 'description']),
-               JoinType.LEFT_OUTER,
-               'productType',
-               'classificationType'
-            )
-         )
-         ->filter(row|$row.getString('name') == 'ProductName2')
+         ->from(milestoningmap, $runtime)
       },
-      milestoningmap, meta::external::store::relational::tests::testRuntime(), meta::relational::extension::relationalExtensions()
+      ^Mapping(name = ''), ^meta::core::runtime::Runtime(), meta::relational::extension::relationalExtensions()
    );
+
+   // Same expression with ->concatenate([]) — triggers processConcatenate, altering isolation strategy.
+   let concatResult = execute(
+      {|Product.all(%2015-10-16)
+         ->project([p|$p.id, p|$p.classification(%2015-10-16).description], ['id', 'classDesc'])
+         ->from(milestoningmap, $runtime)
+         ->join(
+            Product.all(%2015-10-16)
+               ->project([p|$p.id], ['id2'])
+               ->from(milestoningmap, $runtime),
+            JoinType.LEFT_OUTER,
+            ['id'], ['id2']
+         )
+         ->from(milestoningmap, $runtime)
+         ->concatenate([])
+      },
+      ^Mapping(name = ''), ^meta::core::runtime::Runtime(), meta::relational::extension::relationalExtensions()
+   );
+
+   let standaloneTds = $standaloneResult.values->at(0);
    let concatTds = $concatResult.values->at(0);
-   assertEquals(2, $concatTds.rows->size());
-   assertEquals(['ProductName2,STOCK,STOCK,STOCK DESC-V3', 'ProductName2,STOCK,STOCK,STOCK DESC-V3'], $concatTds.rows->map(r|$r.values->makeString(',')));
+
+   assertEquals($standaloneTds.rows->size(), $concatTds.rows->size());
+   assertEquals($standaloneTds.rows->map(r|$r.values->makeString(','))->sort(), $concatTds.rows->map(r|$r.values->makeString(','))->sort());
 }
 
 function <<test.Test>> meta::relational::tests::milestoning::businessdate::testQueryOfMilestonedTypeWithFilterInMapping():Boolean[1]


### PR DESCRIPTION
#### What type of PR is this?

Choose one of the following labels :
- Improvement


#### What does this PR do / why is it needed ?
Rewrites testMilestoningFiltersPreservedInTdsJoinWithConcatenate to better replicate the actual bug pattern:  milestoned filter + TDS join + concatenate. Asserts standalone and concatenated queries return identical row counts, confirming milestoning predicates aren't lost.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
