### PR TITLE
Fix OOM in reAliasColumnName::replace on shared-DAG unions

### DIFF
--- a/docs/engineering/architecture/router-and-pure-to-sql.md
+++ b/docs/engineering/architecture/router-and-pure-to-sql.md
@@ -371,6 +371,25 @@ After `processQuery` completes, several post-processors are applied:
 - Milestoning post-processors add temporal WHERE clauses.
 - `PostProcessor` chain (registered via `RelationalExecutionContext`) can apply user-defined
   SQL transformations (e.g. add schema prefixes, apply row-level-security policies).
+- Alias-limit column renaming — for dialects that set `aliasLimit` on their `DbExtension`
+  (e.g. Snowflake, see §5.3), `dbSpecificProcessor` runs
+  `meta::relational::postProcessor::reAliasColumnName::trimColumnName`, which shortens any
+  column alias longer than the dialect's limit while preserving output. It runs in two passes:
+  `search` collects the over-long names (computing the limit once via `lengthConfig` — see the
+  performance note below), and `replace` rebuilds the AST with the shortened aliases substituted.
+
+> **Performance note (why `replace` is memoized).** The `SQLQuery` AST is a **DAG, not a tree**:
+> a `Union` of many set-implementations doing many `SemiStructuredPropertyAccess` navigations
+> shares common base operands, so one node is reachable by many paths. A naive recursive rebuild
+> re-materializes each shared node once *per reaching path*, which is exponential in the sharing
+> depth and can exhaust even a large heap. `reAliasColumnName::replace` therefore threads an
+> **identity-keyed cache** (`Map<RelationalOperationElement, RelationalOperationElement>`, mirroring
+> `meta::relational::postProcessor::transform`): each distinct node is rebuilt once and reused by
+> identity, keeping the result a DAG. `search` similarly hoists `lengthConfig` (which builds the
+> full `DbExtension` registry) out of the per-node recursion so it runs once rather than per leaf.
+> If you add another AST-walking post-processor over this graph, follow the same two patterns —
+> memoize by node identity and hoist any per-dialect config lookups — or you will reintroduce the
+> same blow-up. See `trimColumnNamePostProcessor.pure`.
 
 ---
 
@@ -429,6 +448,7 @@ overridden by a dialect's extension implementation:
 | `ddlCommandsTranslator` | — | CREATE TABLE / DROP TABLE / LOAD TABLE DDL |
 | `isBooleanLiteralSupported` | true | Whether `TRUE`/`FALSE` literals are valid |
 | `isDbReservedIdentifier` | empty list | Whether an identifier needs quoting |
+| `aliasLimit` | empty (no limit) | Max column-alias length; when set, triggers the alias-limit column-rename post-processor (§4.6) |
 
 ### 5.4 DynaFunction Dispatch
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-pure/src/main/resources/core_relational_snowflake/relational/tests/testSnowflakePostProcessor.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-pure/src/main/resources/core_relational_snowflake/relational/tests/testSnowflakePostProcessor.pure
@@ -22,6 +22,7 @@ import meta::relational::runtime::*;
 import meta::external::store::relational::runtime::*;
 import meta::relational::metamodel::relation::*;
 import meta::relational::metamodel::*;
+import meta::relational::metamodel::operation::*;
 import meta::relational::tests::postProcessor::*;
 import meta::relational::metamodel::join::*;
 import meta::relational::postProcessor::*;
@@ -38,6 +39,50 @@ function <<test.Test>> meta::relational::tests::postProcessor::snowflake::testSn
    let runtime = ^meta::core::runtime::Runtime(connectionStores = ^meta::core::runtime::ConnectionStore(element = meta::relational::tests::mapping::union::myDB, connection=^meta::external::store::relational::runtime::TestDatabaseConnection(type = DatabaseType.Snowflake)));
    let result = meta::relational::functions::sqlstring::toSQL(|Person.all()->project([p|$p.lastName], ['name']), meta::relational::tests::mapping::union::unionMappingWithLongPropertyMapping, $runtime, meta::relational::extension::relationalExtensions()).sqlQueries->at(0)->cast(@SelectSQLQuery)->meta::relational::postProcessor::reAliasColumnName::trimColumnName($runtime).values->meta::relational::functions::sqlQueryToString::sqlQueryToString(DatabaseType.Snowflake, '', [], meta::relational::extension::relationalExtensions());
    assertEquals('select "unionBase"."concat_thisStringIsThisLongMakeTheGeneratedAliasExplodePastTheDb2limitOf128Characters_concat_ForTestPurposesOnly_PersonSet1lastName_s1_concat_thisStringIsThisLongMakeTheGeneratedAliasExplodePastTheDb2limitOf128Characters____6ce98e09e89aabde27805_0" as "name" from (select "root".ID as "pk_0_0", null as "pk_0_1", concat(\'thisStringIsThisLongMakeTheGeneratedAliasExplodePastTheDb2limitOf128Characters\', concat(\'ForTestPurposesOnly\', "root".lastName_s1)) as "concat_thisStringIsThisLongMakeTheGeneratedAliasExplodePastTheDb2limitOf128Characters_concat_ForTestPurposesOnly_PersonSet1lastName_s1_concat_thisStringIsThisLongMakeTheGeneratedAliasExplodePastTheDb2limitOf128Characters____6ce98e09e89aabde27805_0" from PersonSet1 as "root" UNION ALL select null as "pk_0_0", "root".ID as "pk_0_1", concat(\'thisStringIsThisLongMakeTheGeneratedAliasExplodePastTheDb2limitOf128Characters\', concat(\'ForTestPurposesOnly\', "root".lastName_s2)) as "concat_thisStringIsThisLongMakeTheGeneratedAliasExplodePastTheDb2limitOf128Characters_concat_ForTestPurposesOnly_PersonSet1lastName_s1_concat_thisStringIsThisLongMakeTheGeneratedAliasExplodePastTheDb2limitOf128Characters____6ce98e09e89aabde27805_0" from PersonSet2 as "root") as "unionBase"',$result);
