### PR TITLE
Shared CodeDependencyResolutionState through Java Generation

### DIFF
--- a/legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-pure/src/main/resources/core_java_platform_binding/legendJavaPlatformBinding/bindPlanToLegendJavaPlatform.pure
+++ b/legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-pure/src/main/resources/core_java_platform_binding/legendJavaPlatformBinding/bindPlanToLegendJavaPlatform.pure
@@ -35,7 +35,8 @@ function meta::pure::executionPlan::platformBinding::legendJava::bindPlanToLegen
    let generationContext  = $plan->prepareGenerationContext($legendJavaConfig, $extensions, $debug);
 
    let baseProject        = $generationContext->generateTypes($debug);
-   let generatedNode      = $plan.rootExecutionNode->generateLegendJavaPlatformBindingCode('root', $generationContext, $extensions, $debug);
+   let seededContext      = ^$generationContext(resolutionState = ^CodeDependencyResolutionState(projectsByDependency=^Map<String, Project>()));
+   let generatedNode      = $plan.rootExecutionNode->generateLegendJavaPlatformBindingCode('root', $seededContext, $extensions, $debug);
    let generatedProject   = $baseProject->concatenate($generatedNode.project)->toOneMany()->mergeProjects();
 
    ^$plan
@@ -113,53 +114,69 @@ function <<access.private>> meta::pure::executionPlan::platformBinding::legendJa
 
 // Generate Java Code -----------------------------------------------------------------
 
