### PR TITLE
Fix udtf nested add

### DIFF
--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/postprocessor/functionActivationPostProcessor/replaceFreeMarkerOps.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/postprocessor/functionActivationPostProcessor/replaceFreeMarkerOps.pure
@@ -162,7 +162,11 @@ function <<access.private>> meta::relational::postProcessor::isCollectionReturni
 {
   let collectionFunctionRewrites = multiplicityPreservingDynaFunctionList();
   let collectionFunctionNames = $collectionFunctionRewrites->map(r | [$r.first, $r.second.first]);
-  $d.name->in($collectionFunctionNames);
+
+  // 'add' is the only ambiguous name in multiplicityPreservingDynaFunctionList: scalar addition vs collection append.
+  // All other functions are always collection-returning,so a name-only check suffices for them.
+  // For 'add' we additionally require that at least one parameter actually carries a collection placeholder.
+  $d.name->in($collectionFunctionNames) && ($d.name != 'add' || $d.parameters->exists(p | $p->isOrContainsCollectionPlaceHolder()));
 }
 
 

--- a/legend-engine-xts-snowflake/legend-engine-xt-snowflake-pure-test/src/main/resources/core_snowflake_test/core_snowflakeapp/showcase/showcaseElements.legend
+++ b/legend-engine-xts-snowflake/legend-engine-xt-snowflake-pure-test/src/main/resources/core_snowflake_test/core_snowflakeapp/showcase/showcaseElements.legend
@@ -17,7 +17,8 @@ Class meta::external::function::activator::snowflakeApp::tests::model::simple::P
     gender: Gender[0..1];
     genderFromInt: Gender[0..1];
     age : Integer[0..1];
-    nickName : String[0..1];    
+    ageSum : Integer[0..1];
+    nickName : String[0..1];
     activeEmployment: Boolean[0..1];
     lastUpdated: DateTime[0..1];
     personCode: PersonCode[0..1];
@@ -84,6 +85,7 @@ Mapping meta::external::function::activator::snowflakeApp::tests::simpleRelation
                 (
                     firstName : personTable.FIRSTNAME,
                     age : personTable.AGE,
+                    ageSum : add(add(add(personTable.AGE, personTable.FIRMID), personTable.ADDRESSID), 100),
                     gender:  EnumerationMapping genderEnum: personTable.GENDER,
                     genderFromInt:  EnumerationMapping genderEnum2: personTable.GENDER2,
                     personCode: EnumerationMapping personCodeEnum: personTable.PERSONCODE

--- a/legend-engine-xts-snowflake/legend-engine-xt-snowflake-pure-test/src/main/resources/core_snowflake_test/core_snowflakeapp/tests/testSnowflakeAppGeneration.pure
+++ b/legend-engine-xts-snowflake/legend-engine-xt-snowflake-pure-test/src/main/resources/core_snowflake_test/core_snowflakeapp/tests/testSnowflakeAppGeneration.pure
@@ -337,6 +337,24 @@ function <<test.Test>> meta::external::function::activator::snowflakeApp::tests:
   checkSnowflakeAppGrammar($function, $expected);
 }
 
