### PR TITLE
Extend SELECT * optimization to support parameterized service queries

### DIFF
--- a/legend-engine-xts-sql/legend-engine-xt-sql-http-api/src/main/java/org/finos/legend/engine/query/sql/api/SQLExecutor.java
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-http-api/src/main/java/org/finos/legend/engine/query/sql/api/SQLExecutor.java
@@ -104,6 +104,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.finos.legend.engine.plan.generation.PlanGenerator.transformExecutionPlan;
 
@@ -111,6 +112,7 @@ public class SQLExecutor
 {
     private static final Logger LOGGER = org.slf4j.LoggerFactory.getLogger(SQLExecutor.class);
     private static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.getNewStandardObjectMapperWithPureProtocolExtensionSupports();
+    private static final PureModel CORE_PURE_MODEL = PureModel.getCorePureModel();
     private static final Map<Class<? extends Literal>, String> LITERAL_TO_PURE_TYPES = UnifiedMap.newMapWith(
             Tuples.pair(IntegerLiteral.class, "Integer"),
             Tuples.pair(StringLiteral.class, "String"),
@@ -151,57 +153,78 @@ public class SQLExecutor
 
         if (isSelectStar)
         {
-            return executeWithPreGeneratedPlan(query, user, context, identity);
+            // Resolve upfront — get both sources and model context in a single resolution call
+            Pair<RichIterable<SQLSource>, PureModelContext> resolved = getSourcesAndModel(query, context, identity);
+            return executeWithPreGeneratedPlan(query, resolved.getOne(), resolved.getTwo(), user, identity);
         }
 
         return executeStandard(query, positionalArguments, user, context, identity);
     }
 
-    private Result executeWithPreGeneratedPlan(Query query, String user, SQLContext context, Identity identity)
+    private Result executeWithPreGeneratedPlan(Query query, RichIterable<SQLSource> sources, PureModelContext modelContext, String user, Identity identity)
     {
         return TraceUtils.trace("execute-select-star", span ->
         {
             long start = System.currentTimeMillis();
-            LOGGER.info("Executing query using pre-generated plan path");
 
-            Pair<RichIterable<SQLSource>, PureModelContext> sqlSourcesAndPureModel = getSourcesAndModel(query, context, identity);
-            RichIterable<SQLSource> sources = sqlSourcesAndPureModel.getOne();
-
-            // SELECT * optimization requires exactly one source with a pre-generated plan
             if (sources.size() != 1 || sources.getFirst().getPreGeneratedPlan() == null)
             {
-                LOGGER.info("No pre-generated plan available, falling back to standard execution path");
-                return executeStandard(query, FastList.newList(), user, context, identity);
+                LOGGER.debug("No pre-generated plan available, falling back to standard execution path");
+                return executeWithCompilation(query, sources, modelContext, user, identity, span);
             }
 
             ExecutionPlan preGeneratedPlan = sources.getFirst().getPreGeneratedPlan();
-            span.setTag("selectStar", true);
+            SQLSource source = sources.getFirst();
 
-            if (!(preGeneratedPlan instanceof SingleExecutionPlan))
-            {
-                LOGGER.info("Pre-generated plan is not a SingleExecutionPlan, falling back to standard execution path");
-                return executeStandard(query, FastList.newList(), user, context, identity);
-            }
-
-            SingleExecutionPlan plan = (SingleExecutionPlan) preGeneratedPlan;
             Result result;
             try
             {
-                result = planExecutor.execute(plan, Maps.mutable.empty(), user, identity);
+                SingleExecutionPlan plan = preGeneratedPlan.getSingleExecutionPlan(source.getResolvedArguments() != null ? source.getResolvedArguments() : Maps.mutable.empty());
+                Map<String, Result> arguments = buildPlanArguments(source.getResolvedArguments(), user, identity);
+                result = planExecutor.execute(plan, arguments, user, identity);
             }
             catch (Exception e)
             {
                 LOGGER.warn("Pre-generated plan execution failed, falling back to standard path", e);
-                return executeStandard(query, FastList.newList(), user, context, identity);
+                return executeWithCompilation(query, sources, modelContext, user, identity, span);
             }
 
             long elapsed = System.currentTimeMillis() - start;
+            span.setTag("totalMs", elapsed);
             MetricsHandler.observe("execute", start, System.currentTimeMillis());
+            MetricsHandler.observe("execute_select_star", start, System.currentTimeMillis());
             LOGGER.info(new LogInfo(identity.getName(), LoggingEventType.EXECUTE_INTERACTIVE_STOP, (double) elapsed).toString());
-            LOGGER.debug("SELECT * query executed in {}ms (used pre-generated plan)", elapsed);
 
             return result;
         });
+    }
+
+    private Result executeWithCompilation(Query query, RichIterable<SQLSource> sources, PureModelContext modelContext,
+                                          String user, Identity identity, Span span)
+    {
+        return compileModelAndTransformQuery(sources, modelContext, query, FastList.newList(),
+            (transformedContext, pureModel, compiledSources, positionals, s) ->
+            {
+                long start = System.currentTimeMillis();
+
+                Root_meta_external_query_sql_transformation_queryToPure_PlanGenerationResult plans = planResult(transformedContext, pureModel, compiledSources);
+
+                Map<String, Result> arguments = getPlanArguments(plans._arguments(), pureModel, user, identity);
+
+                SingleExecutionPlan transformedPlan = transformExecutionPlan(plans._plan(), pureModel, PureClientVersions.production, identity, routerExtensions.apply(pureModel), transformers);
+
+                Result result = planExecutor.execute(transformedPlan, arguments, user, identity);
+
+                long elapsed = System.currentTimeMillis() - start;
+                span.setTag("totalMs", elapsed);
+                MetricsHandler.observe("execute", start, System.currentTimeMillis());
+                MetricsHandler.observe("execute_standard", start, System.currentTimeMillis());
+                LOGGER.info(new LogInfo(identity.getName(), LoggingEventType.EXECUTE_INTERACTIVE_STOP, (double) elapsed).toString());
+
+                return result;
+            },
+            (compiledSources, extensions, pureModel) -> core_external_query_sql_binding_fromPure_fromPure.Root_meta_external_query_sql_transformation_queryToPure_rootContext_SQLSource_MANY__Function_1__Extension_MANY__SqlTransformContext_1_(compiledSources, getCompiler(pureModel), extensions, pureModel.getExecutionSupport()),
+            identity, span);
     }
 
     private Result executeStandard(Query query, List<Object> positionalArguments, String user, SQLContext context, Identity identity)
@@ -220,9 +243,11 @@ public class SQLExecutor
             SingleExecutionPlan transformedPlan = transformExecutionPlan(plans._plan(), pureModel, PureClientVersions.production, identity, routerExtensions.apply(pureModel), transformers);
 
             arguments.putAll(positionalArgumentPlans);
+
             Result result = planExecutor.execute(transformedPlan, arguments, user, identity);
 
             long elapsed = System.currentTimeMillis() - start;
+            span.setTag("totalMs", elapsed);
             MetricsHandler.observe("execute", start, System.currentTimeMillis());
             MetricsHandler.observe("execute_standard", start, System.currentTimeMillis());
             LOGGER.info(new LogInfo(identity.getName(), LoggingEventType.EXECUTE_INTERACTIVE_STOP, (double) elapsed).toString());
@@ -253,6 +278,39 @@ public class SQLExecutor
 
             return Tuples.pair(p._name(), result);
         }));
+    }
+
+
+    private Map<String, Result> buildPlanArguments(Map<String, Object> namedArgs, String user, Identity identity)
+    {
+        if (namedArgs == null || namedArgs.isEmpty())
+        {
+            return Maps.mutable.empty();
+        }
+
+        List<SQLQueryParameter> parameters = namedArgs.entrySet().stream()
+            .map(entry -> createSQLQueryParameter(entry.getKey(), entry.getValue()))
+            .collect(Collectors.toList());
+
+        RichIterable<Root_meta_external_query_sql_transformation_queryToPure_SQLPlaceholderParameter> placeholders = new SQLSourceTranslator().translate(parameters, SQLExecutor.CORE_PURE_MODEL);
+        RichIterable<? extends Root_meta_external_query_sql_transformation_queryToPure_PlanParameter> planParams = core_external_query_sql_binding_fromPure_fromPure.Root_meta_external_query_sql_transformation_queryToPure_getPlanParameters_SQLPlaceholderParameter_MANY__Extension_MANY__PlanParameter_MANY_(placeholders, routerExtensions.apply(SQLExecutor.CORE_PURE_MODEL), SQLExecutor.CORE_PURE_MODEL.getExecutionSupport());
+        return getPlanArguments(planParams, SQLExecutor.CORE_PURE_MODEL, user, identity);
+    }
+
+    private List<SQLQueryParameter> buildSQLQueryParameters(List<Object> positionalArguments)
+    {
+        return ListIterate.collectWithIndex(positionalArguments, (argument, index) ->
+            createSQLQueryParameter("_" + (index + 1), argument));
+    }
+
+    private SQLQueryParameter createSQLQueryParameter(String name, Object value)
+    {
+        Expression expression = createParameterValueExpression(value);
+        Variable variable = new Variable();
+        variable.name = name;
+        variable.multiplicity = Multiplicity.PURE_ONE;
+        variable.genericType = new GenericType(new PackageableType(LITERAL_TO_PURE_TYPES.get(expression.getClass())));
+        return new SQLQueryParameter(variable, expression);
     }
 
     public LambdaFunction lambda(Query query, SQLContext context, Identity identity)