+function meta::pure::executionPlan::platformBinding::legendJava::lastResolutionState(nodes: GeneratedNode[*], default: CodeDependencyResolutionState[1]): CodeDependencyResolutionState[1]
+{
+   let withState = $nodes->filter(n | $n.resolutionState->isNotEmpty());
+   if($withState->isEmpty(), | $default, | $withState->last()->toOne().resolutionState->toOne());
+}
+
 function meta::pure::executionPlan::platformBinding::legendJava::generateLegendJavaPlatformBindingCode(node: ExecutionNode[1], path: String[1], context: GenerationContext[1], extensions: Extension[*], debug: DebugContext[1]): GeneratedNode[1]
 {
    let supportingExtension = $node->supportingLegendJavaExtension($extensions);
+   let ctxIn = ^$context(resolutionState = $context->currentResolutionState());
 
    let generated = if ($supportingExtension.generateLegendJavaCodeForNode->isNotEmpty(),
-                       | $supportingExtension.generateLegendJavaCodeForNode->toOne()->eval($node, $path, $context, $extensions, $debug),
+                       | $supportingExtension.generateLegendJavaCodeForNode->toOne()->eval($node, $path, $ctxIn, $extensions, $debug),
                        | $node->match([
-                            p:PureExpressionPlatformExecutionNode[1]                    | $p->generateImplementionForPlatformNode($path, $context, $extensions, $debug),
-                            p:PlatformPrimitiveQualifierLocalGraphFetchExecutionNode[1] | $p->generateImplementationForPlatformPrimitiveQualifierLocalGraphFetchExecutionNode($path, $context, $extensions, $debug),
-                            f:FunctionParametersValidationNode[1]                       | $f->generateJavaClassForFunctionParameters($context, $debug),
+                            p:PureExpressionPlatformExecutionNode[1]                    | $p->generateImplementionForPlatformNode($path, $ctxIn, $extensions, $debug),
+                            p:PlatformPrimitiveQualifierLocalGraphFetchExecutionNode[1] | $p->generateImplementationForPlatformPrimitiveQualifierLocalGraphFetchExecutionNode($path, $ctxIn, $extensions, $debug),
+                            f:FunctionParametersValidationNode[1]                       | $f->generateJavaClassForFunctionParameters($ctxIn, $debug),
                             e:ExecutionNode[1]                                          | ^GeneratedCode()
                          ])
                    );
 
-   let generatedChildren = $node.executionNodes->generateLegendJavaPlatformBindingCodeForChildNodes(1, $path, $context, $extensions, $debug);
+   let stateAfterGen = if($generated.resolutionState->isEmpty(), | $ctxIn.resolutionState->toOne(), | $generated.resolutionState->toOne());
+   let ctxAfterGen = ^$context(resolutionState = $stateAfterGen);
+
+   let generatedChildren = $node.executionNodes->generateLegendJavaPlatformBindingCodeForChildNodes(1, $path, $ctxAfterGen, $extensions, $debug);
+   let stateAfterChildren = $generatedChildren->lastResolutionState($stateAfterGen);
+   let ctxAfterChildren = ^$context(resolutionState = $stateAfterChildren);
 
    let newNode     = ^$node(executionNodes = $generatedChildren.node, implementation = $generated.implementation);
    let fullProject = $generated.project->concatenate($generatedChildren.project)->concatenate($context.baseProject)->mergeProjectsNullable();
 
    if ($supportingExtension.generateLegendJavaCodeForExtraChildNodes->isNotEmpty(),
-       | $supportingExtension.generateLegendJavaCodeForExtraChildNodes->toOne()->eval($newNode, $fullProject, $path, $context, $extensions, $debug),
+       | $supportingExtension.generateLegendJavaCodeForExtraChildNodes->toOne()->eval($newNode, $fullProject, $path, $ctxAfterChildren, $extensions, $debug),
        | $newNode->match([
             {g:GlobalGraphFetchExecutionNode[1] |
-               let transformedChildren = $g.children->size()->range()->map(x | $g.children->at($x)->generateLegendJavaPlatformBindingCode($path + '.globalChild' + $x->toString(), $context, $extensions, $debug));
-               let transformedLocal = $g.localGraphFetchExecutionNode->generateLegendJavaPlatformBindingCode($path + localGraphFetchNodePathPrefix(), $context, $extensions, $debug);
+               let transformedChildren = $g.children->size()->range()->map(x | $g.children->at($x)->generateLegendJavaPlatformBindingCode($path + '.globalChild' + $x->toString(), $ctxAfterChildren, $extensions, $debug));
+               let stateAfterGlobalChildren = $transformedChildren->lastResolutionState($stateAfterChildren);
+               let transformedLocal = $g.localGraphFetchExecutionNode->generateLegendJavaPlatformBindingCode($path + localGraphFetchNodePathPrefix(), ^$context(resolutionState = $stateAfterGlobalChildren), $extensions, $debug);
                ^GeneratedNode(
                   node = ^$g
                          (
                             children = $transformedChildren.node->cast(@GlobalGraphFetchExecutionNode),
                             localGraphFetchExecutionNode = $transformedLocal.node->cast(@LocalGraphFetchExecutionNode)
                          ),
-                  project = $fullProject->concatenate($transformedChildren.project)->concatenate($transformedLocal.project)->mergeProjectsNullable()
+                  project = $fullProject->concatenate($transformedChildren.project)->concatenate($transformedLocal.project)->mergeProjectsNullable(),
+                  resolutionState = $transformedLocal->lastResolutionState($stateAfterGlobalChildren)
                );
             },
             {f:FreeMarkerConditionalExecutionNode[1] |
-               let transformedTrueBlock = $f.trueBlock->generateLegendJavaPlatformBindingCode($path + '.trueBlock', $context, $extensions, $debug);
-               let transformedFalseBlock = if($f.falseBlock->isEmpty(), |[], |$f.falseBlock->toOne()->generateLegendJavaPlatformBindingCode($path + '.falseBlock', $context, $extensions, $debug));
+               let transformedTrueBlock = $f.trueBlock->generateLegendJavaPlatformBindingCode($path + '.trueBlock', $ctxAfterChildren, $extensions, $debug);
+               let stateAfterTrue = $transformedTrueBlock->lastResolutionState($stateAfterChildren);
+               let transformedFalseBlock = if($f.falseBlock->isEmpty(), |[], |$f.falseBlock->toOne()->generateLegendJavaPlatformBindingCode($path + '.falseBlock', ^$context(resolutionState = $stateAfterTrue), $extensions, $debug));
                ^GeneratedNode(
                   node = ^$f
                          (
                             trueBlock = $transformedTrueBlock.node,
                             falseBlock = $transformedFalseBlock.node
                          ),
-                  project = $fullProject->concatenate($transformedTrueBlock.project)->concatenate($transformedFalseBlock.project)->mergeProjectsNullable()
+                  project = $fullProject->concatenate($transformedTrueBlock.project)->concatenate($transformedFalseBlock.project)->mergeProjectsNullable(),
+                  resolutionState = $transformedFalseBlock->lastResolutionState($stateAfterTrue)
                );
             },
-            {e:ExecutionNode[1] | ^GeneratedNode(node = $newNode, project = $fullProject)}
+            {e:ExecutionNode[1] | ^GeneratedNode(node = $newNode, project = $fullProject, resolutionState = $stateAfterChildren)}
          ])
    );
 }
