### PR TITLE
EMIT: add legend-engine-core-emit-tests with core-language and M2M models

### DIFF
--- a/docs/emit/emit-authoring.md
+++ b/docs/emit/emit-authoring.md
@@ -89,8 +89,9 @@ Apply the rule from `emit.md` §3.2:
 
 | Your model uses… | Place it in… |
 |---|---|
-| Only basic types (`class`, `enumeration`, `association`, `function`, constraints) | `legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/` (bootstrap examples for the framework itself — only for true core fixtures) |
-| M2M mapping (no service, no store) | `legend-engine-core/legend-engine-core-emit/legend-engine-emit-m2m` |
+| A fixture whose purpose is to exercise the EMIT runner itself (e.g. a deliberate compile failure, a dependency-clash case) | `legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/test/resources/emit-models/` (bootstrap examples for the framework, several using fake test-only SPIs — not catalog content) |
+| Core Pure language constructs — constraint, measure, profile, qualified property, inheritance, function, association traversal | `legend-engine-core/legend-engine-core-emit-tests`, under `src/test/resources/grammar-emit-models/`, run by `GrammarEMITTests` |
+| M2M mapping (no service, no store) | `legend-engine-core/legend-engine-core-emit-tests`, under `src/test/resources/m2m-emit-models/`, run by `M2MEMITTests` |
 | Relational store / mapping / connection (including embedded service tests) | `legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit`, under `src/test/resources/relational-emit-models/`, run by `RelationalEMITTests` |
 | Relation (`~func`) function-based class mapping — `ClassName: Relation { ~func f():Relation<Any>[1]; ... }` | `legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit`, under `src/test/resources/relation-emit-models/`, run by `RelationEMITTests` |
 | Service / service-test (where the mapping & store are already on the service-emit classpath) | `legend-engine-xts-service/legend-engine-xt-service-emit` |
@@ -415,14 +416,19 @@ discovered — `"emit-models/"` is the convention. Discovery will find
 everything in the root and all its sub-directories, so adding a new
 descriptor is purely a matter of dropping the YAML in.
 
-If your target module already hosts an independently-owned suite for a different feature
-area, don't share its root — give your suite its own disambiguated root name and its own
-`*EMITTests` class, so a failure is attributable to one feature rather than the whole module.
+If your target module hosts more than one subject area, don't share a single root — give each
+subject its own disambiguated root name and its own `*EMITTests` class, so each area can be run
+on its own and a failure is attributable to one subject rather than the whole module.
 `legend-engine-xt-relationalStore-emit` does this: classic relational-mapping models live under
 `relational-emit-models/` (`RelationalEMITTests`), and relation (`~func`) mapping models live
-under `relation-emit-models/` (`RelationEMITTests`). Note the HTML coverage-report caveat in
+under `relation-emit-models/` (`RelationEMITTests`). `legend-engine-core-emit-tests` does the same
+with `grammar-emit-models/` (`GrammarEMITTests`) and `m2m-emit-models/` (`M2MEMITTests`).
+
+Split by **subject**, not by size: the test is whether someone debugging one area would want to
+run it without the other. Note the HTML coverage-report caveat in
 `emit.md` §5.4 — a disambiguated root needs an explicit `includedRelativeSubpaths` entry in the
-consuming pom to show up in that report; plain `emit-models/` roots don't need this.
+consuming pom to show up in that report; plain `emit-models/` roots don't need this. Add the entry
+in the same PR that introduces the root.
 
 `testContainers(...)` returns one `DynamicContainer` per model, named after
 the model, with its tasks grouped by phase: a `Load Model Descriptor` task,
@@ -565,3 +571,38 @@ duplicates:
 - `{A, B, C, D}` tests the full multi-feature composition.
 
 All three provide distinct regression coverage and should all be kept.
+
+### 11.3 Don't Tag a Capability the Fixture Cannot Execute
+
+Some capabilities are only meaningful at run time — a mapping transform, a local
+mapping property, a merge operation. If you cannot make the model *execute* the
+capability, **do not add a fixture that merely parses and compiles it** and tag the
+capability in `features`. Every feature tag is a claim of coverage: it lands in the
+HTML coverage dashboard (`emit.md` §5.4) and in any gap analysis computed from
+descriptor metadata. A tag backed only by successful compilation reports a capability
+as exercised while proving nothing about its behaviour, and a false green is worse
+than an honest gap — it stops anyone from looking again.
+
+Leave the capability untagged and uncovered instead, and say why: in the descriptor of
+whatever related fixture you *are* adding, or in the commit that decides not to add
+one. An honest gap is discoverable; a wrong tag is not.
+
+A worked example. Model-to-model mapping test suites can supply exactly **one** source
+connection: `ModelStoreTestConnectionFactory.buildModelStoreConnectionsForStore`
+returns inside its loop on the first entry, and
+`buildCloseableConnectionFromExternalFormat` installs a single `StreamProviderHolder`
+thread-local stream. So a `ModelStore: ModelStore #{ ClassA: …, ClassB: … }#` block
+silently uses only `ClassA`, and any query whose plan crosses two set implementations
+yields an `InMemoryCrossStoreGraphFetchExecutionNode` whose second store read fails
+with `RuntimeException: Input stream was not provided`. That behaviour is long-standing
+and intentionally left alone — other code depends on its particulars. It means
+`mapping:m2m-local-property` and the two `mapping:operation-mapping-merge*`
+capabilities cannot be proven by any M2M fixture, since each needs two populated
+sources. All three have real, verified grammar; authoring them is easy and would be
+dishonest. They wait for a cross-store fixture where a second store supplies the other
+side.
+
+This is not an argument against parse-and-compile fixtures generally. A fixture whose
+subject *is* the language construct — everything under `grammar-emit-models/` — proves
+exactly what it claims, because there is nothing to execute. The rule is about matching
+the claim to what the fixture actually demonstrates.