@@ -313,8 +371,6 @@ public class SQLExecutor
 
     private Root_meta_external_query_sql_transformation_queryToPure_PlanGenerationResult planResult(Root_meta_external_query_sql_transformation_queryToPure_SqlTransformContext transformedContext, PureModel pureModel, RichIterable<Root_meta_external_query_sql_transformation_queryToPure_SQLSource> sources)
     {
-        long startTime = System.currentTimeMillis();
-
         Root_meta_external_query_sql_transformation_queryToPure_PlanGenerationResult result = core_external_query_sql_binding_fromPure_fromPure.Root_meta_external_query_sql_transformation_queryToPure_getPlanResult_SqlTransformContext_1__SQLSource_MANY__Extension_MANY__PlanGenerationResult_1_(transformedContext, sources, routerExtensions.apply(pureModel), pureModel.getExecutionSupport());
 
         if (result._plan() == null)
@@ -329,11 +385,9 @@ public class SQLExecutor
         }
         else
         {
-            LOGGER.debug("Binding plan from Pure (TDS path)");
             result._plan(PlanPlatform.JAVA.bindPlan(result._plan(), null, pureModel, routerExtensions.apply(pureModel)));
         }
 
-        LOGGER.debug("Plan generation took {}ms", System.currentTimeMillis() - startTime);
         return result;
     }
 
@@ -358,39 +412,36 @@ public class SQLExecutor
             RichIterable<SQLSource> sources = sqlSourcesAndPureModel.getOne();
             PureModelContext pureModelContext = sqlSourcesAndPureModel.getTwo();
 
-            PureModel pureModel = modelManager.loadModel(pureModelContext, PureClientVersions.production, identity, "");
-
-            List<SQLQueryParameter> parameters = ListIterate.collectWithIndex(positionalArguments, (argument, index) ->
-            {
-                Expression expression = createParameterValueExpression(argument);
-                Variable variable = new Variable();
-                variable.name = "_" + (index + 1);
-                variable.multiplicity = Multiplicity.PURE_ONE;
-                variable.genericType = new GenericType(new PackageableType(LITERAL_TO_PURE_TYPES.get(expression.getClass())));
-
-                return new SQLQueryParameter(variable, expression);
-            });
-
-            Query finalQuery = QueryRealiaser.realias(query);
-            span.setTag("re-aliasedQueryHash", hash(finalQuery));
-
-            Root_meta_external_query_sql_metamodel_Query compiledQuery = new ProtocolToMetamodelTranslator().translate(finalQuery, pureModel);
-
-            RichIterable<Root_meta_external_query_sql_transformation_queryToPure_SQLSource> compiledSources = new SQLSourceTranslator().translate(sources, pureModel);
-            LOGGER.info("{}", new LogInfo(identity.getName(), LoggingEventType.GENERATE_PLAN_START));
-
-            Root_meta_external_query_sql_transformation_queryToPure_SqlTransformContext transformContext = transformContextFunc.value(compiledSources, routerExtensions.apply(pureModel), pureModel);
-            RichIterable<Root_meta_external_query_sql_transformation_queryToPure_SQLPlaceholderParameter> positionals = new SQLSourceTranslator().translate(parameters, pureModel);
-
-            transformContext._positionals(IterableIterate.collect(positionals, Root_meta_external_query_sql_transformation_queryToPure_SQLPlaceholderParameter::_variable));
-
-            Root_meta_external_query_sql_transformation_queryToPure_SqlTransformContext transformedContext = core_external_query_sql_binding_fromPure_fromPure.Root_meta_external_query_sql_transformation_queryToPure_processRootQuery_Query_1__SqlTransformContext_1__SqlTransformContext_1_(
-                    compiledQuery, transformContext, pureModel.getExecutionSupport());
-
-            return func.value(transformedContext, pureModel, compiledSources, positionals, span);
+            return compileModelAndTransformQuery(sources, pureModelContext, query, positionalArguments, func, transformContextFunc, identity, span);
         });
     }
 
+    private <T> T compileModelAndTransformQuery(RichIterable<SQLSource> sources,
+                                    PureModelContext pureModelContext,
+                                    Query query,
+                                    List<Object> positionalArguments,
+                                    Function5<Root_meta_external_query_sql_transformation_queryToPure_SqlTransformContext, PureModel, RichIterable<Root_meta_external_query_sql_transformation_queryToPure_SQLSource>, RichIterable<Root_meta_external_query_sql_transformation_queryToPure_SQLPlaceholderParameter>, Span, T> func,
+                                    Function3<RichIterable<Root_meta_external_query_sql_transformation_queryToPure_SQLSource>, RichIterable<? extends Root_meta_pure_extension_Extension>, PureModel, Root_meta_external_query_sql_transformation_queryToPure_SqlTransformContext> transformContextFunc,
+                                    Identity identity,
+                                    Span span)
+    {
+        PureModel pureModel = modelManager.loadModel(pureModelContext, PureClientVersions.production, identity, "");
+
+        List<SQLQueryParameter> parameters = buildSQLQueryParameters(positionalArguments);
+        Query finalQuery = QueryRealiaser.realias(query);
+
+        Root_meta_external_query_sql_metamodel_Query compiledQuery = new ProtocolToMetamodelTranslator().translate(finalQuery, pureModel);
+        RichIterable<Root_meta_external_query_sql_transformation_queryToPure_SQLSource> compiledSources = new SQLSourceTranslator().translate(sources, pureModel);
+
+        Root_meta_external_query_sql_transformation_queryToPure_SqlTransformContext transformContext = transformContextFunc.value(compiledSources, routerExtensions.apply(pureModel), pureModel);
+        RichIterable<Root_meta_external_query_sql_transformation_queryToPure_SQLPlaceholderParameter> positionals = new SQLSourceTranslator().translate(parameters, pureModel);
+
+        transformContext._positionals(IterableIterate.collect(positionals, Root_meta_external_query_sql_transformation_queryToPure_SQLPlaceholderParameter::_variable));
+        Root_meta_external_query_sql_transformation_queryToPure_SqlTransformContext transformedContext = core_external_query_sql_binding_fromPure_fromPure.Root_meta_external_query_sql_transformation_queryToPure_processRootQuery_Query_1__SqlTransformContext_1__SqlTransformContext_1_(
+                compiledQuery, transformContext, pureModel.getExecutionSupport());
+
+        return func.value(transformedContext, pureModel, compiledSources, positionals, span);
+    }
 
     private Expression createParameterValueExpression(Object o)
     {

--- a/legend-engine-xts-sql/legend-engine-xt-sql-http-api/src/main/java/org/finos/legend/engine/query/sql/api/SelectStarQueryDetector.java
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-http-api/src/main/java/org/finos/legend/engine/query/sql/api/SelectStarQueryDetector.java
@@ -16,11 +16,15 @@
 package org.finos.legend.engine.query.sql.api;
 
 import org.finos.legend.engine.protocol.sql.metamodel.AllColumns;
+import org.finos.legend.engine.protocol.sql.metamodel.Expression;
 import org.finos.legend.engine.protocol.sql.metamodel.Join;
+import org.finos.legend.engine.protocol.sql.metamodel.Literal;
+import org.finos.legend.engine.protocol.sql.metamodel.NamedArgumentExpression;
 import org.finos.legend.engine.protocol.sql.metamodel.Query;
 import org.finos.legend.engine.protocol.sql.metamodel.QuerySpecification;
 import org.finos.legend.engine.protocol.sql.metamodel.SetOperation;
 import org.finos.legend.engine.protocol.sql.metamodel.TableFunction;
+import org.finos.legend.engine.protocol.sql.metamodel.Union;
 import org.finos.legend.engine.protocol.sql.visitors.BaseNodeCollectorVisitor;
 
 /**
@@ -29,10 +33,10 @@ import org.finos.legend.engine.protocol.sql.visitors.BaseNodeCollectorVisitor;
  * A query qualifies as SELECT * if:
  * - It selects all columns (SELECT *)                                                    
  * - It has exactly one service/table function source (no JOINs, no multiple tables)
- * - The table function has exactly one argument (the service name, no parameters) [Version 1]
  * - It has no WHERE, ORDER BY, GROUP BY, HAVING, LIMIT, or OFFSET clauses
  * - It's not a UNION/INTERSECT/EXCEPT operation
  */
+
 public class SelectStarQueryDetector extends BaseNodeCollectorVisitor<Boolean>
 {
     private SelectStarQueryDetector()
@@ -63,8 +67,7 @@ public class SelectStarQueryDetector extends BaseNodeCollectorVisitor<Boolean>
             return false;
         }
 
-        // Must have exactly one source in FROM clause
-        if (spec.from == null || spec.from.size() != 1)
+        if (spec.from == null || spec.from.size() != 1 || spec.from.get(0) == null)
         {
             return false;
         }
@@ -94,12 +97,36 @@ public class SelectStarQueryDetector extends BaseNodeCollectorVisitor<Boolean>
     @Override
     public Boolean visit(TableFunction val)
     {
-        // For iteration 1, only optimize when the table function has exactly one argument
-        // (the service name), e.g. service('/myService'). Parameterized services like
-        // service('/myService', businessDate => '2015-01-01') go through the standard path.
-        return val.functionCall != null
-                && val.functionCall.arguments != null
-                && val.functionCall.arguments.size() == 1;
+        if (val.functionCall == null || val.functionCall.arguments == null || val.functionCall.arguments.isEmpty())
+        {
+            return false;
+        }
+
+        // All arguments must be literals or named arguments wrapping literals.
+        // This rejects complex expressions (CURRENT_DATE, subqueries, function calls, etc.)
+        // that cannot be safely passed to a pre-generated plan.
+        for (Expression arg : val.functionCall.arguments)
+        {
+            if (!isLiteralArgument(arg))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean isLiteralArgument(Expression arg)
+    {
+        if (arg instanceof Literal)
+        {
+            return true;
+        }
+        if (arg instanceof NamedArgumentExpression)
+        {
+            Expression value = ((NamedArgumentExpression) arg).expression;
+            return value instanceof Literal;
+        }
+        return false;
     }
 
     @Override
@@ -110,6 +137,12 @@ public class SelectStarQueryDetector extends BaseNodeCollectorVisitor<Boolean>
 
     @Override
     public Boolean visit(SetOperation val)
+    {
+        return false;
+    }
+
+    @Override
+    public Boolean visit(Union val)
     {
         return false;
     }

--- a/legend-engine-xts-sql/legend-engine-xt-sql-http-api/src/test/java/org/finos/legend/engine/query/sql/api/SelectStarQueryDetectorTest.java
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-http-api/src/test/java/org/finos/legend/engine/query/sql/api/SelectStarQueryDetectorTest.java
@@ -24,7 +24,7 @@ import static org.junit.Assert.assertTrue;
 
 /**
  * Unit tests for SelectStarQueryDetector.
- * A SELECT * query is one with no modifications (no WHERE, ORDER BY, etc.) 
+ * A SELECT * query is one with no modifications (no WHERE, ORDER BY, etc.)
  * has a single service source (no JOINs or multiple tables)
  * that can use a pre-generated execution plan directly without SQL-to-Pure transformation.
  */
@@ -46,6 +46,31 @@ public class SelectStarQueryDetectorTest
                 SelectStarQueryDetector.isSelectStar(query));
     }
 
+
+    private void assertIsNotSelectStarOrNotYetSupported(String featureName, String sql)
+    {
+        try
+        {
+            Query query = (Query) PARSER.parseStatement(sql);
+            // Parser supports this - verify detector rejects it
+            assertFalse(featureName + " should NOT qualify for SELECT * optimization: " + sql,
+                    SelectStarQueryDetector.isSelectStar(query));
+        }
+        catch (RuntimeException e)
+        {
+            if (e.getMessage() != null && e.getMessage().contains("Not supported yet"))
+            {
+                // Parser doesn't support this yet - When support is added, this will automatically start testing the detector
+                System.out.println("INFO: " + featureName + " not yet supported by SQL parser. " +
+                        "SelectStarQueryDetector already handles this (returns false) for when support is added.");
+            }
+            else
+            {
+                throw new AssertionError(featureName + " parsing failed unexpectedly: " + e.getMessage(), e);
+            }
+        }
+    }
+
     // ==================== OPTIMIZABLE QUERIES ====================
     @Test
     public void testSelectStar()
@@ -58,6 +83,32 @@ public class SelectStarQueryDetectorTest
         assertIsSelectStar("SELECT * FROM (SELECT * FROM service('/myService') AS inner_t) AS outer_t");
     }
 