@@ -168,9 +185,12 @@ function <<access.private>> meta::pure::executionPlan::platformBinding::legendJa
 {
    $nodes->head()->match([
       n0:ExecutionNode[0] | [],
-      n :ExecutionNode[1] | $n->generateLegendJavaPlatformBindingCode($parentPath + '.n' + $childNo->toString(), $context, $extensions, $debug)->concatenate(
-                               $nodes->tail()->generateLegendJavaPlatformBindingCodeForChildNodes($childNo + 1, $parentPath, $context, $extensions, $debug)
-                            )
+      n :ExecutionNode[1] |
+         let gn = $n->generateLegendJavaPlatformBindingCode($parentPath + '.n' + $childNo->toString(), $context, $extensions, $debug);
+         let stateAfter = $gn->lastResolutionState($context->currentResolutionState());
+         $gn->concatenate(
+            $nodes->tail()->generateLegendJavaPlatformBindingCodeForChildNodes($childNo + 1, $parentPath, ^$context(resolutionState = $stateAfter), $extensions, $debug)
+         );
    ]);
 }
 

--- a/legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-pure/src/main/resources/core_java_platform_binding/legendJavaPlatformBinding/executionPlanNodes/graphFetch/inMemory/graphFetchInMemory.pure
+++ b/legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-pure/src/main/resources/core_java_platform_binding/legendJavaPlatformBinding/executionPlanNodes/graphFetch/inMemory/graphFetchInMemory.pure
@@ -110,10 +110,12 @@ function meta::pure::mapping::modelToModel::executionPlan::platformBinding::lege
    );
 }
 
-function meta::pure::mapping::modelToModel::executionPlan::platformBinding::legendJava::graphFetch::generateInMemoryStoreGraphFetchProject(node: InMemoryGraphFetchExecutionNode[1], path: String[1], context: GenerationContext[1],extensions: Extension[*], debug: DebugContext[1]):Project[1]
+function meta::pure::mapping::modelToModel::executionPlan::platformBinding::legendJava::graphFetch::generateInMemoryStoreGraphFetchProject(node: InMemoryGraphFetchExecutionNode[1], path: String[1], context: GenerationContext[1],extensions: Extension[*], debug: DebugContext[1]):ProjectAndState[1]
 {
    $node->match([
-      c : InMemoryCrossStoreGraphFetchExecutionNode[1]  | $c->generateInMemoryStoreRootNodeProject($path, $context, $extensions,  $debug)->addInMemoryCrossStoreMethods($c, $path, $context, $extensions, $debug),
+      c : InMemoryCrossStoreGraphFetchExecutionNode[1]  |
+             let rns = $c->generateInMemoryStoreRootNodeProject($path, $context, $extensions,  $debug);
+             ^ProjectAndState(project = $rns.project->toOne()->addInMemoryCrossStoreMethods($c, $path, $context, $extensions, $debug), resolutionState = $rns.resolutionState);,
       r : InMemoryRootGraphFetchExecutionNode[1]        | $r->generateInMemoryStoreRootNodeProject($path, $context, $extensions, $debug),
       p : InMemoryPropertyGraphFetchExecutionNode[1]    | $p->generateInMemoryStorePropertyNodeProject($path, $context, $extensions, $debug)
    ])
@@ -187,7 +189,7 @@ function <<access.private>> meta::pure::mapping::modelToModel::executionPlan::pl
    newProject()->concatenate($projects)->toOneMany()->mergeProjects();
 }
 