--- a/docs/emit/emit.md
+++ b/docs/emit/emit.md
@@ -295,6 +295,18 @@ The parent aggregator sits directly under `legend-engine-core/` (as a sibling of
 pipeline — parsing, compilation, generation, test execution, and plan generation — rather than
 being scoped to the `Testable` metamodel concept alone.
 
+**Everything inside `legend-engine-core-emit/` is framework.** The EMIT models under
+`legend-engine-emit/src/test/resources/emit-models/` are self-test fixtures for the runner —
+several drive fake test-only SPIs (`EmitDemo*Extension`) rather than real engine extensions, and
+one (`compile-failure`) is expected to fail. They exist to exercise the runner, not to demonstrate
+engine features, and should not be read as catalog examples. (Note that the §5.4 coverage report
+does still render them: the server pom excludes only `legend-engine-emit-junit` by name, so
+`legend-engine-emit`'s own fixtures reach the dashboard. Adding `legend-engine-emit` to
+`excludedDirectoryNames` would keep self-test fixtures out of the catalog view.) Catalog models for
+core engine features live in a separate module,
+`legend-engine-core/legend-engine-core-emit-tests`, which is a *sibling* of
+`legend-engine-core-emit` rather than a child of it precisely so the two are not confused.
+
 #### Distributed Test Locations
 
 Actual EMIT tests are **spread throughout the codebase**, living in the modules that own the
@@ -341,12 +353,41 @@ mechanism; see §4.1.)
 
 The same pattern applies to other extension modules (`legend-engine-xts-service`, `legend-engine-xts-generation`, etc.) — each owns the EMIT models for its feature area, with one `*.emit.yaml` per test and a sibling source-root directory. Most modules host a single suite and keep the plain `emit-models/` root name; disambiguate only when a module genuinely hosts more than one independently-owned suite, as above.
 
+Feature areas that are not extensions at all — core Pure language constructs and model-to-model
+mappings — are owned the same way by `legend-engine-core/legend-engine-core-emit-tests`. It applies
+the same two-suite split as the relational module, because language constructs and M2M mappings are
+independent subjects that should be runnable and attributable separately:
+
+```
+legend-engine-core/
+  legend-engine-core-emit-tests/            ← Core-feature catalog models (no store extension)
+    src/test/java/.../emit/core/
+      grammar/GrammarEMITTests.java         ← Pure language suite
+      m2m/M2MEMITTests.java                 ← Model-to-model mapping suite
+    src/test/resources/
+      grammar-emit-models/                  ← Parse + compile only: no store, no mapping
+        grammar-constraint.emit.yaml
+        grammar-constraint/model.pure
+        grammar-measure.emit.yaml
+        ...
+      m2m-emit-models/                      ← M2M mappings with executing test suites
+        m2m-transform.emit.yaml
+        m2m-transform/
+          model/source.pure
+          model/target.pure
+          mapping/employeeMapping.pure
+        ...
+```
+
 > **Coverage-report caveat:** the HTML coverage report's discovery walk (§5.4) only looks under
 > a root literally named `emit-models/` by default. A module using a disambiguated root name —
-> like `relational-emit-models/` and `relation-emit-models/` above — is invisible to the report
+> like `relational-emit-models/` and `relation-emit-models/` above, or `grammar-emit-models/` and
+> `m2m-emit-models/` in the core-feature module — is invisible to the report
 > unless its consuming pom adds that root to `includedRelativeSubpaths`. `legend-engine-server-http-server`
-> does this explicitly (see the table in §5.4) so both relational-store suites are represented in
+> does this explicitly (see the table in §5.4) so every such suite is represented in
 > the coverage dashboard; any other module that disambiguates its root needs the same override.
+> **This is the standing cost of the two-suite split** — pay it deliberately, and update the
+> server pom in the same PR that introduces the root.
 
 The `EMITRunner` automatically discovers all `*.emit.yaml` files. The YAML file explicitly configures which directories and files comprise the test.
 
@@ -666,7 +707,7 @@ still applies, are:
 | Parameter | Default | Server override |
 |---|---|---|
 | `outputFilePath` | `${project.build.outputDirectory}/emit/emit-coverage.html` (i.e. `target/classes/emit/...`, so jar packaging automatically bundles it into the consuming jar) | Pinned explicitly to the default so the server jar's bundled resource path stays fixed if the plugin default ever changes |