+    @Test
+    public void testSelectStarWithServiceParameters()
+    {
+        // Parameterized service calls with literal values ARE optimizable
+        assertIsSelectStar("SELECT * FROM service('/myService', businessDate => '2015-01-01')");
+        assertIsSelectStar("SELECT * FROM service('/myService', date => '2023-08-24', type => 'Type1')");
+        assertIsSelectStar("SELECT * FROM service('/myService', names => ARRAY['Alice', 'Bob'])");
+        assertIsSelectStar("SELECT * FROM service('/myService', id => 42)");
+        assertIsSelectStar("SELECT * FROM service('/myService', active => true)");
+        assertIsSelectStar("SELECT * FROM service('/myService', rating => 9.5)");
+
+        // Nested with parameters
+        assertIsSelectStar("SELECT * FROM (SELECT * FROM service('/myService', businessDate => '2015-01-01'))");
+        assertIsSelectStar("SELECT * FROM (SELECT * FROM service('/myService', businessDate => '2015-01-01')) AS t");
+    }
+
+    @Test
+    public void testSelectStarWithNonLiteralParameters()
+    {
+        assertIsNotSelectStar("SELECT * FROM service('/myService', businessDate => CURRENT_DATE)");
+        assertIsNotSelectStar("SELECT * FROM service('/myService', ts => CURRENT_TIMESTAMP)");
+        assertIsNotSelectStar("SELECT * FROM service('/myService', businessDate => now())");
+        assertIsNotSelectStar("SELECT * FROM service('/myService', id => 1 + 2)");
+        assertIsNotSelectStarOrNotYetSupported("subquery param", "SELECT * FROM service('/myService', id => (SELECT max(id) FROM service('/other')))");
+    }
+
     // ==================== NON-OPTIMIZABLE QUERIES ====================
     @Test
     public void testWithWhere()
@@ -66,6 +117,7 @@ public class SelectStarQueryDetectorTest
         assertIsNotSelectStar("SELECT * FROM service('/myService') WHERE age > 30");
         assertIsNotSelectStar("SELECT * FROM (SELECT * FROM service('/myService') WHERE age > 30)");
         assertIsNotSelectStar("SELECT * FROM (SELECT * FROM service('/myService')) WHERE age > 30");
+        assertIsNotSelectStar("SELECT * FROM service('/myService', businessDate => '2015-01-01') WHERE age > 30");
     }
 
     @Test
@@ -74,9 +126,9 @@ public class SelectStarQueryDetectorTest
         // Selecting specific columns requires transformation to project only those columns
         assertIsNotSelectStar("SELECT name FROM service('/myService')");
         assertIsNotSelectStar("SELECT name, age FROM service('/myService')");
-        
-        // Inner query with specific columns disqualifies the entire query
         assertIsNotSelectStar("SELECT * FROM (SELECT name FROM service('/myService'))");
+        assertIsNotSelectStar("SELECT name FROM service('/myService', businessDate => '2015-01-01')");
+        assertIsNotSelectStar("SELECT name, age FROM service('/myService', date => '2023-08-24', type => 'Type1')");
     }
 
     @Test
@@ -85,6 +137,7 @@ public class SelectStarQueryDetectorTest
         // ORDER BY requires transformation to apply sorting logic
         assertIsNotSelectStar("SELECT * FROM service('/myService') ORDER BY name");
         assertIsNotSelectStar("SELECT * FROM (SELECT * FROM service('/myService')) ORDER BY name");
+        assertIsNotSelectStar("SELECT * FROM service('/myService', businessDate => '2015-01-01') ORDER BY name");
     }
 
     @Test
@@ -93,6 +146,7 @@ public class SelectStarQueryDetectorTest
         // LIMIT/OFFSET requires transformation to apply pagination
         assertIsNotSelectStar("SELECT * FROM service('/myService') LIMIT 10");
         assertIsNotSelectStar("SELECT * FROM service('/myService') OFFSET 5");
+        assertIsNotSelectStar("SELECT * FROM service('/myService', businessDate => '2015-01-01') LIMIT 10");
     }
 
     @Test
@@ -100,12 +154,30 @@ public class SelectStarQueryDetectorTest
     {
         assertIsNotSelectStar("SELECT * FROM service('/myService') GROUP BY name");
         assertIsNotSelectStar("SELECT name, count(*) FROM service('/myService') GROUP BY name HAVING count(*) > 1");
+        assertIsNotSelectStar("SELECT * FROM service('/myService', businessDate => '2015-01-01') GROUP BY name");
     }
 
     @Test
     public void testWithDistinct()
     {
         assertIsNotSelectStar("SELECT DISTINCT * FROM service('/myService')");
+        assertIsNotSelectStar("SELECT DISTINCT * FROM service('/myService', businessDate => '2015-01-01')");
+    }
+
+    @Test
+    public void testWithExpressions()
+    {
+        // Aggregate functions in SELECT
+        assertIsNotSelectStar("SELECT count(*) FROM service('/myService')");
+        assertIsNotSelectStar("SELECT sum(salary) FROM service('/myService')");
+        assertIsNotSelectStar("SELECT name AS n FROM service('/myService')");
+    }
+
+    @Test
+    public void testNonStarInnerSubquery()
+    {
+        assertIsNotSelectStar("SELECT * FROM (SELECT name, age FROM service('/myService'))");
+        assertIsNotSelectStar("SELECT * FROM (SELECT name FROM service('/myService', businessDate => '2015-01-01'))");
     }
 
     @Test
@@ -116,12 +188,15 @@ public class SelectStarQueryDetectorTest
     }
 
     @Test
-    public void testWithServiceParameters()
+    public void testWithSetOperations()
     {
-        // Parameterized service calls require the standard path for version 1
-        assertIsNotSelectStar("SELECT * FROM service('/myService', businessDate => '2015-01-01')");
-        assertIsNotSelectStar("SELECT * FROM service('/myService', date => '2023-08-24', type => 'Type1')");
-        assertIsNotSelectStar("SELECT * FROM service('/myService', names => ARRAY['Alice', 'Bob'])");
+        // UNION is supported - test directly
+        assertIsNotSelectStar("SELECT * FROM service('/myService') UNION SELECT * FROM service('/otherService')");
+        assertIsNotSelectStar("SELECT * FROM service('/myService') UNION ALL SELECT * FROM service('/otherService')");
+
+        // INTERSECT and EXCEPT may not be supported yet - use graceful helper
+        assertIsNotSelectStarOrNotYetSupported("INTERSECT", "SELECT * FROM service('/myService') INTERSECT SELECT * FROM service('/otherService')");
+        assertIsNotSelectStarOrNotYetSupported("EXCEPT", "SELECT * FROM service('/myService') EXCEPT SELECT * FROM service('/otherService')");
     }
 
     @Test

