### PR TITLE
EMIT: fixes and additional tests

### DIFF
--- a/docs/emit/emit-authoring.md
+++ b/docs/emit/emit-authoring.md
@@ -94,13 +94,37 @@ Apply the rule from `emit.md` §3.2:
 | M2M mapping (no service, no store) | `legend-engine-core/legend-engine-core-emit-tests`, under `src/test/resources/m2m-emit-models/`, run by `M2MEMITTests` |
 | Relational store / mapping / connection (including embedded service tests) | `legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit`, under `src/test/resources/relational-emit-models/`, run by `RelationalEMITTests` |
 | Relation (`~func`) function-based class mapping — `ClassName: Relation { ~func f():Relation<Any>[1]; ... }` | `legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit`, under `src/test/resources/relation-emit-models/`, run by `RelationEMITTests` |
-| Service / service-test (where the mapping & store are already on the service-emit classpath) | `legend-engine-xts-service/legend-engine-xt-service-emit` |
+| Service shapes — multi-execution, test data shared between services, and the deprecated `test: Single` block on a Service (Phase 5's legacy service test runner) | `legend-engine-xts-service/legend-engine-xt-service-emit`, under `src/test/resources/emit-models/`, run by `ServiceEMITTests` |
 | File / model generation | `legend-engine-xts-generation/legend-engine-xt-generation-emit` |
 | External format / binding | The format's `-emit` module under `legend-engine-core-external-format` or its `xts-*` peer (e.g. `legend-engine-xts-json/legend-engine-external-format-jsonSchema-emit`) |
 | Flat-data store | `legend-engine-xts-flatdata/legend-engine-xt-flatdata-emit` |
 | Persistence (service-output target, ingestion tests) | `legend-engine-xts-persistence/legend-engine-xt-persistence-emit` |
 
 If the module you want doesn't exist yet, create it — see §9.
+
+#### Legacy `MappingTests` place by mapping kind, not by runner
+
+A deprecated `MappingTests [ ... ]` block on a Mapping (Phase 5's legacy
+`MappingTestRunner`) involves **no Service**, so it does not belong with the
+service fixtures even though it is the sibling of the legacy *service* test
+runner. Place it with the mappings it exercises, exactly as you would a modern
+`testSuites` block:
+
+| The mapping under test is… | Place it in… |
+|---|---|
+| Relational | `relational-emit-models/` — `relational-legacy-mapping-test` |
+| M2M | `m2m-emit-models/` in `legend-engine-core-emit-tests` — `m2m-legacy-mapping-test` |
+| Spanning several feature areas | `legend-engine-emit-tests` (cross-feature, §3.2) |
+
+The runner being deprecated is a property of the *test style*, not a feature
+area; grouping by it would scatter mappings away from their own suites.
+
+The split also matters for coverage, not just tidiness: `MappingTestRunner`
+resolves `<Object, JSON, …>` input data into a `JsonModelConnection` over a
+base64 `data:` URL, while store-backed input data goes through
+`ConnectionFactoryExtension` and, for relational, becomes H2 setup SQL. One
+fixture proves nothing about the other branch, so a new store flavour wanting
+legacy-mapping-test coverage needs its own fixture in its own suite.
 
 ### 3.2 Cross-feature module (multi-area combinations)
 

--- a/docs/emit/emit.md
+++ b/docs/emit/emit.md
@@ -929,6 +929,8 @@ so live in the `mapping:` domain alongside their relational counterparts:
 | `execution:external-format-binding` | External format binding |
 | `execution:file-generation` | File generation specification |
 | `execution:hosted-service` | Hosted service function activator |
+| `execution:legacy-mapping-test` | Deprecated `MappingTests` block on a Mapping (EMIT Phase 5's legacy `MappingTestRunner`) |
+| `execution:legacy-service-test` | Deprecated `test: Single` / `test: Multi` block on a Service (EMIT Phase 5's legacy `ServiceTestRunner`) |
 | `execution:model-generation` | Model generation specification |
 | `execution:multi-execution-service` | Multi-execution service |
 | `execution:plan-generation` | Execution plan generation |

--- a/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/m2m-emit-models/m2m-legacy-mapping-test.emit.yaml
+++ b/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/m2m-emit-models/m2m-legacy-mapping-test.emit.yaml
@@ -1,0 +1,41 @@
+name: m2m-legacy-mapping-test
+title: "M2M Mapping Tested Through the Deprecated MappingTests Block"
+description: |
+  A model-to-model mapping carrying the deprecated `MappingTests [ ... ]` block
+  with `<Object, JSON, sourceClass, '...'>` input data. This is the M2M half of
+  EMIT Phase 5's legacy `MappingTestRunner`, and it takes a materially different
+  code path from its relational sibling `relational-legacy-mapping-test`:
+  `buildTestConnection` turns the input data into a `JsonModelConnection` whose
+  url is a base64 `data:` URL, where the relational form generates H2 setup SQL
+  through `meta::relational::functions::database::setUpData`. Two tests are
+  declared, one filtered, so the per-test loop and more than one input data set
+  are both exercised.
+
+  Note the contrast with the modern M2M test suites in this same directory: the
+  legacy path reaches its single source class through a `data:` URL rather than
+  through `ModelStoreTestConnectionFactory`'s thread-local stream provider, so it
+  does not share that factory's single-connection behaviour — though it is
+  likewise limited to one input data set per test, by an explicit check in
+  `MappingTestRunner.buildTestConnection`.
+
+modelSources:
+  model:
+    root: m2m-legacy-mapping-test
+    files:
+      - model/source.pure
+      - model/target.pure
+      - mapping/personMapping.pure
+
+features:
+  - execution:legacy-mapping-test
+  - execution:test-data
+  - mapping:m2m-transform
+  - mapping:mapping
+  - scaffolding:class
+  - scaffolding:m2m-mapping
+stores: []
+complexity: basic
+tags:
+  - legacy-mapping-test
+  - deprecated
+  - m2m

--- a/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/m2m-emit-models/m2m-legacy-mapping-test/mapping/personMapping.pure
+++ b/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/m2m-emit-models/m2m-legacy-mapping-test/mapping/personMapping.pure
@@ -1,0 +1,47 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Mapping
+Mapping demo::m2m::legacy::PersonMapping
+(
+  *demo::m2m::legacy::target::Person: Pure
+  {
+    ~src demo::m2m::legacy::source::S_Person
+
+    fullName: $src.firstName + ' ' + $src.lastName,
+    birthYear: $src.birthYear
+  }
+
+  MappingTests
+  [
+    allPersons
+    (
+      query: |demo::m2m::legacy::target::Person.all()->graphFetch(#{demo::m2m::legacy::target::Person{fullName, birthYear}}#)->serialize(#{demo::m2m::legacy::target::Person{fullName, birthYear}}#);
+      data:
+      [
+        <Object, JSON, demo::m2m::legacy::source::S_Person, '[{"firstName":"Ada","lastName":"Lovelace","birthYear":1815},{"firstName":"Grace","lastName":"Hopper","birthYear":1906}]'>
+      ];
+      assert: '[{"fullName":"Ada Lovelace","birthYear":1815},{"fullName":"Grace Hopper","birthYear":1906}]';
+    ),
+    filteredPersons
+    (
+      query: |demo::m2m::legacy::target::Person.all()->filter(p|$p.birthYear > 1850)->graphFetch(#{demo::m2m::legacy::target::Person{fullName, birthYear}}#)->serialize(#{demo::m2m::legacy::target::Person{fullName, birthYear}}#);
+      data:
+      [
+        <Object, JSON, demo::m2m::legacy::source::S_Person, '[{"firstName":"Ada","lastName":"Lovelace","birthYear":1815},{"firstName":"Grace","lastName":"Hopper","birthYear":1906},{"firstName":"Alan","lastName":"Turing","birthYear":1912}]'>
+      ];
+      assert: '[{"fullName":"Grace Hopper","birthYear":1906},{"fullName":"Alan Turing","birthYear":1912}]';
+    )
+  ]
+)

--- a/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/m2m-emit-models/m2m-legacy-mapping-test/model/source.pure
+++ b/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/m2m-emit-models/m2m-legacy-mapping-test/model/source.pure
@@ -1,0 +1,21 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+Class demo::m2m::legacy::source::S_Person
+{
+  firstName: String[1];
+  lastName: String[1];
+  birthYear: Integer[1];
+}

--- a/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/m2m-emit-models/m2m-legacy-mapping-test/model/target.pure
+++ b/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/m2m-emit-models/m2m-legacy-mapping-test/model/target.pure
@@ -1,0 +1,20 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+Class demo::m2m::legacy::target::Person
+{
+  fullName: String[1];
+  birthYear: Integer[1];
+}

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/main/java/org/finos/legend/engine/test/emit/EMITRunner.java
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/main/java/org/finos/legend/engine/test/emit/EMITRunner.java
@@ -22,8 +22,6 @@ import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
 import org.finos.legend.engine.language.pure.dsl.generation.extension.Artifact;
 import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
 import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.ExecutionPlan;
-import org.finos.legend.engine.protocol.pure.v1.model.test.result.TestExecuted;
-import org.finos.legend.engine.protocol.pure.v1.model.test.result.TestExecutionStatus;
 import org.finos.legend.engine.test.emit.EMITTasks.ArtifactCandidate;
 import org.finos.legend.engine.test.emit.EMITTasks.LegacyMappingTestCandidate;
 import org.finos.legend.engine.test.emit.EMITTasks.LegacyServiceTestCandidate;
@@ -285,7 +283,7 @@ public class EMITRunner
                 RunTestsResult runTestsResult = EMITTasks.runTests(testableInputs, model.getPmcd(), model.getPureModel());
                 outputs.add(runTestsResult);
                 total += runTestsResult.results.size();
-                failed += ListIterate.count(runTestsResult.results, r -> !(r instanceof TestExecuted) || (((TestExecuted) r).testExecutionStatus == TestExecutionStatus.FAIL));
+                failed += ListIterate.count(runTestsResult.results, r -> !EMITTasks.isTestPassed(r));
             }
 
             // Legacy Mapping tests

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/main/java/org/finos/legend/engine/test/emit/EMITTasks.java
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit/src/main/java/org/finos/legend/engine/test/emit/EMITTasks.java
@@ -78,6 +78,7 @@ import org.finos.legend.engine.testable.extension.TestableRunnerExtensionLoader;
 import org.finos.legend.engine.testable.model.RunTestsResult;
 import org.finos.legend.engine.testable.model.RunTestsTestableInput;
 import org.finos.legend.engine.testable.model.UniqueTestId;
+import org.finos.legend.engine.testable.service.result.MultiExecutionServiceTestResult;
 import org.finos.legend.pure.generated.Root_meta_pure_extension_Extension;
 import org.finos.legend.pure.generated.Root_meta_pure_generation_metamodel_GenerationOutput;
 import org.finos.legend.pure.generated.Root_meta_pure_test_AtomicTest;
@@ -89,6 +90,7 @@ import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.ServiceLoader;
 
@@ -391,28 +393,56 @@ public final class EMITTasks
     }
 
     /**
+     * Whether a test result is a pass — the predicate form of {@link #assertTestPassed(TestResult)},
+     * for callers that tally results rather than failing on the first bad one. A
+     * {@link MultiExecutionServiceTestResult} passes only if it has results and all of them are passes.
+     */
+    public static boolean isTestPassed(TestResult result)
+    {
+        if (result instanceof TestExecuted)
+        {
+            return ((TestExecuted) result).testExecutionStatus == TestExecutionStatus.PASS;
+        }
+        if (result instanceof MultiExecutionServiceTestResult)
+        {
+            Map<String, TestResult> resultsByKey = ((MultiExecutionServiceTestResult) result).getKeyIndexedTestResults();
+            return !resultsByKey.isEmpty() && Iterate.allSatisfy(resultsByKey.values(), EMITTasks::isTestPassed);
+        }
+        return false;
+    }
+
+    /**
      * Throws an {@link EMITAssertionError} if the given test result is anything other than {@code PASS}.
+     *
+     * <p>A test on a multi-execution service yields a {@link MultiExecutionServiceTestResult}:
+     * the atomic test is run once per execution key the test applies to, and the per-key
+     * results are bundled together. Such a result is unwrapped and every key asserted, so a
+     * failure under any one key fails the task and names the key that failed.</p>
      *
      * @param result test result
      * @throws EMITAssertionError if the given test result is anything other than {@code PASS}
      */
     public static void assertTestPassed(TestResult result)
     {
-        StringBuilder builder = new StringBuilder(result.testable);
-        if (result.testSuiteId != null)
-        {
-            builder.append(" / ").append(result.testSuiteId);
-        }
-        builder.append(" / ").append(result.atomicTestId);
+        assertTestPassed(result, null);
+    }
+
+    /**
+     * @param executionKey the multi-execution key this result was produced under, or
+     *                     {@code null} for a result that is not keyed by execution
+     */
+    private static void assertTestPassed(TestResult result, String executionKey)
+    {
         if (result instanceof TestError)
         {
-            throw new EMITException(EMITPhase.TEST_EXECUTION, builder.append("; ").append(((TestError) result).error).toString());
+            throw new EMITException(EMITPhase.TEST_EXECUTION, describeTest(result, executionKey).append("; ").append(((TestError) result).error).toString());
         }
         if (result instanceof TestExecuted)
         {
             TestExecuted executed = (TestExecuted) result;
             if (executed.testExecutionStatus != TestExecutionStatus.PASS)
             {
+                StringBuilder builder = describeTest(result, executionKey);
                 builder.append(" did not pass; status=").append(executed.testExecutionStatus).append("; assertions=[");
                 executed.assertStatuses.forEach(s -> printAssertStatus(builder, s).append(", "));
                 builder.setLength(builder.length() - 2);
@@ -421,7 +451,32 @@ public final class EMITTasks
             }
             return;
         }
-        throw new EMITException(EMITPhase.TEST_EXECUTION, builder.append("Unexpected test result type: ").append(result.getClass().getSimpleName()).toString());
+        if (result instanceof MultiExecutionServiceTestResult)
+        {
+            Map<String, TestResult> resultsByKey = ((MultiExecutionServiceTestResult) result).getKeyIndexedTestResults();
+            if (resultsByKey.isEmpty())
+            {
+                throw new EMITException(EMITPhase.TEST_EXECUTION, describeTest(result, null).append(" ran under no execution key; the test's 'keys' match none of the service's execution keys").toString());
+            }
+            resultsByKey.forEach((key, keyResult) -> assertTestPassed(keyResult, key));
+            return;
+        }
+        throw new EMITException(EMITPhase.TEST_EXECUTION, describeTest(result, executionKey).append("Unexpected test result type: ").append(result.getClass().getSimpleName()).toString());
+    }
+
+    private static StringBuilder describeTest(TestResult result, String executionKey)
+    {
+        StringBuilder builder = new StringBuilder(result.testable);
+        if (result.testSuiteId != null)
+        {
+            builder.append(" / ").append(result.testSuiteId);
+        }
+        builder.append(" / ").append(result.atomicTestId);
+        if (executionKey != null)
+        {
+            builder.append(" [key=").append(executionKey).append(']');
+        }
+        return builder;
     }
 
     private static StringBuilder printAssertStatus(StringBuilder builder, AssertionStatus status)

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-emit/src/test/java/org/finos/legend/engine/test/emit/persistence/PersistenceEMITTests.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-emit/src/test/java/org/finos/legend/engine/test/emit/persistence/PersistenceEMITTests.java
@@ -24,12 +24,6 @@ import java.util.stream.Stream;
  * EMIT coverage for persistence models. Each {@code *.emit.yaml} under
  * {@code emit-models/} becomes one {@link DynamicContainer} whose leaves run
  * the full EMIT pipeline (parse → compile → … → test execution).
- *
- * <p>Note that these dynamic tests pass <em>vacuously</em> if no persistence
- * test is ever discovered: a model that yields no Test tasks simply contributes
- * no failing leaf. The guard against that silent regression lives in
- * {@link TestPersistenceEMITTestSuiteBuilder} (for this JUnit integration) and
- * {@link TestPersistenceEMITRunner} (for the standalone runner).
  */
 public class PersistenceEMITTests
 {

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-legacy-mapping-test.emit.yaml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-legacy-mapping-test.emit.yaml
@@ -1,0 +1,36 @@
+name: relational-legacy-mapping-test
+title: "Relational Mapping Tested Through the Deprecated MappingTests Block"
+description: |
+  A relational mapping over the Person class from `relational-shared-domain`
+  carrying the deprecated `MappingTests [ ... ]` block — `query` / `data` /
+  `assert` triples with `<Relational, CSV, store, '...'>` data — instead of a
+  modern `testSuites` block. This is the only example anywhere in the catalog
+  of the second of EMIT Phase 5's three runners: it drives the legacy
+  `MappingTestRunner`, which sets up H2 from the CSV, plans and executes each
+  query, and compares the serialised TDS against the `assert` string. Two
+  tests are declared so the per-test loop is exercised rather than a single
+  case.
+
+modelSources:
+  model:
+    root: relational-legacy-mapping-test
+    files:
+      - store/db.pure
+      - mapping/personMapping.pure
+  dependencies:
+    - source: relational-shared-domain.emit.yaml
+
+features:
+  - execution:legacy-mapping-test
+  - execution:test-data
+  - scaffolding:class
+  - scaffolding:relational-mapping
+  - scaffolding:relational-store
+stores:
+  - relational
+complexity: basic
+tags:
+  - legacy-mapping-test
+  - deprecated
+  - h2
+  - shared-domain

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-legacy-mapping-test/mapping/personMapping.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-legacy-mapping-test/mapping/personMapping.pure
@@ -1,0 +1,50 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Mapping
+Mapping demo::PersonMapping
+(
+  *demo::Person: Relational
+  {
+    ~primaryKey
+    (
+      [demo::store::PersonDB]PersonTable.id
+    )
+    ~mainTable [demo::store::PersonDB]PersonTable
+    firstName: [demo::store::PersonDB]PersonTable.firstName,
+    lastName: [demo::store::PersonDB]PersonTable.lastName
+  }
+
+  MappingTests
+  [
+    allPersons
+    (
+      query: |demo::Person.all()->project([p|$p.firstName, p|$p.lastName], ['First Name', 'Last Name']);
+      data:
+      [
+        <Relational, CSV, demo::store::PersonDB, 'default\nPersonTable\nid,firstName,lastName\n1,Ada,Lovelace\n2,Grace,Hopper\n\n\n\n'>
+      ];
+      assert: '[{"values":["Ada","Lovelace"]},{"values":["Grace","Hopper"]}]';
+    ),
+    lovelaceOnly
+    (
+      query: |demo::Person.all()->filter(p|$p.lastName == 'Lovelace')->project([p|$p.firstName], ['First Name']);
+      data:
+      [
+        <Relational, CSV, demo::store::PersonDB, 'default\nPersonTable\nid,firstName,lastName\n1,Ada,Lovelace\n2,Grace,Hopper\n\n\n\n'>
+      ];
+      assert: '[{"values":["Ada"]}]';
+    )
+  ]
+)

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-legacy-mapping-test/store/db.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-legacy-mapping-test/store/db.pure
@@ -1,0 +1,24 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Relational
+Database demo::store::PersonDB
+(
+  Table PersonTable
+  (
+    id INTEGER PRIMARY KEY,
+    firstName VARCHAR(200),
+    lastName VARCHAR(200)
+  )
+)

--- a/legend-engine-xts-service/legend-engine-xt-service-emit/pom.xml
+++ b/legend-engine-xts-service/legend-engine-xt-service-emit/pom.xml
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2026 Goldman Sachs
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.finos.legend.engine</groupId>
+        <artifactId>legend-engine-xts-service</artifactId>
+        <version>4.137.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>legend-engine-xt-service-emit</artifactId>
+    <name>Legend Engine - XT - Service - EMIT Tests</name>
+    <description>EMIT (Engine Model Integration Test) models exercising service shapes: multi-execution services, test data shared between services via a Data element, and the deprecated ServiceTest block that EMIT Phase 5's legacy service test runner drives. Models execute against an in-memory H2.</description>
+
+    <dependencies>
+        <!-- EMIT framework + JUnit integration -->
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-emit-junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- EMIT -->
+
+        <!-- JUnit 5 -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- JUnit 5 -->
+
+        <!-- Service test runner: registers ServiceTestableRunnerExtension via ServiceLoader and
+             carries the legacy ServiceTestRunner that EMIT Phase 5 drives for `test: Single`. -->
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-test-runner-service</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Service DSL: grammar / protocol / compiler / Pure metamodel for the Service element. -->
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-language-pure-dsl-service</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-language-pure-dsl-service-pure</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Relational store: grammar (also carries compiler extensions) / protocol / Pure / execution / Java binding.
+             The service models are backed by an H2 relational mapping, mirroring the relational EMIT module. -->
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-relationalStore-grammar</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-relationalStore-protocol</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-relationalStore-core-pure</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-relationalStore-executionPlan</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-relationalStore-javaPlatformBinding-pure</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- H2 driver shaded for Legend's relational execution. -->
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-relationalStore-h2-execution-2.1.214</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Plan generation + serialisation, in-memory store, json model, java binding —
+             same set as the relational EMIT module, kept here to mirror that profile. -->
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-executionPlan-execution-store-inMemory</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-external-format-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-json-model</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-pure-runtime-java-extension-compiled-functions-json</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-javaPlatformBinding-pure</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-configuration-plan-generation-serialization</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/legend-engine-xts-service/legend-engine-xt-service-emit/src/test/java/org/finos/legend/engine/test/emit/service/ServiceEMITTests.java
+++ b/legend-engine-xts-service/legend-engine-xt-service-emit/src/test/java/org/finos/legend/engine/test/emit/service/ServiceEMITTests.java
@@ -1,0 +1,47 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.test.emit.service;
+
+import org.finos.legend.engine.test.emit.junit.EMITTestSuiteBuilder;
+import org.junit.jupiter.api.DynamicContainer;
+import org.junit.jupiter.api.TestFactory;
+
+import java.util.stream.Stream;
+
+/**
+ * JUnit 5 runner for the <b>service shapes</b> EMIT suite: services whose execution
+ * shape is the subject — multi-execution routing by env key, test data shared between
+ * services through a {@code Data} element — plus the deprecated {@code test: Single}
+ * block that EMIT Phase 5's legacy service test runner drives, which has no example
+ * anywhere else in the catalog.
+ *
+ * <p>Only service-bearing models belong here. The legacy <i>mapping</i> test runner is
+ * the sibling Phase 5 path but involves no Service, so its example lives with the
+ * mappings it exercises — {@code relational-legacy-mapping-test} in the relational
+ * suite.
+ *
+ * <p>All models are backed by an in-memory H2 relational mapping so the tests execute
+ * rather than only compile. The module hosts a single subject area, so it keeps the
+ * conventional {@code emit-models/} root and needs no {@code includedRelativeSubpaths}
+ * override in the server pom (see {@code docs/emit/emit.md} §5.4).
+ */
+public class ServiceEMITTests
+{
+    @TestFactory
+    Stream<DynamicContainer> emit()
+    {
+        return EMITTestSuiteBuilder.testContainers("emit-models/");
+    }
+}

--- a/legend-engine-xts-service/legend-engine-xt-service-emit/src/test/resources/emit-models/service-legacy-test.emit.yaml
+++ b/legend-engine-xts-service/legend-engine-xt-service-emit/src/test/resources/emit-models/service-legacy-test.emit.yaml
@@ -1,0 +1,40 @@
+name: service-legacy-test
+title: "Service Tested Through the Deprecated ServiceTest Block"
+description: |
+  A relational-backed service carrying the deprecated `test: Single { data;
+  asserts }` block instead of a modern `testSuites` block. EMIT Phase 5 runs
+  three test runners — Testable, legacy Mapping and legacy Service — and this
+  is the only distributed example of the third: it drives `ServiceTestRunner`,
+  which turns the CSV `data` string into H2 setup SQL through
+  `meta::relational::functions::database::setUpData`, generates and compiles a
+  plan, then compiles the assert lambdas to Java and evaluates them against the
+  `Result`. Both the runner and that CSV-to-SQL path are otherwise unexercised
+  by the catalog.
+
+modelSources:
+  model:
+    root: service-legacy-test
+    files:
+      - runtime/personRuntime.pure
+      - service/personService.pure
+  dependencies:
+    - source: service-shared-domain.emit.yaml
+
+features:
+  - execution:legacy-service-test
+  - execution:plan-generation
+  - execution:service
+  - execution:test-data
+  - scaffolding:class
+  - scaffolding:relational-connection
+  - scaffolding:relational-mapping
+  - scaffolding:relational-store
+  - scaffolding:runtime
+stores:
+  - relational
+complexity: basic
+tags:
+  - legacy-service-test
+  - deprecated
+  - h2
+  - shared-domain

--- a/legend-engine-xts-service/legend-engine-xt-service-emit/src/test/resources/emit-models/service-legacy-test/runtime/personRuntime.pure
+++ b/legend-engine-xts-service/legend-engine-xt-service-emit/src/test/resources/emit-models/service-legacy-test/runtime/personRuntime.pure
@@ -1,0 +1,40 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Connection
+RelationalDatabaseConnection demo::connection::PersonH2Connection
+{
+  store: demo::store::PersonDB;
+  type: H2;
+  specification: LocalH2
+  {
+  };
+  auth: DefaultH2;
+}
+
+###Runtime
+Runtime demo::runtime::PersonRuntime
+{
+  mappings:
+  [
+    demo::PersonMapping
+  ];
+  connections:
+  [
+    demo::store::PersonDB:
+    [
+      h2: demo::connection::PersonH2Connection
+    ]
+  ];
+}

--- a/legend-engine-xts-service/legend-engine-xt-service-emit/src/test/resources/emit-models/service-legacy-test/service/personService.pure
+++ b/legend-engine-xts-service/legend-engine-xt-service-emit/src/test/resources/emit-models/service-legacy-test/service/personService.pure
@@ -1,0 +1,36 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Service
+Service demo::service::LegacyPersonService
+{
+  pattern: '/api/legacy/persons';
+  documentation: 'List all persons; tested through the deprecated single ServiceTest block.';
+  autoActivateUpdates: true;
+  execution: Single
+  {
+    query: |demo::Person.all()->project([x|$x.firstName, x|$x.lastName], ['First Name', 'Last Name']);
+    mapping: demo::PersonMapping;
+    runtime: demo::runtime::PersonRuntime;
+  }
+  test: Single
+  {
+    data: 'default\nPersonTable\nid,firstName,lastName\n1,Ada,Lovelace\n2,Grace,Hopper\n\n\n\n';
+    asserts:
+    [
+      { [], res: meta::pure::mapping::Result<Any|*>[1]|$res.values->cast(@meta::pure::tds::TabularDataSet).rows->size() == 2 },
+      { [], res: meta::pure::mapping::Result<Any|*>[1]|$res.values->cast(@meta::pure::tds::TabularDataSet).rows->at(0).getString('Last Name') == 'Lovelace' }
+    ];
+  }
+}

--- a/legend-engine-xts-service/legend-engine-xt-service-emit/src/test/resources/emit-models/service-multi-execution.emit.yaml
+++ b/legend-engine-xts-service/legend-engine-xt-service-emit/src/test/resources/emit-models/service-multi-execution.emit.yaml
@@ -1,0 +1,41 @@
+name: service-multi-execution
+title: "Multi-Execution Service Routed by Environment Key"
+description: |
+  A Service whose execution is `Multi`, keyed on `env`: the same query is bound
+  to a QA and a UAT execution, each with its own runtime and its own H2
+  connection. The test suite primes both connections with different rows and
+  pins each atomic test to one key, so a test only passes if the engine routed
+  it to that key's runtime — proving per-key resolution rather than merely that
+  a multi-execution service compiles. Plan generation runs over the resulting
+  `CompositeExecutionPlan`.
+
+modelSources:
+  model:
+    root: service-multi-execution
+    files:
+      - connection/connections.pure
+      - runtime/runtimes.pure
+      - service/personEnvService.pure
+  dependencies:
+    - source: service-shared-domain.emit.yaml
+
+features:
+  - execution:multi-execution-service
+  - execution:plan-generation
+  - execution:service
+  - execution:service-test
+  - execution:test-data
+  - scaffolding:class
+  - scaffolding:relational-connection
+  - scaffolding:relational-mapping
+  - scaffolding:relational-store
+  - scaffolding:runtime
+stores:
+  - relational
+complexity: basic
+tags:
+  - multi-execution
+  - h2
+  - service-test
+  - plan-generation
+  - shared-domain

--- a/legend-engine-xts-service/legend-engine-xt-service-emit/src/test/resources/emit-models/service-multi-execution/connection/connections.pure
+++ b/legend-engine-xts-service/legend-engine-xt-service-emit/src/test/resources/emit-models/service-multi-execution/connection/connections.pure
@@ -1,0 +1,34 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Connection
+RelationalDatabaseConnection demo::connection::QaH2Connection
+{
+  store: demo::store::PersonDB;
+  type: H2;
+  specification: LocalH2
+  {
+  };
+  auth: DefaultH2;
+}
+
+RelationalDatabaseConnection demo::connection::UatH2Connection
+{
+  store: demo::store::PersonDB;
+  type: H2;
+  specification: LocalH2
+  {
+  };
+  auth: DefaultH2;
+}

--- a/legend-engine-xts-service/legend-engine-xt-service-emit/src/test/resources/emit-models/service-multi-execution/runtime/runtimes.pure
+++ b/legend-engine-xts-service/legend-engine-xt-service-emit/src/test/resources/emit-models/service-multi-execution/runtime/runtimes.pure
@@ -1,0 +1,44 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Runtime
+Runtime demo::runtime::QaRuntime
+{
+  mappings:
+  [
+    demo::PersonMapping
+  ];
+  connections:
+  [
+    demo::store::PersonDB:
+    [
+      qaH2: demo::connection::QaH2Connection
+    ]
+  ];
+}
+
+Runtime demo::runtime::UatRuntime
+{
+  mappings:
+  [
+    demo::PersonMapping
+  ];
+  connections:
+  [
+    demo::store::PersonDB:
+    [
+      uatH2: demo::connection::UatH2Connection
+    ]
+  ];
+}

--- a/legend-engine-xts-service/legend-engine-xt-service-emit/src/test/resources/emit-models/service-multi-execution/service/personEnvService.pure
+++ b/legend-engine-xts-service/legend-engine-xt-service-emit/src/test/resources/emit-models/service-multi-execution/service/personEnvService.pure
@@ -1,0 +1,108 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Service
+Service demo::service::PersonEnvService
+{
+  pattern: '/api/persons/{env}';
+  documentation: 'List all persons from the environment selected by the env key.';
+  autoActivateUpdates: true;
+  execution: Multi
+  {
+    query: |demo::Person.all()->project([x|$x.firstName, x|$x.lastName], ['First Name', 'Last Name']);
+    key: 'env';
+    executions['QA']:
+    {
+      mapping: demo::PersonMapping;
+      runtime: demo::runtime::QaRuntime;
+    }
+    executions['UAT']:
+    {
+      mapping: demo::PersonMapping;
+      runtime: demo::runtime::UatRuntime;
+    }
+  }
+  testSuites:
+  [
+    envSuite:
+    {
+      data:
+      [
+        connections:
+        [
+          qaH2:
+            Relational
+            #{
+              default.PersonTable:
+                'id,firstName,lastName\n' +
+                '1,Ada,Lovelace\n';
+            }#,
+          uatH2:
+            Relational
+            #{
+              default.PersonTable:
+                'id,firstName,lastName\n' +
+                '1,Grace,Hopper\n' +
+                '2,Alan,Turing\n';
+            }#
+        ]
+      ]
+      tests:
+      [
+        qaEnv:
+        {
+          serializationFormat: PURE_TDSOBJECT;
+          keys:
+          [
+            'QA'
+          ];
+          asserts:
+          [
+            shouldSeeQaData:
+              EqualToJson
+              #{
+                expected:
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '[{"First Name":"Ada","Last Name":"Lovelace"}]';
+                  }#;
+              }#
+          ]
+        },
+        uatEnv:
+        {
+          serializationFormat: PURE_TDSOBJECT;
+          keys:
+          [
+            'UAT'
+          ];
+          asserts:
+          [
+            shouldSeeUatData:
+              EqualToJson
+              #{
+                expected:
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '[{"First Name":"Grace","Last Name":"Hopper"},{"First Name":"Alan","Last Name":"Turing"}]';
+                  }#;
+              }#
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/legend-engine-xts-service/legend-engine-xt-service-emit/src/test/resources/emit-models/service-shared-domain.emit.yaml
+++ b/legend-engine-xts-service/legend-engine-xt-service-emit/src/test/resources/emit-models/service-shared-domain.emit.yaml
@@ -1,0 +1,29 @@
+name: service-shared-domain
+title: "Shared Person Domain, H2 Store and Relational Mapping"
+description: |
+  A reusable bundle consumed by every service EMIT example in this module: a
+  Person class with a `fullName` derived property, a single-table H2 store,
+  and the relational mapping that ties them together. Declaring no connection,
+  runtime or service, it leaves each consumer free to layer on the execution
+  shape that is actually under test — one runtime or two, a modern test suite
+  or a deprecated one. Its own EMIT run only exercises parse + compile.
+
+modelSources:
+  model:
+    root: service-shared-domain
+    files:
+      - model/person.pure
+      - store/personDb.pure
+      - mapping/personMapping.pure
+
+features:
+  - grammar:derived-property
+  - scaffolding:class
+  - scaffolding:relational-mapping
+  - scaffolding:relational-store
+stores:
+  - relational
+complexity: basic
+tags:
+  - shared-domain
+  - h2

--- a/legend-engine-xts-service/legend-engine-xt-service-emit/src/test/resources/emit-models/service-shared-domain/mapping/personMapping.pure
+++ b/legend-engine-xts-service/legend-engine-xt-service-emit/src/test/resources/emit-models/service-shared-domain/mapping/personMapping.pure
@@ -1,0 +1,28 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Mapping
+Mapping demo::PersonMapping
+(
+  *demo::Person: Relational
+  {
+    ~primaryKey
+    (
+      [demo::store::PersonDB]PersonTable.id
+    )
+    ~mainTable [demo::store::PersonDB]PersonTable
+    firstName: [demo::store::PersonDB]PersonTable.firstName,
+    lastName: [demo::store::PersonDB]PersonTable.lastName
+  }
+)

--- a/legend-engine-xts-service/legend-engine-xt-service-emit/src/test/resources/emit-models/service-shared-domain/model/person.pure
+++ b/legend-engine-xts-service/legend-engine-xt-service-emit/src/test/resources/emit-models/service-shared-domain/model/person.pure
@@ -1,0 +1,21 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+Class demo::Person
+{
+  firstName: String[1];
+  lastName: String[1];
+  fullName() {$this.firstName + ' ' + $this.lastName}: String[1];
+}

--- a/legend-engine-xts-service/legend-engine-xt-service-emit/src/test/resources/emit-models/service-shared-domain/store/personDb.pure
+++ b/legend-engine-xts-service/legend-engine-xt-service-emit/src/test/resources/emit-models/service-shared-domain/store/personDb.pure
@@ -1,0 +1,24 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Relational
+Database demo::store::PersonDB
+(
+  Table PersonTable
+  (
+    id INTEGER PRIMARY KEY,
+    firstName VARCHAR(200),
+    lastName VARCHAR(200)
+  )
+)

--- a/legend-engine-xts-service/legend-engine-xt-service-emit/src/test/resources/emit-models/service-shared-test-data.emit.yaml
+++ b/legend-engine-xts-service/legend-engine-xt-service-emit/src/test/resources/emit-models/service-shared-test-data.emit.yaml
@@ -1,0 +1,42 @@
+name: service-shared-test-data
+title: "One Data Element Feeding Two Services' Test Suites"
+description: |
+  Two services over the same relational mapping — a full listing and a filtered
+  lookup — whose test suites both prime their connection from a single
+  `demo::data::PersonData` element via `Reference #{ ... }#` rather than
+  restating the rows inline. The point is the sharing: one edit to the Data
+  element must move both services' expectations, so the model is a regression
+  for `Data`-element resolution through `EmbeddedDataCompilerHelper` on the
+  service-test path, not merely for a service having test data at all.
+
+modelSources:
+  model:
+    root: service-shared-test-data
+    files:
+      - data/personData.pure
+      - runtime/personRuntime.pure
+      - service/personServices.pure
+  dependencies:
+    - source: service-shared-domain.emit.yaml
+
+features:
+  - execution:data-element
+  - execution:plan-generation
+  - execution:service
+  - execution:service-test
+  - execution:shared-test-data
+  - execution:test-data
+  - scaffolding:class
+  - scaffolding:relational-connection
+  - scaffolding:relational-mapping
+  - scaffolding:relational-store
+  - scaffolding:runtime
+stores:
+  - relational
+complexity: basic
+tags:
+  - shared-test-data
+  - data-element
+  - h2
+  - service-test
+  - shared-domain

--- a/legend-engine-xts-service/legend-engine-xt-service-emit/src/test/resources/emit-models/service-shared-test-data/data/personData.pure
+++ b/legend-engine-xts-service/legend-engine-xt-service-emit/src/test/resources/emit-models/service-shared-test-data/data/personData.pure
@@ -1,0 +1,25 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Data
+Data demo::data::PersonData
+{
+  Relational
+  #{
+    default.PersonTable:
+      'id,firstName,lastName\n' +
+      '1,Ada,Lovelace\n' +
+      '2,Grace,Hopper\n';
+  }#
+}

--- a/legend-engine-xts-service/legend-engine-xt-service-emit/src/test/resources/emit-models/service-shared-test-data/runtime/personRuntime.pure
+++ b/legend-engine-xts-service/legend-engine-xt-service-emit/src/test/resources/emit-models/service-shared-test-data/runtime/personRuntime.pure
@@ -1,0 +1,40 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Connection
+RelationalDatabaseConnection demo::connection::PersonH2Connection
+{
+  store: demo::store::PersonDB;
+  type: H2;
+  specification: LocalH2
+  {
+  };
+  auth: DefaultH2;
+}
+
+###Runtime
+Runtime demo::runtime::PersonRuntime
+{
+  mappings:
+  [
+    demo::PersonMapping
+  ];
+  connections:
+  [
+    demo::store::PersonDB:
+    [
+      h2: demo::connection::PersonH2Connection
+    ]
+  ];
+}

--- a/legend-engine-xts-service/legend-engine-xt-service-emit/src/test/resources/emit-models/service-shared-test-data/service/personServices.pure
+++ b/legend-engine-xts-service/legend-engine-xt-service-emit/src/test/resources/emit-models/service-shared-test-data/service/personServices.pure
@@ -1,0 +1,114 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Service
+Service demo::service::PersonListService
+{
+  pattern: '/api/persons';
+  documentation: 'List every person.';
+  autoActivateUpdates: true;
+  execution: Single
+  {
+    query: |demo::Person.all()->project([x|$x.firstName, x|$x.lastName], ['First Name', 'Last Name']);
+    mapping: demo::PersonMapping;
+    runtime: demo::runtime::PersonRuntime;
+  }
+  testSuites:
+  [
+    listSuite:
+    {
+      data:
+      [
+        connections:
+        [
+          h2:
+            Reference
+            #{
+              demo::data::PersonData
+            }#
+        ]
+      ]
+      tests:
+      [
+        allPersons:
+        {
+          serializationFormat: PURE_TDSOBJECT;
+          asserts:
+          [
+            shouldListBoth:
+              EqualToJson
+              #{
+                expected:
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '[{"First Name":"Ada","Last Name":"Lovelace"},{"First Name":"Grace","Last Name":"Hopper"}]';
+                  }#;
+              }#
+          ]
+        }
+      ]
+    }
+  ]
+}
+
+Service demo::service::PersonByLastNameService
+{
+  pattern: '/api/persons/hopper';
+  documentation: 'Find the people whose last name is Hopper.';
+  autoActivateUpdates: true;
+  execution: Single
+  {
+    query: |demo::Person.all()->filter(p|$p.lastName == 'Hopper')->project([x|$x.firstName], ['First Name']);
+    mapping: demo::PersonMapping;
+    runtime: demo::runtime::PersonRuntime;
+  }
+  testSuites:
+  [
+    lookupSuite:
+    {
+      data:
+      [
+        connections:
+        [
+          h2:
+            Reference
+            #{
+              demo::data::PersonData
+            }#
+        ]
+      ]
+      tests:
+      [
+        onlyHopper:
+        {
+          serializationFormat: PURE_TDSOBJECT;
+          asserts:
+          [
+            shouldFindGrace:
+              EqualToJson
+              #{
+                expected:
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '[{"First Name":"Grace"}]';
+                  }#;
+              }#
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/legend-engine-xts-service/pom.xml
+++ b/legend-engine-xts-service/pom.xml
@@ -35,5 +35,6 @@
         <module>legend-engine-services-model</module>
         <module>legend-engine-services-model-http-api</module>
         <module>legend-engine-test-runner-service</module>
+        <module>legend-engine-xt-service-emit</module>
     </modules>
 </project>


### PR DESCRIPTION
- Fix a bug with handling of multi-execution service test results in EMIT
- Add an M2M legacy mapping test
- Add a relational legacy mapping test
- Add service EMIT tests
- Fix a typo in the doc for PersistenceEMITTests