-| `includedRelativeSubpaths` | `["src/test/resources/emit-models"]` | `["src/test/resources/emit-models", "src/test/resources/relational-emit-models", "src/test/resources/relation-emit-models"]` (adds the two disambiguated relational-store roots on top of the default) |
+| `includedRelativeSubpaths` | `["src/test/resources/emit-models"]` | `["src/test/resources/emit-models", "src/test/resources/relational-emit-models", "src/test/resources/relation-emit-models", "src/test/resources/grammar-emit-models", "src/test/resources/m2m-emit-models"]` (adds the two disambiguated relational-store roots and the two core-feature roots on top of the default) |
 | `excludedDirectoryNames` | `["target"]` | `["target", "legend-engine-emit-junit"]` (excludes the binding module's bootstrap examples from the server-side report) |
 | `excludedDirectoryNamePrefixes` | `["."]` | — |
 | `excludedRelativeSubpaths` | `["src/main"]` | — |

--- a/legend-engine-config/legend-engine-server/legend-engine-server-http-server/pom.xml
+++ b/legend-engine-config/legend-engine-server/legend-engine-server-http-server/pom.xml
@@ -50,6 +50,8 @@
                                 <subpath>src/test/resources/emit-models</subpath>
                                 <subpath>src/test/resources/relational-emit-models</subpath>
                                 <subpath>src/test/resources/relation-emit-models</subpath>
+                                <subpath>src/test/resources/grammar-emit-models</subpath>
+                                <subpath>src/test/resources/m2m-emit-models</subpath>
                             </includedRelativeSubpaths>
                         </configuration>
                     </execution>

--- a/legend-engine-core/legend-engine-core-emit-tests/pom.xml
+++ b/legend-engine-core/legend-engine-core-emit-tests/pom.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2026 Goldman Sachs
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.finos.legend.engine</groupId>
+        <artifactId>legend-engine-core</artifactId>
+        <version>4.136.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>legend-engine-core-emit-tests</artifactId>
+    <name>Legend Engine - Core - Core-Feature EMIT Tests</name>
+    <description>EMIT (Engine Model Integration Test) models exercising core engine features that need no store extension: Pure language constructs (constraints, measures, profiles, qualified properties, inheritance, functions) and model-to-model mappings. This module hosts EMIT test models only; the EMIT framework itself lives in legend-engine-core-emit.</description>
+
+    <dependencies>
+        <!-- EMIT framework + JUnit integration -->
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-emit-junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- EMIT -->
+
+        <!-- JUnit 5 -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- JUnit 5 -->
+
+        <!-- Mapping test runner: registers MappingTestableRunnerExtension via ServiceLoader,
+             so EMIT models with Mapping testSuites can actually execute tests. -->
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-test-runner-mapping</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Plan generation + serialisation, in-memory store, json model, java binding —
+             the same profile the EMIT framework's own m2m fixtures use. The M2M half of
+             this module executes its mapping test suites, which needs the in-memory store
+             executor plus the JSON external format and Java platform binding. -->
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-executionPlan-execution-store-inMemory</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-external-format-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-json-model</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-pure-runtime-java-extension-compiled-functions-json</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-javaPlatformBinding-pure</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-configuration-plan-generation-serialization</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/legend-engine-core/legend-engine-core-emit-tests/src/test/java/org/finos/legend/engine/test/emit/core/grammar/GrammarEMITTests.java
+++ b/legend-engine-core/legend-engine-core-emit-tests/src/test/java/org/finos/legend/engine/test/emit/core/grammar/GrammarEMITTests.java
@@ -1,0 +1,41 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.test.emit.core.grammar;
+
+import org.finos.legend.engine.test.emit.junit.EMITTestSuiteBuilder;
+import org.junit.jupiter.api.DynamicContainer;
+import org.junit.jupiter.api.TestFactory;
+
+import java.util.stream.Stream;
+
+/**
+ * JUnit 5 runner for the <b>Pure language</b> EMIT suite: models exercising domain
+ * grammar constructs — constraints, measures, profiles, qualified properties,
+ * inheritance, functions and multi-level association traversal. These models carry no
+ * store and no mapping, so they run parse and compile only; a failure is attributable
+ * to the language construct rather than to a mapping strategy that happens to carry it.
+ *
+ * <p>The sibling model-to-model suite lives under {@code m2m-emit-models/} and is
+ * driven by {@link org.finos.legend.engine.test.emit.core.m2m.M2MEMITTests}. The two
+ * use separate resource roots so each subject area can be run on its own.
+ */
+public class GrammarEMITTests
+{
+    @TestFactory
+    Stream<DynamicContainer> emit()
+    {
+        return EMITTestSuiteBuilder.testContainers("grammar-emit-models/");
+    }
+}

--- a/legend-engine-core/legend-engine-core-emit-tests/src/test/java/org/finos/legend/engine/test/emit/core/m2m/M2MEMITTests.java
+++ b/legend-engine-core/legend-engine-core-emit-tests/src/test/java/org/finos/legend/engine/test/emit/core/m2m/M2MEMITTests.java
@@ -1,0 +1,40 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.test.emit.core.m2m;
+
+import org.finos.legend.engine.test.emit.junit.EMITTestSuiteBuilder;
+import org.junit.jupiter.api.DynamicContainer;
+import org.junit.jupiter.api.TestFactory;
+
+import java.util.stream.Stream;
+
+/**
+ * JUnit 5 runner for the <b>model-to-model mapping</b> EMIT suite: Pure class mappings
+ * whose embedded test suites execute against the in-memory store over ModelStore test
+ * data, so each mapping feature is proven through plan generation and execution rather
+ * than only through compilation.
+ *
+ * <p>The sibling Pure language suite lives under {@code grammar-emit-models/} and is
+ * driven by {@link org.finos.legend.engine.test.emit.core.grammar.GrammarEMITTests}.
+ * The two use separate resource roots so each subject area can be run on its own.
+ */
+public class M2MEMITTests
+{
+    @TestFactory
+    Stream<DynamicContainer> emit()
+    {
+        return EMITTestSuiteBuilder.testContainers("m2m-emit-models/");
+    }
+}

--- a/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/grammar-emit-models/grammar-class-inheritance.emit.yaml
+++ b/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/grammar-emit-models/grammar-class-inheritance.emit.yaml
@@ -1,0 +1,28 @@
+name: grammar-class-inheritance
+title: "Class Inheritance Hierarchy"
+description: |
+  A branching three-level class hierarchy — a root, two siblings extending it, and a
+  leaf extending one of those — together with a subclass whose derived property
+  reaches a property declared on its supertype, and a class holding a property typed
+  as the root that any subtype satisfies. Proves that supertype resolution, inherited
+  property visibility, and subtype substitutability hold through parse and compile
+  without a store or mapping involved. The existing inheritance coverage is all
+  relational (single-table / joined-table strategies), where the mapping strategy can
+  mask a plain modelling regression; this isolates the language construct.
+
+modelSources:
+  model:
+    root: grammar-class-inheritance
+    files:
+      - model.pure
+
+features:
+  - grammar:class-inheritance
+  - grammar:derived-property
+  - scaffolding:class
+stores: []
+complexity: basic
+tags:
+  - inheritance
+  - subtype
+  - hierarchy

--- a/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/grammar-emit-models/grammar-class-inheritance/model.pure
+++ b/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/grammar-emit-models/grammar-class-inheritance/model.pure
@@ -1,0 +1,63 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+// Root of a three-level hierarchy.
+Class demo::inheritance::LegalEntity
+{
+  entityId: String[1];
+  legalName: String[1];
+}
+
+// Level two, with two siblings, so the hierarchy branches rather than being a
+// single chain.
+Class demo::inheritance::Firm extends demo::inheritance::LegalEntity
+{
+  incorporationDate: StrictDate[1];
+}
+
+Class demo::inheritance::Fund extends demo::inheritance::LegalEntity
+{
+  strategy: String[1];
+}
+
+// Level three: a subclass whose inherited properties come from two levels up.
+Class demo::inheritance::PublicFirm extends demo::inheritance::Firm
+{
+  ticker: String[1];
+}
+
+// A derived property declared on the root and reaching only root properties, so
+// every subtype inherits a working implementation.
+Class demo::inheritance::Party
+{
+  partyId: String[1];
+  displayLabel() { $this.partyId + ' (party)' }: String[1];
+}
+
+// A subclass that adds a derived property reaching an inherited property — the
+// case where compilation must resolve $this.partyId against the supertype.
+Class demo::inheritance::Counterparty extends demo::inheritance::Party
+{
+  rating: String[1];
+  ratedLabel() { $this.partyId + ' rated ' + $this.rating }: String[1];
+}
+
+// A property typed as the supertype, satisfiable by any subtype — the reason the
+// hierarchy has to be resolved at compile time rather than at use.
+Class demo::inheritance::Trade
+{
+  tradeId: String[1];
+  counterparty: demo::inheritance::LegalEntity[1];
+}

--- a/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/grammar-emit-models/grammar-constraint.emit.yaml
+++ b/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/grammar-emit-models/grammar-constraint.emit.yaml
@@ -1,0 +1,27 @@
+name: grammar-constraint
+title: "Class Constraints"
+description: |
+  Classes carrying constraints in every form the Legend grammar accepts: an
+  anonymous boolean expression, a named short-form constraint, and the full form
+  with ~owner, ~externalId, ~function, ~enforcementLevel (both Error and Warn) and
+  a ~message lambda over $this. A fourth class constrains a value against a
+  property reached through an association-free reference to another class, so
+  constraint compilation must resolve beyond the constrained class's own
+  properties. Proves that constraint definitions survive parse and compile as
+  first-class model content rather than being dropped or deferred.
+
+modelSources:
+  model:
+    root: grammar-constraint
+    files:
+      - model.pure
+
+features:
+  - grammar:constraint
+  - scaffolding:class
+stores: []
+complexity: basic
+tags:
+  - constraint
+  - enforcement-level
+  - validation

--- a/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/grammar-emit-models/grammar-constraint/model.pure
+++ b/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/grammar-emit-models/grammar-constraint/model.pure
@@ -1,0 +1,70 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+// Anonymous and named constraints in their short form: a bare boolean expression,
+// and an id-prefixed one. Both compile to a Constraint on the class.
+Class demo::constraint::Account
+[
+  $this.balance >= 0.0,
+  nonEmptyName: $this.accountName->length() > 0
+]
+{
+  accountName: String[1];
+  balance: Float[1];
+}
+
+// The full constraint form, exercising every optional clause the grammar offers:
+// ~owner, ~externalId, ~function, ~enforcementLevel and ~message. The message is a
+// function of $this, so it is compiled as a lambda rather than a literal.
+Class demo::constraint::Trade
+[
+  positiveQuantity
+  (
+    ~owner: RiskDesk
+    ~externalId: 'TRD-001'
+    ~function: $this.quantity > 0
+    ~enforcementLevel: Error
+    ~message: 'quantity must be positive but was ' + $this.quantity->toString()
+  ),
+  settlementAfterTrade
+  (
+    ~externalId: 'TRD-002'
+    ~function: $this.settlementDate >= $this.tradeDate
+    ~enforcementLevel: Warn
+    ~message: 'settlementDate precedes tradeDate for trade ' + $this.tradeId
+  )
+]
+{
+  tradeId: String[1];
+  quantity: Integer[1];
+  tradeDate: StrictDate[1];
+  settlementDate: StrictDate[1];
+}
+
+// A constraint that navigates a property of another class, so constraint
+// compilation has to resolve a reference beyond $this's own properties.
+Class demo::constraint::Order
+[
+  quantityWithinAccountLimit: $this.quantity <= $this.account.dailyLimit
+]
+{
+  quantity: Integer[1];
+  account: demo::constraint::LimitedAccount[1];
+}
+
+Class demo::constraint::LimitedAccount
+{
+  dailyLimit: Integer[1];
+}

--- a/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/grammar-emit-models/grammar-function.emit.yaml
+++ b/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/grammar-emit-models/grammar-function.emit.yaml
@@ -1,0 +1,28 @@
+name: grammar-function
+title: "Standalone Pure Functions"
+description: |
+  Standalone function elements across the signature and body shapes the grammar
+  supports: scalar in / scalar out, collection parameters and returns, optional
+  [0..1] returns, a zero-parameter function returning a literal collection, a
+  multi-statement body with let bindings, and a function that calls two other
+  functions defined in the same model. Proves that function elements compile as
+  packageable elements with their signatures and bodies intact, and that
+  cross-function references resolve at compile time. Existing coverage of
+  grammar:function is incidental — every relation-mapping model carries a ~func —
+  so this is the first fixture where the function element itself is the subject.
+
+modelSources:
+  model:
+    root: grammar-function
+    files:
+      - model.pure
+
+features:
+  - grammar:function
+  - scaffolding:class
+stores: []
+complexity: basic
+tags:
+  - function
+  - lambda
+  - let

--- a/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/grammar-emit-models/grammar-function/model.pure
+++ b/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/grammar-emit-models/grammar-function/model.pure
@@ -1,0 +1,63 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+Class demo::function::Employee
+{
+  firstName: String[1];
+  lastName: String[1];
+  department: String[1];
+  salary: Integer[1];
+}
+
+// Simplest form: scalar parameters, scalar return, single-expression body.
+function demo::function::fullName(firstName: String[1], lastName: String[1]): String[1]
+{
+  $firstName + ' ' + $lastName
+}
+
+// Collection parameter and collection return.
+function demo::function::inDepartment(employees: demo::function::Employee[*], department: String[1]): demo::function::Employee[*]
+{
+  $employees->filter(e | $e.department == $department)
+}
+
+// Multi-statement body with let bindings, returning a scalar aggregate.
+function demo::function::averageSalary(employees: demo::function::Employee[*]): Float[1]
+{
+  let total = $employees->map(e | $e.salary)->sum();
+  let count = $employees->size();
+  if($count == 0, | 0.0, | $total->toFloat() / $count->toFloat());
+}
+
+// A function calling two other functions in this model, so cross-function
+// resolution has to happen at compile time.
+function demo::function::departmentSummary(employees: demo::function::Employee[*], department: String[1]): String[1]
+{
+  let members = demo::function::inDepartment($employees, $department);
+  $department + ': ' + $members->size()->toString() + ' staff, average ' + demo::function::averageSalary($members)->toString();
+}
+
+// Optional parameter and optional return, exercising non-[1] multiplicities on
+// both sides of the signature.
+function demo::function::firstOrNone(employees: demo::function::Employee[*]): demo::function::Employee[0..1]
+{
+  $employees->first()
+}
+
+// Zero-parameter function returning a literal collection.
+function demo::function::knownDepartments(): String[*]
+{
+  ['ENGINEERING', 'OPERATIONS', 'RISK']
+}

--- a/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/grammar-emit-models/grammar-measure.emit.yaml
+++ b/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/grammar-emit-models/grammar-measure.emit.yaml
@@ -1,0 +1,27 @@
+name: grammar-measure
+title: "Measures and Units"
+description: |
+  Two Measure definitions, each with a canonical unit and non-canonical units whose
+  conversion functions are lambdas back to the canonical one, consumed by classes
+  through unit-typed properties in the Measure~Unit form across all three
+  multiplicities, plus one property typed at the measure level rather than at a
+  specific unit. Proves that measure and unit declarations compile as types and are
+  resolvable from property signatures — the unit namespace is per-measure, so the
+  compiler has to bind each unit to its owning measure rather than to the measure
+  name alone.
+
+modelSources:
+  model:
+    root: grammar-measure
+    files:
+      - model.pure
+
+features:
+  - grammar:measure
+  - scaffolding:class
+stores: []
+complexity: basic
+tags:
+  - measure
+  - unit
+  - conversion

--- a/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/grammar-emit-models/grammar-measure/model.pure
+++ b/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/grammar-emit-models/grammar-measure/model.pure
@@ -1,0 +1,53 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+// A measure with a canonical unit (marked with *) and two non-canonical units
+// whose conversion functions are lambdas back to the canonical unit.
+Measure demo::measure::Mass
+{
+  *Gram: x -> $x;
+  Kilogram: x -> $x * 1000;
+  Pound: x -> $x * 453.59;
+}
+
+// A second measure, to prove unit namespaces stay distinct: Second here must not
+// collide with anything in Mass, and the conversion arithmetic differs in kind
+// (integral multiples rather than decimal factors).
+Measure demo::measure::Duration
+{
+  *Second: x -> $x;
+  Minute: x -> $x * 60;
+  Hour: x -> $x * 3600;
+}
+
+// Unit-typed properties: the Measure~Unit form, across all three multiplicities
+// and across both measures, so the compiler must resolve each unit against its
+// owning measure rather than against the measure alone.
+Class demo::measure::Shipment
+{
+  shipmentId: String[1];
+  netWeight: demo::measure::Mass~Kilogram[1];
+  tareWeight: demo::measure::Mass~Gram[0..1];
+  itemWeights: demo::measure::Mass~Pound[*];
+  transitTime: demo::measure::Duration~Hour[1];
+}
+
+// A measure-typed property declared at the measure level rather than at a
+// specific unit, which is the weaker typing the metamodel also allows.
+Class demo::measure::WeighingRecord
+{
+  recordedBy: String[1];
+  measured: demo::measure::Mass[1];
+}

--- a/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/grammar-emit-models/grammar-nested-association.emit.yaml
+++ b/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/grammar-emit-models/grammar-nested-association.emit.yaml
@@ -1,0 +1,29 @@
+name: grammar-nested-association
+title: "Multi-Level Association Traversal"
+description: |
+  Three chained associations — Person to Firm, Firm to Address, Address to Country —
+  each declared as an independent element, traversed by derived properties two, three
+  and four hops deep, including one traversal that crosses every association in the
+  model and comes back down the far side into a collection. Proves that property
+  references spanning several separately-declared associations resolve at compile
+  time, with multiplicity propagating correctly from [1] hops to [*] hops. The
+  existing nested-association coverage traverses a relation-function ModelJoin chain;
+  this isolates the plain association form.
+
+modelSources:
+  model:
+    root: grammar-nested-association
+    files:
+      - model.pure
+
+features:
+  - grammar:association
+  - grammar:derived-property
+  - grammar:nested-association
+  - scaffolding:class
+stores: []
+complexity: basic
+tags:
+  - association
+  - traversal
+  - multi-level

--- a/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/grammar-emit-models/grammar-nested-association/model.pure
+++ b/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/grammar-emit-models/grammar-nested-association/model.pure
@@ -1,0 +1,67 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+Class demo::nested::Person
+{
+  firstName: String[1];
+  lastName: String[1];
+
+  // Two-hop traversal: person -> firm -> address.
+  firmCity() { $this.firm.address.city }: String[1];
+
+  // Four-hop traversal that crosses every association in the model and comes back
+  // down the far side, ending in a collection that is then aggregated.
+  countryStaffCount() { $this.firm.address.country.addresses.firms.staff->size() }: Integer[1];
+}
+
+Class demo::nested::Firm
+{
+  legalName: String[1];
+
+  // Traversal that starts at the far end of one association and crosses another.
+  staffCities() { $this.staff.firm.address.city }: String[*];
+}
+
+Class demo::nested::Address
+{
+  street: String[1];
+  city: String[1];
+}
+
+Class demo::nested::Country
+{
+  countryCode: String[1];
+}
+
+// A chain of three associations: Person -> Firm -> Address -> Country. Each is an
+// independent element, so multi-level traversal requires the compiler to stitch
+// property references across all three.
+Association demo::nested::Firm_Person
+{
+  firm: demo::nested::Firm[1];
+  staff: demo::nested::Person[*];
+}
+
+Association demo::nested::Firm_Address
+{
+  address: demo::nested::Address[1];
+  firms: demo::nested::Firm[*];
+}
+
+Association demo::nested::Address_Country
+{
+  country: demo::nested::Country[1];
+  addresses: demo::nested::Address[*];
+}

--- a/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/grammar-emit-models/grammar-profile.emit.yaml
+++ b/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/grammar-emit-models/grammar-profile.emit.yaml
@@ -1,0 +1,31 @@
+name: grammar-profile
+title: "Profiles, Stereotypes and Tagged Values"
+description: |
+  Two profiles declaring stereotypes and tags, applied at every element position the
+  domain grammar allows them: class, property, enumeration, enumeration value,
+  association, association property, and standalone function. One property carries
+  stereotypes and tagged values drawn from both profiles at once, so annotation
+  references must be resolved against their owning profile rather than by bare name.
+  Proves that profile definitions and their applications survive compilation as
+  model content — annotations are silently droppable in a way that is easy to miss
+  without an end-to-end fixture.
+
+modelSources:
+  model:
+    root: grammar-profile
+    files:
+      - model.pure
+
+features:
+  - grammar:association
+  - grammar:enumeration
+  - grammar:function
+  - grammar:profile
+  - scaffolding:class
+stores: []
+complexity: basic
+tags:
+  - profile
+  - stereotype
+  - tagged-value
+  - annotation

--- a/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/grammar-emit-models/grammar-profile/model.pure
+++ b/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/grammar-emit-models/grammar-profile/model.pure
@@ -1,0 +1,66 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+Profile demo::profile::Governance
+{
+  stereotypes: [pii, deprecated, internal];
+  tags: [owner, classification, since];
+}
+
+// A second profile, so stereotype and tag references have to be resolved against
+// the right profile rather than by bare name.
+Profile demo::profile::Lineage
+{
+  stereotypes: [derived];
+  tags: [sourceSystem];
+}
+
+// Stereotypes and tagged values applied to a class, and to individual properties
+// of that class — including a property carrying stereotypes and tags from both
+// profiles at once.
+Class <<demo::profile::Governance.internal>> {demo::profile::Governance.owner = 'data-platform', demo::profile::Governance.classification = 'restricted'} demo::profile::Customer
+{
+  customerId: String[1];
+  <<demo::profile::Governance.pii>> {demo::profile::Governance.classification = 'sensitive'} emailAddress: String[1];
+  <<demo::profile::Governance.deprecated>> {demo::profile::Governance.since = '2024-01-01'} legacyCode: String[0..1];
+  <<demo::profile::Governance.pii, demo::profile::Lineage.derived>> {demo::profile::Lineage.sourceSystem = 'crm'} normalisedName: String[1];
+}
+
+// Stereotypes and tagged values on an enumeration and on one of its values.
+Enum <<demo::profile::Governance.internal>> {demo::profile::Governance.owner = 'risk'} demo::profile::Tier
+{
+  GOLD,
+  <<demo::profile::Governance.deprecated>> {demo::profile::Governance.since = '2023-06-01'} PLATINUM,
+  SILVER
+}
+
+// Stereotypes and tagged values on an association and on its properties.
+Association <<demo::profile::Lineage.derived>> {demo::profile::Lineage.sourceSystem = 'crm'} demo::profile::Customer_Account
+{
+  <<demo::profile::Governance.internal>> account: demo::profile::Account[*];
+  customer: demo::profile::Customer[1];
+}
+
+Class demo::profile::Account
+{
+  accountId: String[1];
+  tier: demo::profile::Tier[1];
+}
+
+// Stereotypes and tagged values on a standalone function.
+function <<demo::profile::Governance.internal>> {demo::profile::Governance.owner = 'data-platform'} demo::profile::activeAccounts(accounts: demo::profile::Account[*]): demo::profile::Account[*]
+{
+  $accounts->filter(a | $a.tier != demo::profile::Tier.SILVER)
+}

--- a/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/grammar-emit-models/grammar-qualified-property.emit.yaml
+++ b/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/grammar-emit-models/grammar-qualified-property.emit.yaml
@@ -1,0 +1,27 @@
+name: grammar-qualified-property
+title: "Qualified (Parameterised) Properties"
+description: |
+  Qualified properties across the shapes the grammar supports: one parameter, two
+  parameters of different types, an enum-typed parameter, an optional [0..1]
+  parameter, a multi-statement body using a let, a scalar return type alongside
+  collection returns, and one qualified property invoking another on the same class.
+  Proves that parameterised property bodies compile as lambdas with their parameters
+  correctly bound and their return types honoured — distinct from the no-argument
+  derived-property path, which is already covered elsewhere.
+
+modelSources:
+  model:
+    root: grammar-qualified-property
+    files:
+      - model.pure
+
+features:
+  - grammar:enumeration
+  - grammar:qualified-property
+  - scaffolding:class
+stores: []
+complexity: basic
+tags:
+  - qualified-property
+  - parameterised
+  - lambda

--- a/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/grammar-emit-models/grammar-qualified-property/model.pure
+++ b/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/grammar-emit-models/grammar-qualified-property/model.pure
@@ -1,0 +1,73 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+Enum demo::qualified::Currency
+{
+  USD,
+  EUR,
+  GBP
+}
+
+Class demo::qualified::Firm
+{
+  legalName: String[1];
+  employees: demo::qualified::Employee[*];
+
+  // Single-parameter qualified property filtering an owned collection.
+  employeesByDepartment(department: String[1])
+  {
+    $this.employees->filter(e | $e.department == $department)
+  }: demo::qualified::Employee[*];
+
+  // Two parameters of different types, combined in one predicate.
+  employeesAbove(department: String[1], threshold: Integer[1])
+  {
+    $this.employees->filter(e | ($e.department == $department) && ($e.salary > $threshold))
+  }: demo::qualified::Employee[*];
+
+  // A multi-statement body with a let, returning a scalar rather than a collection.
+  headcountIn(department: String[1])
+  {
+    let matching = $this.employees->filter(e | $e.department == $department);
+    $matching->size();
+  }: Integer[1];
+
+  // An enum-typed parameter, so parameter binding is not purely primitive.
+  employeesPaidIn(currency: demo::qualified::Currency[1])
+  {
+    $this.employees->filter(e | $e.payCurrency == $currency)
+  }: demo::qualified::Employee[*];
+
+  // A qualified property calling another qualified property on the same class.
+  hasStaffIn(department: String[1])
+  {
+    $this.headcountIn($department) > 0
+  }: Boolean[1];
+}
+
+Class demo::qualified::Employee
+{
+  firstName: String[1];
+  lastName: String[1];
+  department: String[1];
+  salary: Integer[1];
+  payCurrency: demo::qualified::Currency[1];
+
+  // An optional parameter, exercising a non-[1] parameter multiplicity.
+  displayName(prefix: String[0..1])
+  {
+    if($prefix->isEmpty(), | $this.firstName + ' ' + $this.lastName, | $prefix->toOne() + ' ' + $this.firstName + ' ' + $this.lastName)
+  }: String[1];
+}

--- a/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/m2m-emit-models/m2m-derived-source-property.emit.yaml
+++ b/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/m2m-emit-models/m2m-derived-source-property.emit.yaml
@@ -1,0 +1,32 @@
+name: m2m-derived-source-property
+title: "Derived Properties on an M2M Source Class"
+description: |
+  A model-to-model mapping that reads only derived and qualified properties of its
+  source class, never the stored properties directly: one derived from two stored
+  properties, one computed by arithmetic, one that reads another derived property,
+  and a parameterised property invoked with a literal argument. Only the stored
+  properties are supplied as test data, so the embedded test suite proves the derived
+  properties are actually evaluated on the deserialized source instance at execution
+  time rather than expected to arrive in the input.
+
+modelSources:
+  model:
+    root: m2m-derived-source-property
+    files:
+      - model.pure
+      - mapping.pure
+
+features:
+  - execution:test-data
+  - grammar:derived-property
+  - grammar:qualified-property
+  - mapping:m2m-derived-source-property
+  - mapping:mapping
+  - scaffolding:class
+  - scaffolding:m2m-mapping
+stores: []
+complexity: basic
+tags:
+  - m2m
+  - derived-property
+  - mapping-test

--- a/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/m2m-emit-models/m2m-derived-source-property/mapping.pure
+++ b/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/m2m-emit-models/m2m-derived-source-property/mapping.pure
@@ -1,0 +1,98 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Mapping
+Mapping demo::m2m::derived::PersonMapping
+(
+  *demo::m2m::derived::target::Person: Pure
+  {
+    ~src demo::m2m::derived::source::S_Person
+
+    // Straight read of a derived source property.
+    name: $src.fullName,
+    // Derived source property computed by arithmetic.
+    age: $src.age,
+    // Derived source property that itself reads another derived property.
+    descriptor: $src.descriptor,
+    // Parameterised source property invoked with a literal argument.
+    initials: $src.initial('.')
+  }
+
+  testSuites:
+  [
+    derivedSourceSuite:
+    {
+      function: |demo::m2m::derived::target::Person.all()->graphFetch(#{demo::m2m::derived::target::Person{name, age, descriptor, initials}}#)->serialize(#{demo::m2m::derived::target::Person{name, age, descriptor, initials}}#);
+      tests:
+      [
+        johnSmith:
+        {
+          data:
+          [
+            ModelStore: ModelStore
+              #{
+                demo::m2m::derived::source::S_Person:
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '{"firstName":"John","lastName":"Smith","birthYear":1980,"observationYear":2026}';
+                  }#
+              }#
+          ];
+          asserts:
+          [
+            expected:
+              EqualToJson
+              #{
+                expected:
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '{"name":"John Smith","age":46,"descriptor":"John Smith (46)","initials":"J.S"}';
+                  }#;
+              }#
+          ];
+        },
+        janeDoe:
+        {
+          data:
+          [
+            ModelStore: ModelStore
+              #{
+                demo::m2m::derived::source::S_Person:
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '{"firstName":"Jane","lastName":"Doe","birthYear":1995,"observationYear":2026}';
+                  }#
+              }#
+          ];
+          asserts:
+          [
+            expected:
+              EqualToJson
+              #{
+                expected:
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '{"name":"Jane Doe","age":31,"descriptor":"Jane Doe (31)","initials":"J.D"}';
+                  }#;
+              }#
+          ];
+        }
+      ];
+    }
+  ]
+)

