### PR TITLE
Fix bi-temporal union duplicate column regression

### DIFF
--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery.pure
@@ -1212,7 +1212,9 @@ function meta::relational::functions::pureToSqlQuery::buildCorrelatedSubQuery(se
                            ->concatenate($select.extraFilteringOperation)
                            ->extractTableAliasColumns()
                            ->filter(t|$t.alias->in($foundNodeSubNodes))
-                           ->filter(c|!($c.alias == $child.alias && $nestedSelect.columns->cast(@Alias).name->contains($c.column.name)))
+                           // Strip quotes before comparing — milestoning aliases in the union are quoted (e.g. "lake_thru_0")
+                           // but column references may use the unquoted form. Without this, duplicates slip through.
+                            ->filter(c|!($c.alias == $child.alias && $nestedSelect.columns->cast(@Alias).name->map(n|$n->stripMatchingQuotes())->contains($c.column.name->stripMatchingQuotes())))
                            ->filter(c|!$c.alias.relationalElement->instanceOf(SemiStructuredArrayFlatten) && !$c.alias.relationalElement->instanceOf(meta::relational::functions::pureToSqlQuery::metamodel::SemiStructuredArrayFlattenRelation));
 
    let flattenColumnsInSelect = if($isolateGroupBy, |[], |
@@ -1904,7 +1906,8 @@ function meta::relational::functions::pureToSqlQuery::findUnionPropertyMapping(u
 
 function meta::relational::functions::pureToSqlQuery::addMissingColumn(nested:Boolean[1], union:Union[1], propName:String[1], relationalPropertyMappings:RelationalPropertyMapping[*], property:AbstractProperty<Any>[1], propertyOwnerClass:Class<Any>[1], oldSrcOperation:SelectWithCursor[1], state:State[1], joinType:JoinType[1], nodeId:String[1], aggFromMap:List<ColumnGroup>[1], context:DebugContext[1], extensions:Extension[*]):SelectWithCursor[1]
 {
-   $oldSrcOperation->addMissingColumnToUnion({q,i|if( $q.columns->filter(c|$c->cast(@Alias).name == $propName)->isEmpty(),
+   // Compare with stripMatchingQuotes — milestoning aliases are quoted in the union (e.g. "lake_thru_0") and we must recognize them as already present to avoid adding unquoted duplicates.
+   $oldSrcOperation->addMissingColumnToUnion({q,i|if( $q.columns->filter(c|$c->cast(@Alias).name == $propName || $c->cast(@Alias).name->stripMatchingQuotes() == $propName->stripMatchingQuotes())->isEmpty(),
                                                      |
                                                      let filteredRelationalPropertyMappings =  findUnionPropertyMapping($union, $i, $property, $relationalPropertyMappings, $state, $extensions);
                                                      if ($filteredRelationalPropertyMappings->isEmpty(),

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery_union.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery_union.pure
@@ -56,8 +56,8 @@ function meta::relational::functions::pureToSqlQuery::union::addMissingColumnToU
                                        relationalElement = ^$select
                                                            (
                                                               columns = $select.columns->concatenate(
-                                                                $propNames->map({propName | 
-                                                                  if($select.columns->exists(c | $c->cast(@Alias).name == $propName),
+                                                                 $propNames->map({propName |
+                                                                  if($select.columns->exists(c | $c->cast(@Alias).name->stripMatchingQuotes() == $propName->stripMatchingQuotes()),
                                                                      | [],
                                                                      | ^Alias
                                                                         (
@@ -253,13 +253,19 @@ function meta::relational::functions::pureToSqlQuery::union::buildUnion(setImpls
                                                             |[]
                                                         );
 
+                                                        // Milestoning columns (e.g. "lake_thru_0") are already in the union via $milestoning.
+                                                        // FK joins can produce columns with the same base name (e.g. lake_thru_0) — filter
+                                                        // them out to prevent duplicate column errors in the UNION ALL.
+                                                        let milestoningNames = $milestoning->map(m|$m.name->stripMatchingQuotes());
+                                                        let dedupedExtraFKs = $extraFKs->filter(fk|!$milestoningNames->contains($fk.name->stripMatchingQuotes()));
+
                                                         let cols = if($fullGet,
                                                                       | $allColumnsName->map(n|let found = $vals->filter(a|$a.name == $n);
                                                                                           if ($found->isEmpty(),|^Alias(name=$n, relationalElement = $sqlNull),|$found);
                                                                                       ),
                                                                       |[]
                                                                   );
-                                                        ^$q(columns = $newKeys->concatenate($cols)->concatenate($milestoning)->concatenate($extraFKs));
+                                                        ^$q(columns = $newKeys->concatenate($cols)->concatenate($milestoning)->concatenate($dedupedExtraFKs));
                                                     )->pushSavedFilteringOperation($extensions);
                                                  );
 
@@ -311,11 +317,21 @@ function <<access.private>> meta::relational::functions::pureToSqlQuery::union::
 {
   $element->match(   [
                         c:TableAliasColumn[1]|let col = $c.column;
-                                              let tableInJoin = $c.alias.relationalElement->findMainRelation();
+                                               let tableInJoin = $c.alias.relationalElement->findMainRelation();
+                                              // Milestoning columns in the union are aliased with quotes (e.g. "lake_thru_0").
+                                              // ON clause references must also be quoted to match, otherwise H2 uppercases
+                                              // unquoted identifiers and fails with "Column not found".
+                                              let isSrcMilestoningCol = $sourceTable->match([t:Table[1]|$t.milestoning->getAllTemporalColumns().values->contains($col), r:Relation[1]|false]);
+                                              let isTgtMilestoningCol = $targetTable->match([t:Table[1]|$t.milestoning->getAllTemporalColumns().values->contains($col), r:Relation[1]|false]);
                                               let res = if ($processingSide.source,
                                                              | if (isSameRelation($sourceTable, $tableInJoin) && !(!$targetForSelfJoinFromJoin->isEmpty() &&  $targetForSelfJoinFromJoin->toOne() == $c.alias),
                                                                    |let newColumnName = $srcMap->get($col);
-                                                                    ^$c(alias=$newSourceAlias, column=^$col(name=if(!$newColumnName->isEmpty(),|$newColumnName->toOne(),|$col.name + if($sourceIndex == -1, |'', | '_' + $sourceIndex->toString()))));,
+                                                                    let srcColName = if(!$newColumnName->isEmpty(),
+                                                                                       |$newColumnName->toOne(),
+                                                                                       |let baseName = $col.name + if($sourceIndex == -1, |'', | '_' + $sourceIndex->toString());
+                                                                                        if($isSrcMilestoningCol && $sourceIndex != -1, |'"' + $baseName + '"', |$baseName);
+                                                                                    );
+                                                                    ^$c(alias=$newSourceAlias, column=^$col(name=$srcColName));,
                                                                    |$c
                                                                ),
                                                              | $c
@@ -323,7 +339,12 @@ function <<access.private>> meta::relational::functions::pureToSqlQuery::union::
                                               if ($processingSide.target,
                                                     | if ((isSameRelation($targetTable, $tableInJoin) && $targetForSelfJoinFromJoin->isEmpty()) || (!$targetForSelfJoinFromJoin->isEmpty() && $targetForSelfJoinFromJoin->toOne() == $c.alias),
                                                           |let newColumnName = $targetMap->get($col);
-                                                           ^$res(alias=$newTargetAlias, column=^$col(name=if(!$newColumnName->isEmpty(),|$newColumnName->toOne(),|$col.name + if($targetIndex == -1, |'', | '_' + $targetIndex->toString()))));,
+                                                           let tgtColName = if(!$newColumnName->isEmpty(),
+                                                                              |$newColumnName->toOne(),
+                                                                              |let baseName = $col.name + if($targetIndex == -1, |'', | '_' + $targetIndex->toString());
+                                                                               if($isTgtMilestoningCol && $targetIndex != -1, |'"' + $baseName + '"', |$baseName);
+                                                                           );
+                                                           ^$res(alias=$newTargetAlias, column=^$col(name=$tgtColName));,
                                                           |$res
                                                       ),
                                                     | $res
@@ -431,6 +452,10 @@ function meta::relational::functions::pureToSqlQuery::union::buildSQLQueryOutMan
          let missingFks = $sourceCols->map(c|list($c.second.values->map(z|pair($z.name+'_'+$sourceCols->indexOf($c)->toString(), $z))));
          let mappedFkPropertyNames = $sourceCols.first.values.first->removeDuplicates();
 
+         let sourceSetImpls = $sourceSetImplementationIds->map(id| $state->getClassMappingById($id)->cast(@RootRelationalInstanceSetImplementation)->toOne());
+         let srcMilestoningColumns = $sourceSetImpls->map(s|$s.mainTableAlias.relationalElement->findMainNamedRelation()->match([t:Table[1]|$t.milestoning->getAllTemporalColumns(), r:NamedRelation[1]|^List<Column>(values=[])]));
+         let srcMilestoningNames = $sourceSetImpls->map(s| $srcMilestoningColumns->at($sourceSetImpls->indexOf($s)).values->map(c| $c.name->toString() + '_' + $sourceSetImpls->indexOf($s)->toString()))->removeDuplicates();
+
          $srcOperation->addMissingColumnToUnion({q,i|let y = $union.currentTreeNodes->at($i);
 
                                                      let colSet = $sourceCols->at($i);
@@ -449,16 +474,20 @@ function meta::relational::functions::pureToSqlQuery::union::buildSQLQueryOutMan
                                                                                    );
 
 
-                                                     let names = $q.columns->map(m|$m->cast(@Alias).name);
-                                                     let allFks = $mappedOnes->concatenate($col);
-                                                     let partitionedFks = $allFks->partition({c|$names->contains($c.name)});
-                                                      $partitionedFks.first.values->map(f|let col = $q.columns->cast(@Alias)->filter(c|$c.name == $f.name)->toOne(); assertEquals($col.relationalElement,$f.relationalElement,| 'FK column addition failed for column alias: ' + $f.name+ '  , column with same name but different RelationalElement exists in Union'););          
-                                                     ^$q(columns+=$partitionedFks.second.values);
+                                                      let names = $q.columns->map(m|$m->cast(@Alias).name);
+                                                      let allFks = $mappedOnes->concatenate($col);
+                                                      // Filter FK columns that duplicate milestoning aliases already in the union (same logic as buildUnion)
+                                                      let nonMilestoningFks = $allFks->filter(fk|!$srcMilestoningNames->contains($fk.name->stripMatchingQuotes()));
+                                                      let partitionedFks = $nonMilestoningFks->partition({c|$names->contains($c.name)});
+                                                      $partitionedFks.first.values->map(f|let col = $q.columns->cast(@Alias)->filter(c|$c.name == $f.name)->toOne(); assertEquals($col.relationalElement,$f.relationalElement,| 'FK column addition failed for column alias: ' + $f.name+ '  , column with same name but different RelationalElement exists in Union'););
+                                                       
+                                                      ^$q(columns+=$partitionedFks.second.values);
                                                     },
                                                 $sourceRelation->toOne()->isNestedUnion(),
                                                 if($sourceRelation->toOne()->instanceOf(SelectSQLQuery),
                                                    | let selectColNames = $sourceRelation->toOne()->cast(@SelectSQLQuery).columns->cast(@Alias).name;
-                                                     $mappedFkPropertyNames->concatenate($missingFks.values.first)->filter(x | !$selectColNames->contains($x));,
+                                                     let selectColNamesStripped = $selectColNames->map(n|$n->stripMatchingQuotes());
+                                                     $mappedFkPropertyNames->concatenate($missingFks.values.first)->filter(x | !$selectColNames->contains($x) && !$selectColNamesStripped->contains($x->stripMatchingQuotes()));,
                                                    | []
                                                 ),
                                                 $extensions
@@ -708,8 +737,21 @@ function <<access.private>> meta::relational::functions::pureToSqlQuery::union::
                                           );,
                                        | $sourceRelationalElement->cast(@Union)->applyChainedJoinsToUnionQueries($relationalPropertyMappings, $mapping, $missingColumns.first, $parentSourceOperation, $nodeId, $state, $debugContext, $extensions););
    
-   let missingColumnsToAddToUnionQueries = $missingColumns->realiasMissingColumnsToAddToUnionQueries($sourceUnionWithJoinsApplied->resolveUnion().currentTreeNodes.alias.name, $sourceSetImplementationIds);
-   let newAlias = addMissingColumnsToUnion($sourceUnionWithJoinsApplied, $missingColumnsToAddToUnionQueries, $sourceAlias, $extensions);
+    let missingColumnsToAddToUnionQueries = $missingColumns->realiasMissingColumnsToAddToUnionQueries($sourceUnionWithJoinsApplied->resolveUnion().currentTreeNodes.alias.name, $sourceSetImplementationIds);
+
+    // Filter out milestoning columns — the union already has quoted milestoning aliases (e.g. "lake_thru_0").
+    // Without this filter, addMissingColumnsToUnion would add unquoted duplicates (e.g. lake_thru_0)
+    // that cause "Column not found" errors on case-sensitive databases like H2.
+    let sourceSetImpls = $sourceSetImplementationIds->map(id| $state->getClassMappingById($id)->cast(@RootRelationalInstanceSetImplementation)->toOne());
+    let milestoningColNames = $sourceSetImpls->map(s| let idx = $sourceSetImpls->indexOf($s);
+                                                       $s.mainTableAlias.relationalElement->findMainNamedRelation()->match([
+                                                          t:Table[1]|$t.milestoning->getAllTemporalColumns().values->map(c| $c.name + '_' + $idx->toString()),
+                                                          r:NamedRelation[1]|[]
+                                                       ]);
+                                                  )->removeDuplicates();
+    let filteredMissingColumns = $missingColumnsToAddToUnionQueries->filter(p| !$milestoningColNames->contains($p.first.column.name + '_' + $p.second->toString()));
+
+    let newAlias = addMissingColumnsToUnion($sourceUnionWithJoinsApplied, $filteredMissingColumns, $sourceAlias, $extensions);
    pair($newAlias, $updatedRelationalPropertyMappings->list());
 }
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/tests/mapping/union/testUnionBiTemporalSelfJoinDuplicateColumn.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/tests/mapping/union/testUnionBiTemporalSelfJoinDuplicateColumn.pure
@@ -1,0 +1,424 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+import meta::relational::functions::asserts::*;
+import meta::relational::mapping::*;
+import meta::relational::tests::mapping::union::biTemporal::*;
+import meta::relational::tests::*;
+import meta::external::store::relational::tests::*;
+import meta::relational::metamodel::execute::*;
+import meta::external::store::relational::runtime::*;
+import meta::relational::runtime::*;
+
+function <<test.Test>> meta::relational::tests::mapping::union::biTemporal::testBiTemporalUnionWithSelfJoin_duplicateColumnRegression():Boolean[1]
+{
+   let result = execute(
+      |BiTemporalPerson.all(%2024-10-30, %2024-10-30)
+         ->project([p|$p.name, p|$p.contactInfo.email], ['Name', 'Email']),
+      biTemporalUnionMapping,
+      biTemporalTestRuntime(),
+      meta::relational::extension::relationalExtensions()
+   );
+     assertEquals('select "unionBase"."BENEFICIARYLast_Name_CUSTOMERLast_Name" as "Name", "customer_1".Email as "Email" from (select "root".lake_from as "lake_from_0", "root".lake_thru as "lake_thru_0", null as "lake_from_1", null as "lake_thru_1", "root".Beneficiary_Id as "pk_0_0", "root".Account_Id as "pk_1_0", "root".As_Of_Date as "pk_2_0", null as "pk_0_1", null as "pk_1_1", "root".Last_Name as "BENEFICIARYLast_Name_CUSTOMERLast_Name", null as Customer_ID_1, null as Terminated_Record_Flag_1 from OLAP.BENEFICIARY as "root" where "root".lake_from <= DATE\'2024-10-30\' and "root".lake_thru > DATE\'2024-10-30\' union all select null as "lake_from_0", null as "lake_thru_0", "root".lake_from as "lake_from_1", "root".lake_thru as "lake_thru_1", null as "pk_0_0", null as "pk_1_0", null as "pk_2_0", "root".Customer_ID as "pk_0_1", "root".As_Of_Date as "pk_1_1", "root".Last_Name as "BENEFICIARYLast_Name_CUSTOMERLast_Name", "root".Customer_ID as Customer_ID_1, "root".Terminated_Record_Flag as Terminated_Record_Flag_1 from OLAP.CUSTOMER as "root" where "root".lake_from <= DATE\'2024-10-30\' and "root".lake_thru > DATE\'2024-10-30\') as "unionBase" left outer join OLAP.CUSTOMER as "customer_1" on ("unionBase".Customer_ID_1 = "customer_1".Customer_ID and "customer_1".Terminated_Record_Flag = 0 and "customer_1".lake_thru > \'9999-01-01\' and "customer_1".lake_from <= DATE\'2024-10-30\' and "customer_1".lake_thru > DATE\'2024-10-30\' and "customer_1".lake_from <= DATE\'2024-10-30\' and "customer_1".lake_thru > DATE\'2024-10-30\')', $result->sqlRemoveFormatting());
+}
+
+// Regression test: milestoning column references in union join ON clauses must be quoted.
+function <<test.Test>> meta::relational::tests::mapping::union::biTemporal::testBiTemporalUnionJoin_milestoningColumnInOnClause():Boolean[1]
+{
+   let result = execute(
+      |BiTemporalPerson.all(%2024-10-30, %2024-10-30)
+         ->project([p|$p.name, p|$p.relationshipInfo.code], ['Name', 'RelCode']),
+      biTemporalUnionMapping,
+      biTemporalTestRuntime(),
+      meta::relational::extension::relationalExtensions()
+   );
+   // The generated SQL must quote milestoning column references in the ON clause.
+   // If unquoted, H2 would throw: Column "unionalias_X.LAKE_THRU_0" not found (42122)
+   let sql = $result->sqlRemoveFormatting();
+   assert($sql->contains('"lake_thru_0"'), 'Milestoning column reference in ON clause must be quoted to avoid H2 case-sensitivity mismatch');
+   true;
+}
+
+// Regression test: reproduces the PWM failure pattern where a non-union entity navigates
+// TO a union-mapped bi-temporal entity. The union becomes a JOIN TARGET wrapped in a
+// correlated subquery. The wrapper's SELECT list must use quoted milestoning column
+// references (e.g. "lake_thru_0") to match the inner union's quoted aliases.
+// Without the fix, H2 throws: Column "unionalias_X.LAKE_THRU_0" not found (42122)
+function <<test.Test>> meta::relational::tests::mapping::union::biTemporal::testBiTemporalUnionAsJoinTarget_correlatedSubqueryQuoting():Boolean[1]
+{
+   let result = execute(
+      |PartyAccount.all(%2024-10-30, %2024-10-30)
+         ->project([a|$a.accountId, a|$a.owner.name], ['AccountId', 'OwnerName']),
+      biTemporalUnionMapping,
+      biTemporalTestRuntime(),
+      meta::relational::extension::relationalExtensions()
+   );
+   let sql = $result->sqlRemoveFormatting();
+   // Verify the two-level wrapper pattern: inner union "unionalias_1" inside outer wrapper "unionalias_0"
+   assert($sql->contains('as "unionalias_1"'), 'Must have inner union alias (unionalias_1)');
+   assert($sql->contains('as "unionalias_0"'), 'Must have outer wrapper alias (unionalias_0)');
+   // Verify the wrapper SELECT quotes milestoning column references from the inner union.
+   // Without the fix, this would be unquoted: "unionalias_1".lake_thru_0 as lake_thru_0
+   // H2 uppercases the unquoted reference to LAKE_THRU_0, which can't match "lake_thru_0".
+   assert($sql->contains('"unionalias_1"."lake_thru_0" as "lake_thru_0"'), 'Wrapper SELECT must quote milestoning column reference from inner union');
+   // Verify the ON clause also quotes milestoning references on the wrapper
+   assert($sql->contains('"unionalias_0"."lake_thru_0"') || $sql->contains('"unionalias_0"."lake_thru_1"'), 'ON clause must quote milestoning column reference on wrapper');
+   // Verify no unquoted lake_thru_0 reference exists (the actual PWM bug pattern)
+   assert(!$sql->contains('.lake_thru_0 '), 'Must not have unquoted lake_thru_0 reference');
+   true;
+}
+
+function meta::relational::tests::mapping::union::biTemporal::biTemporalTestRuntime():meta::core::runtime::Runtime[1]
+{
+   meta::external::store::relational::tests::testRuntime(biTemporalDB);
+}
+
+
+###Relational
+Database meta::relational::tests::mapping::union::biTemporal::biTemporalDB
+(
+   Schema OLAP
+   (
+      Table CUSTOMER
+      (
+         milestoning(
+            business(BUS_FROM = lake_from, BUS_THRU = lake_thru),
+            processing(PROCESSING_IN = lake_from, PROCESSING_OUT = lake_thru)
+         )
+         Customer_ID INTEGER PRIMARY KEY,
+         As_Of_Date DATE PRIMARY KEY,
+         lake_from DATE,
+         lake_thru DATE,
+         First_Name VARCHAR(100),
+         Last_Name VARCHAR(100),
+         Terminated_Record_Flag INTEGER,
+         active_row_ind VARCHAR(1),
+         Email VARCHAR(200)
+      )
+
+      Table BENEFICIARY
+      (
+         milestoning(
+            business(BUS_FROM = lake_from, BUS_THRU = lake_thru),
+            processing(PROCESSING_IN = lake_from, PROCESSING_OUT = lake_thru)
+         )
+         Beneficiary_Id INTEGER PRIMARY KEY,
+         Account_Id INTEGER PRIMARY KEY,
+         As_Of_Date DATE PRIMARY KEY,
+         lake_from DATE,
+         lake_thru DATE,
+         First_Name VARCHAR(100),
+         Last_Name VARCHAR(100),
+         Terminated_Record_Flag INTEGER
+      )
+
+      Table PARTY_RELATIONSHIP
+      (
+         milestoning(
+            business(BUS_FROM = lake_from, BUS_THRU = lake_thru),
+            processing(PROCESSING_IN = lake_from, PROCESSING_OUT = lake_thru)
+         )
+         rel_id INTEGER PRIMARY KEY,
+         lake_from DATE,
+         lake_thru DATE,
+         active_row_ind VARCHAR(1),
+         source_party_id INTEGER,
+         rel_type_cd VARCHAR(10)
+      )
+
+      Table PARTY_ACCOUNT
+      (
+         milestoning(
+            business(BUS_FROM = lake_from, BUS_THRU = lake_thru),
+            processing(PROCESSING_IN = lake_from, PROCESSING_OUT = lake_thru)
+         )
+         acct_id INTEGER PRIMARY KEY,
+         lake_from DATE,
+         lake_thru DATE,
+         active_row_ind VARCHAR(1),
+         owner_party_id INTEGER,
+         acct_name VARCHAR(100)
+      )
+
+      // Intermediate table between account and party — mirrors PWM's Party_Account_Role.
+      // Forces a chained join path that triggers buildCorrelatedSubQuery when
+      // navigating from account → role → union-mapped party.
+      Table PARTY_ACCOUNT_ROLE
+      (
+         milestoning(
+            business(BUS_FROM = lake_from, BUS_THRU = lake_thru),
+            processing(PROCESSING_IN = lake_from, PROCESSING_OUT = lake_thru)
+         )
+         role_id INTEGER PRIMARY KEY,
+         lake_from DATE,
+         lake_thru DATE,
+         active_row_ind VARCHAR(1),
+         acct_id INTEGER,
+         source_party_id INTEGER,
+         role_type_cd VARCHAR(10)
+      )
+   )
+
+   Join Customer_Self_Join_Live(
+      OLAP.CUSTOMER.Customer_ID = {target}.Customer_ID
+      and {target}.Terminated_Record_Flag = 0
+      and {target}.lake_thru > '9999-01-01'
+   )
+
+   // References milestoning columns on the target (CUSTOMER) side.
+   // When the target is a union, the engine wraps it in a correlated subquery.
+   // The wrapper must quote milestoning column references.
+   Join Account_To_Party(
+      OLAP.PARTY_ACCOUNT.owner_party_id = OLAP.CUSTOMER.Customer_ID
+      and OLAP.CUSTOMER.active_row_ind = 'Y'
+      and OLAP.CUSTOMER.lake_thru >= '9999-01-01'
+   )
+
+   Join Account_To_Beneficiary(
+      OLAP.PARTY_ACCOUNT.owner_party_id = OLAP.BENEFICIARY.Beneficiary_Id
+      and OLAP.BENEFICIARY.lake_thru >= '9999-01-01'
+   )
+
+   // Chained joins for the PWM pattern: Account → AccountRole → Party/Beneficiary
+   // The intermediate table forces the engine through buildCorrelatedSubQuery,
+   // producing the two-level wrapper subquery where the bug manifests.
+   Join Account_To_AccountRole(
+      OLAP.PARTY_ACCOUNT.acct_id = OLAP.PARTY_ACCOUNT_ROLE.acct_id
+      and OLAP.PARTY_ACCOUNT_ROLE.role_type_cd = 'OWN'
+      and OLAP.PARTY_ACCOUNT_ROLE.active_row_ind = 'Y'
+      and OLAP.PARTY_ACCOUNT_ROLE.lake_thru >= '9999-01-01'
+   )
+
+   Join AccountRole_To_Party(
+      OLAP.PARTY_ACCOUNT_ROLE.source_party_id = OLAP.CUSTOMER.Customer_ID
+      and OLAP.CUSTOMER.active_row_ind = 'Y'
+      and OLAP.CUSTOMER.lake_thru >= '9999-01-01'
+   )
+
+   Join AccountRole_To_Beneficiary(
+      OLAP.PARTY_ACCOUNT_ROLE.source_party_id = OLAP.BENEFICIARY.Beneficiary_Id
+      and OLAP.BENEFICIARY.lake_thru >= '9999-01-01'
+   )
+
+   // Join whose condition references milestoning columns (lake_thru, lake_out_id)
+   // from both sides — triggers modifyColumnNameInOperation to suffix them.
+   // If the generated ON clause uses unquoted lake_thru_0, H2 uppercases it
+   // and can't match the inner union's quoted "lake_thru_0".
+   Join Party_To_Relationship(
+      OLAP.CUSTOMER.Customer_ID = OLAP.PARTY_RELATIONSHIP.source_party_id
+      and OLAP.PARTY_RELATIONSHIP.active_row_ind = 'Y'
+      and OLAP.PARTY_RELATIONSHIP.lake_thru >= '9999-11-30'
+      and OLAP.CUSTOMER.active_row_ind = 'Y'
+      and OLAP.CUSTOMER.lake_thru >= '9999-11-30'
+   )
+)
+
+
+###Pure
+import meta::relational::tests::mapping::union::biTemporal::*;
+
+Class <<meta::pure::profiles::temporal.bitemporal>> meta::relational::tests::mapping::union::biTemporal::BiTemporalParty
+{
+   type: String[0..1];
+}
+
+Class <<meta::pure::profiles::temporal.bitemporal>> meta::relational::tests::mapping::union::biTemporal::BiTemporalPerson extends BiTemporalParty
+{
+   name: String[1];
+}
+
+Class <<meta::pure::profiles::temporal.bitemporal>> meta::relational::tests::mapping::union::biTemporal::ContactInfo
+{
+   email: String[0..1];
+   usageType: String[1];
+}
+
+Association meta::relational::tests::mapping::union::biTemporal::Party_ContactInfo
+{
+   party: BiTemporalParty[1];
+   contactInfo: ContactInfo[*];
+}
+
+Class <<meta::pure::profiles::temporal.bitemporal>> meta::relational::tests::mapping::union::biTemporal::RelationshipInfo
+{
+   code: String[0..1];
+}
+
+Association meta::relational::tests::mapping::union::biTemporal::Party_RelationshipInfo
+{
+   partyForRel: BiTemporalParty[1];
+   relationshipInfo: RelationshipInfo[*];
+}
+
+Class <<meta::pure::profiles::temporal.bitemporal>> meta::relational::tests::mapping::union::biTemporal::PartyAccount
+{
+   accountId: Integer[1];
+   acctName: String[0..1];
+}
+
+Association meta::relational::tests::mapping::union::biTemporal::Account_Owner
+{
+   account: PartyAccount[*];
+   owner: BiTemporalPerson[0..1];
+}
+
+###Mapping
+import meta::relational::tests::mapping::union::biTemporal::*;
+
+Mapping meta::relational::tests::mapping::union::biTemporal::biTemporalUnionMapping
+(
+   BiTemporalParty[selectParty]: Relational
+   {
+      ~primaryKey
+      (
+         [biTemporalDB]OLAP.CUSTOMER.Customer_ID,
+         [biTemporalDB]OLAP.CUSTOMER.As_Of_Date
+      )
+      ~mainTable [biTemporalDB]OLAP.CUSTOMER
+      type: 'Individual'
+   }
+
+   BiTemporalParty[selectBeneficiary]: Relational
+   {
+      ~primaryKey
+      (
+         [biTemporalDB]OLAP.BENEFICIARY.Beneficiary_Id,
+         [biTemporalDB]OLAP.BENEFICIARY.Account_Id,
+         [biTemporalDB]OLAP.BENEFICIARY.As_Of_Date
+      )
+      ~mainTable [biTemporalDB]OLAP.BENEFICIARY
+      type: 'Beneficiary'
+   }
+
+   *BiTemporalParty: Operation
+   {
+      meta::pure::router::operations::union_OperationSetImplementation_1__SetImplementation_MANY_(selectParty, selectBeneficiary)
+   }
+
+   BiTemporalPerson[selectPerson] extends [selectParty]: Relational
+   {
+      name: [biTemporalDB]OLAP.CUSTOMER.Last_Name
+   }
+
+   BiTemporalPerson[selectBeneficiaryPerson] extends [selectBeneficiary]: Relational
+   {
+      name: [biTemporalDB]OLAP.BENEFICIARY.Last_Name
+   }
+
+   *BiTemporalPerson: Operation
+   {
+      meta::pure::router::operations::union_OperationSetImplementation_1__SetImplementation_MANY_(selectBeneficiaryPerson, selectPerson)
+   }
+
+   ContactInfo[selectContactInfo]: Relational
+   {
+      ~primaryKey
+      (
+         [biTemporalDB]OLAP.CUSTOMER.Customer_ID,
+         [biTemporalDB]OLAP.CUSTOMER.As_Of_Date
+      )
+      ~mainTable [biTemporalDB]OLAP.CUSTOMER
+      email: [biTemporalDB]OLAP.CUSTOMER.Email,
+      usageType: 'primaryEmail'
+   }
+
+   Party_ContactInfo: Relational
+   {
+      AssociationMapping
+      (
+         party[selectContactInfo, selectParty]: [biTemporalDB]@Customer_Self_Join_Live,
+         contactInfo[selectParty, selectContactInfo]: [biTemporalDB]@Customer_Self_Join_Live
+      )
+   }
+
+   RelationshipInfo[selectRelationship]: Relational
+   {
+      ~primaryKey
+      (
+         [biTemporalDB]OLAP.PARTY_RELATIONSHIP.rel_id
+      )
+      ~mainTable [biTemporalDB]OLAP.PARTY_RELATIONSHIP
+      code: [biTemporalDB]OLAP.PARTY_RELATIONSHIP.rel_type_cd
+   }
+
+   Party_RelationshipInfo: Relational
+   {
+      AssociationMapping
+      (
+         partyForRel[selectRelationship, selectParty]: [biTemporalDB]@Party_To_Relationship,
+         relationshipInfo[selectParty, selectRelationship]: [biTemporalDB]@Party_To_Relationship
+      )
+   }
+
+   PartyAccount[selectAccount]: Relational
+   {
+      ~primaryKey
+      (
+         [biTemporalDB]OLAP.PARTY_ACCOUNT.acct_id
+      )
+      ~mainTable [biTemporalDB]OLAP.PARTY_ACCOUNT
+      accountId: [biTemporalDB]OLAP.PARTY_ACCOUNT.acct_id,
+      acctName: [biTemporalDB]OLAP.PARTY_ACCOUNT.acct_name
+   }
+
+   Account_Owner: Relational
+   {
+      AssociationMapping
+      (
+         // Chained joins through intermediate table — mirrors PWM's
+         // Account → Party_Account_Role → Party_Refined pattern.
+         // Forces engine through buildCorrelatedSubQuery, producing
+         // the two-level wrapper subquery (unionalias_1 inside unionalias_0).
+         owner[selectAccount, selectPerson]: [biTemporalDB]@Account_To_AccountRole > [biTemporalDB]@AccountRole_To_Party,
+         owner[selectAccount, selectBeneficiaryPerson]: [biTemporalDB]@Account_To_AccountRole > [biTemporalDB]@AccountRole_To_Beneficiary,
+         account[selectPerson, selectAccount]: [biTemporalDB]@AccountRole_To_Party > [biTemporalDB]@Account_To_AccountRole,
+         account[selectBeneficiaryPerson, selectAccount]: [biTemporalDB]@AccountRole_To_Beneficiary > [biTemporalDB]@Account_To_AccountRole
+      )
+   }
+)
+
+
+###Pure
+import meta::relational::tests::mapping::union::biTemporal::*;
+import meta::relational::metamodel::execute::*;
+
+function <<test.BeforePackage>> meta::relational::tests::mapping::union::biTemporal::setUp():Boolean[1]
+{
+   let connection = biTemporalTestRuntime().connectionByElement(biTemporalDB)->cast(@meta::external::store::relational::runtime::TestDatabaseConnection);
+
+   executeInDb('CREATE SCHEMA IF NOT EXISTS OLAP;', $connection);
+
+   meta::relational::functions::toDDL::dropAndCreateTableInDb(biTemporalDB, 'OLAP', 'CUSTOMER', $connection);
+   meta::relational::functions::toDDL::dropAndCreateTableInDb(biTemporalDB, 'OLAP', 'BENEFICIARY', $connection);
+   meta::relational::functions::toDDL::dropAndCreateTableInDb(biTemporalDB, 'OLAP', 'PARTY_RELATIONSHIP', $connection);
+   meta::relational::functions::toDDL::dropAndCreateTableInDb(biTemporalDB, 'OLAP', 'PARTY_ACCOUNT', $connection);
+   meta::relational::functions::toDDL::dropAndCreateTableInDb(biTemporalDB, 'OLAP', 'PARTY_ACCOUNT_ROLE', $connection);
+
+   executeInDb('insert into OLAP.CUSTOMER (Customer_ID, As_Of_Date, lake_from, lake_thru, First_Name, Last_Name, Terminated_Record_Flag, active_row_ind, Email) values (1, \'2024-10-30\', \'2020-01-01\', \'9999-12-31\', \'Alice\', \'Alice\', 0, \'Y\', \'alice@test.com\');', $connection);
+   executeInDb('insert into OLAP.CUSTOMER (Customer_ID, As_Of_Date, lake_from, lake_thru, First_Name, Last_Name, Terminated_Record_Flag, active_row_ind, Email) values (2, \'2024-10-30\', \'2020-01-01\', \'9999-12-31\', \'Bob\', \'Bob\', 0, \'Y\', \'bob@test.com\');', $connection);
+
+   executeInDb('insert into OLAP.BENEFICIARY (Beneficiary_Id, Account_Id, As_Of_Date, lake_from, lake_thru, First_Name, Last_Name, Terminated_Record_Flag) values (10, 100, \'2024-10-30\', \'2020-01-01\', \'9999-12-31\', \'Charlie\', \'Charlie\', 0);', $connection);
+
+   executeInDb('insert into OLAP.PARTY_RELATIONSHIP (rel_id, lake_from, lake_thru, active_row_ind, source_party_id, rel_type_cd) values (1, \'2020-01-01\', \'9999-12-31\', \'Y\', 1, \'MNGR\');', $connection);
+   executeInDb('insert into OLAP.PARTY_RELATIONSHIP (rel_id, lake_from, lake_thru, active_row_ind, source_party_id, rel_type_cd) values (2, \'2020-01-01\', \'9999-12-31\', \'Y\', 2, \'OFFC\');', $connection);
+
+   executeInDb('insert into OLAP.PARTY_ACCOUNT (acct_id, lake_from, lake_thru, active_row_ind, owner_party_id, acct_name) values (1001, \'2020-01-01\', \'9999-12-31\', \'Y\', 1, \'Acct-Alice\');', $connection);
+   executeInDb('insert into OLAP.PARTY_ACCOUNT (acct_id, lake_from, lake_thru, active_row_ind, owner_party_id, acct_name) values (1002, \'2020-01-01\', \'9999-12-31\', \'Y\', 2, \'Acct-Bob\');', $connection);
+
+   executeInDb('insert into OLAP.PARTY_ACCOUNT_ROLE (role_id, lake_from, lake_thru, active_row_ind, acct_id, source_party_id, role_type_cd) values (1, \'2020-01-01\', \'9999-12-31\', \'Y\', 1001, 1, \'OWN\');', $connection);
+   executeInDb('insert into OLAP.PARTY_ACCOUNT_ROLE (role_id, lake_from, lake_thru, active_row_ind, acct_id, source_party_id, role_type_cd) values (2, \'2020-01-01\', \'9999-12-31\', \'Y\', 1002, 2, \'OWN\');', $connection);
+
+   true;
+}


### PR DESCRIPTION
#### What type of PR is this?
- Bug Fix


#### What does this PR do / why is it needed ?
##### Problem

Bi-temporal union mappings with self-joins (e.g., `Customer_Self_Join_Live`) produce invalid SQL in two ways:

1. **Duplicate column aliases in UNION ALL** — `buildUnion` adds milestoning columns (e.g., `"lake_from_0"`, `"lake_thru_0"`) and separately the FK logic adds the same columns unquoted (e.g., `lake_from_0`). H2 and other databases reject duplicate aliases.

2. **"Column not found" in ON clauses** — `modifyColumnNameInOperation` computes unquoted column names (e.g., `lake_thru_1`) for join ON clause references, but the union defines them quoted (e.g., `"lake_thru_1"`). H2 uppercases unquoted identifiers, so `LAKE_THRU_1` ≠ `"lake_thru_1"`.

##### Testing

- New test: `testBiTemporalUnionWithSelfJoin_duplicateColumnRegression` — verifies no duplicate columns and correct SQL shape
- New test: `testBiTemporalUnionJoin_milestoningColumnInOnClause` — verifies milestoning column refs are quoted in ON clauses

<!--
Describe change being introduced by this PR.
-->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