--- a/legend-engine-xts-sql/legend-engine-xt-sql-http-api/src/test/java/org/finos/legend/engine/query/sql/api/TestSQLSourceProvider.java
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-http-api/src/test/java/org/finos/legend/engine/query/sql/api/TestSQLSourceProvider.java
@@ -33,8 +33,11 @@ import org.finos.legend.engine.plan.generation.transformers.PlanTransformer;
 import org.finos.legend.engine.plan.platform.PlanPlatform;
 import org.finos.legend.engine.protocol.pure.PureClientVersions;
 import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
+import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.CompositeExecutionPlan;
 import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.ExecutionPlan;
 import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.SingleExecutionPlan;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service.KeyedExecutionParameter;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service.PureMultiExecution;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service.PureSingleExecution;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service.Service;
 import org.finos.legend.engine.pure.code.core.PureCoreExtensionLoader;
@@ -55,6 +58,7 @@ import org.finos.legend.pure.generated.Root_meta_core_runtime_Runtime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -124,6 +128,22 @@ public class TestSQLSourceProvider implements SQLSourceProvider
                         LOGGER.warn("Failed to generate plan for service {}: {}", service.pattern, e.getMessage());
                     }
                 }
+                else if (service.execution instanceof PureMultiExecution)
+                {
+                    try
+                    {
+                        ExecutionPlan plan = generateCompositePlanForService(service, (PureMultiExecution) service.execution);
+                        if (plan != null)
+                        {
+                            preGeneratedPlans.put(service.pattern, plan);
+                            LOGGER.debug("Pre-generated composite plan for service: {}", service.pattern);
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        LOGGER.warn("Failed to generate composite plan for service {}: {}", service.pattern, e.getMessage());
+                    }
+                }
             }
 
             LOGGER.info("Initialized {} pre-generated execution plans", preGeneratedPlans.size());
@@ -154,6 +174,40 @@ public class TestSQLSourceProvider implements SQLSourceProvider
         SingleExecutionPlan plan = PlanGenerator.generateExecutionPlan(pureLambda, mapping, runtime,null, compiledModel, PureClientVersions.production, PlanPlatform.JAVA,null, extensions, transformers);
 
         return plan;
+    }
+
+    private ExecutionPlan generateCompositePlanForService(Service service, PureMultiExecution execution)
+    {
+        LambdaFunction<?> pureLambda = HelperValueSpecificationBuilder.buildLambda(execution.func.body, execution.func.parameters, compiledModel.getContext());
+
+        Map<String, SingleExecutionPlan> executionPlans = new HashMap<>();
+        List<String> executionKeys = FastList.newList();
+
+        for (KeyedExecutionParameter kep : execution.executionParameters)
+        {
+            Mapping mapping = compiledModel.getMapping(kep.mapping);
+            Root_meta_core_runtime_Runtime runtime;
+
+            if (kep.runtime instanceof RuntimePointer)
+            {
+                runtime = compiledModel.getRuntime(((RuntimePointer) kep.runtime).runtime);
+            }
+            else
+            {
+                continue;
+            }
+
+            SingleExecutionPlan keyPlan = PlanGenerator.generateExecutionPlan(pureLambda, mapping, runtime, null, compiledModel, PureClientVersions.production, PlanPlatform.JAVA, null, extensions, transformers);
+            executionPlans.put(kep.key, keyPlan);
+            executionKeys.add(kep.key);
+        }
+
+        if (executionPlans.isEmpty())
+        {
+            return null;
+        }
+
+        return new CompositeExecutionPlan(executionPlans, execution.executionKey, executionKeys);
     }
 
     @Override
@@ -200,7 +254,12 @@ public class TestSQLSourceProvider implements SQLSourceProvider
             if (service.execution instanceof PureSingleExecution)
             {
                 ExecutionPlan preGeneratedPlan = enablePreGeneratedPlans ? preGeneratedPlans.get(pattern) : null;
-                sqlSources.add(from((PureSingleExecution) service.execution, keys, preGeneratedPlan));
+                sqlSources.add(from((PureSingleExecution) service.execution, source, keys, preGeneratedPlan));
+            }
+            else if (service.execution instanceof PureMultiExecution)
+            {
+                ExecutionPlan preGeneratedPlan = enablePreGeneratedPlans ? preGeneratedPlans.get(pattern) : null;
+                sqlSources.add(from((PureMultiExecution) service.execution, source, keys, preGeneratedPlan));
             }
         });
         return new SQLSourceResolvedContext(pureModelContextData, sqlSources);
@@ -221,8 +280,36 @@ public class TestSQLSourceProvider implements SQLSourceProvider
         return preGeneratedPlans.size();
     }
 
-    private SQLSource from(PureSingleExecution pse, List<SQLSourceArgument> keys, ExecutionPlan preGeneratedPlan)
+    private SQLSource from(PureSingleExecution pse, TableSource source, List<SQLSourceArgument> keys, ExecutionPlan preGeneratedPlan)
     {
-        return new SQLSource(SERVICE_TYPE, pse.func, pse.mapping, pse.runtime, pse.executionOptions, null, keys, preGeneratedPlan);
+        Map<String, Object> resolvedArguments = resolveArguments(source);
+        return new SQLSource(SERVICE_TYPE, pse.func, pse.mapping, pse.runtime, pse.executionOptions, null, keys, preGeneratedPlan, resolvedArguments);
+    }
+
+    private SQLSource from(PureMultiExecution pme, TableSource source, List<SQLSourceArgument> keys, ExecutionPlan preGeneratedPlan)
+    {
+        String key = (String) source.getArgument(pme.executionKey, -1).getValue();
+        Optional<KeyedExecutionParameter> optional = ListIterate.select(pme.executionParameters, e -> e.key.equals(key)).getFirstOptional();
+
+        KeyedExecutionParameter execution = optional.orElseThrow(() -> new IllegalArgumentException("No execution found for key " + key));
+
+        keys.add(new SQLSourceArgument(pme.executionKey, null, key));
+
+        Map<String, Object> resolvedArguments = resolveArguments(source);
+        return new SQLSource(SERVICE_TYPE, pme.func, execution.mapping, execution.runtime, execution.executionOptions, null, keys, preGeneratedPlan, resolvedArguments);
+    }
+
+    private Map<String, Object> resolveArguments(TableSource source)
+    {
+        Map<String, Object> resolved = new HashMap<>();
+        for (TableSourceArgument arg : source.getArguments())
+        {
+            if (arg.getName() != null && arg.getValue() != null)
+            {
+                resolved.put(arg.getName(), arg.getValue());
+            }
+        }
+
+        return resolved.isEmpty() ? null : resolved;
     }
 }

--- a/legend-engine-xts-sql/legend-engine-xt-sql-http-api/src/test/java/org/finos/legend/engine/query/sql/api/execute/SelectStarExecutionRegressionTest.java
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-http-api/src/test/java/org/finos/legend/engine/query/sql/api/execute/SelectStarExecutionRegressionTest.java
@@ -37,16 +37,29 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.client.Entity;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.ServiceLoader;
+import java.util.stream.Collectors;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
- * Integration tests for SELECT * Query Optimization.
+ * Regression tests for SELECT * Query Optimization.
  * These tests verify that:
  * - SELECT * queries (with no modifications) can use pre-generated execution plans,
- * skipping SQL-to-Pure transformation and plan generation for simple SELECT * queries.
+ *   skipping SQL-to-Pure transformation and plan generation.
+ * - Parameterized SELECT * queries correctly extract service parameters and pass
+ *   them to the pre-generated plan with proper type conversion (Date, Enum, String[], Integer, Float, Decimal, Boolean).
+ * - The optimized path produces identical results to the standard path (regression tests).
+ * Test data (from proj-1.pure H2 setup):
+ *   Alice:    id=101, ratings=9.1, salary=50000.00, type=Type1, start_date=2023-08-24
+ *   Bob:      id=102, ratings=9.2, salary=60000.50, type=Type2, start_date=2022-08-24
+ *   Curtis:   id=103, ratings=9.3, salary=75000.75, type=Type2, start_date=2022-07-24
+ *   Danielle: id=104, ratings=9.4, salary=80000.25, type=Type1, start_date=2022-07-23
  */
 public class SelectStarExecutionRegressionTest
 {
@@ -59,16 +72,16 @@ public class SelectStarExecutionRegressionTest
     }
 
     @ClassRule
-    public static final ResourceTestRule resources = getResourceTestRule();
+    public static final ResourceTestRule resources = buildResources(true);
 
-    public static ResourceTestRule getResourceTestRule()
+    public static ResourceTestRule buildResources(boolean enablePreGeneratedPlans)
     {
         ModelManager modelManager = new ModelManager(DeploymentMode.TEST);
         PlanExecutor executor = PlanExecutor.newPlanExecutorWithAvailableStoreExecutors();
         MutableList<PlanGeneratorExtension> generatorExtensions = Lists.mutable.withAll(ServiceLoader.load(PlanGeneratorExtension.class));
 
-        TestSQLSourceProvider testSQLSourceProvider = new TestSQLSourceProvider(true);
-        LOGGER.info("Pre-generated plans enabled: {}, count: {}", testSQLSourceProvider.isPreGeneratedPlansEnabled(), testSQLSourceProvider.getPreGeneratedPlanCount());
+        TestSQLSourceProvider testSQLSourceProvider = new TestSQLSourceProvider(enablePreGeneratedPlans);
+        LOGGER.info("Building resources: preGeneratedPlans={}, planCount={}", testSQLSourceProvider.isPreGeneratedPlansEnabled(), testSQLSourceProvider.getPreGeneratedPlanCount());
 
         SqlExecute sqlExecute = new SqlExecute(modelManager, executor, (pm) -> PureCoreExtensionLoader.extensions().flatCollect(g -> g.extraPureCoreExtensions(pm.getExecutionSupport())), FastList.newListWith(testSQLSourceProvider), generatorExtensions.flatCollect(PlanGeneratorExtension::getExtraPlanTransformers));
 
@@ -81,115 +94,324 @@ public class SelectStarExecutionRegressionTest
                 .build();
     }
 
