### PR TITLE
Fix SemiStructuredArrayFlattenOutput match failures in join, subquery, , concatenate, and type inference paths

### DIFF
--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-h2/legend-engine-xt-relationalStore-h2-PCT/src/main/resources/pct-manifests/relational-h2/RelationFunctions_manifest.json
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-h2/legend-engine-xt-relationalStore-h2-PCT/src/main/resources/pct-manifests/relational-h2/RelationFunctions_manifest.json
@@ -62,7 +62,7 @@
     "expectedError" : "Execution error at (resource:/core_relational/relational/sqlDialectTranslation/toPostgresModel.pure line:264 column:54), \"Couldn't find DynaFunction to Postgres model translation for keys().\""
   }, {
     "test" : "meta::pure::functions::relation::tests::composition::testVariantMapColumn_values_LateralFlatten_Function_1__Boolean_1_",
-    "expectedError" : "Execution error at (resource:/core_relational/relational/pureToSQLQuery/pureToSQLQuery.pure line:9196 column:71), \"Expected one table alias column in operation\""
+    "expectedError" : "Execution error at (resource:/core_relational/relational/pureToSQLQuery/pureToSQLQuery.pure line:9203 column:71), \"Expected one table alias column in operation\""
   }, {
     "test" : "meta::pure::functions::relation::tests::composition::test_Extend_Filter_Select_ComplexGroupBy_Pivot_Function_1__Boolean_1_",
     "expectedError" : "Dialect translation for node of type \"meta::external::query::sql::metamodel::extension::PivotedRelation\" not implemented in SqlDialect for database type \"H2\""

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery.pure
@@ -1188,7 +1188,7 @@ function meta::relational::functions::pureToSqlQuery::buildCorrelatedSubQuery(se
                              data= ^RootJoinTreeNode(alias = $child.alias, childrenData=$child.childrenData)
                            ),
                           |let q = $child.alias.relationalElement->cast(@SelectSQLQuery);
-                           ^$q(columns=$q.columns->map(c|$c->match([a:Alias[1]|$a, t:TableAliasColumn[1]|^Alias(name=$t.column.name, relationalElement=$t)])));
+                           ^$q(columns=$q.columns->map(c|$c->match([a:Alias[1]|$a, t:TableAliasColumn[1]|^Alias(name=$t.column.name, relationalElement=$t), s:SemiStructuredArrayFlattenOutput[1]|let colName = $s->extractColumnName(); ^Alias(name = $colName, relationalElement = $s);])));
                       );
 
    let targetAlias = if($child.alias.relationalElement->instanceOf(SelectSQLQuery),|$child.alias, |^TableAlias(name=$child.alias.name, relationalElement=$nestedSelect));
@@ -1374,6 +1374,7 @@ function <<access.private>> meta::relational::functions::pureToSqlQuery::extract
                 w:WindowColumn[1]|$w.columnName,
                 tac:TableAliasColumn[1]|$tac.columnName->orElse($tac.column.name),
                 c:Column[1]|$c.name,
+                s:SemiStructuredArrayFlattenOutput[1]|$s.tableAliasColumn.column.name,
                 r:RelationalOperationElement[1]|fail('Extracting column name from ' + $r->type().name->toOne() + ' not supported yet!'); '';
               ]);
 }