--- a/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/m2m-emit-models/m2m-derived-source-property/model.pure
+++ b/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/m2m-emit-models/m2m-derived-source-property/model.pure
@@ -1,0 +1,50 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+// The source class carries derived properties. Only its stored properties are
+// populated from the test data; the derived ones are computed on the source
+// instance at execution time and are what the mapping actually reads.
+Class demo::m2m::derived::source::S_Person
+{
+  firstName: String[1];
+  lastName: String[1];
+  birthYear: Integer[1];
+  observationYear: Integer[1];
+
+  // Derived from two stored properties.
+  fullName() { $this.firstName + ' ' + $this.lastName }: String[1];
+
+  // Arithmetic over stored properties.
+  age() { $this.observationYear - $this.birthYear }: Integer[1];
+
+  // A derived property that reads another derived property, so the chain has to
+  // be resolved rather than just the first level.
+  descriptor() { $this.fullName + ' (' + $this.age->toString() + ')' }: String[1];
+
+  // A parameterised (qualified) property on the source, invoked with a literal
+  // argument from the mapping.
+  initial(separator: String[1])
+  {
+    $this.firstName->substring(0, 1) + $separator + $this.lastName->substring(0, 1)
+  }: String[1];
+}
+
+Class demo::m2m::derived::target::Person
+{
+  name: String[1];
+  age: Integer[1];
+  descriptor: String[1];
+  initials: String[1];
+}