-function <<access.private>> meta::pure::mapping::modelToModel::executionPlan::platformBinding::legendJava::graphFetch::generateInMemoryStoreRootNodeProject(node: InMemoryRootGraphFetchExecutionNode[1], path: String[1], context: GenerationContext[1], extensions: Extension[*], debug: DebugContext[1]):Project[1]
+function <<access.private>> meta::pure::mapping::modelToModel::executionPlan::platformBinding::legendJava::graphFetch::generateInMemoryStoreRootNodeProject(node: InMemoryRootGraphFetchExecutionNode[1], path: String[1], context: GenerationContext[1], extensions: Extension[*], debug: DebugContext[1]):ProjectAndState[1]
 {
    print(if($debug.debug,|$debug.space+'('+$path+') generateCodeForInMemoryRootGraphFetch\n', |''));
    if($node->nodeIsMerged(),
@@ -215,10 +217,15 @@ function <<access.private>> meta::pure::mapping::modelToModel::executionPlan::pl
 
         let executeClass   = $executeClassWithImports->addMethod($transformMethod)->addMethod($filterMethod);
         let executeProject = newProject()->addClasses($executeClass);
-        let allProjects    = $executeProject->concatenate($transformMethodCodes->dependencies()->resolveAndGetProjects())
-        ->concatenate($filterMethodCode->dependencies()->resolveAndGetProjects())
+        let s0             = $context->currentResolutionState();
+        let transformDeps  = $transformMethodCodes->dependencies();
+        let s1             = $transformDeps->resolveProjects($s0);
+        let filterDeps     = $filterMethodCode->dependencies();
+        let s2             = $filterDeps->resolveProjects($s1);
+        let allProjects    = $executeProject->concatenate($s2->getProjects($transformDeps))
+        ->concatenate($s2->getProjects($filterDeps))
         ->toOneMany();
-        $allProjects->mergeProjects();
+        ^ProjectAndState(project = $allProjects->mergeProjects(), resolutionState = $s2);
      );
 }
 
@@ -231,7 +238,7 @@ function <<access.private>> meta::pure::mapping::modelToModel::executionPlan::pl
 }
 
 
-function <<access.private>> meta::pure::mapping::modelToModel::executionPlan::platformBinding::legendJava::graphFetch::generateInMemoryStoreMergeRootNodes(node: InMemoryRootGraphFetchExecutionNode[1], path: String[1], context: GenerationContext[1], extensions: Extension[*], debug: DebugContext[1]):Project[1]
+function <<access.private>> meta::pure::mapping::modelToModel::executionPlan::platformBinding::legendJava::graphFetch::generateInMemoryStoreMergeRootNodes(node: InMemoryRootGraphFetchExecutionNode[1], path: String[1], context: GenerationContext[1], extensions: Extension[*], debug: DebugContext[1]):ProjectAndState[1]
 {
 
   print(if($debug.debug,|$debug.space+'('+$path+') generateCodeForInMemoryRootGraphFetch for Merge\n', |''));
@@ -269,8 +276,11 @@ function <<access.private>> meta::pure::mapping::modelToModel::executionPlan::pl
 
   let executeClass   = $executeClassWithImports->addMethods($transformMethod->concatenate($mergeMethods));
   let executeProject = newProject()->addClasses($executeClass);
-  let allProjects    = $executeProject->concatenate($transform->dependencies()->resolveAndGetProjects())->toOneMany();
-  $allProjects->mergeProjects();
+  let s0             = $context->currentResolutionState();
+  let transformDeps  = $transform->dependencies();
+  let s1             = $transformDeps->resolveProjects($s0);
+  let allProjects    = $executeProject->concatenate($s1->getProjects($transformDeps))->toOneMany();
+  ^ProjectAndState(project = $allProjects->mergeProjects(), resolutionState = $s1);
  }
 
 Class <<access.private>> meta::pure::mapping::modelToModel::executionPlan::platformBinding::legendJava::graphFetch::MergedPropertyHolder