@@ -1382,7 +1383,8 @@ function meta::relational::functions::pureToSqlQuery::getNewColumnNameWithAlias(
 {
   let existingColumnCount = $s.columns->map(c | $c->match([
                                                             a: Alias[1] | $a.name->toLower()->stripMatchingQuotes(),
-                                                            t: TableAliasColumn[1] | $t.column.name->toLower()->stripMatchingQuotes()
+                                                            t: TableAliasColumn[1] | $t.column.name->toLower()->stripMatchingQuotes(),
+                                                            s: SemiStructuredArrayFlattenOutput[1] | $s->extractColumnName()->toLower()->stripMatchingQuotes()
                                                           ])
                                             )->filter(c|$c->startsWith($aliasesToUse->toOne().column.name->toLower()->stripMatchingQuotes() + '_'))->size();
   let existingColumnName = $aliasesToUse->toOne().column.name;
@@ -2764,7 +2766,8 @@ function meta::relational::functions::pureToSqlQuery::processConcatenate(f:Funct
           select = ^$firstSel(
                          columns = $transformed.element->cast(@SelectWithCursor).select->at(0).columns
                                       ->map(c|$c->match([a:Alias[1]|^$a(relationalElement=^TableAliasColumn(column=^Column(name=$a.name, type=^meta::relational::metamodel::datatype::Integer()), alias=$rootTable)),
-                                                         t:TableAliasColumn[1]|^$t(alias=$rootTable)
+                                                         t:TableAliasColumn[1]|^$t(alias=$rootTable),
+                                                         s:SemiStructuredArrayFlattenOutput[1]|let colName = $s->extractColumnName(); ^Alias(name = $colName, relationalElement = ^TableAliasColumn(column = ^Column(name = $colName, type = ^meta::relational::metamodel::datatype::SemiStructured()), alias = $rootTable));
                                                         ])),
                          data = $newRoot,
                          savedFilteringOperation = [],
@@ -6859,10 +6862,14 @@ function meta::relational::functions::pureToSqlQuery::switchAliasForColumns(newA
                   ^Alias(
                       name=$als.name,
                       relationalElement=^TableAliasColumn( alias = $newAlias, column = ^Column(name = $als.name, type = ^meta::relational::metamodel::datatype::Integer()))
-                  );
+                  );,
+                s:SemiStructuredArrayFlattenOutput[1] |
+                  ^Alias(name=$als.name, relationalElement=^TableAliasColumn(alias=$newAlias, column=^Column(name = $als.name, type = ^meta::relational::metamodel::datatype::SemiStructured())))
             ]);,
         tac: TableAliasColumn[1] | ^Alias(name=$tac.columnName->orElse($tac.column.name), relationalElement=^$tac(alias =$newAlias)),
-        cn:ColumnName[1] | ^Alias(name=$cn.name, relationalElement=^TableAliasColumn( alias = $newAlias, column = ^Column(name = $cn.name, type = ^meta::relational::metamodel::datatype::Integer())))
+        cn:ColumnName[1] | ^Alias(name=$cn.name, relationalElement=^TableAliasColumn( alias = $newAlias, column = ^Column(name = $cn.name, type = ^meta::relational::metamodel::datatype::Integer()))),
+        s:SemiStructuredArrayFlattenOutput[1] | let colName = $s->extractColumnName();
+                                                ^Alias(name = $colName, relationalElement = ^TableAliasColumn(alias = $newAlias, column = ^Column(name = $colName, type = ^meta::relational::metamodel::datatype::SemiStructured())));
       ]);
    );
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/relationalExtension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/relationalExtension.pure
@@ -181,6 +181,7 @@ function meta::relational::functions::typeInference::inferRelationalType(rop: Re
         assert(!$failOnMatchFailure || $type->isNotEmpty(), 'Fail to find type of semi structure array operand');
         $type->head();,
       fl: meta::relational::metamodel::FoldRelationalLambda[1] | $fl.parameters->at(1).value->inferRelationalType($failOnMatchFailure),
+      s: meta::relational::metamodel::relation::SemiStructuredArrayFlattenOutput[1] | $s.tableAliasColumn.column.type,
       l : Any[1] | if($failOnMatchFailure, | fail('Not supported yet: ' + $l->type()->elementToPath()); ^meta::relational::metamodel::datatype::DataType();, |[]);
    ]);
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/tests/semistructured/model/semiStructuredArrayScalarOperations.legend
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/tests/semistructured/model/semiStructuredArrayScalarOperations.legend
@@ -461,3 +461,78 @@ function flatten::semiStructuredArrayFilterJoinStringsPrefixSuffix(): TabularDat
         col(x | $x.firm.addresses->filter(a | $a.name->startsWith('A1')).name->joinStrings('[', '-', ']'), 'Matching Address Names')
     ])
 }