-    private String executeQuery(String sql)
+    // ==================== HELPER METHODS ====================
+
+    private TDSExecuteResult execute(String sql) throws JsonProcessingException
     {
-        return resources.target("sql/v1/execution/execute")
+        String response = resources.target("sql/v1/execution/execute")
                 .request()
                 .post(Entity.json(new SQLQueryInput(null, sql, FastList.newList())))
                 .readEntity(String.class);
+        TDSExecuteResult result = OM.readValue(response, TDSExecuteResult.class);
+        assertNotNull("Result should not be null for: " + sql, result);
+        assertNotNull("Result.result should not be null for: " + sql + "\nRaw response: " + response, result.result);
+        return result;
     }
 
-    // ==================== SELECT * QUERY TESTS ====================
-
-    @Test
-    public void testSelectStar_SimpleSelectAll() throws JsonProcessingException
+    private int getColumnIndex(TDSExecuteResult result, String columnName)
     {
-        String sql = "SELECT * FROM service('/testService')";
-        String result = executeQuery(sql);
-
-        TDSExecuteResult tdsResult = OM.readValue(result, TDSExecuteResult.class);
-        assertFalse("Should return rows", tdsResult.result.rows.isEmpty());
+        int index = result.result.columns.indexOf(columnName);
+        assertTrue("Column '" + columnName + "' not found. Available: " + result.result.columns, index >= 0);
+        return index;
     }
 
-    @Test
-    public void testSelectStar_NestedSelectAll() throws JsonProcessingException
+    private Set<Object> getColumnValues(TDSExecuteResult result, String columnName)
     {
-        String sql = "SELECT * FROM (SELECT * FROM service('/testService'))";
-        String result = executeQuery(sql);
-
-        TDSExecuteResult tdsResult = OM.readValue(result, TDSExecuteResult.class);
-        assertFalse("Should return rows", tdsResult.result.rows.isEmpty());
+        int colIndex = getColumnIndex(result, columnName);
+        return result.result.rows.stream()
+                .map(row -> row.values.get(colIndex))
+                .collect(Collectors.toSet());
     }
 
-    @Test
-    public void testSelectStar_WithTableAlias() throws JsonProcessingException
+    private void assertReturnsNames(String sql, String... expectedNames) throws JsonProcessingException
     {
-        String sql = "SELECT * FROM service('/testService') AS t";
-        String result = executeQuery(sql);
-
-        TDSExecuteResult tdsResult = OM.readValue(result, TDSExecuteResult.class);
-        assertFalse("Should return rows", tdsResult.result.rows.isEmpty());
+        TDSExecuteResult result = execute(sql);
+        assertEquals("Row count mismatch for: " + sql, expectedNames.length, result.result.rows.size());
+        Set<Object> actualNames = getColumnValues(result, "Name");
+        Set<Object> expected = new HashSet<>();
+        for (String name : expectedNames)
+        {
+            expected.add(name);
+        }
+        assertEquals("Names mismatch for: " + sql, expected, actualNames);
     }
 
-    // ==================== STANDARD PATH TESTS ====================
-
-    @Test
-    public void testStandard_SelectWithWhereClause() throws JsonProcessingException
+    private void assertReturnsEmpty(String sql) throws JsonProcessingException
     {
-        String sql = "SELECT * FROM service('/testService') WHERE Id > 0";
-        String result = executeQuery(sql);
-
-        TDSExecuteResult tdsResult = OM.readValue(result, TDSExecuteResult.class);
-        assertNotNull("Should return result", tdsResult.result);
+        TDSExecuteResult result = execute(sql);
+        assertTrue("Expected no rows for: " + sql, result.result.rows.isEmpty());
     }
 
-    @Test
-    public void testStandard_SelectSpecificColumns() throws JsonProcessingException
+    private void assertReturnsRows(String sql) throws JsonProcessingException
     {
-        String sql = "SELECT Name FROM service('/testService')";
-        String result = executeQuery(sql);
-
-        TDSExecuteResult tdsResult = OM.readValue(result, TDSExecuteResult.class);
-        assertFalse("Should return rows", tdsResult.result.rows.isEmpty());
+        TDSExecuteResult result = execute(sql);
+        assertFalse("Expected rows for: " + sql, result.result.rows.isEmpty());
     }
 
-    @Test
-    public void testStandard_SelectWithOrderBy() throws JsonProcessingException
+    private void assertOptimizedMatchesStandard(String selectStarSql, String standardSql) throws JsonProcessingException
     {
-        String sql = "SELECT * FROM service('/testService') ORDER BY Name";
-        String result = executeQuery(sql);
+        TDSExecuteResult selectStarResult = execute(selectStarSql);
+        TDSExecuteResult standardResult = execute(standardSql);
 
-        TDSExecuteResult tdsResult = OM.readValue(result, TDSExecuteResult.class);
-        assertFalse("Should return rows", tdsResult.result.rows.isEmpty());
+        assertEquals("Row count should match between optimized and standard paths",
+                selectStarResult.result.rows.size(),
+                standardResult.result.rows.size());
+
+        for (String col : standardResult.result.columns)
+        {
+            assertTrue("SELECT * should contain column '" + col + "'",
+                    selectStarResult.result.columns.contains(col));
+        }
+
+        if (standardResult.result.columns.contains("Name") && selectStarResult.result.columns.contains("Name"))
+        {
+            Set<Object> starNames = getColumnValues(selectStarResult, "Name");
+            Set<Object> stdNames = getColumnValues(standardResult, "Name");
+            assertEquals("Names should match between optimized and standard paths", starNames, stdNames);
+        }
     }
 
-    @Test
-    public void testStandard_SelectWithLimit() throws JsonProcessingException
-    {
-        String sql = "SELECT * FROM service('/testService') LIMIT 10";
-        String result = executeQuery(sql);
+    // ==================== TESTING FOR VARIOUS DATATYPE PARAMETERS ====================
 
-        TDSExecuteResult tdsResult = OM.readValue(result, TDSExecuteResult.class);
-        assertNotNull("Should return result", tdsResult.result);
-    }
+    // ---- DateTime format tests (biggest risk: requires getPlanParameters Pure pipeline) ----
 
     @Test
-    public void testStandard_SelectWithGroupBy() throws JsonProcessingException
+    public void testDateTimeParameter_IsoWithT() throws JsonProcessingException
     {
-        String sql = "SELECT Name, count(*) FROM service('/testService') GROUP BY Name";
-        String result = executeQuery(sql);
-
-        TDSExecuteResult tdsResult = OM.readValue(result, TDSExecuteResult.class);
-        assertNotNull("Should return result", tdsResult.result);
+        // Format: yyyy-MM-ddTHH:mm:ss (ISO 8601 with T separator)
+        assertReturnsNames("SELECT * FROM service('/personServiceByDateTimeExact', dateTime => '2023-08-24T12:00:00')", "Alice");
+        assertReturnsNames("SELECT * FROM service('/personServiceByDateTimeExact', dateTime => '2022-08-24T15:30:00')", "Bob");
+        assertReturnsNames("SELECT * FROM service('/personServiceByDateTimeExact', dateTime => '2022-07-23T18:45:30')", "Danielle");
     }
 
     @Test
-    public void testStandard_NestedSelectWithWhere() throws JsonProcessingException
+    public void testDateTimeParameter_SpaceSeparator() throws JsonProcessingException
     {
-        String sql = "SELECT * FROM (SELECT * FROM service('/testService') WHERE Id > 0)";
-        String result = executeQuery(sql);
-
-        TDSExecuteResult tdsResult = OM.readValue(result, TDSExecuteResult.class);
-        assertNotNull("Should return result", tdsResult.result);
+        // Format: yyyy-MM-dd HH:mm:ss (space separator instead of T)
+        assertReturnsNames("SELECT * FROM service('/personServiceByDateTimeExact', dateTime => '2023-08-24 12:00:00')", "Alice");
+        assertReturnsNames("SELECT * FROM service('/personServiceByDateTimeExact', dateTime => '2022-08-24 15:30:00')", "Bob");
+        assertReturnsNames("SELECT * FROM service('/personServiceByDateTimeExact', dateTime => '2022-07-23 18:45:30')", "Danielle");
     }
 
     @Test
-    public void testStandard_SelectDistinct() throws JsonProcessingException
+    public void testDateTimeParameter_IsoWithMilliseconds() throws JsonProcessingException
     {
-        String sql = "SELECT DISTINCT Name FROM service('/testService')";
-        String result = executeQuery(sql);
+        // Format: yyyy-MM-ddTHH:mm:ss.SSS (ISO 8601 with milliseconds)
+        assertReturnsNames("SELECT * FROM service('/personServiceByDateTimeExact', dateTime => '2023-08-24T12:00:00.000')", "Alice");
+        assertReturnsNames("SELECT * FROM service('/personServiceByDateTimeExact', dateTime => '2022-07-23T18:45:30.000')", "Danielle");
+        assertReturnsEmpty("SELECT * FROM service('/personServiceByDateTimeExact', dateTime => '2023-08-24T12:00:00.001')");
+    }
 