--- a/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/m2m-emit-models/m2m-enumeration-mapping.emit.yaml
+++ b/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/m2m-emit-models/m2m-enumeration-mapping.emit.yaml
@@ -1,0 +1,32 @@
+name: m2m-enumeration-mapping
+title: "Enumeration Mapping in an M2M Mapping"
+description: |
+  A model-to-model mapping whose target enum properties are populated through named
+  EnumerationMappings rather than by direct assignment: one keyed on strings, where
+  several source spellings collapse onto a single enum value so the transform is a
+  genuine many-to-one lookup, and one keyed on integers. The embedded test suite
+  feeds a lower-case and an upper-case spelling through the same mapping, proving the
+  lookup is applied at execution time. Enumeration mapping is store-agnostic and was
+  previously proven only over relational and relation-function sources; this
+  establishes the M2M code path.
+
+modelSources:
+  model:
+    root: m2m-enumeration-mapping
+    files:
+      - model.pure
+      - mapping.pure
+
+features:
+  - execution:test-data
+  - grammar:enumeration
+  - mapping:enumeration-mapping
+  - mapping:mapping
+  - scaffolding:class
+  - scaffolding:m2m-mapping
+stores: []
+complexity: basic
+tags:
+  - m2m
+  - enumeration
+  - mapping-test