+}
+
+function <<test.Test>> meta::relational::tests::postProcessor::snowflake::testSnowflakeColumnRenameSemiStructuredUnion():Boolean[1]
+{
+   let runtime = ^meta::core::runtime::Runtime(connectionStores = ^meta::core::runtime::ConnectionStore(element = meta::relational::tests::mapping::union::myDB, connection=^meta::external::store::relational::runtime::TestDatabaseConnection(type = DatabaseType.Snowflake)));
+   let query = meta::relational::tests::postProcessor::snowflake::semiStructuredUnionQuery();
+   let result = $query->meta::relational::postProcessor::reAliasColumnName::trimColumnName($runtime).values->meta::relational::functions::sqlQueryToString::sqlQueryToString(DatabaseType.Snowflake, '', [], meta::relational::extension::relationalExtensions());
+   assertEquals('select "unionBase"."firmDetailsSemiStructuredPropertyAliasIntentionallyLongerThanTheSnowflakeAliasLimitToForceRenamingfirmDetailsSemiStructuredPropertyAliasIntentionallyLongerThanTheSnowflakeAliasLimitToForceRenamingfirmDetailsSemiStructuredPropertyAliasIntentional_0" as col0, "unionBase"."firmDetailsSemiStructuredPropertyAliasIntentionallyLongerThanTheSnowflakeAliasLimitToForceRenamingfirmDetailsSemiStructuredPropertyAliasIntentionallyLongerThanTheSnowflakeAliasLimitToForceRenamingfirmDetailsSemiStructuredPropertyAliasIntentional_1" as col1, "unionBase"."firmDetailsSemiStructuredPropertyAliasIntentionallyLongerThanTheSnowflakeAliasLimitToForceRenamingfirmDetailsSemiStructuredPropertyAliasIntentionallyLongerThanTheSnowflakeAliasLimitToForceRenamingfirmDetailsSemiStructuredPropertyAliasIntentional_2" as col2 from (select "root".FIRM_DETAILS[\'firm\'][\'prop0\']::varchar as "firmDetailsSemiStructuredPropertyAliasIntentionallyLongerThanTheSnowflakeAliasLimitToForceRenamingfirmDetailsSemiStructuredPropertyAliasIntentionallyLongerThanTheSnowflakeAliasLimitToForceRenamingfirmDetailsSemiStructuredPropertyAliasIntentional_0", "root".FIRM_DETAILS[\'firm\'][\'prop1\']::varchar as "firmDetailsSemiStructuredPropertyAliasIntentionallyLongerThanTheSnowflakeAliasLimitToForceRenamingfirmDetailsSemiStructuredPropertyAliasIntentionallyLongerThanTheSnowflakeAliasLimitToForceRenamingfirmDetailsSemiStructuredPropertyAliasIntentional_1", "root".FIRM_DETAILS[\'firm\'][\'prop2\']::varchar as "firmDetailsSemiStructuredPropertyAliasIntentionallyLongerThanTheSnowflakeAliasLimitToForceRenamingfirmDetailsSemiStructuredPropertyAliasIntentionallyLongerThanTheSnowflakeAliasLimitToForceRenamingfirmDetailsSemiStructuredPropertyAliasIntentional_2" from PERSON_TABLE_1 as "root" UNION ALL select "root".FIRM_DETAILS[\'firm\'][\'prop0\']::varchar as "firmDetailsSemiStructuredPropertyAliasIntentionallyLongerThanTheSnowflakeAliasLimitToForceRenamingfirmDetailsSemiStructuredPropertyAliasIntentionallyLongerThanTheSnowflakeAliasLimitToForceRenamingfirmDetailsSemiStructuredPropertyAliasIntentional_0", "root".FIRM_DETAILS[\'firm\'][\'prop1\']::varchar as "firmDetailsSemiStructuredPropertyAliasIntentionallyLongerThanTheSnowflakeAliasLimitToForceRenamingfirmDetailsSemiStructuredPropertyAliasIntentionallyLongerThanTheSnowflakeAliasLimitToForceRenamingfirmDetailsSemiStructuredPropertyAliasIntentional_1", "root".FIRM_DETAILS[\'firm\'][\'prop2\']::varchar as "firmDetailsSemiStructuredPropertyAliasIntentionallyLongerThanTheSnowflakeAliasLimitToForceRenamingfirmDetailsSemiStructuredPropertyAliasIntentionallyLongerThanTheSnowflakeAliasLimitToForceRenamingfirmDetailsSemiStructuredPropertyAliasIntentional_2" from PERSON_TABLE_2 as "root") as "unionBase"', $result);
+}
+
+// Builds a Union of set-implementations whose projected columns share a common semi-structured operand, mirroring
+// shape from many SemiStructuredPropertyAccess chains over one VARIANT column
+function <<access.private>> meta::relational::tests::postProcessor::snowflake::semiStructuredUnionQuery():SelectSQLQuery[1]
+{
+   let seg = 'firmDetailsSemiStructuredPropertyAliasIntentionallyLongerThanTheSnowflakeAliasLimitToForceRenaming';
+   let longNames = [0, 1, 2]->map(j | $seg + $seg + $seg + $j->toString());
+   let sub1 = meta::relational::tests::postProcessor::snowflake::semiStructuredUnionBranch('PERSON_TABLE_1', $longNames);
+   let sub2 = meta::relational::tests::postProcessor::snowflake::semiStructuredUnionBranch('PERSON_TABLE_2', $longNames);
+   let union = ^UnionAll(queries = [$sub1, $sub2]);
+   let unionAlias = ^TableAlias(name = 'unionBase', relationalElement = $union);
+   let outerColumns = range($longNames->size())->map(j | ^Alias(name = 'col' + $j->toString(), relationalElement = ^TableAliasColumnName(alias = $unionAlias, columnName = $longNames->at($j))));
+   ^SelectSQLQuery(data = ^RootJoinTreeNode(alias = $unionAlias), columns = $outerColumns);
+}
+
+function <<access.private>> meta::relational::tests::postProcessor::snowflake::semiStructuredUnionBranch(tableName:String[1], longNames:String[*]):SelectSQLQuery[1]
+{
+   let rootAlias = ^TableAlias(name = 'root', relationalElement = ^Table(name = $tableName, schema = ^Schema(name = 'default', database = ^Database(name = 'testDB'))));
+   let variant = ^TableAliasColumn(alias = $rootAlias, column = ^Column(name = 'FIRM_DETAILS', type = ^meta::relational::metamodel::datatype::DataType()));
+   let firm = ^SemiStructuredPropertyAccess(operand = $variant, property = ^Literal(value = 'firm'), avoidCastIfPrimitive = true);
+   let columns = range($longNames->size())->map(j | ^Alias(name = $longNames->at($j), relationalElement = ^SemiStructuredPropertyAccess(operand = $firm, property = ^Literal(value = 'prop' + $j->toString()), returnType = String)));
+   ^SelectSQLQuery(data = ^RootJoinTreeNode(alias = $rootAlias), columns = $columns);
+}
+
+// Regression test for the reAliasColumnName::replace OOM: a 30-node shared DAG (each node referenced twice) reachable
+// by 2^30 paths. Without the identity cache replace re-materializes it per path and OOMs
+function <<test.Test>> meta::relational::tests::postProcessor::snowflake::testReplaceSharedDagMemoization():Boolean[1]
+{
+   let rootAlias = ^TableAlias(name = 'root', relationalElement = ^Table(name = 'PERSON_TABLE_1', schema = ^Schema(name = 'default', database = ^Database(name = 'testDB'))));
+   let variant = ^TableAliasColumn(alias = $rootAlias, column = ^Column(name = 'FIRM_DETAILS', type = ^meta::relational::metamodel::datatype::DataType()));
+   let base = ^SemiStructuredPropertyAccess(operand = $variant, property = ^Literal(value = 'firm'), returnType = String)->cast(@RelationalOperationElement);
+   let expr = range(30)->fold({i, e | ^DynaFunction(name = 'concat', parameters = [$e, $e])->cast(@RelationalOperationElement)}, $base);
+   let result = $expr->meta::relational::postProcessor::reAliasColumnName::replace(^Map<String, String>());
+   assertEquals('concat', $result->cast(@DynaFunction).name);
+   assertEquals(2, $result->cast(@DynaFunction).parameters->size());
 }
 
 function <<test.Test>> meta::relational::tests::postProcessor::snowflake::testPostProcessingOfGroupByAndHavingOp():Boolean[1]

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/postprocessor/defaultPostProcessor/trimColumnNamePostProcessor.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/postprocessor/defaultPostProcessor/trimColumnNamePostProcessor.pure
@@ -62,38 +62,43 @@ function meta::relational::postProcessor::reAliasColumnName::lengthConfig(runtim
 
 function  meta::relational::postProcessor::reAliasColumnName::search(q:RelationalOperationElement[*],runtime:Runtime[1] ): Pair<String,String>[*]
 {
+   $q->search(lengthConfig($runtime));
+}
+
+function  meta::relational::postProcessor::reAliasColumnName::search(q:RelationalOperationElement[*],maxLength:Integer[1] ): Pair<String,String>[*]
+{
    $q->map(r| $r->match([
-                    v:ViewSelectSQLQuery[1]|$v.selectSQLQuery->search($runtime);,
-                    c:CommonTableExpression[1] | $c.sqlQuery->search($runtime),
-                    s:SelectSQLQuery[1] | let dataProcessed = if($s.data->isNotEmpty(), | $s.data->toOne()->search($runtime), | []);
+                    v:ViewSelectSQLQuery[1]|$v.selectSQLQuery->search($maxLength);,
+                    c:CommonTableExpression[1] | $c.sqlQuery->search($maxLength),
+                    s:SelectSQLQuery[1] | let dataProcessed = if($s.data->isNotEmpty(), | $s.data->toOne()->search($maxLength), | []);
                                                                     let cols = $s.columns;
                                                                     let cteSearch = $s.commonTableExpressions->fold({c, res |
-                                                                      $res->concatenate($c->search($runtime));
+                                                                      $res->concatenate($c->search($maxLength));
                                                                       }, []);
-                                                                    $dataProcessed->concatenate($cols->search($runtime))->concatenate($s.filteringOperation->search($runtime))->concatenate($cteSearch);,
+                                                                    $dataProcessed->concatenate($cols->search($maxLength))->concatenate($s.filteringOperation->search($maxLength))->concatenate($cteSearch);,
                      ta:TableAlias[1]| let name = $ta.name; let relElement = $ta.relationalElement;
                                        $relElement->match([t:Table[1]|[],
                                                            tf:TabularFunction[1]|[],
-                                                           u: Union[1]|$u->search($runtime),
-                                                           s: SelectSQLQuery[1]|$s->search($runtime);,
-                                                           s: SemiStructuredArrayFlatten[1]|$s.navigation->search($runtime),
-                                                           s: SemiStructuredArrayFlattenRelation[1]|$s.navigation->search($runtime)
+                                                           u: Union[1]|$u->search($maxLength),
+                                                           s: SelectSQLQuery[1]|$s->search($maxLength);,
+                                                           s: SemiStructuredArrayFlatten[1]|$s.navigation->search($maxLength),
+                                                           s: SemiStructuredArrayFlattenRelation[1]|$s.navigation->search($maxLength)
                                                           ]);,
-                     tac:TableAliasColumn[1]| $tac.column->search($runtime);,
-                     tacn:TableAliasColumnName[1]| getSanitizedAndOriginalNamePair($tacn.columnName, lengthConfig($runtime));,
-                     cn:ColumnName[1]| getSanitizedAndOriginalNamePair($cn.name, lengthConfig($runtime));,
-                     union: Union[1]|$union.queries->search($runtime),
-                     u:UnaryOperation[1]|$u.nested->search($runtime);,
-                     d: DynaFunction[1]| $d.parameters->search($runtime);,
-                     b: BinaryOperation[1] |$b.left->search($runtime)->concatenate($b.right->search($runtime));,
-                     a: Alias[1] | getSanitizedAndOriginalNamePair($a.name, lengthConfig($runtime))->concatenate($a.relationalElement->search($runtime));,
-                     js: JoinStrings[1]| $js.strings->search($runtime)->concatenate($js.prefix->search($runtime))->concatenate($js.suffix->search($runtime))->concatenate($js.separator->search($runtime));,
-                     c: Column[1]| getSanitizedAndOriginalNamePair($c.name, lengthConfig($runtime));,
-                     s:SemiStructuredPropertyAccess[1] | $s.operand->concatenate($s.property)->concatenate($s.index)->search($runtime),
-                     s:SemiStructuredArrayElementAccess[1] | $s.operand->concatenate($s.index)->search($runtime),
-                     s:SemiStructuredArrayFlatten[1] | $s.navigation->search($runtime),
-                     s:SemiStructuredArrayFlattenRelation[1] | $s.navigation->search($runtime),
-                     s:SemiStructuredArrayFlattenOutput[1] | $s.tableAliasColumn->search($runtime),
+                     tac:TableAliasColumn[1]| $tac.column->search($maxLength);,
+                     tacn:TableAliasColumnName[1]| getSanitizedAndOriginalNamePair($tacn.columnName, $maxLength);,
+                     cn:ColumnName[1]| getSanitizedAndOriginalNamePair($cn.name, $maxLength);,
+                     union: Union[1]|$union.queries->search($maxLength),
+                     u:UnaryOperation[1]|$u.nested->search($maxLength);,
+                     d: DynaFunction[1]| $d.parameters->search($maxLength);,
+                     b: BinaryOperation[1] |$b.left->search($maxLength)->concatenate($b.right->search($maxLength));,
+                     a: Alias[1] | getSanitizedAndOriginalNamePair($a.name, $maxLength)->concatenate($a.relationalElement->search($maxLength));,
+                     js: JoinStrings[1]| $js.strings->search($maxLength)->concatenate($js.prefix->search($maxLength))->concatenate($js.suffix->search($maxLength))->concatenate($js.separator->search($maxLength));,
+                     c: Column[1]| getSanitizedAndOriginalNamePair($c.name, $maxLength);,
+                     s:SemiStructuredPropertyAccess[1] | $s.operand->concatenate($s.property)->concatenate($s.index)->search($maxLength),
+                     s:SemiStructuredArrayElementAccess[1] | $s.operand->concatenate($s.index)->search($maxLength),
+                     s:SemiStructuredArrayFlatten[1] | $s.navigation->search($maxLength),
+                     s:SemiStructuredArrayFlattenRelation[1] | $s.navigation->search($maxLength),
+                     s:SemiStructuredArrayFlattenOutput[1] | $s.tableAliasColumn->search($maxLength),
                      any:Any[1]| [];
                    ]);
             );
@@ -116,12 +121,17 @@ function <<access.private>> meta::relational::postProcessor::reAliasColumnName::
 
 function meta::relational::postProcessor::reAliasColumnName::search(q:RelationalTreeNode[*],runtime:Runtime[1]): Pair<String,String>[*]
 {
+    $q->search(lengthConfig($runtime));
+}
+
+function meta::relational::postProcessor::reAliasColumnName::search(q:RelationalTreeNode[*],maxLength:Integer[1]): Pair<String,String>[*]
+{
     $q->map(a|
               let alias =  $a.alias;
               let relElement = $alias.relationalElement;
-              let results = $relElement ->search($runtime)->concatenate($a.childrenData->cast(@JoinTreeNode)->search($runtime))
+              let results = $relElement ->search($maxLength)->concatenate($a.childrenData->cast(@JoinTreeNode)->search($maxLength))
               ->concatenate($a->match([
-                                      j: JoinTreeNode[1]|  $j.join.operation->search($runtime);,
+                                      j: JoinTreeNode[1]|  $j.join.operation->search($maxLength);,
                                       r: RootJoinTreeNode[1]| [];
                                      ])
                            );
@@ -132,72 +142,177 @@ function meta::relational::postProcessor::reAliasColumnName::search(q:Relational
 
 function meta::relational::postProcessor::reAliasColumnName::replace(r:RelationalOperationElement[1], m:Map<String,String>[1]):RelationalOperationElement[1]
 {
-   $r->match([
-               v:VarSetPlaceHolder[1] | $v;,
-               s:SelectSQLQuery[1] | let newS = ^$s( data=if($s.data->isNotEmpty(), | $s.data->toOne()->replace($m), | [])->cast(@RootJoinTreeNode),
-                                                       columns = $s.columns->map(c| $c->replace($m)),
-                                                       extraFilteringOperation = $s.extraFilteringOperation->map(ef|$ef->replace($m)),
-                                                       savedFilteringOperation = $s.savedFilteringOperation->map(sf|pair($sf.first->replace($m), $sf.second->replace($m))),
-                                                       groupBy=$s.groupBy->map(gb|$gb->replace($m)),
-                                                       havingOperation=$s.havingOperation->map(ho|$ho->replace($m)),
-                                                       qualifyOperation=$s.qualifyOperation->map(qo|$qo->replace($m)),
-                                                       orderBy = $s.orderBy->map(ob|$ob->replace($m)),
-                                                       filteringOperation= $s.filteringOperation->map(fo | $fo->replace($m)));
-                                       if(!$newS.leftSideOfFilter->isEmpty(),| ^$newS(leftSideOfFilter=$s.leftSideOfFilter->toOne()->meta::relational::functions::pureToSqlQuery::findOneNode($s.data->toOne(), $newS.data->toOne())),|$newS);,
-
-                v:ViewSelectSQLQuery[1] | ^$v(selectSQLQuery=$v.selectSQLQuery->replace($m)->cast(@SelectSQLQuery));,
-                u:Union[1] |  ^$u(queries = $u.queries->map(q|$q->replace($m);)->cast(@SelectSQLQuery));,
-                ta:TableAlias[1]| ^$ta(relationalElement = $ta.relationalElement->replace($m));,
-                t:Table[1] |  $t;,
-                // TODO: Trying to replace table aliases seems redundant since we are only looking for column names. Even in the search above, we only search the column part. Keeping for now
-                tac:TableAliasColumn[1] | let new = $m->get($tac.alias.name); 
-                                          let alias = $tac.alias;
-                                          let newAlias = if($new->isNotEmpty(), | ^$alias(name = $new->toOne()), | $alias);
-                                          ^$tac(alias = $newAlias, column = $tac.column->replace($m)->cast(@Column));,
-                tacn:TableAliasColumnName[1] |  let newAliasName = $m->get($tacn.alias.name); 
-                                                let alias = $tacn.alias;
-                                                let newAlias = if($newAliasName->isNotEmpty(), | ^$alias(name = $newAliasName->toOne()), | $alias);
-                                                let newColumnName = $m->get($tacn.columnName); 
-                                                ^$tacn(alias = $newAlias, columnName = if($newColumnName->isNotEmpty(), | $newColumnName->toOne(), | $tacn.columnName));,
-                cn:ColumnName[1] |  let new = $m->get($cn.name);
-                                    ^$cn(name = if($new->isNotEmpty(), | $new->toOne(), | $cn.name));,
-                a:Alias[1] | ^$a(name = if($m->get($a.name)->isNotEmpty(),|$m->get($a.name)->toOne(),|$a.name),relationalElement=$a.relationalElement->replace($m));,
-                u:UnaryOperation[1] | ^$u(nested=replace($u.nested, $m));,
-                b:BinaryOperation[1] | ^$b(left=replace($b.left, $m), right=replace($b.right, $m));,
-                roj: RelationalOperationElementWithJoin[1]| ^$roj(relationalOperationElement=$roj.relationalOperationElement->map(r|$r->replace($m)),joinTreeNode=$roj.joinTreeNode->map(j|$j->replace($m))->cast(@JoinTreeNode));,
-                va:VariableArityOperation[1] | ^$va(args=$va.args->map(e | $e->replace($m)));,
-                d:DynaFunction[1] |  ^$d(parameters=$d.parameters->map(p | $p->replace($m)));,
-                wc:WindowColumn[1] |^$wc(window = $wc.window->replace($m)->cast(@meta::relational::metamodel::Window),func=$wc.func->replace($m)->cast(@DynaFunction));,
-                w:meta::relational::metamodel::Window[1]|^$w(partition=$w.partition->map(p|$p->replace($m)), sortBy=$w.sortBy->map(p|^$p(sortByElement = $p.sortByElement->replace($m))));,
-                j:JoinStrings[1] |  ^$j(strings=$j.strings->map(v | $v->replace($m)),
-                                         prefix=if($j.prefix->isEmpty(), | [], | $j.prefix->toOne()->replace($m)),
-                                         separator=if($j.separator->isEmpty(), | [], | $j.separator->toOne()->replace($m)),
-                                         suffix=if($j.suffix->isEmpty(), | [], | $j.suffix->toOne()->replace($m)));,
-                c:Column[1] |let newName = $m->get($c.name); if($newName->isNotEmpty(),|^$c(name = $newName->toOne()),|$c);,
-                s:SemiStructuredPropertyAccess[1] | ^$s(operand = $s.operand->replace($m), property = $s.property->replace($m), index = $s.index->map(i | $i->replace($m))),
-                s:SemiStructuredArrayElementAccess[1] | ^$s(operand = $s.operand->replace($m), index = $s.index->replace($m)),
-                s:SemiStructuredArrayFlatten[1] | ^$s(navigation = $s.navigation->replace($m)),
-                s:SemiStructuredArrayFlattenOutput[1] | ^$s(tableAliasColumn = $s.tableAliasColumn->replace($m)->cast(@TableAliasColumn)),
-                rel: RelationalOperationElement[1] |  $rel;
-              ]);
+   replace($r, $m, ^Map<RelationalOperationElement, RelationalOperationElement>()).first;
 }
 
+// Cache-carrying variant of replace. The relational graph is a DAG, so an identity cache keyed by node avoids
+// re-materializing shared nodes once per reaching path (mirrors meta::relational::postProcessor::transform).
+function meta::relational::postProcessor::reAliasColumnName::replace(r:RelationalOperationElement[1], m:Map<String,String>[1], cache:Map<RelationalOperationElement, RelationalOperationElement>[1]):Pair<RelationalOperationElement, Map<RelationalOperationElement, RelationalOperationElement>>[1]
+{
+   let cached = $cache->get($r);
+   if($cached->isNotEmpty(),
+      | pair($cached->toOne(), $cache),
+      | let result = $r->match([
+               v:VarSetPlaceHolder[1] | pair($v, $cache);,
+               s:SelectSQLQuery[1] | let dataReplaced = $s.data->map(d | $d->replace($m, $cache));
+                                     let newData = $dataReplaced.first->cast(@RootJoinTreeNode);
+                                     let cacheAfterData = if($dataReplaced->isEmpty(), | $cache, | $dataReplaced.second->toOne());
+                                     let columnsResult = $s.columns->replaceList($m, $cacheAfterData);
+                                     let extraFilterResult = $s.extraFilteringOperation->replaceList($m, $columnsResult.second);
+                                     let savedFilterResult = $s.savedFilteringOperation->fold({sf, agg |
+                                        let f = $sf.first->replace($m, $agg.second);
+                                        let s2 = $sf.second->replace($m, $f.second);
+                                        pair(list($agg.first.values->add(pair($f.first, $s2.first))), $s2.second);
+                                     }, pair(^List<Pair<RelationalTreeNode, RelationalOperationElement>>(), $extraFilterResult.second));
+                                     let groupByResult = $s.groupBy->replaceList($m, $savedFilterResult.second);
+                                     let havingResult = $s.havingOperation->replaceList($m, $groupByResult.second);
+                                     let qualifyResult = $s.qualifyOperation->replaceList($m, $havingResult.second);
+                                     let orderByResult = $s.orderBy->fold({ob, agg |
+                                        let o = $ob->replace($m, $agg.second);
+                                        pair(list($agg.first.values->add($o.first)), $o.second);
+                                     }, pair(^List<OrderBy>(), $qualifyResult.second));
+                                     let filterResult = $s.filteringOperation->replaceList($m, $orderByResult.second);
+                                     let newS = ^$s( data=$newData,
+                                                     columns = $columnsResult.first.values,
+                                                     extraFilteringOperation = $extraFilterResult.first.values,
+                                                     savedFilteringOperation = $savedFilterResult.first.values,
+                                                     groupBy=$groupByResult.first.values,
+                                                     havingOperation=$havingResult.first.values,
+                                                     qualifyOperation=$qualifyResult.first.values,
+                                                     orderBy = $orderByResult.first.values,
+                                                     filteringOperation= $filterResult.first.values);
+                                     let finalS = if(!$newS.leftSideOfFilter->isEmpty(),| ^$newS(leftSideOfFilter=$s.leftSideOfFilter->toOne()->meta::relational::functions::pureToSqlQuery::findOneNode($s.data->toOne(), $newS.data->toOne())),|$newS);
+                                     pair($finalS, $filterResult.second);,
+
+                v:ViewSelectSQLQuery[1] | let r = $v.selectSQLQuery->replace($m, $cache);
+                                          pair(^$v(selectSQLQuery=$r.first->cast(@SelectSQLQuery)), $r.second);,
+                u:Union[1] | let r = $u.queries->replaceList($m, $cache);
+                             pair(^$u(queries = $r.first.values->cast(@SelectSQLQuery)), $r.second);,
+                ta:TableAlias[1]| let r = $ta.relationalElement->replace($m, $cache);
+                                  pair(^$ta(relationalElement = $r.first), $r.second);,
+                t:Table[1] |  pair($t, $cache);,
+                // TODO: Trying to replace table aliases seems redundant since we are only looking for column names. Even in the search above, we only search the column part. Keeping for now
+                tac:TableAliasColumn[1] | let new = $m->get($tac.alias.name);
+                                          let alias = $tac.alias;
+                                          let newAlias = if($new->isNotEmpty(), | ^$alias(name = $new->toOne()), | $alias);
+                                          let colResult = $tac.column->replace($m, $cache);
+                                          pair(^$tac(alias = $newAlias, column = $colResult.first->cast(@Column)), $colResult.second);,
+                tacn:TableAliasColumnName[1] |  let newAliasName = $m->get($tacn.alias.name);
+                                                let alias = $tacn.alias;
+                                                let newAlias = if($newAliasName->isNotEmpty(), | ^$alias(name = $newAliasName->toOne()), | $alias);
+                                                let newColumnName = $m->get($tacn.columnName);
+                                                pair(^$tacn(alias = $newAlias, columnName = if($newColumnName->isNotEmpty(), | $newColumnName->toOne(), | $tacn.columnName)), $cache);,
+                cn:ColumnName[1] |  let new = $m->get($cn.name);
+                                    pair(^$cn(name = if($new->isNotEmpty(), | $new->toOne(), | $cn.name)), $cache);,
+                a:Alias[1] | let r = $a.relationalElement->replace($m, $cache);
+                             pair(^$a(name = if($m->get($a.name)->isNotEmpty(),|$m->get($a.name)->toOne(),|$a.name),relationalElement=$r.first), $r.second);,
+                u:UnaryOperation[1] | let r = $u.nested->replace($m, $cache);
+                                      pair(^$u(nested=$r.first), $r.second);,
+                b:BinaryOperation[1] | let l = $b.left->replace($m, $cache);
+                                       let rt = $b.right->replace($m, $l.second);
+                                       pair(^$b(left=$l.first, right=$rt.first), $rt.second);,
+                roj: RelationalOperationElementWithJoin[1]| let afterRoe = if($roj.relationalOperationElement->isEmpty(),
+                                                                              | pair($roj, $cache),
+                                                                              | let r = $roj.relationalOperationElement->toOne()->replace($m, $cache);
+                                                                                pair(^$roj(relationalOperationElement=$r.first), $r.second););
+                                                           let rojRoe = $afterRoe.first;
+                                                           let afterJtn = if($rojRoe.joinTreeNode->isEmpty(),
+                                                                             | pair($rojRoe, $afterRoe.second),
+                                                                             | let j = $rojRoe.joinTreeNode->toOne()->replace($m, $afterRoe.second);
+                                                                               pair(^$rojRoe(joinTreeNode=$j.first->cast(@JoinTreeNode)), $j.second););
+                                                           pair($afterJtn.first, $afterJtn.second);,
+                va:VariableArityOperation[1] | let r = $va.args->replaceList($m, $cache);
+                                               pair(^$va(args=$r.first.values), $r.second);,
+                d:DynaFunction[1] |  let r = $d.parameters->replaceList($m, $cache);
+                                     pair(^$d(parameters=$r.first.values), $r.second);,
+                wc:WindowColumn[1] | let w = $wc.window->replace($m, $cache);
+                                     let f = $wc.func->replace($m, $w.second);
+                                     pair(^$wc(window = $w.first->cast(@meta::relational::metamodel::Window),func=$f.first->cast(@DynaFunction)), $f.second);,
+                w:meta::relational::metamodel::Window[1]| let partResult = $w.partition->replaceList($m, $cache);
+                                                          let sortResult = $w.sortBy->fold({p, agg |
+                                                             let se = $p.sortByElement->replace($m, $agg.second);
+                                                             pair(list($agg.first.values->add(^$p(sortByElement = $se.first))), $se.second);
+                                                          }, pair(^List<meta::relational::metamodel::SortByInfo>(), $partResult.second));
+                                                          pair(^$w(partition=$partResult.first.values, sortBy=$sortResult.first.values), $sortResult.second);,
+                j:JoinStrings[1] |  let stringsResult = $j.strings->replaceList($m, $cache);
+                                    let pfx = $j.prefix->replaceList($m, $stringsResult.second);
+                                    let sep = $j.separator->replaceList($m, $pfx.second);
+                                    let suf = $j.suffix->replaceList($m, $sep.second);
+                                    pair(^$j(strings=$stringsResult.first.values, prefix=$pfx.first.values->first(), separator=$sep.first.values->first(), suffix=$suf.first.values->first()), $suf.second);,
+                c:Column[1] |let newName = $m->get($c.name); pair(if($newName->isNotEmpty(),|^$c(name = $newName->toOne()),|$c), $cache);,
+                s:SemiStructuredPropertyAccess[1] | let op = $s.operand->replace($m, $cache);
+                                                    let prop = $s.property->replace($m, $op.second);
+                                                    if($s.index->isEmpty(),
+                                                       | pair(^$s(operand = $op.first, property = $prop.first), $prop.second),
+                                                       | let i = $s.index->toOne()->replace($m, $prop.second);
+                                                         pair(^$s(operand = $op.first, property = $prop.first, index = $i.first), $i.second););,
+                s:SemiStructuredArrayElementAccess[1] | let op = $s.operand->replace($m, $cache);
+                                                        let i = $s.index->replace($m, $op.second);
+                                                        pair(^$s(operand = $op.first, index = $i.first), $i.second);,
+                s:SemiStructuredArrayFlatten[1] | let n = $s.navigation->replace($m, $cache);
+                                                  pair(^$s(navigation = $n.first), $n.second);,
+                s:SemiStructuredArrayFlattenOutput[1] | let t = $s.tableAliasColumn->replace($m, $cache);
+                                                        pair(^$s(tableAliasColumn = $t.first->cast(@TableAliasColumn)), $t.second);,
+                rel: RelationalOperationElement[1] |  pair($rel, $cache);
+              ]);
+        pair($result.first, $result.second->put($r, $result.first));
+   );
+}
+
+function <<access.private>> meta::relational::postProcessor::reAliasColumnName::replaceList(elements:RelationalOperationElement[*], m:Map<String,String>[1], cache:Map<RelationalOperationElement, RelationalOperationElement>[1]):Pair<List<RelationalOperationElement>, Map<RelationalOperationElement, RelationalOperationElement>>[1]
+{
+   $elements->fold({e, agg |
+      let r = $e->replace($m, $agg.second);
+      pair(list($agg.first.values->add($r.first)), $r.second);
+   }, pair(^List<RelationalOperationElement>(), $cache));
+}
+
+function <<access.private>> meta::relational::postProcessor::reAliasColumnName::replaceChildren(children:TreeNode[*], m:Map<String,String>[1], cache:Map<RelationalOperationElement, RelationalOperationElement>[1]):Pair<List<RelationalTreeNode>, Map<RelationalOperationElement, RelationalOperationElement>>[1]
+{
+   $children->fold({c, agg |
+      let cr = $c->cast(@JoinTreeNode)->replace($m, $agg.second);
+      pair(list($agg.first.values->add($cr.first)), $cr.second);
+   }, pair(^List<RelationalTreeNode>(), $cache));
+}
 
 function meta::relational::postProcessor::reAliasColumnName::replace(o:OrderBy[1],m:Map<String,String>[1]):OrderBy[1]
 {
-     ^$o(column= $o.column->map(c| $c->replace($m)))
+     replace($o, $m, ^Map<RelationalOperationElement, RelationalOperationElement>()).first;
+}
+
+function meta::relational::postProcessor::reAliasColumnName::replace(o:OrderBy[1],m:Map<String,String>[1],cache:Map<RelationalOperationElement, RelationalOperationElement>[1]):Pair<OrderBy, Map<RelationalOperationElement, RelationalOperationElement>>[1]
+{
+     let c = $o.column->replace($m, $cache);
+     pair(^$o(column= $c.first), $c.second);
 }
 
 function meta::relational::postProcessor::reAliasColumnName::replace(r:RelationalTreeNode[1], m:Map<String,String>[1]):RelationalTreeNode[1]
 {
+     replace($r, $m, ^Map<RelationalOperationElement, RelationalOperationElement>()).first;
+}
+
+function meta::relational::postProcessor::reAliasColumnName::replace(r:RelationalTreeNode[1], m:Map<String,String>[1], cache:Map<RelationalOperationElement, RelationalOperationElement>[1]):Pair<RelationalTreeNode, Map<RelationalOperationElement, RelationalOperationElement>>[1]
+{
      $r->match([
                  j:JoinTreeNode[1] |  let join = $j.join;
                                       // TODO: traversing aliases and target is redundant as only childrenData is used for SQL string generation
-                                      let replacedJoin = ^$join(aliases = $join.aliases->map(a|pair(replace($a.first,$m)->cast(@TableAlias), replace($a.second,$m)->cast(@TableAlias))),
-                                                                operation = $join.operation->replace($m)->cast(@Operation),
-                                                                target = if(!$join.target->isEmpty(),|replace($join.target->toOne(),$m)->cast(@TableAlias),|[]));
-                                      ^$j(join=$replacedJoin, alias=$j.alias->replace($m)->cast(@TableAlias), childrenData=$j.childrenData->map(c | $c->cast(@JoinTreeNode)->replace($m)));,
-                 r:RootJoinTreeNode[1] | ^$r(alias=$r.alias->replace($m)->cast(@TableAlias), childrenData=$r.childrenData->map(c | $c->cast(@JoinTreeNode)->replace($m)));
+                                      let aliasesResult = $join.aliases->fold({a, agg |
+                                         let f = replace($a.first, $m, $agg.second);
+                                         let s = replace($a.second, $m, $f.second);
+                                         pair(list($agg.first.values->add(pair($f.first->cast(@TableAlias), $s.first->cast(@TableAlias)))), $s.second);
+                                      }, pair(^List<Pair<TableAlias, TableAlias>>(), $cache));
+                                      let operationResult = $join.operation->replace($m, $aliasesResult.second);
+                                      let joinWithTargetResult = if($join.target->isEmpty(),
+                                                                    | pair(^$join(aliases = $aliasesResult.first.values, operation = $operationResult.first->cast(@Operation)), $operationResult.second),
+                                                                    | let t = replace($join.target->toOne(), $m, $operationResult.second);
+                                                                      pair(^$join(aliases = $aliasesResult.first.values, operation = $operationResult.first->cast(@Operation), target = $t.first->cast(@TableAlias)), $t.second););
+                                      let replacedJoin = $joinWithTargetResult.first;
+                                      let aliasResult = $j.alias->replace($m, $joinWithTargetResult.second);
+                                      let childrenResult = $j.childrenData->replaceChildren($m, $aliasResult.second);
+                                      pair(^$j(join=$replacedJoin, alias=$aliasResult.first->cast(@TableAlias), childrenData=$childrenResult.first.values), $childrenResult.second);,
+                 r:RootJoinTreeNode[1] | let aliasResult = $r.alias->replace($m, $cache);
+                                         let childrenResult = $r.childrenData->replaceChildren($m, $aliasResult.second);
+                                         pair(^$r(alias=$aliasResult.first->cast(@TableAlias), childrenData=$childrenResult.first.values), $childrenResult.second);
               ]);
 }
 


### PR DESCRIPTION
#### What type of PR is this?
- Bug Fix
<!--
Choose one of the following labels :
- Improvement
- Bug Fix
-->

#### What does this PR do / why is it needed ?
The relational SQL AST is a DAG, not a tree: unions of many
set-implementations doing many SemiStructuredPropertyAccess navigations
share common operands, so a node can be reachable by many paths. The
alias-limit column-rename post-processor's replace() rebuilt the AST
recursively without memoization, re-materializing each shared node once
per reaching path — exponential in the sharing depth and able to exhaust
the heap.
Fix by threading an identity-keyed cache (Map<RelationalOperationElement,
RelationalOperationElement>) through replace(), mirroring the existing
pattern in meta::relational::postProcessor::transform, so each distinct
node is rebuilt once and reused by identity. Also hoist lengthConfig()
out of search()'s per-node recursion into a single upfront computation.
<!--
Describe change being introduced by this PR.
-->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
