### PR TITLE
Add Subseconds Precision on Freemarkers

### DIFF
--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-executionPlan-execution/legend-engine-executionPlan-execution/src/main/java/org/finos/legend/engine/plan/execution/result/freemarker/PlanDateParameterDateFormat.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-executionPlan-execution/legend-engine-executionPlan-execution/src/main/java/org/finos/legend/engine/plan/execution/result/freemarker/PlanDateParameterDateFormat.java
@@ -30,7 +30,9 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoField;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -60,15 +62,63 @@ public class PlanDateParameterDateFormat extends TemplateDateFormat
         boolean performTzConversion;
         public boolean hasSubSecond;
         private final String datePattern;
+        private final String basePattern;
 
         PlanDateParameterFormatter(String datePattern, boolean isDateTime, boolean hasTimeOffset, boolean performTzConversion, boolean hasSubSecond)
         {
             this.isDateTime = isDateTime;
             this.hasTimeOffset = hasTimeOffset;
-            this.dateFormatter = DateTimeFormatter.ofPattern(datePattern);
-            this.performTzConversion = performTzConversion;
             this.hasSubSecond = hasSubSecond;
             this.datePattern = datePattern;
+            this.basePattern = hasSubSecond ? datePattern.substring(0, datePattern.indexOf(".SSS")) : datePattern;
+            this.dateFormatter = hasSubSecond ? buildSubSecondFormatter(this.basePattern, hasTimeOffset) : DateTimeFormatter.ofPattern(datePattern);
+            this.performTzConversion = performTzConversion;
+        }
+
+        private static DateTimeFormatter buildSubSecondFormatter(String basePattern, boolean hasTimeOffset)
+        {
+            // Accept 1-9 fractional-second digits (milliseconds, microseconds, nanoseconds) rather than the
+            // fixed 3-digit '.SSS' pattern, which rejects e.g. microsecond precision such as '.000000'.
+            DateTimeFormatterBuilder builder = new DateTimeFormatterBuilder()
+                    .appendPattern(basePattern)
+                    .appendFraction(ChronoField.NANO_OF_SECOND, 1, 9, true);
+            if (hasTimeOffset)
+            {
+                builder.appendPattern("Z");
+            }
+            return builder.toFormatter();
+        }
+
+        /**
+         * Builds an output formatter that preserves the fractional-second precision of the original date string.
+         * For example, if the input had 6 fractional digits (".000000"), the output formatter will always emit
+         * exactly 6 fractional digits, rather than trimming trailing zeros down to 1 digit.
+         */
+        DateTimeFormatter buildOutputFormatter(String originalDate)
+        {
+            int dotIndex = originalDate.indexOf('.');
+            if (dotIndex < 0)
+            {
+                return this.dateFormatter;
+            }
+            int fracDigits = 0;
+            for (int i = dotIndex + 1; i < originalDate.length() && Character.isDigit(originalDate.charAt(i)); i++)
+            {
+                fracDigits++;
+            }
+            if (fracDigits == 0)
+            {
+                return this.dateFormatter;
+            }
+            int clampedFracDigits = Math.min(Math.max(fracDigits, 1), 9);
+            DateTimeFormatterBuilder builder = new DateTimeFormatterBuilder()
+                    .appendPattern(this.basePattern)
+                    .appendFraction(ChronoField.NANO_OF_SECOND, clampedFracDigits, clampedFracDigits, true);
+            if (this.hasTimeOffset)
+            {
+                builder.appendPattern("Z");
+            }
+            return builder.toFormatter();
         }
 
         public LocalDateTime parse(String date) throws DateTimeParseException