+
+// ===== Tests for SemiStructuredArrayFlattenOutput in join/subquery code paths =====
+
+// Exercises switchAliasForColumns (inner + outer match) with a basic join containing a primitive String[*] array,
+// plus filter on the flattened array column to validate the alias was remapped correctly.
+function flatten::semiStructuredPrimitiveArrayInJoinWithFilter(): TabularDataSet[1]
+{
+    flatten::model::Person.all()
+    ->project([
+        col(x | $x.firstName, 'First Name'),
+        col(x | $x.lastName, 'Last Name')
+    ])
+    ->join(
+        flatten::model::Person.all()
+        ->project([
+            col(x | $x.firstName, 'First Name Right'),
+            col(x | $x.firm.otherNames, 'Other Names')
+        ]),
+        meta::relational::metamodel::join::JoinType.INNER,
+        {a, b | $a.getString('First Name') == $b.getString('First Name Right')}
+    )
+    ->filter(row | $row.getString('Other Names') == 'O1')
+}
+
+// Exercises buildCorrelatedSubQuery, extractColumnName, getNewColumnNameWithAlias, and switchAliasForColumns.
+function flatten::semiStructuredPrimitiveArrayGroupByAggJoin(): TabularDataSet[1]
+{
+    flatten::model::Person.all()
+    ->groupBy(
+        [x | $x.firstName],
+        [agg(x | $x.lastName, x | $x->count())],
+        ['First Name', 'Name Count']
+    )
+    ->join(
+        flatten::model::Person.all()
+        ->project([
+            col(x | $x.firstName, 'First Name Right'),
+            col(x | $x.firm.otherNames, 'Other Names')
+        ]),
+        meta::relational::metamodel::join::JoinType.INNER,
+        {a, b | $a.getString('First Name') == $b.getString('First Name Right')}
+    )
+}
+
+// Exercises inferRelationalType and the replace DynaFunction type guard when a primitive String[*] array column
+// coexists with a replace() call in the same project.
+function flatten::semiStructuredPrimitiveArrayWithReplace(): TabularDataSet[1]
+{
+    flatten::model::Person.all()
+    ->project([
+        col(x | $x.firstName, 'First Name'),
+        col(x | $x.lastName->replace('i', 'I'), 'Last Name Modified'),
+        col(x | $x.firm.otherNames, 'Other Names')
+    ])
+}
+
+// Exercises processConcatenate column mapping when a SemiStructuredArrayFlattenOutput column
+// appears in a UNION ALL (concatenate) of two TDS results.
+function flatten::semiStructuredPrimitiveArrayConcatenate(): TabularDataSet[1]
+{
+    flatten::model::Person.all()
+    ->filter(x | $x.firstName == 'Peter')
+    ->project([
+        col(x | $x.firstName, 'First Name'),
+        col(x | $x.firm.otherNames, 'Other Names')
+    ])
+    ->concatenate(
+        flatten::model::Person.all()
+        ->filter(x | $x.firstName == 'Fabrice')
+        ->project([
+            col(x | $x.firstName, 'First Name'),
+            col(x | $x.firm.otherNames, 'Other Names')
+        ])
+    )
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/tests/semistructured/testSemiStructuredArrayScalarOperations.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/tests/semistructured/testSemiStructuredArrayScalarOperations.pure
@@ -336,3 +336,85 @@ function <<paramTest.Test>> meta::relational::tests::semistructured::flattening:
     'R3,1,1,GroupA,B3,CREATE,Y3,Unknown,999,Z3,999,L6,2,1,1,1,1\n'
   );
 }