-        TDSExecuteResult tdsResult = OM.readValue(result, TDSExecuteResult.class);
-        assertNotNull("Should return result", tdsResult.result);
+    @Test
+    public void testDateTimeParameter_SpaceWithMilliseconds() throws JsonProcessingException
+    {
+        // Format: yyyy-MM-dd HH:mm:ss.SSS (space separator with milliseconds)
+        assertReturnsNames("SELECT * FROM service('/personServiceByDateTimeExact', dateTime => '2023-08-24 12:00:00.000')", "Alice");
+        assertReturnsNames("SELECT * FROM service('/personServiceByDateTimeExact', dateTime => '2022-07-23 18:45:30.000')", "Danielle");
+        assertReturnsEmpty("SELECT * FROM service('/personServiceByDateTimeExact', dateTime => '2022-07-23 18:45:30.001')");
+    }
+
+    @Test
+    public void testDateTimeParameter_RangeWithMultipleFormats() throws JsonProcessingException
+    {
+        // Verify >= comparison works correctly with all DateTime formats
+        // sinceDateTime >= '2022-08-24T15:30:00' should return Alice (2023-08-24 12:00:00), Bob (2022-08-24 15:30:00)
+        assertReturnsNames("SELECT * FROM service('/personServiceByDateTimeRange', sinceDateTime => '2022-08-24T15:30:00')", "Alice", "Bob");
+        assertReturnsNames("SELECT * FROM service('/personServiceByDateTimeRange', sinceDateTime => '2022-08-24 15:30:00')", "Alice", "Bob");
+        assertReturnsNames("SELECT * FROM service('/personServiceByDateTimeRange', sinceDateTime => '2022-08-24T15:30:00.000')", "Alice", "Bob");
+        assertReturnsNames("SELECT * FROM service('/personServiceByDateTimeRange', sinceDateTime => '2022-08-24 15:30:00.000')", "Alice", "Bob");
+    }
+
+    @Test
+    public void testDateTimeParameter_NoMatch() throws JsonProcessingException
+    {
+        // Future date — no data should match
+        assertReturnsEmpty("SELECT * FROM service('/personServiceByDateTimeExact', dateTime => '2026-06-09T22:10:11.000')");
+        assertReturnsEmpty("SELECT * FROM service('/personServiceByDateTimeExact', dateTime => '2026-06-09 22:10:11.000')");
+        assertReturnsEmpty("SELECT * FROM service('/personServiceByDateTimeRange', sinceDateTime => '2026-06-09T22:10:11.000')");
+        assertReturnsEmpty("SELECT * FROM service('/personServiceByDateTimeRange', sinceDateTime => '2026-06-09 22:10:11.000')");
+    }
+
+    @Test
+    public void testDateTimeParameter_FormatConsistency() throws JsonProcessingException
+    {
+        // Same logical DateTime in all four formats must produce identical results
+        TDSExecuteResult isoWithT = execute("SELECT * FROM service('/personServiceByDateTimeRange', sinceDateTime => '2022-07-24T09:15:30')");
+        TDSExecuteResult spaceNoMs = execute("SELECT * FROM service('/personServiceByDateTimeRange', sinceDateTime => '2022-07-24 09:15:30')");
+        TDSExecuteResult isoWithMs = execute("SELECT * FROM service('/personServiceByDateTimeRange', sinceDateTime => '2022-07-24T09:15:30.000')");
+        TDSExecuteResult spaceWithMs = execute("SELECT * FROM service('/personServiceByDateTimeRange', sinceDateTime => '2022-07-24 09:15:30.000')");
+
+        assertEquals("ISO with T and space separator must return same row count",
+                isoWithT.result.rows.size(), spaceNoMs.result.rows.size());
+        assertEquals("ISO with T and ISO with millis must return same row count",
+                isoWithT.result.rows.size(), isoWithMs.result.rows.size());
+        assertEquals("ISO with T and space with millis must return same row count",
+                isoWithT.result.rows.size(), spaceWithMs.result.rows.size());
+
+        Set<Object> namesT = getColumnValues(isoWithT, "Name");
+        Set<Object> namesSpace = getColumnValues(spaceNoMs, "Name");
+        Set<Object> namesMs = getColumnValues(isoWithMs, "Name");
+        Set<Object> namesSpaceMs = getColumnValues(spaceWithMs, "Name");
+
+        assertEquals("All four DateTime formats must produce identical results", namesT, namesSpace);
+        assertEquals("All four DateTime formats must produce identical results", namesT, namesMs);
+        assertEquals("All four DateTime formats must produce identical results", namesT, namesSpaceMs);
+    }
+
+    // ---- Other datatype parameter tests ----
+
+    @Test
+    public void testDateParameter() throws JsonProcessingException
+    {
+        assertReturnsNames("SELECT * FROM service('/personServiceForStartDate/{date}', date => '2023-08-24')", "Alice");
+        assertReturnsNames("SELECT * FROM service('/personServiceForStartDate/{date}', date => '2022-07-23')", "Danielle");
+        assertReturnsEmpty("SELECT * FROM service('/personServiceForStartDate/{date}', date => '1999-01-01')");
+    }
+
+    @Test
+    public void testStrictDateParameter() throws JsonProcessingException
+    {
+        // asOfDate >= 2022-08-01: Alice (2023-08-24), Bob (2022-08-24)
+        assertReturnsNames("SELECT * FROM service('/personServiceByStrictDate', asOfDate => '2022-08-01')", "Alice", "Bob");
+    }
+
+    @Test
+    public void testEnumParameter() throws JsonProcessingException
+    {
+        assertReturnsNames("SELECT * FROM service('/personServiceForStartDate/{date}', date => '2023-08-24', type => 'Type1')", "Alice");
+        assertReturnsEmpty("SELECT * FROM service('/personServiceForStartDate/{date}', date => '2023-08-24', type => 'Type2')");
+    }
+
+    @Test
+    public void testStringArrayParameter() throws JsonProcessingException
+    {
+        assertReturnsNames("SELECT * FROM service('/personServiceForNames', names => ARRAY['Alice', 'Bob'])", "Alice", "Bob");
+        assertReturnsNames("SELECT * FROM service('/personServiceForNames', names => ARRAY['Curtis'])", "Curtis");
+        assertReturnsNames("SELECT * FROM service('/personServiceForNames', names => ARRAY['Alice', 'Bob', 'Curtis', 'Danielle'])", "Alice", "Bob", "Curtis", "Danielle");
+    }
+
+    @Test
+    public void testIntegerParameter() throws JsonProcessingException
+    {
+        assertReturnsNames("SELECT * FROM service('/personServiceById', minId => 103)", "Curtis", "Danielle");
+        assertReturnsNames("SELECT * FROM service('/personServiceById', minId => 100)", "Alice", "Bob", "Curtis", "Danielle");
+        assertReturnsEmpty("SELECT * FROM service('/personServiceById', minId => 999)");
+        assertReturnsNames("SELECT * FROM service('/personServiceById', minId => '103')", "Curtis", "Danielle");
+    }
+
+    @Test
+    public void testStringParameter() throws JsonProcessingException
+    {
+        assertReturnsNames("SELECT * FROM service('/personServiceByName', name => 'Alice')", "Alice");
+        assertReturnsEmpty("SELECT * FROM service('/personServiceByName', name => 'Wendy')");
+    }
+
+    @Test
+    public void testBooleanParameter() throws JsonProcessingException
+    {
+        assertReturnsNames("SELECT * FROM service('/personServiceByHighRating', highOnly => true)", "Curtis", "Danielle");
+        assertReturnsNames("SELECT * FROM service('/personServiceByHighRating', highOnly => false)", "Alice", "Bob", "Curtis", "Danielle");
+        assertReturnsNames("SELECT * FROM service('/personServiceByHighRating', highOnly => 'true')", "Curtis", "Danielle");
+    }
+
+    @Test
+    public void testFloatParameter() throws JsonProcessingException
+    {
+        assertReturnsNames("SELECT * FROM service('/personServiceByRating', minRating => 9.25)", "Curtis", "Danielle");
+        assertReturnsNames("SELECT * FROM service('/personServiceByRating', minRating => 9.1)", "Alice", "Bob", "Curtis", "Danielle");
+        assertReturnsNames("SELECT * FROM service('/personServiceByRating', minRating => '9.25')", "Curtis", "Danielle");
+    }
+
+    @Test
+    public void testDecimalParameter() throws JsonProcessingException
+    {
+        assertReturnsNames("SELECT * FROM service('/personServiceBySalary', minSalary => '70000.00')", "Curtis", "Danielle");
+        assertReturnsNames("SELECT * FROM service('/personServiceBySalary', minSalary => '50000.00')", "Alice", "Bob", "Curtis", "Danielle");
+        assertReturnsEmpty("SELECT * FROM service('/personServiceBySalary', minSalary => '100000.00')");
+    }
+
+    @Test
+    public void testMultipleParameters() throws JsonProcessingException
+    {
+        assertReturnsNames("SELECT * FROM service('/personServiceMultiParam', minId => 101, type => 'Type1')", "Alice", "Danielle");
+        assertReturnsNames("SELECT * FROM service('/personServiceMultiParam', minId => 104, type => 'Type1')", "Danielle");
+    }
+
+    // ==================== NESTED QUERIES ====================
+    @Test
+    public void testNestedQueries() throws JsonProcessingException
+    {
+        // Nested SELECT * with parameters
+        assertReturnsNames("SELECT * FROM (SELECT * FROM service('/personServiceById', minId => 103))", "Curtis", "Danielle");
+        assertReturnsNames("SELECT * FROM service('/personServiceById', minId => 102) AS t", "Bob", "Curtis", "Danielle");
+    }
+
+    // ==================== MULTI-EXECUTION SERVICE ====================
+    @Test
+    public void testMultiExecService_Env1() throws JsonProcessingException
+    {
+        // Multi-execution service with env key — resolves CompositeExecutionPlan to the sub-plan for 'env1'
+        assertReturnsNames("SELECT * FROM service('/personServiceMultiExec/{env}', env => 'env1', minId => 103)", "Curtis", "Danielle");
+        assertReturnsNames("SELECT * FROM service('/personServiceMultiExec/{env}', env => 'env1', minId => 101)", "Alice", "Bob", "Curtis", "Danielle");
+    }
+
+    @Test
+    public void testMultiExecService_Env2() throws JsonProcessingException
+    {
+        // Same query routed to 'env2' — both envs point to the same DB so results are identical
+        assertReturnsNames("SELECT * FROM service('/personServiceMultiExec/{env}', env => 'env2', minId => 103)", "Curtis", "Danielle");
+        assertReturnsNames("SELECT * FROM service('/personServiceMultiExec/{env}', env => 'env2', minId => 101)", "Alice", "Bob", "Curtis", "Danielle");
+    }
+
+    @Test
+    public void testMultiExecService_ConsistentAcrossKeys() throws JsonProcessingException
+    {
+        // Verify both execution keys produce identical results (same underlying DB)
+        TDSExecuteResult env1Result = execute("SELECT * FROM service('/personServiceMultiExec/{env}', env => 'env1', minId => 102)");
+        TDSExecuteResult env2Result = execute("SELECT * FROM service('/personServiceMultiExec/{env}', env => 'env2', minId => 102)");
+
+        assertEquals("Both execution keys should return same row count",
+                env1Result.result.rows.size(), env2Result.result.rows.size());
+
+        Set<Object> env1Names = getColumnValues(env1Result, "Name");
+        Set<Object> env2Names = getColumnValues(env2Result, "Name");
+        assertEquals("Both execution keys should return same names", env1Names, env2Names);
+    }
+
+    // ==================== BASIC SERVICE (NO PARAMETERS) ====================
+    @Test
+    public void testBasicService() throws JsonProcessingException
+    {
+        assertReturnsRows("SELECT * FROM service('/testService')");
+        assertReturnsRows("SELECT * FROM (SELECT * FROM service('/testService'))");
+
+        // Schema validation
+        TDSExecuteResult result = execute("SELECT * FROM service('/personServiceById', minId => 101)");
+        assertFalse("Columns should not be empty", result.result.columns.isEmpty());
+    }
+
+    // ==================== STANDARD PATH FALLBACK ====================
+    @Test
+    public void testStandardPathFallback() throws JsonProcessingException
+    {
+        // These disqualify SELECT * optimization and fall back to standard path
+        assertReturnsRows("SELECT * FROM service('/testService') WHERE Id > 0");
+        assertReturnsRows("SELECT Name FROM service('/testService')");
+        assertReturnsRows("SELECT * FROM service('/testService') ORDER BY Name");
+    }
+
+    // ==================== SELECT * VS STANDARD PATH REGRESSION ====================
+    @Test
+    public void testOptimizedMatchesStandardPath() throws JsonProcessingException
+    {
+        assertOptimizedMatchesStandard("SELECT * FROM service('/testService')","SELECT Name, Id FROM service('/testService')");
+        assertOptimizedMatchesStandard("SELECT * FROM service('/personServiceById', minId => 103)","SELECT Name, Id FROM service('/personServiceById', minId => 103)");
+    }
+
+    // ==================== OPTIONAL PARAMETER HANDLING ====================
+    @Test
+    public void testOptionalParameter_Omitted() throws JsonProcessingException
+    {
+        assertReturnsRows("SELECT * FROM service('/personServiceForStartDate/{date}', date => '2023-08-24')");
     }
 }

