### PR TITLE
Colspec - handle clash with constraint grammar 

### DIFF
--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-grammar/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/domain/DomainLexerGrammar.g4
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-grammar/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/domain/DomainLexerGrammar.g4
@@ -19,11 +19,13 @@ EXTENDS:                                    'extends';
 STEREOTYPES:                                'stereotypes';
 TAGS:                                       'tags';
 
-CONSTRAINT_OWNER:                           '~owner';
-CONSTRAINT_EXTERNAL_ID:                     '~externalId';
-CONSTRAINT_FUNCTION:                        '~function';
-CONSTRAINT_MESSAGE:                         '~message';
-CONSTRAINT_ENFORCEMENT:                     '~enforcementLevel';
+
+CONSTRAINT_OWNER:                           '~owner'            [ \t\r\n]* ':';
+CONSTRAINT_EXTERNAL_ID:                     '~externalId'       [ \t\r\n]* ':';
+CONSTRAINT_FUNCTION:                        '~function'         [ \t\r\n]* ':';
+CONSTRAINT_MESSAGE:                         '~message'          [ \t\r\n]* ':';
+CONSTRAINT_ENFORCEMENT:                     '~enforcementLevel' [ \t\r\n]* ':';
+
 CONSTRAINT_ENFORCEMENT_LEVEL_ERROR:         'Error';
 CONSTRAINT_ENFORCEMENT_LEVEL_WARN:          'Warn';
 

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-grammar/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/domain/DomainLexerGrammar.g4
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-grammar/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/domain/DomainLexerGrammar.g4
@@ -20,11 +20,11 @@ STEREOTYPES:                                'stereotypes';
 TAGS:                                       'tags';
 
 
-CONSTRAINT_OWNER:                           '~owner'            [ \t\r\n]* ':';
-CONSTRAINT_EXTERNAL_ID:                     '~externalId'       [ \t\r\n]* ':';
-CONSTRAINT_FUNCTION:                        '~function'         [ \t\r\n]* ':';
-CONSTRAINT_MESSAGE:                         '~message'          [ \t\r\n]* ':';
-CONSTRAINT_ENFORCEMENT:                     '~enforcementLevel' [ \t\r\n]* ':';
+CONSTRAINT_OWNER:                           '~owner'            CONSTRAINT_SEPARATOR;
+CONSTRAINT_EXTERNAL_ID:                     '~externalId'       CONSTRAINT_SEPARATOR;
+CONSTRAINT_FUNCTION:                        '~function'         CONSTRAINT_SEPARATOR;
+CONSTRAINT_MESSAGE:                         '~message'          CONSTRAINT_SEPARATOR;
+CONSTRAINT_ENFORCEMENT:                     '~enforcementLevel' CONSTRAINT_SEPARATOR;
 
 CONSTRAINT_ENFORCEMENT_LEVEL_ERROR:         'Error';
 CONSTRAINT_ENFORCEMENT_LEVEL_WARN:          'Warn';
@@ -37,3 +37,5 @@ AS:                                         'as';
 AGGREGATION_TYPE_COMPOSITE:                 'composite';
 AGGREGATION_TYPE_SHARED:                    'shared';
 AGGREGATION_TYPE_NONE:                      'none';
+
+fragment CONSTRAINT_SEPARATOR:              Whitespace? COLON;

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-grammar/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/domain/DomainParserGrammar.g4
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-grammar/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/domain/DomainParserGrammar.g4
@@ -211,17 +211,17 @@ complexConstraint:                              identifier
                                                         constraintMessage?
                                                     PAREN_CLOSE
 ;
-constraintOwner:                                CONSTRAINT_OWNER COLON identifier
+constraintOwner:                                CONSTRAINT_OWNER identifier
 ;
-constraintExternalId:                           CONSTRAINT_EXTERNAL_ID COLON STRING
+constraintExternalId:                           CONSTRAINT_EXTERNAL_ID STRING
 ;
-constraintFunction:                             CONSTRAINT_FUNCTION COLON combinedExpression
+constraintFunction:                             CONSTRAINT_FUNCTION combinedExpression
 ;
-constraintEnforcementLevel:                     CONSTRAINT_ENFORCEMENT COLON constraintEnforcementLevelType
+constraintEnforcementLevel:                     CONSTRAINT_ENFORCEMENT constraintEnforcementLevelType
 ;
 constraintEnforcementLevelType:                 CONSTRAINT_ENFORCEMENT_LEVEL_ERROR | CONSTRAINT_ENFORCEMENT_LEVEL_WARN
 ;
-constraintMessage:                              CONSTRAINT_MESSAGE COLON combinedExpression
+constraintMessage:                              CONSTRAINT_MESSAGE combinedExpression
 ;
 constraintId:                                   identifier COLON
 ;

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/parser/TestDomainGrammarParser.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/parser/TestDomainGrammarParser.java
@@ -219,4 +219,23 @@ public class TestDomainGrammarParser extends TestGrammarParser.TestGrammarParser
                 "  }#;\n" +
                 "}\n", "PARSER error at [6:29-10:4]: Unsupported embedded data type for function test assertion: Unsupported. Only 'Relation' is supported.");
     }
+
+    @Test
+    public void testConstraints()
+    {
+        //tests different whitespacing after the constraint param
+        test("Class my::TestClass\n" +
+                "[\n" +
+                "  myConstraint\n" +
+                "  (\n" +
+                "    ~owner\n: abc\n" +
+                "    ~externalId\t:'abc'\n" +
+                "    ~function: eq($this.var2 / $this.var1, $this.var4 / $this.var3)\n" +
+                "    ~enforcementLevel : Error\n" +
+                "  )\n" +
+                "]\n" +
+                "{\n" +
+                "  var1: Float[1];\n" +
+                "}\n");
+    }
 }

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/TestDomainGrammarRoundtrip.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/roundtrip/TestDomainGrammarRoundtrip.java
@@ -562,6 +562,24 @@ public class TestDomainGrammarRoundtrip extends TestGrammarRoundtrip.TestGrammar
     }
 
     @Test
+    public void testColSpecsWithPotentialClashes()
+    {
+        test("function withPath::f(s: Integer[1]): String[1]\n" +
+                "{\n" +
+                "  ~owner_abc:String;\n" +
+                "  ~function_abc:String;\n" +
+                "  ~message_abc:String;\n" +
+                "  ~enforcementLevel_abc:String;\n" +
+                "  ~externalId_abc:String;\n" +
+                "  ~owner;\n" +
+                "  ~function;\n" +
+                "  ~message;\n" +
+                "  ~enforcementLevel;\n" +
+                "  ~externalId;\n" +
+                "}\n");
+    }
+
+    @Test
     public void testTypeArgumentsAreBackwardCompatibleForOldProtocolMissingIt() throws JsonProcessingException
     {
         testComposedGrammar("{\n" +


### PR DESCRIPTION
#### What type of PR is this?
Bug Fix

#### What does this PR do / why is it needed ?
currently there are clashes whenever a colspec is specified where the name clashes with the constraint grammar a colspec of \~owner_abc would fail to parse

this change mostly fixes this in that you can now specify any colspec with these reserved words \~owner or \~owner:String but it would not currently cover the case where the colspec exactly matches the reserved word with a type specified e.g \~owner:String

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