@@ -285,7 +295,7 @@ Class <<access.private>> meta::pure::mapping::modelToModel::executionPlan::platf
 
 
 
-function <<access.private>> meta::pure::mapping::modelToModel::executionPlan::platformBinding::legendJava::graphFetch::generateInMemoryStorePropertyNodeProject(node: InMemoryPropertyGraphFetchExecutionNode[1], path: String[1], context: GenerationContext[1], extensions: Extension[*], debug: DebugContext[1]):Project[1]
+function <<access.private>> meta::pure::mapping::modelToModel::executionPlan::platformBinding::legendJava::graphFetch::generateInMemoryStorePropertyNodeProject(node: InMemoryPropertyGraphFetchExecutionNode[1], path: String[1], context: GenerationContext[1], extensions: Extension[*], debug: DebugContext[1]):ProjectAndState[1]
 {
    print(if($debug.debug,|$debug.space+'('+$path+') generateCodeForInMemoryPropertyGraphFetch\n', |''));
 
@@ -420,13 +430,20 @@ function <<access.private>> meta::pure::mapping::modelToModel::executionPlan::pl
    let executeClass            = $executeClassWithFields ->addMethod($transformPropertyMethod);
    let executeProject          = newProject()->addClasses($executeClass);
 
+   let s0             = $context->currentResolutionState();
+   let d1             = $propMappingTransformers->dependencies();
+   let s1             = $d1->resolveProjects($s0);
+   let d2             = $targetSetTransformers->dependencies();
+   let s2             = $d2->resolveProjects($s1);
+   let d3             = $transformPropertyMethodCodes->dependencies();
+   let s3             = $d3->resolveProjects($s2);
    let allProjects = $executeProject
-      ->concatenate($propMappingTransformers->dependencies()->resolveAndGetProjects())
-      ->concatenate($targetSetTransformers->dependencies()->resolveAndGetProjects())
-      ->concatenate($transformPropertyMethodCodes->dependencies()->resolveAndGetProjects())
+      ->concatenate($s3->getProjects($d1))
+      ->concatenate($s3->getProjects($d2))
+      ->concatenate($s3->getProjects($d3))
       ->toOneMany();
 
-    $allProjects->mergeProjects();
+    ^ProjectAndState(project = $allProjects->mergeProjects(), resolutionState = $s3);
 }
 function <<access.private>> meta::pure::mapping::modelToModel::executionPlan::platformBinding::legendJava::graphFetch::addFilterForSubtype(input:Code[1],propertyType: Code[1],targetSRCType:meta::external::language::java::metamodel::Type[1], targetSet:InstanceSetImplementation[1],context: GenerationContext[1],extensions: Extension[*]):Code[1]
 {

--- a/legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-pure/src/main/resources/core_java_platform_binding/legendJavaPlatformBinding/main.pure
+++ b/legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-pure/src/main/resources/core_java_platform_binding/legendJavaPlatformBinding/main.pure
@@ -39,6 +39,7 @@ Class meta::pure::executionPlan::platformBinding::legendJava::GenerationContext
    nodeInfos                 : NodeInfo[*];
    baseProject               : Project[0..1];
    suppliedClassesForGeneration : meta::pure::metamodel::type::Class<Any>[*];
+   resolutionState           : CodeDependencyResolutionState[0..1];
 }
 
 Class meta::pure::executionPlan::platformBinding::legendJava::NodeInfo
@@ -70,12 +71,27 @@ Class meta::pure::executionPlan::platformBinding::legendJava::GeneratedCode
 {
    project: Project[0..1];
    implementation: JavaPlatformImplementation[0..1];
+   resolutionState: CodeDependencyResolutionState[0..1];
 }
 
 Class meta::pure::executionPlan::platformBinding::legendJava::GeneratedNode
 {
    project: Project[0..1];
    node: ExecutionNode[1];
+   resolutionState: CodeDependencyResolutionState[0..1];
+}
+
+Class meta::pure::executionPlan::platformBinding::legendJava::ProjectAndState
+{
+   project: Project[0..1];
+   resolutionState: CodeDependencyResolutionState[1];
+}
+
+function meta::pure::executionPlan::platformBinding::legendJava::currentResolutionState(context:GenerationContext[1]): CodeDependencyResolutionState[1]
+{
+   if($context.resolutionState->isEmpty(),
+      | ^CodeDependencyResolutionState(projectsByDependency=^Map<String, Project>()),
+      | $context.resolutionState->toOne());
 }
 
 