--- a/legend-engine-xts-sql/legend-engine-xt-sql-http-api/src/test/resources/proj-1.pure
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-http-api/src/test/resources/proj-1.pure
@@ -23,12 +23,14 @@ Database demo::H2DemoDataBase
   Table EmployeeTable
   (
     id INTEGER PRIMARY KEY,
-    ratings DECIMAL(10,2),
+    ratings FLOAT,
+    salary DECIMAL(10,2),
     firm_id INTEGER,
     name VARCHAR(200),
     country_id INTEGER,
     type VARCHAR(25),
-    start_date DATE
+    start_date DATE,
+    created_at TIMESTAMP
   )
   Table CountryTable
   (
@@ -309,6 +311,305 @@ Service demo::H2PersonServiceDateParameterizedRelation
   }
 }
 
+Service demo::H2PersonServiceByIdParameterized
+{
+  pattern: '/personServiceById';
+  owners:
+  [
+    'anonymous1',
+    'anonymous2'
+  ];
+  documentation: '';
+  autoActivateUpdates: true;
+  execution: Single
+  {
+    query: {minId:Integer[1]|demo::employee.all()->filter(p | $p.id >= $minId)->project(
+      [
+        x|$x.id,
+        x|$x.name,
+        x|$x.type
+      ],
+      [
+        'Id',
+        'Name',
+        'Employee Type'
+      ]
+    )};
+    mapping: demo::DemoRelationalMapping;
+    runtime: demo::H2DemoRuntime;
+  }
+}
+
+Service demo::H2PersonServiceByRatingParameterized
+{
+  pattern: '/personServiceByRating';
+  owners:
+  [
+    'anonymous1',
+    'anonymous2'
+  ];
+  documentation: '';
+  autoActivateUpdates: true;
+  execution: Single
+  {
+    query: {minRating:Float[1]|demo::employee.all()->filter(p | $p.ratings >= $minRating)->project(
+      [
+        x|$x.id,
+        x|$x.name,
+        x|$x.ratings
+      ],
+      [
+        'Id',
+        'Name',
+        'Ratings'
+      ]
+    )};
+    mapping: demo::DemoRelationalMapping;
+    runtime: demo::H2DemoRuntime;
+  }
+}
+
+Service demo::H2PersonServiceByStrictDateParameterized
+{
+  pattern: '/personServiceByStrictDate';
+  owners:
+  [
+    'anonymous1',
+    'anonymous2'
+  ];
+  documentation: '';
+  autoActivateUpdates: true;
+  execution: Single
+  {
+    query: {asOfDate:StrictDate[1]|demo::employee.all()->filter(p | $p.startDate >= $asOfDate)->project(
+      [
+        x|$x.id,
+        x|$x.name,
+        x|$x.startDate
+      ],
+      [
+        'Id',
+        'Name',
+        'Start Date'
+      ]
+    )};
+    mapping: demo::DemoRelationalMapping;
+    runtime: demo::H2DemoRuntime;
+  }
+}
+
+Service demo::H2PersonServiceMultiParamParameterized
+{
+  pattern: '/personServiceMultiParam';
+  owners:
+  [
+    'anonymous1',
+    'anonymous2'
+  ];
+  documentation: '';
+  autoActivateUpdates: true;
+  execution: Single
+  {
+    query: {minId:Integer[1], type:demo::employeeType[1]|demo::employee.all()->filter(p | $p.id >= $minId && $p.type == $type)->project(
+      [
+        x|$x.id,
+        x|$x.name,
+        x|$x.type
+      ],
+      [
+        'Id',
+        'Name',
+        'Employee Type'
+      ]
+    )};
+    mapping: demo::DemoRelationalMapping;
+    runtime: demo::H2DemoRuntime;
+  }
+}
+
+Service demo::H2PersonServiceByNameParameterized
+{
+  pattern: '/personServiceByName';
+  owners:
+  [
+    'anonymous1',
+    'anonymous2'
+  ];
+  documentation: '';
+  autoActivateUpdates: true;
+  execution: Single
+  {
+    query: {name:String[1]|demo::employee.all()->filter(p | $p.name == $name)->project(
+      [
+        x|$x.id,
+        x|$x.name,
+        x|$x.type
+      ],
+      [
+        'Id',
+        'Name',
+        'Employee Type'
+      ]
+    )};
+    mapping: demo::DemoRelationalMapping;
+    runtime: demo::H2DemoRuntime;
+  }
+}
+
+Service demo::H2PersonServiceByHighRatingParameterized
+{
+  pattern: '/personServiceByHighRating';
+  owners:
+  [
+    'anonymous1',
+    'anonymous2'
+  ];
+  documentation: '';
+  autoActivateUpdates: true;
+  execution: Single
+  {
+    query: {highOnly:Boolean[1]|demo::employee.all()->filter(p | (!$highOnly) || ($p.ratings > 9.2))->project(
+      [
+        x|$x.id,
+        x|$x.name,
+        x|$x.ratings
+      ],
+      [
+        'Id',
+        'Name',
+        'Ratings'
+      ]
+    )};
+    mapping: demo::DemoRelationalMapping;
+    runtime: demo::H2DemoRuntime;
+  }
+}
+
+Service demo::H2PersonServiceBySalaryParameterized
+{
+  pattern: '/personServiceBySalary';
+  owners:
+  [
+    'anonymous1',
+    'anonymous2'
+  ];
+  documentation: '';
+  autoActivateUpdates: true;
+  execution: Single
+  {
+    query: {minSalary:Decimal[1]|demo::employee.all()->filter(p | $p.salary >= $minSalary)->project(
+      [
+        x|$x.id,
+        x|$x.name,
+        x|$x.salary
+      ],
+      [
+        'Id',
+        'Name',
+        'Salary'
+      ]
+    )};
+    mapping: demo::DemoRelationalMapping;
+    runtime: demo::H2DemoRuntime;
+  }
+}
+
+Service demo::H2PersonServiceMultiExec
+{
+  pattern: '/personServiceMultiExec/{env}';
+  owners:
+  [
+    'anonymous1',
+    'anonymous2'
+  ];
+  documentation: '';
+  autoActivateUpdates: true;
+  execution: Multi
+  {
+    query: {minId:Integer[1]|demo::employee.all()->filter(p | $p.id >= $minId)->project(
+      [
+        x|$x.id,
+        x|$x.name,
+        x|$x.type
+      ],
+      [
+        'Id',
+        'Name',
+        'Employee Type'
+      ]
+    )};
+    key: 'env';
+    executions['env1']:
+    {
+      mapping: demo::DemoRelationalMapping;
+      runtime: demo::H2DemoRuntime;
+    }
+    executions['env2']:
+    {
+      mapping: demo::DemoRelationalMapping;
+      runtime: demo::H2DemoRuntime;
+    }
+  }
+}
+
+Service demo::H2PersonServiceByDateTimeExact
+{
+  pattern: '/personServiceByDateTimeExact';
+  owners:
+  [
+    'anonymous1',
+    'anonymous2'
+  ];
+  documentation: '';
+  autoActivateUpdates: true;
+  execution: Single
+  {
+    query: {dateTime:DateTime[1]|demo::employee.all()->filter(p | $p.createdAt == $dateTime)->project(
+      [
+        x|$x.id,
+        x|$x.name,
+        x|$x.createdAt
+      ],
+      [
+        'Id',
+        'Name',
+        'Created At'
+      ]
+    )};
+    mapping: demo::DemoRelationalMapping;
+    runtime: demo::H2DemoRuntime;
+  }
+}
+
+Service demo::H2PersonServiceByDateTimeRange
+{
+  pattern: '/personServiceByDateTimeRange';
+  owners:
+  [
+    'anonymous1',
+    'anonymous2'
+  ];
+  documentation: '';
+  autoActivateUpdates: true;
+  execution: Single
+  {
+    query: {sinceDateTime:DateTime[1]|demo::employee.all()->filter(p | $p.createdAt >= $sinceDateTime)->project(
+      [
+        x|$x.id,
+        x|$x.name,
+        x|$x.createdAt
+      ],
+      [
+        'Id',
+        'Name',
+        'Created At'
+      ]
+    )};
+    mapping: demo::DemoRelationalMapping;
+    runtime: demo::H2DemoRuntime;
+  }
+}
+
 
 ###Pure
 Enum demo::employeeType