+
+function <<paramTest.Test>> meta::relational::tests::semistructured::flattening::testSemiStructuredPrimitiveArrayInJoinWithFilter(conn: Connection[1]):Boolean[1]
+{
+  // Basic join with primitive String[*] array + filter on the flattened column.
+  // Exercises switchAliasForColumns (inner + outer match arms).
+  arrayScalarExecute($conn,
+    'flatten::semiStructuredPrimitiveArrayInJoinWithFilter__TabularDataSet_1_',
+    'flatten::mapping::H2Mapping',
+    'First Name,Last Name,First Name Right,Other Names\n' +
+    'Anthony,Allen,Anthony,O1\n' +
+    'John,Hill,John,O1\n' +
+    'John,Johnson,John,O1\n' +
+    'John,Hill,John,O1\n' +
+    'John,Johnson,John,O1\n' +
+    'Peter,Smith,Peter,O1\n'
+  );
+}
+
+function <<paramTest.Test>> meta::relational::tests::semistructured::flattening::testSemiStructuredPrimitiveArrayGroupByAggJoin(conn: Connection[1]):Boolean[1]
+{
+  // User's exact pattern: groupBy(agg) -> join with project containing String[*] array.
+  // Exercises buildCorrelatedSubQuery, extractColumnName, getNewColumnNameWithAlias, switchAliasForColumns.
+  arrayScalarExecute($conn,
+    'flatten::semiStructuredPrimitiveArrayGroupByAggJoin__TabularDataSet_1_',
+    'flatten::mapping::H2Mapping',
+    'First Name,Name Count,First Name Right,Other Names\n' +
+    'Anthony,1,Anthony,O1\n' +
+    'Anthony,1,Anthony,O2\n' +
+    'David,1,David,O5\n' +
+    'David,1,David,O6\n' +
+    'Fabrice,1,Fabrice,O3\n' +
+    'Fabrice,1,Fabrice,O4\n' +
+    'John,2,John,O1\n' +
+    'John,2,John,O1\n' +
+    'John,2,John,O2\n' +
+    'John,2,John,O2\n' +
+    'Oliver,1,Oliver,O5\n' +
+    'Oliver,1,Oliver,O6\n' +
+    'Peter,1,Peter,O1\n' +
+    'Peter,1,Peter,O2\n'
+  );
+}
+
+function <<paramTest.Test>> meta::relational::tests::semistructured::flattening::testSemiStructuredPrimitiveArrayWithReplace(conn: Connection[1]):Boolean[1]
+{
+  // replace() alongside a primitive String[*] array column in the same project.
+  // Exercises inferRelationalType and the replace DynaFunction type guard.
+  arrayScalarExecute($conn,
+    'flatten::semiStructuredPrimitiveArrayWithReplace__TabularDataSet_1_',
+    'flatten::mapping::H2Mapping',
+    'First Name,Last Name Modified,Other Names\n' +
+    'Anthony,Allen,O1\n' +
+    'Anthony,Allen,O2\n' +
+    'David,HarrIs,O5\n' +
+    'David,HarrIs,O6\n' +
+    'Fabrice,Roberts,O3\n' +
+    'Fabrice,Roberts,O4\n' +
+    'John,HIll,O1\n' +
+    'John,HIll,O2\n' +
+    'John,Johnson,O1\n' +
+    'John,Johnson,O2\n' +
+    'Oliver,HIll,O5\n' +
+    'Oliver,HIll,O6\n' +
+    'Peter,SmIth,O1\n' +
+    'Peter,SmIth,O2\n'
+  );
+}
+
+function <<paramTest.Test>> meta::relational::tests::semistructured::flattening::testSemiStructuredPrimitiveArrayConcatenate(conn: Connection[1]):Boolean[1]
+{
+  // UNION ALL of two TDS results each containing a primitive String[*] array column.
+  // Exercises processConcatenate column mapping for SemiStructuredArrayFlattenOutput.
+  arrayScalarExecute($conn,
+    'flatten::semiStructuredPrimitiveArrayConcatenate__TabularDataSet_1_',
+    'flatten::mapping::H2Mapping',
+    'First Name,Other Names\n' +
+    'Peter,O1\n' +
+    'Peter,O2\n' +
+    'Fabrice,O3\n' +
+    'Fabrice,O4\n'
+  );
+}


### PR DESCRIPTION
When a primitive String[*] array property from a semi-structured JSON column is used in a TDS join, the engine crashes during plan generation with: Match failure: SemiStructuredArrayFlattenOutputObject instanceOf SemiStructuredArrayFlattenOutput

This occurs because SemiStructuredArrayFlattenOutput (the column type produced by LATERAL FLATTEN on primitive arrays) was never added to several match expressions that walk over query columns during join processing, correlated subquery construction, UNION ALL assembly, and type inference.

**Root Cause**
SemiStructuredArrayFlattenOutput is a relatively new column type introduced for LATERAL FLATTEN support on primitive arrays. It was added to some column-walking functions (processColumnsInRelationalOperationElements, reprocessAliases, extractTableAliasColumns) but missed in others that are only reached through the join and concatenate code paths.


#### What type of PR is this?
- Improvement


#### What does this PR do / why is it needed ?

<!--
Describe change being introduced by this PR.
-->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