+function <<test.Test>> {doc.doc = 'Mapping-level add() without collection params must render as arithmetic +, not array_append'}
+meta::external::function::activator::snowflakeApp::tests::testMappingAddWithoutCollectionParams():Boolean[1]
+{
+  // Mapping uses nested add(add(AGE, FIRMID), ADDRESSID) — must stay as arithmetic +
+  let expected = '';
+  let function = ' function : meta::external::function::activator::snowflakeApp::tests::simpleRelationalfunctionWithMappingNestedAdd():TabularDataSet[1];\n';
+  checkSnowflakeAppGrammar($function, $expected);
+}
+
+function <<test.Test>> {doc.doc = 'Nested collection add() must render as nested array_append, not arithmetic +'}
+meta::external::function::activator::snowflakeApp::tests::testNestedCollectionAddRendersAsArrayAppend():Boolean[1]
+{
+  let expected = 'CREATE OR REPLACE SECURE FUNCTION ${catalogSchemaName}.LEGEND_NATIVE_APPS.APP1("myValues" ARRAY) RETURNS TABLE ("FIRSTNAME" VARCHAR,"LASTNAME" VARCHAR,"AGE" INTEGER,"NEWCOL" INTEGER) LANGUAGE SQL AS $$ select "root".FIRSTNAME as "firstName", "root".LASTNAME as "lastName", "root".AGE as "age", array_min(array_append(array_append(array_append(myValues, "root".AGE), 100), 50)) as "newCol" from personTable as "root" $$;';
+
+  let function = ' function : meta::external::function::activator::snowflakeApp::tests::simpleRelationalfunctionWithNestedCollectionAdd(Integer[*]):TabularDataSet[1];\n';
+
+  checkSnowflakeAppGrammar($function, $expected);
+}
 
 function <<test.Test>> meta::external::function::activator::snowflakeApp::tests::testSimpleRelationalfunctionWithMultipleCollectionParamsInFilter():Boolean[1]
 {
@@ -618,8 +636,15 @@ function meta::external::function::activator::snowflakeApp::tests::simpleRelatio
 
 function meta::external::function::activator::snowflakeApp::tests::simpleRelationalfunctionWithCollectionParamsUsingAddInExtend(myValues: Integer[*]):TabularDataSet[1]
 {
-  PersonX.all()->project([col(p|$p.firstName, 'firstName'), col(p|$p.lastName, 'lastName'), col(p|$p.age, 'age')])
-  ->extend(col(x:TDSRow[1] | $myValues->add($x.getInteger('age')->toOne())->least(), 'newCol'))
+    PersonX.all()->project([col(p|$p.firstName, 'firstName'), col(p|$p.lastName, 'lastName'), col(p|$p.age, 'age')])
+    ->extend(col(x:TDSRow[1] | $myValues->add($x.getInteger('age')->toOne())->least(), 'newCol'))
+    ->from(simpleRelationalMapping, testRuntime(dbInc))
+}
+
+function meta::external::function::activator::snowflakeApp::tests::simpleRelationalfunctionWithNestedCollectionAdd(myValues: Integer[*]):TabularDataSet[1]
+{
+    PersonX.all()->project([col(p|$p.firstName, 'firstName'), col(p|$p.lastName, 'lastName'), col(p|$p.age, 'age')])
+    ->extend(col(x:TDSRow[1] | add(add(add($myValues, $x.getInteger('age')->toOne()), 100), 50)->least(), 'newCol'))
     ->from(simpleRelationalMapping, testRuntime(dbInc))
 }
 
@@ -676,6 +701,12 @@ function meta::external::function::activator::snowflakeApp::tests::simpleRelatio
 function meta::external::function::activator::snowflakeApp::tests::simpleRelationalfunctionWithCollectionParams_NestedFunctionWithCollectionParams(myValues: Integer[*]):TabularDataSet[1]
 {
     PersonX.all()->filter(p| $p.age->toOne() > least(sort($myValues))->toOne())->project([col(p|$p.firstName, 'firstName'), col(p|$p.lastName, 'lastName'), col(p|$p.age, 'age')])
+    ->from(simpleRelationalMapping, testRuntime(dbInc))
+}
+
+function meta::external::function::activator::snowflakeApp::tests::simpleRelationalfunctionWithMappingNestedAdd():TabularDataSet[1]
+{
+    PersonX.all()->project([col(p|$p.ageSum, 'ageSum')])
     ->from(simpleRelationalMapping, testRuntime(dbInc))
 }
 

--- a/legend-engine-xts-snowflake/legend-engine-xt-snowflake-pure-test/src/main/resources/core_snowflake_test/core_snowflakeapp/tests/testSnowflakeAppGeneration.pure
+++ b/legend-engine-xts-snowflake/legend-engine-xt-snowflake-pure-test/src/main/resources/core_snowflake_test/core_snowflakeapp/tests/testSnowflakeAppGeneration.pure
@@ -341,7 +341,7 @@ function <<test.Test>> {doc.doc = 'Mapping-level add() without collection params
 meta::external::function::activator::snowflakeApp::tests::testMappingAddWithoutCollectionParams():Boolean[1]
 {
   // Mapping uses nested add(add(AGE, FIRMID), ADDRESSID) — must stay as arithmetic +
-  let expected = '';
+  let expected = 'CREATE OR REPLACE SECURE FUNCTION ${catalogSchemaName}.LEGEND_NATIVE_APPS.APP1() RETURNS TABLE ("AGESUM" INTEGER) LANGUAGE SQL AS $$ select ((("root".AGE + "root".FIRMID) + "root".ADDRESSID) + 100) as "ageSum" from personTable as "root" $$;';
   let function = ' function : meta::external::function::activator::snowflakeApp::tests::simpleRelationalfunctionWithMappingNestedAdd():TabularDataSet[1];\n';
   checkSnowflakeAppGrammar($function, $expected);
 }

--- a/legend-engine-xts-snowflake/legend-engine-xt-snowflake-pure/src/main/resources/core_snowflake/core_snowflakeapp/showcase/showcaseModel.pure
+++ b/legend-engine-xts-snowflake/legend-engine-xt-snowflake-pure/src/main/resources/core_snowflake/core_snowflakeapp/showcase/showcaseModel.pure
@@ -18,7 +18,8 @@ Class meta::external::function::activator::snowflakeApp::tests::model::simple::P
     gender: Gender[0..1];
     genderFromInt: Gender[0..1];
     age : Integer[0..1];
-    nickName : String[0..1];    
+    ageSum : Integer[0..1];
+    nickName : String[0..1];  
     activeEmployment: Boolean[0..1];
     lastUpdated: DateTime[0..1];
     personCode: PersonCode[0..1];
@@ -92,6 +93,7 @@ Mapping meta::external::function::activator::snowflakeApp::tests::simpleRelation
                 (
                     firstName : personTable.FIRSTNAME,
                     age : personTable.AGE,
+                    ageSum : add(add(add(personTable.AGE, personTable.FIRMID), personTable.ADDRESSID), 100),
                     gender:  EnumerationMapping genderEnum: personTable.GENDER,
                     genderFromInt:  EnumerationMapping genderEnum2: personTable.GENDER2,
                     personCode: EnumerationMapping personCodeEnum: personTable.PERSONCODE,


### PR DESCRIPTION
#### What type of PR is this?

<!--
Choose one of the following labels :
- Improvement
- Bug Fix
-->

#### What does this PR do / why is it needed ?

<!--
Describe change being introduced by this PR.
-->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
When derived properties are defined using nested add() statements like add(add(a,b),c), udtf generation incorrectly generated array_append(array_append(a,b),c). This fix enables it to correctly generate ((a+b)+c) while maintaining that add(add([a,b],c),d) generates array_append(array_append([a,b],c),d).

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