--- a/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/m2m-emit-models/m2m-enumeration-mapping/mapping.pure
+++ b/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/m2m-emit-models/m2m-enumeration-mapping/mapping.pure
@@ -1,0 +1,110 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Mapping
+Mapping demo::m2m::enumeration::InstrumentMapping
+(
+  *demo::m2m::enumeration::target::Instrument: Pure
+  {
+    ~src demo::m2m::enumeration::source::S_Instrument
+
+    identifier: $src.identifier,
+    // Named enumeration mapping applied to a string-valued source property.
+    identifierType: EnumerationMapping SynonymTypeMapping: $src.identifierType,
+    // A second enumeration mapping, keyed on integers rather than strings.
+    side: EnumerationMapping TradeSideMapping: $src.side
+  }
+
+  // Multiple source spellings collapse onto one enum value, so the transform is a
+  // genuine many-to-one lookup rather than a name match.
+  demo::m2m::enumeration::target::SynonymType: EnumerationMapping SynonymTypeMapping
+  {
+    CUSIP: ['cusip', 'CUSIP'],
+    ISIN: ['isin', 'ISIN'],
+    SEDOL: ['sedol', 'SEDOL']
+  }
+
+  demo::m2m::enumeration::target::TradeSide: EnumerationMapping TradeSideMapping
+  {
+    BUY: [0],
+    SELL: [1]
+  }
+
+  testSuites:
+  [
+    enumerationSuite:
+    {
+      function: |demo::m2m::enumeration::target::Instrument.all()->graphFetch(#{demo::m2m::enumeration::target::Instrument{identifier, identifierType, side}}#)->serialize(#{demo::m2m::enumeration::target::Instrument{identifier, identifierType, side}}#);
+      tests:
+      [
+        lowerCaseIsinBuy:
+        {
+          data:
+          [
+            ModelStore: ModelStore
+              #{
+                demo::m2m::enumeration::source::S_Instrument:
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '{"identifier":"US0378331005","identifierType":"isin","side":0}';
+                  }#
+              }#
+          ];
+          asserts:
+          [
+            expected:
+              EqualToJson
+              #{
+                expected:
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '{"identifier":"US0378331005","identifierType":"ISIN","side":"BUY"}';
+                  }#;
+              }#
+          ];
+        },
+        upperCaseCusipSell:
+        {
+          data:
+          [
+            ModelStore: ModelStore
+              #{
+                demo::m2m::enumeration::source::S_Instrument:
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '{"identifier":"037833100","identifierType":"CUSIP","side":1}';
+                  }#
+              }#
+          ];
+          asserts:
+          [
+            expected:
+              EqualToJson
+              #{
+                expected:
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '{"identifier":"037833100","identifierType":"CUSIP","side":"SELL"}';
+                  }#;
+              }#
+          ];
+        }
+      ];
+    }
+  ]
+)

