### PR TITLE
Make handling of single-element collection literals consistent with Pure compiler

### DIFF
--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/ValueSpecificationBuilder.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/ValueSpecificationBuilder.java
@@ -885,7 +885,7 @@ public class ValueSpecificationBuilder implements ValueSpecificationVisitor<Valu
         MutableList<org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.ValueSpecification> transformed =
                 ListIterate.collect(collection.values, expression ->
                 {
-                    org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.ValueSpecification res = expression.accept(this);
+                    ValueSpecification res = expression.accept(this);
                     if (collection.values.size() > 1 && !isExactlyOne(res._multiplicity()))
                     {
                         throw new EngineException(

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/ValueSpecificationBuilder.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/ValueSpecificationBuilder.java
@@ -882,31 +882,60 @@ public class ValueSpecificationBuilder implements ValueSpecificationVisitor<Valu
     @Override
     public ValueSpecification visit(Collection collection)
     {
-        MutableList<org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.ValueSpecification> transformed = ListIterate.collect(collection.values, expression ->
-        {
-            ValueSpecification res = expression.accept(this);
-            if (res._multiplicity()._lowerBound()._value() != 1 || res._multiplicity()._upperBound()._value() == null || res._multiplicity()._upperBound()._value() != 1)
-            {
-                throw new EngineException("Collection element must have a multiplicity [1] - Context:" + processingContext.getStack() + ", multiplicity:" + org.finos.legend.pure.m3.navigation.multiplicity.Multiplicity.print(res._multiplicity()), expression.sourceInformation, EngineErrorType.COMPILATION);
-            }
-            return res;
-        });
+        MutableList<org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.ValueSpecification> transformed =
+                ListIterate.collect(collection.values, expression ->
+                {
+                    org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.ValueSpecification res = expression.accept(this);
+                    // Multi-element collection literals still require every element to be [1] --
+                    // this preserves the invariant that operators like `+` / `-` / `*` (which the parser
+                    // rewrites into variadic `plus([a, b])` etc.) rely on for element-wise semantics.
+                    // Single-element literals are treated as a semantically transparent wrapper (matches
+                    // Pure's own behaviour and fixes PROD-85545: e.g. `concatenate([$optional], $many)`).
+                    if (collection.values.size() > 1 && !isExactlyOne(res._multiplicity()))
+                    {
+                        throw new EngineException(
+                                "Collection element must have a multiplicity [1] - Context:" + processingContext.getStack()
+                                        + ", multiplicity:" + org.finos.legend.pure.m3.navigation.multiplicity.Multiplicity.print(res._multiplicity()),
+                                expression.sourceInformation, EngineErrorType.COMPILATION);
+                    }
+                    return res;
+                });
+
         GenericType _genericType = collection.values.isEmpty()
                 ? this.context.pureModel.getGenericType(M3Paths.Nil)
                 : MostCommonType.mostCommon(transformed.collect(ValueSpecificationAccessor::_genericType).distinct(), this.context.pureModel);
         _genericType._classifierGenericType(this.context.pureModel.getGenericType(M3Paths.GenericType));
+
+        // For a single-element literal wrapping a non-[1] variable, the effective outer multiplicity is
+        // that element's multiplicity (bracket is a semantic no-op). Otherwise trust the parser-supplied
+        // literal-count multiplicity, as before.
+        Multiplicity effectiveMultiplicity =
+                (transformed.size() == 1 && !isExactlyOne(transformed.get(0)._multiplicity()))
+                        ? transformed.get(0)._multiplicity()
+                        : this.context.pureModel.getMultiplicity(collection.multiplicity);
+
         return new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl("", null, this.context.pureModel.getClass(M3Paths.InstanceValue))
                 ._genericType(_genericType)
-                ._multiplicity(this.context.pureModel.getMultiplicity(collection.multiplicity))
+                ._multiplicity(effectiveMultiplicity)
                 ._values(transformed.collect(valueSpecification ->
-                        {
-                            if (valueSpecification instanceof InstanceValue && ((InstanceValue) valueSpecification)._values().size() == 1)
-                            {
-                                return ((InstanceValue) valueSpecification)._values().getFirst();
-                            }
-                            return valueSpecification;
-                        }
-                ));
+                {
+                    // Only auto-unwrap InstanceValues that are truly [1] with a single stored raw.
+                    // Many-mult wrappers stay wrapped so downstream flattening sees the correct shape.
+                    if (valueSpecification instanceof InstanceValue
+                            && ((InstanceValue) valueSpecification)._values().size() == 1
+                            && isExactlyOne(valueSpecification._multiplicity()))
+                    {
+                        return ((InstanceValue) valueSpecification)._values().getFirst();
+                    }
+                    return valueSpecification;
+                }));
+    }
+
+    private static boolean isExactlyOne(Multiplicity m)
+    {
+        Long lb = m._lowerBound()._value();
+        Long ub = m._upperBound()._value();
+        return lb != null && lb == 1L && ub != null && ub == 1L;
     }
 
     @Override

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/ValueSpecificationBuilder.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/ValueSpecificationBuilder.java
@@ -886,11 +886,6 @@ public class ValueSpecificationBuilder implements ValueSpecificationVisitor<Valu
                 ListIterate.collect(collection.values, expression ->
                 {
                     org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.ValueSpecification res = expression.accept(this);
-                    // Multi-element collection literals still require every element to be [1] --
-                    // this preserves the invariant that operators like `+` / `-` / `*` (which the parser
-                    // rewrites into variadic `plus([a, b])` etc.) rely on for element-wise semantics.
-                    // Single-element literals are treated as a semantically transparent wrapper (matches
-                    // Pure's own behaviour and fixes PROD-85545: e.g. `concatenate([$optional], $many)`).
                     if (collection.values.size() > 1 && !isExactlyOne(res._multiplicity()))
                     {
                         throw new EngineException(
@@ -906,9 +901,6 @@ public class ValueSpecificationBuilder implements ValueSpecificationVisitor<Valu
                 : MostCommonType.mostCommon(transformed.collect(ValueSpecificationAccessor::_genericType).distinct(), this.context.pureModel);
         _genericType._classifierGenericType(this.context.pureModel.getGenericType(M3Paths.GenericType));
 
-        // For a single-element literal wrapping a non-[1] variable, the effective outer multiplicity is
-        // that element's multiplicity (bracket is a semantic no-op). Otherwise trust the parser-supplied
-        // literal-count multiplicity, as before.
         Multiplicity effectiveMultiplicity =
                 (transformed.size() == 1 && !isExactlyOne(transformed.get(0)._multiplicity()))
                         ? transformed.get(0)._multiplicity()
@@ -919,8 +911,6 @@ public class ValueSpecificationBuilder implements ValueSpecificationVisitor<Valu
                 ._multiplicity(effectiveMultiplicity)
                 ._values(transformed.collect(valueSpecification ->
                 {
-                    // Only auto-unwrap InstanceValues that are truly [1] with a single stored raw.
-                    // Many-mult wrappers stay wrapped so downstream flattening sees the correct shape.
                     if (valueSpecification instanceof InstanceValue
                             && ((InstanceValue) valueSpecification)._values().size() == 1
                             && isExactlyOne(valueSpecification._multiplicity()))

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/test/java/org/finos/legend/engine/language/pure/compiler/test/fromGrammar/TestDomainCompilationFromGrammar.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/test/java/org/finos/legend/engine/language/pure/compiler/test/fromGrammar/TestDomainCompilationFromGrammar.java
@@ -1555,7 +1555,7 @@ public class TestDomainCompilationFromGrammar extends TestCompilationFromGrammar
     }
 
     @Test
-    public void testSingleElementCollectionLiteralAcceptsOptional_PROD_85545()
+    public void testSingleElementCollectionLiteralAcceptsOptional()
     {
 
         test("Class test::A\n" +
@@ -1567,7 +1567,7 @@ public class TestDomainCompilationFromGrammar extends TestCompilationFromGrammar
     }
 
     @Test
-    public void testSingleElementCollectionLiteralAcceptsMany_PROD_85545()
+    public void testSingleElementCollectionLiteralAcceptsMany()
     {
 
         test("Class test::A\n" +
@@ -1579,7 +1579,7 @@ public class TestDomainCompilationFromGrammar extends TestCompilationFromGrammar
     }
 
     @Test
-    public void testSingleElementCollectionInIfBranches_PROD_85545()
+    public void testSingleElementCollectionInIfBranches()
     {
         test("Class test::A\n" +
                 "{\n" +
@@ -1589,7 +1589,7 @@ public class TestDomainCompilationFromGrammar extends TestCompilationFromGrammar
     }
 
     @Test
-    public void testSingleElementCollectionInConstructorManySlot_PROD_85545()
+    public void testSingleElementCollectionInConstructorManySlot()
     {
 
         test("Class test::Foo { xs : String[*]; }\n" +
@@ -1600,7 +1600,7 @@ public class TestDomainCompilationFromGrammar extends TestCompilationFromGrammar
     }
 
     @Test
-    public void testMultiElementCollectionStillRejectsNonOne_PROD_85545()
+    public void testMultiElementCollectionStillRejectsNonOne()
     {
 
         test("Class test::A\n" +

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/test/java/org/finos/legend/engine/language/pure/compiler/test/fromGrammar/TestDomainCompilationFromGrammar.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/test/java/org/finos/legend/engine/language/pure/compiler/test/fromGrammar/TestDomainCompilationFromGrammar.java
@@ -1555,6 +1555,62 @@ public class TestDomainCompilationFromGrammar extends TestCompilationFromGrammar
     }
 
     @Test
+    public void testSingleElementCollectionLiteralAcceptsOptional_PROD_85545()
+    {
+
+        test("Class test::A\n" +
+                "{\n" +
+                "   optional : String[0..1];\n" +
+                "   many : String[*];\n" +
+                "   prop() { concatenate([$this.optional], $this.many) } : String[*];\n" +
+                "}");
+    }
+
+    @Test
+    public void testSingleElementCollectionLiteralAcceptsMany_PROD_85545()
+    {
+
+        test("Class test::A\n" +
+                "{\n" +
+                "   many1 : String[*];\n" +
+                "   many2 : String[*];\n" +
+                "   prop() { concatenate([$this.many1], $this.many2) } : String[*];\n" +
+                "}");
+    }
+
+    @Test
+    public void testSingleElementCollectionInIfBranches_PROD_85545()
+    {
+        test("Class test::A\n" +
+                "{\n" +
+                "   optional : String[0..1];\n" +
+                "   prop(cond:Boolean[1]) { if($cond, | [$this.optional], | []) } : String[*];\n" +
+                "}");
+    }
+
+    @Test
+    public void testSingleElementCollectionInConstructorManySlot_PROD_85545()
+    {
+
+        test("Class test::Foo { xs : String[*]; }\n" +
+                "function test::mkFoo(opt:String[0..1]):test::Foo[1]\n" +
+                "{\n" +
+                "   ^test::Foo(xs = [$opt])\n" +
+                "}");
+    }
+
+    @Test
+    public void testMultiElementCollectionStillRejectsNonOne_PROD_85545()
+    {
+
+        test("Class test::A\n" +
+                "{\n" +
+                "   optional : String[0..1];\n" +
+                "   prop() { [$this.optional, 'x'] } : String[*];\n" +
+                "}", "COMPILATION error at [4:20-27]: Collection element must have a multiplicity [1] - Context:[Class 'test::A' Third Pass, Qualified Property prop], multiplicity:[0..1]");
+    }
+
+    @Test
     public void testConstraint()
     {
         test("Class test::A\n" +


### PR DESCRIPTION
## Purpose

Aligns Legend Java compiler's handling of single-element collection literals

(`[$x]`) with Pure's own compiler. Previously, wrapping any non-`[1]` variable

in brackets — e.g. `[$optional]` where `$optional : String[0..1]` — was

rejected by `ValueSpecificationBuilder.visit(Collection)` with:

 

    Collection element must have a multiplicity [1] ... multiplicity:[0..1]

 

## Reproduction (before fix)

 

    function test::f(opt:String[0..1], many:String[*]):String[*]

    {

       concatenate([$opt], $many)

    }

 

- Pure IDE: compiles

- Legend compiler: [Error] "Collection element must have a multiplicity [1] ... [0..1]"

 

## Fix

 

In `ValueSpecificationBuilder.visit(Collection)`:

 

1. **Guard relaxed to multi-element case only.** The `[1]`-only element rule

   now fires only when `collection.values.size() > 1`. Single-element literals

   `[$x]` are accepted regardless of the wrapped variable's multiplicity —

   they act as a semantically transparent wrapper (Pure has no nested

   collections; `[$x]` and `$x` produce the same flat shape).

 

2. **Effective multiplicity propagated truthfully.** For a 1-element literal

   wrapping a non-`[1]` variable, the resulting `InstanceValue`'s multiplicity

   is set to the inner variable's multiplicity (not the parser-supplied count

   of `1`). This ensures downstream consumers see the real runtime cardinality

   rather than being told "exactly 1" when the value could be `[0..1]` or

   `[*]`.

 

3. **Unwrap guarded by `isExactlyOne`.** The value-compaction step (unwrap a

   single-element `InstanceValue` into its raw first value) now only fires

   when the element's multiplicity is exactly `[1]`.

 

For every collection shape that compiled before this change, the resulting

M3 graph is byte-identical. Only newly-accepted shapes produce a new graph,

and that graph matches what Pure's own compiler produces from equivalent

`.pure` source.

 

## Patterns unblocked

 

All five surface syntaxes that lower to `visit(Collection)`:

 

1. **Function arguments** — `concatenate([$opt], $many)` (the ticket case).

2. **`if` branches** — `if($cond, | [$opt], | [])`.

3. **Class constructor slots** — `^Foo(xs = [$opt])` where `xs : String[*]`.

4. **Pipeline steps** — `$people->filter(p | [$p.middleName]->isNotEmpty())`.

 

## Invariant preserved

 

Multi-element literals `[a, b, ...]` still require every element to be `[1]`.

This is the invariant that parser-rewritten binary operators rely on:

 

    $a + 'x'  →  plus([$a, 'x'])   -- 2-element, still strict-checked

 

## Files changed

 

- `ValueSpecificationBuilder.java` — the fix (+ `isExactlyOne` helper).

- `TestDomainCompilationFromGrammar.java` — 5 regression tests.