@@ -144,13 +194,16 @@ public class PlanDateParameterDateFormat extends TemplateDateFormat
             try
             {
                 LocalDateTime dateTime = dtf.parse(dateAndTimeZone.date);
+                DateTimeFormatter outputFormatter = dtf.hasSubSecond
+                        ? dtf.buildOutputFormatter(dateAndTimeZone.date)
+                        : dtf.dateFormatter;
                 if (dtf.performTzConversion)
                 {
-                    return new PlanDateParameter(dateTime, dtf.dateFormatter, dateAndTimeZone.tz);
+                    return new PlanDateParameter(dateTime, outputFormatter, dateAndTimeZone.tz);
                 }
                 else
                 {
-                    return new PlanDateParameter(dateTime, dtf.dateFormatter);
+                    return new PlanDateParameter(dateTime, outputFormatter);
                 }
             }
             catch (DateTimeParseException e)

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/freemarker/TestFreemarkerTimeZoneProcessing.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/freemarker/TestFreemarkerTimeZoneProcessing.java
@@ -77,6 +77,133 @@ public class TestFreemarkerTimeZoneProcessing
     }
 
     @Test
+    public void testDateTimeConstantWithMicrosecondTimeZoneConversion() throws Exception
+    {
+        MutableMap<String, Object> freeMarkerDateParameters = Maps.mutable.with("dateParam", "2018-10-15T20:00:00.123456");
+        Assert.assertEquals("2018-10-15T16:00:00.123456", processDateConstantTimeZoneNoConversion("America/New_York", freeMarkerDateParameters));
+        Assert.assertEquals("2018-10-15T20:00:00.123456", processDateConstantTimeZoneNoConversion("GMT", freeMarkerDateParameters));
+        Assert.assertEquals("2018-10-15T20:00:00.123456", processDateConstantTimeZoneNoConversion("UTC", freeMarkerDateParameters));
+    }
+
+    @Test
+    public void testDateTimeConstantWithMicrosecondSpaceSeparatedTimeZoneConversion() throws Exception
+    {
+        MutableMap<String, Object> freeMarkerDateParameters = Maps.mutable.with("dateParam", "2018-10-15 20:00:00.123456");
+        Assert.assertEquals("2018-10-15 16:00:00.123456", processDateConstantTimeZoneNoConversion("America/New_York", freeMarkerDateParameters));
+        Assert.assertEquals("2018-10-15 20:00:00.123456", processDateConstantTimeZoneNoConversion("GMT", freeMarkerDateParameters));
+        Assert.assertEquals("2018-10-15 20:00:00.123456", processDateConstantTimeZoneNoConversion("UTC", freeMarkerDateParameters));
+    }
+
+    @Test
+    public void testDateTimeConstantWithMicrosecondZerosTimeZoneConversion() throws Exception
+    {
+        MutableMap<String, Object> spaceSeparated = Maps.mutable.with("dateParam", "2026-07-06 23:59:59.000000");
+        Assert.assertEquals("2026-07-06 19:59:59.000000", processDateConstantTimeZoneNoConversion("America/New_York", spaceSeparated));
+        Assert.assertEquals("2026-07-06 23:59:59.000000", processDateConstantTimeZoneNoConversion("GMT", spaceSeparated));
+        Assert.assertEquals("2026-07-06 23:59:59.000000", processDateConstantTimeZoneNoConversion("UTC", spaceSeparated));
+
+        MutableMap<String, Object> tSeparated = Maps.mutable.with("dateParam", "2026-07-06T23:59:59.000000");
+        Assert.assertEquals("2026-07-06T19:59:59.000000", processDateConstantTimeZoneNoConversion("America/New_York", tSeparated));
+        Assert.assertEquals("2026-07-06T23:59:59.000000", processDateConstantTimeZoneNoConversion("GMT", tSeparated));
+        Assert.assertEquals("2026-07-06T23:59:59.000000", processDateConstantTimeZoneNoConversion("UTC", tSeparated));
+    }
+
+    // In TestFreemarkerTimeZoneProcessing.java
+    @Test
+    public void testDateTimeConstantWithMicrosecondsTimeZoneConversion() throws Exception
+    {
+        MutableMap<String, Object> freeMarkerDateParameters = Maps.mutable.with("dateParam", "2026-07-06 23:59:59.000000");
+        // These assertions capture the desired post-fix behavior.
+        // Before the fix, the call throws IllegalArgumentException (reproduces the bug).
+        Assert.assertEquals("2026-07-06 23:59:59.000000", processDateConstantTimeZoneNoConversion("GMT", freeMarkerDateParameters));
+        Assert.assertEquals("2026-07-06 23:59:59.000000", processDateConstantTimeZoneNoConversion("UTC", freeMarkerDateParameters));
+    }
+
+    @Test
+    public void testDateTimeConstantWith2SubSecondsTimeZoneConversion() throws Exception
+    {
+        MutableMap<String, Object> tSeparated = Maps.mutable.with("dateParam", "2018-10-15T20:00:00.12");
+        Assert.assertEquals("2018-10-15T16:00:00.12", processDateConstantTimeZoneNoConversion("America/New_York", tSeparated));
+        Assert.assertEquals("2018-10-15T20:00:00.12", processDateConstantTimeZoneNoConversion("GMT", tSeparated));
+        Assert.assertEquals("2018-10-15T20:00:00.12", processDateConstantTimeZoneNoConversion("UTC", tSeparated));
+
+        MutableMap<String, Object> zeros = Maps.mutable.with("dateParam", "2026-07-06T23:59:59.00");
+        Assert.assertEquals("2026-07-06T19:59:59.00", processDateConstantTimeZoneNoConversion("America/New_York", zeros));
+        Assert.assertEquals("2026-07-06T23:59:59.00", processDateConstantTimeZoneNoConversion("GMT", zeros));
+        Assert.assertEquals("2026-07-06T23:59:59.00", processDateConstantTimeZoneNoConversion("UTC", zeros));
+    }
+
+    @Test
+    public void testDateTimeConstantWith4SubSecondsTimeZoneConversion() throws Exception
+    {
+        MutableMap<String, Object> tSeparated = Maps.mutable.with("dateParam", "2018-10-15T20:00:00.1234");
+        Assert.assertEquals("2018-10-15T16:00:00.1234", processDateConstantTimeZoneNoConversion("America/New_York", tSeparated));
+        Assert.assertEquals("2018-10-15T20:00:00.1234", processDateConstantTimeZoneNoConversion("GMT", tSeparated));
+        Assert.assertEquals("2018-10-15T20:00:00.1234", processDateConstantTimeZoneNoConversion("UTC", tSeparated));
+
+        MutableMap<String, Object> zeros = Maps.mutable.with("dateParam", "2026-07-06T23:59:59.0000");
+        Assert.assertEquals("2026-07-06T19:59:59.0000", processDateConstantTimeZoneNoConversion("America/New_York", zeros));
+        Assert.assertEquals("2026-07-06T23:59:59.0000", processDateConstantTimeZoneNoConversion("GMT", zeros));
+        Assert.assertEquals("2026-07-06T23:59:59.0000", processDateConstantTimeZoneNoConversion("UTC", zeros));
+    }
+
+    @Test
+    public void testDateTimeConstantWith5SubSecondsTimeZoneConversion() throws Exception
+    {
+        MutableMap<String, Object> tSeparated = Maps.mutable.with("dateParam", "2018-10-15T20:00:00.12345");
+        Assert.assertEquals("2018-10-15T16:00:00.12345", processDateConstantTimeZoneNoConversion("America/New_York", tSeparated));
+        Assert.assertEquals("2018-10-15T20:00:00.12345", processDateConstantTimeZoneNoConversion("GMT", tSeparated));
+        Assert.assertEquals("2018-10-15T20:00:00.12345", processDateConstantTimeZoneNoConversion("UTC", tSeparated));
+
+        MutableMap<String, Object> zeros = Maps.mutable.with("dateParam", "2026-07-06T23:59:59.00000");
+        Assert.assertEquals("2026-07-06T19:59:59.00000", processDateConstantTimeZoneNoConversion("America/New_York", zeros));
+        Assert.assertEquals("2026-07-06T23:59:59.00000", processDateConstantTimeZoneNoConversion("GMT", zeros));
+        Assert.assertEquals("2026-07-06T23:59:59.00000", processDateConstantTimeZoneNoConversion("UTC", zeros));
+    }
+
+    @Test
+    public void testDateTimeConstantWith7SubSecondsTimeZoneConversion() throws Exception
+    {
+        MutableMap<String, Object> tSeparated = Maps.mutable.with("dateParam", "2018-10-15T20:00:00.1234567");
+        Assert.assertEquals("2018-10-15T16:00:00.1234567", processDateConstantTimeZoneNoConversion("America/New_York", tSeparated));
+        Assert.assertEquals("2018-10-15T20:00:00.1234567", processDateConstantTimeZoneNoConversion("GMT", tSeparated));
+        Assert.assertEquals("2018-10-15T20:00:00.1234567", processDateConstantTimeZoneNoConversion("UTC", tSeparated));
+
+        MutableMap<String, Object> zeros = Maps.mutable.with("dateParam", "2026-07-06T23:59:59.0000000");
+        Assert.assertEquals("2026-07-06T19:59:59.0000000", processDateConstantTimeZoneNoConversion("America/New_York", zeros));
+        Assert.assertEquals("2026-07-06T23:59:59.0000000", processDateConstantTimeZoneNoConversion("GMT", zeros));
+        Assert.assertEquals("2026-07-06T23:59:59.0000000", processDateConstantTimeZoneNoConversion("UTC", zeros));
+    }
+
+    @Test
+    public void testDateTimeConstantWith8SubSecondsTimeZoneConversion() throws Exception
+    {
+        MutableMap<String, Object> tSeparated = Maps.mutable.with("dateParam", "2018-10-15T20:00:00.12345678");
+        Assert.assertEquals("2018-10-15T16:00:00.12345678", processDateConstantTimeZoneNoConversion("America/New_York", tSeparated));
+        Assert.assertEquals("2018-10-15T20:00:00.12345678", processDateConstantTimeZoneNoConversion("GMT", tSeparated));
+        Assert.assertEquals("2018-10-15T20:00:00.12345678", processDateConstantTimeZoneNoConversion("UTC", tSeparated));
+
+        MutableMap<String, Object> zeros = Maps.mutable.with("dateParam", "2026-07-06T23:59:59.00000000");
+        Assert.assertEquals("2026-07-06T19:59:59.00000000", processDateConstantTimeZoneNoConversion("America/New_York", zeros));
+        Assert.assertEquals("2026-07-06T23:59:59.00000000", processDateConstantTimeZoneNoConversion("GMT", zeros));
+        Assert.assertEquals("2026-07-06T23:59:59.00000000", processDateConstantTimeZoneNoConversion("UTC", zeros));
+    }
+
+    @Test
+    public void testDateTimeConstantWith9SubSecondsTimeZoneConversion() throws Exception
+    {
+        MutableMap<String, Object> tSeparated = Maps.mutable.with("dateParam", "2018-10-15T20:00:00.123456789");
+        Assert.assertEquals("2018-10-15T16:00:00.123456789", processDateConstantTimeZoneNoConversion("America/New_York", tSeparated));
+        Assert.assertEquals("2018-10-15T20:00:00.123456789", processDateConstantTimeZoneNoConversion("GMT", tSeparated));
+        Assert.assertEquals("2018-10-15T20:00:00.123456789", processDateConstantTimeZoneNoConversion("UTC", tSeparated));
+
+        MutableMap<String, Object> zeros = Maps.mutable.with("dateParam", "2026-07-06T23:59:59.000000000");
+        Assert.assertEquals("2026-07-06T19:59:59.000000000", processDateConstantTimeZoneNoConversion("America/New_York", zeros));
+        Assert.assertEquals("2026-07-06T23:59:59.000000000", processDateConstantTimeZoneNoConversion("GMT", zeros));
+        Assert.assertEquals("2026-07-06T23:59:59.000000000", processDateConstantTimeZoneNoConversion("UTC", zeros));
+    }
+
+    @Test
     public void testConstantDateCollectionTimeZoneNoConversion() throws Exception
     {
         MutableMap<String, Object> freeMarkerDateParameters = Maps.mutable.with("dateParam", Lists.mutable.with("2018-10-15", "2018-10-16"));


### PR DESCRIPTION
#### What type of PR is this?

<!--
Choose one of the following labels :
- Improvement
- Bug Fix
-->
- Bug Fix

#### What does this PR do / why is it needed ?
Adds a fix to allow milliseconds of up to 9 digit precision.
<!--
Describe change being introduced by this PR.
-->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