--- a/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/m2m-emit-models/m2m-enumeration-mapping/model.pure
+++ b/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/m2m-emit-models/m2m-enumeration-mapping/model.pure
@@ -1,0 +1,43 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+Enum demo::m2m::enumeration::target::SynonymType
+{
+  CUSIP,
+  ISIN,
+  SEDOL
+}
+
+Enum demo::m2m::enumeration::target::TradeSide
+{
+  BUY,
+  SELL
+}
+
+// The source carries the enum values as raw strings and integers, in the varied
+// spellings a real feed would produce.
+Class demo::m2m::enumeration::source::S_Instrument
+{
+  identifier: String[1];
+  identifierType: String[1];
+  side: Integer[1];
+}
+
+Class demo::m2m::enumeration::target::Instrument
+{
+  identifier: String[1];
+  identifierType: demo::m2m::enumeration::target::SynonymType[1];
+  side: demo::m2m::enumeration::target::TradeSide[1];
+}

--- a/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/m2m-emit-models/m2m-transform.emit.yaml
+++ b/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/m2m-emit-models/m2m-transform.emit.yaml
@@ -1,0 +1,33 @@
+name: m2m-transform
+title: "Model-to-Model Transform Expressions"
+description: |
+  A model-to-model mapping whose every property is produced by a different shape of
+  transform expression rather than a straight property copy: string concatenation,
+  nested function application (substring then concatenate), arithmetic over two
+  source properties, a collection function chain (split then at), and a conditional
+  selecting between two literals. The embedded test suite executes the mapping over
+  ModelStore test data for an active and an inactive employee, so each transform
+  shape is proven to survive plan generation and in-memory execution — not merely to
+  compile. This is the distributed counterpart to the framework's own m2m fixtures,
+  which only exercise a single concatenation.
+
+modelSources:
+  model:
+    root: m2m-transform
+    files:
+      - model/source.pure
+      - model/target.pure
+      - mapping/employeeMapping.pure
+
+features:
+  - execution:test-data
+  - mapping:m2m-transform
+  - mapping:mapping
+  - scaffolding:class
+  - scaffolding:m2m-mapping
+stores: []
+complexity: basic
+tags:
+  - m2m
+  - transform
+  - mapping-test