--- a/legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-pure/src/main/resources/core_java_platform_binding/legendJavaPlatformBinding/store/m2m/m2mLegendJavaPlatformBindingExtension.pure
+++ b/legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-pure/src/main/resources/core_java_platform_binding/legendJavaPlatformBinding/store/m2m/m2mLegendJavaPlatformBindingExtension.pure
@@ -68,12 +68,14 @@ function meta::pure::mapping::modelToModel::executionPlan::platformBinding::lege
                   $impl->enrichForInMemoryGraphExecution($i, $context, $extensions, $debug)
                };
                let baseProject  = $i->generateBaseProjectForLocalGraphFetchNode($path, $context, $inMemoryGraphImplUpdateFunction, $extensions, $debug);
-               let storeProject = $i->generateInMemoryStoreGraphFetchProject($path, $context, $extensions, $debug);
+               let storeResult  = $i->generateInMemoryStoreGraphFetchProject($path, $context, $extensions, $debug);
+               let storeProject = $storeResult.project->toOne();
 
-               generatedCode(
+               let gc = generatedCode(
                   $baseProject->concatenate($storeProject)->toOneMany()->mergeProjects(),
                   $storeProject->resolve($context.conventions->planNodeClass('public', $path, 'Execute'))
                );
+               ^$gc(resolutionState = $storeResult.resolutionState);
             },
             s: StoreStreamReadingExecutionNode[1] | $s->generateCodeForStoreStreamReadingExecutionNode($path, $context, $extensions, $debug),
             n: ExecutionNode[1]                   | ^GeneratedCode()
@@ -83,11 +85,16 @@ function meta::pure::mapping::modelToModel::executionPlan::platformBinding::lege
       generateLegendJavaCodeForExtraChildNodes = {node: ExecutionNode[1], project: Project[0..1], path: String[1], context: GenerationContext[1], extensions: Extension[*], debug: DebugContext[1] |
          $node->match([
             {i: InMemoryGraphFetchExecutionNode[1] |
-               let transformedChildren = $i.children->size()->range()->map(x | $i.children->at($x)->generateLegendJavaPlatformBindingCode($path + '.localChild' + $x->toString(), $context, $extensions, $debug));
+               let transformedChildren = $i.children->size()->range()->fold({x, acc |
+                  let stateSoFar = $acc->lastResolutionState($context->currentResolutionState());
+                  let gn = $i.children->at($x)->generateLegendJavaPlatformBindingCode($path + '.localChild' + $x->toString(), ^$context(resolutionState = $stateSoFar), $extensions, $debug);
+                  $acc->concatenate($gn);
+               }, []);
                ^GeneratedNode
                (
                   node    = ^$i(children = $transformedChildren.node->cast(@InMemoryGraphFetchExecutionNode)),
-                  project = $project->concatenate($transformedChildren.project)->mergeProjectsNullable()
+                  project = $project->concatenate($transformedChildren.project)->mergeProjectsNullable(),
+                  resolutionState = $transformedChildren->lastResolutionState($context->currentResolutionState())
                );
             },
             n: ExecutionNode[1] | ^GeneratedNode(node = $node, project = $project)


### PR DESCRIPTION
#### What type of PR is this?

- Improvement


#### What does this PR do / why is it needed ?

Thread a single CodeDependencyResolutionState through the whole generation. It's seeded once at the bindPlan root and carried through the execution-node recursion (child nodes, GlobalGraphFetch/FreeMarker branches) and the m2m/graphFetch handler chain, so once a function is generated it's cached and reused everywhere else instead of being regenerated.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