@@ -320,10 +621,12 @@ Enum demo::employeeType
 Class demo::employee
 {
   id: Integer[1];
-  ratings: Decimal[1];
+  ratings: Float[1];
+  salary: Decimal[1];
   name: String[1];
   type: demo::employeeType[1];
   startDate: Date[1];
+  createdAt: DateTime[1];
   derivedName() {$this.name+'_derived'} : String[1];
 }
 
@@ -340,9 +643,11 @@ Mapping demo::DemoRelationalMapping
     ~mainTable [demo::H2DemoDataBase]EmployeeTable
     id: [demo::H2DemoDataBase]EmployeeTable.id,
     ratings: [demo::H2DemoDataBase]EmployeeTable.ratings,
+    salary: [demo::H2DemoDataBase]EmployeeTable.salary,
     name: [demo::H2DemoDataBase]EmployeeTable.name,
     type: EnumerationMapping EmployeeType: [demo::H2DemoDataBase]EmployeeTable.type,
-    startDate: [demo::H2DemoDataBase]EmployeeTable.start_date
+    startDate: [demo::H2DemoDataBase]EmployeeTable.start_date,
+    createdAt: [demo::H2DemoDataBase]EmployeeTable.created_at
   }
 
    demo::employeeType : EnumerationMapping EmployeeType
@@ -361,7 +666,7 @@ RelationalDatabaseConnection demo::H2DemoConnection
   specification: LocalH2
   {
     testDataSetupSqls: [
-      'Drop table if exists EmployeeTable;\nCreate Table EmployeeTable(id INTEGER PRIMARY KEY,ratings DECIMAL,firm_id INTEGER,name VARCHAR(200),country_id INTEGER, type VARCHAR(25), start_date DATE);\nInsert into EmployeeTable (id, ratings, firm_id, name, country_id, type, start_date) values (101,9.1,202, \'Alice\', 303, \'Type1\', \'2023-08-24\');\nInsert into EmployeeTable (id, ratings, firm_id, name, country_id, type, start_date) values (102,9.2,203, \'Bob\', 304, \'Type2\', \'2022-08-24\');\nInsert into EmployeeTable (id, ratings, firm_id, name, country_id, type, start_date) values (103,9.3,204, \'Curtis\', 305, \'Type2\', \'2022-07-24\');\nInsert into EmployeeTable (id, ratings, firm_id, name, country_id, type, start_date) values (104,9.4,205, \'Danielle\', 306, \'Type1\', \'2022-07-23\');\n'
+      'Drop table if exists EmployeeTable;\nCreate Table EmployeeTable(id INTEGER PRIMARY KEY,ratings FLOAT,salary DECIMAL(10,2),firm_id INTEGER,name VARCHAR(200),country_id INTEGER, type VARCHAR(25), start_date DATE, created_at TIMESTAMP);\nInsert into EmployeeTable (id, ratings, salary, firm_id, name, country_id, type, start_date, created_at) values (101,9.1,50000.00,202, \'Alice\', 303, \'Type1\', \'2023-08-24\', \'2023-08-24 12:00:00\');\nInsert into EmployeeTable (id, ratings, salary, firm_id, name, country_id, type, start_date, created_at) values (102,9.2,60000.50,203, \'Bob\', 304, \'Type2\', \'2022-08-24\', \'2022-08-24 15:30:00\');\nInsert into EmployeeTable (id, ratings, salary, firm_id, name, country_id, type, start_date, created_at) values (103,9.3,75000.75,204, \'Curtis\', 305, \'Type2\', \'2022-07-24\', \'2022-07-24 09:15:30\');\nInsert into EmployeeTable (id, ratings, salary, firm_id, name, country_id, type, start_date, created_at) values (104,9.4,80000.25,205, \'Danielle\', 306, \'Type1\', \'2022-07-23\', \'2022-07-23 18:45:30\');\n'
       ];
   };
   auth: DefaultH2;

--- a/legend-engine-xts-sql/legend-engine-xt-sql-transformation/legend-engine-xt-sql-providers/legend-engine-xt-sql-providers-core/src/main/java/org/finos/legend/engine/query/sql/providers/core/SQLSource.java
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-transformation/legend-engine-xt-sql-providers/legend-engine-xt-sql-providers-core/src/main/java/org/finos/legend/engine/query/sql/providers/core/SQLSource.java
@@ -23,6 +23,7 @@ import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.exe
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 public class SQLSource
 {
@@ -34,13 +35,19 @@ public class SQLSource
     private final ExecutionContext executionContext;
     private final List<SQLSourceArgument> key;
     private final ExecutionPlan preGeneratedPlan;
+    private final Map<String, Object> resolvedArguments;
 
     public SQLSource(String type, LambdaFunction func, String mapping, Runtime runtime, List<ExecutionOption> executionOptions, ExecutionContext executionContext, List<SQLSourceArgument> key)
     {
-        this(type, func, mapping, runtime, executionOptions, executionContext, key, null);
+        this(type, func, mapping, runtime, executionOptions, executionContext, key, null, null);
     }
 
     public SQLSource(String type, LambdaFunction func, String mapping, Runtime runtime, List<ExecutionOption> executionOptions, ExecutionContext executionContext, List<SQLSourceArgument> key, ExecutionPlan preGeneratedPlan)
+    {
+        this(type, func, mapping, runtime, executionOptions, executionContext, key, preGeneratedPlan, null);
+    }
+
+    public SQLSource(String type, LambdaFunction func, String mapping, Runtime runtime, List<ExecutionOption> executionOptions, ExecutionContext executionContext, List<SQLSourceArgument> key, ExecutionPlan preGeneratedPlan, Map<String, Object> resolvedArguments)
     {
         this.type = type;
         this.func = func;
@@ -50,6 +57,7 @@ public class SQLSource
         this.executionContext = executionContext;
         this.key = key == null ? Collections.emptyList() : key;
         this.preGeneratedPlan = preGeneratedPlan;
+        this.resolvedArguments = resolvedArguments;
     }
 
     public String getType()
@@ -90,5 +98,10 @@ public class SQLSource
     public ExecutionPlan getPreGeneratedPlan()
     {
         return preGeneratedPlan;
+    }
+
+    public Map<String, Object> getResolvedArguments()
+    {
+        return resolvedArguments;
     }
 }


### PR DESCRIPTION
#### What type of PR is this?
- Improvement


#### What does this PR do / why is it needed ?
Extend the SELECT * optimization to handle parameterized service queries like SELECT * FROM service('/myService', businessDate => '2015-01-01') and multi-execution (composite plan) services. Previously, any query with service parameters fell back to the expensive standard execution path (~300ms). Now these queries use the pre-generated plan with extracted parameters (~15ms).


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