--- a/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/m2m-emit-models/m2m-transform/mapping/employeeMapping.pure
+++ b/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/m2m-emit-models/m2m-transform/mapping/employeeMapping.pure
@@ -1,0 +1,100 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Mapping
+Mapping demo::m2m::transform::EmployeeMapping
+(
+  *demo::m2m::transform::target::Employee: Pure
+  {
+    ~src demo::m2m::transform::source::S_Employee
+
+    // String concatenation across two source properties.
+    fullName: $src.firstName + ' ' + $src.lastName,
+    // Nested function application: substring of each name, then concatenated.
+    initials: $src.firstName->substring(0, 1) + $src.lastName->substring(0, 1),
+    // Arithmetic over two source properties.
+    netSalary: $src.grossSalary * (1.0 - $src.taxRate),
+    // Collection function chain: split a composite code and take one part.
+    department: $src.departmentCode->split('-')->at(0),
+    // Conditional transform selecting between two literals.
+    status: if($src.active, |'ACTIVE', |'INACTIVE')
+  }
+
+  testSuites:
+  [
+    transformSuite:
+    {
+      function: |demo::m2m::transform::target::Employee.all()->graphFetch(#{demo::m2m::transform::target::Employee{fullName, initials, netSalary, department, status}}#)->serialize(#{demo::m2m::transform::target::Employee{fullName, initials, netSalary, department, status}}#);
+      tests:
+      [
+        activeEmployee:
+        {
+          data:
+          [
+            ModelStore: ModelStore
+              #{
+                demo::m2m::transform::source::S_Employee:
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '{"firstName":"John","lastName":"Smith","grossSalary":120000.0,"taxRate":0.25,"departmentCode":"ENG-NYC","active":true}';
+                  }#
+              }#
+          ];
+          asserts:
+          [
+            expected:
+              EqualToJson
+              #{
+                expected:
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '{"fullName":"John Smith","initials":"JS","netSalary":90000.0,"department":"ENG","status":"ACTIVE"}';
+                  }#;
+              }#
+          ];
+        },
+        inactiveEmployee:
+        {
+          data:
+          [
+            ModelStore: ModelStore
+              #{
+                demo::m2m::transform::source::S_Employee:
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '{"firstName":"Jane","lastName":"Doe","grossSalary":80000.0,"taxRate":0.5,"departmentCode":"OPS-LDN","active":false}';
+                  }#
+              }#
+          ];
+          asserts:
+          [
+            expected:
+              EqualToJson
+              #{
+                expected:
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '{"fullName":"Jane Doe","initials":"JD","netSalary":40000.0,"department":"OPS","status":"INACTIVE"}';
+                  }#;
+              }#
+          ];
+        }
+      ];
+    }
+  ]
+)

--- a/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/m2m-emit-models/m2m-transform/model/source.pure
+++ b/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/m2m-emit-models/m2m-transform/model/source.pure
@@ -1,0 +1,24 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+Class demo::m2m::transform::source::S_Employee
+{
+  firstName: String[1];
+  lastName: String[1];
+  grossSalary: Float[1];
+  taxRate: Float[1];
+  departmentCode: String[1];
+  active: Boolean[1];
+}

--- a/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/m2m-emit-models/m2m-transform/model/target.pure
+++ b/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/m2m-emit-models/m2m-transform/model/target.pure
@@ -1,0 +1,23 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+Class demo::m2m::transform::target::Employee
+{
+  fullName: String[1];
+  netSalary: Float[1];
+  department: String[1];
+  status: String[1];
+  initials: String[1];
+}

--- a/legend-engine-core/pom.xml
+++ b/legend-engine-core/pom.xml
@@ -35,5 +35,6 @@
         <module>legend-engine-core-query-pure-http-api</module>
         <module>legend-engine-core-identity</module>
         <module>legend-engine-core-emit</module>
+        <module>legend-engine-core-emit-tests</module>
     </modules>
 </project>


### PR DESCRIPTION
EMIT: add legend-engine-core-emit-tests with core-language and M2M models

Stands up a catalog module for EMIT models exercising engine features that need no store extension, and adds the first ten.

The module is a leaf sibling of legend-engine-core-emit rather than a child of it: everything inside that aggregator is framework, including the self-test fixtures under legend-engine-emit/src/test, and a catalog module nested there would be easily mistaken for one of them.

Two independently-runnable suites, split by subject so each area can be run on its own and a failure is attributable to one of them:

  grammar-emit-models/ -> GrammarEMITTests  7 models, 28 dynamic tests
  m2m-emit-models/     -> M2MEMITTests      3 models, 24 dynamic tests

The grammar models run parse and compile only, with no store and no mapping, so a regression in a language construct is attributable to the construct rather than to a mapping strategy that happened to carry it. They cover constraints (short, named and full ~owner/~externalId/~function/~enforcementLevel/~message forms), measures and unit-typed properties, profiles applied at every element position the domain grammar allows, qualified properties, class inheritance, standalone functions, and multi-level association traversal.

The M2M models execute their embedded test suites against the in-memory store, covering transform expressions, derived and qualified properties on the source class, and enumeration mappings keyed on both strings and integers.

Both resource roots are disambiguated, so both are added to the coverage report's includedRelativeSubpaths in legend-engine-server-http-server.

Docs: emit.md gains the module layout and states that everything inside legend-engine-core-emit is framework; emit-authoring.md gains the placement entries, guidance to split roots by subject, and a new section 11.3 on not tagging a capability the fixture cannot execute.