### PR TITLE
M2M: Fix cast of collection types

### DIFF
--- a/legend-engine-core/legend-engine-core-query-pure-http-api/src/test/java/org/finos/legend/engine/query/pure/api/test/inMemory/TestM2MGrammarCompileAndExecute.java
+++ b/legend-engine-core/legend-engine-core-query-pure-http-api/src/test/java/org/finos/legend/engine/query/pure/api/test/inMemory/TestM2MGrammarCompileAndExecute.java
@@ -353,6 +353,58 @@ public class TestM2MGrammarCompileAndExecute
         assertEquals("{\"builder\":{\"_type\":\"json\"},\"values\":{\"name\":\"b\",\"idx\":1}}", json);
     }
 
+    @Test
+    public void testM2MDowncastCollectionElementsToSubtype() throws IOException
+    {
+        // Regression for castCoder in essential/lang.pure: whole-list downcast followed by property navigation.
+        PureModelContextData contextData = PureGrammarParser.newInstance().parseModel("" +
+                "Class test::S_Box\n" +
+                "{\n" +
+                "   kind  : String[1];\n" +
+                "   items : test::S_Shape[*];\n" +
+                "}\n" +
+                "Class test::S_Shape\n" +
+                "{\n" +
+                "}\n" +
+                "Class test::S_Circle extends test::S_Shape\n" +
+                "{\n" +
+                "   label : String[1];\n" +
+                "}\n" +
+                "Class test::T_Row\n" +
+                "{\n" +
+                "   labels : String[*];\n" +
+                "}\n" +
+                "function test::circleLabels(box: test::S_Box[1]): String[*]\n" +
+                "{\n" +
+                "   if($box.kind == 'c', |$box.items->cast(@test::S_Circle).label, |[])\n" +
+                "}\n" +
+                "\n" +
+                "###Mapping\n" +
+                "Mapping test::TestMapping\n" +
+                "(\n" +
+                "   *test::T_Row : Pure\n" +
+                "   {\n" +
+                "     ~src test::S_Box\n" +
+                "     labels : $src->test::circleLabels()\n" +
+                "   }\n" +
+                ")\n"
+        );
+
+        ClassInstance fetchTree = rootGFT("test::T_Row", propertyGFT("labels"));
+        LambdaFunction lambda = lambda(apply(SERIALIZE, apply(GRAPH_FETCH, apply(GET_ALL, clazz("test::T_Row")), fetchTree), fetchTree));
+
+        ExecuteInput input = new ExecuteInput();
+        input.clientVersion = "vX_X_X";
+        input.model = contextData;
+        input.mapping = "test::TestMapping";
+        input.function = lambda;
+        input.runtime = runtimeValue(jsonModelConnection("test::S_Box",
+                "{\"kind\":\"c\",\"items\":[{\"@type\":\"S_Circle\",\"label\":\"alpha\"},{\"@type\":\"S_Circle\",\"label\":\"beta\"}]}"));
+        input.context = context();
+        String json = responseAsString(runTest(input));
+        assertEquals("{\"builder\":{\"_type\":\"json\"},\"values\":{\"labels\":[\"alpha\",\"beta\"]}}", json);
+    }
+
     private Response runTest(ExecuteInput input)
     {
         ModelManager modelManager = new ModelManager(DeploymentMode.TEST);

--- a/legend-engine-xts-java/legend-engine-xt-javaGeneration-conventions-essential-pure/src/main/resources/core_external_language_java_conventions_essential/essential/lang.pure
+++ b/legend-engine-xts-java/legend-engine-xt-javaGeneration-conventions-essential-pure/src/main/resources/core_external_language_java_conventions_essential/essential/lang.pure
@@ -48,13 +48,10 @@ function meta::external::language::java::generation::essential::lang::unitImpl(c
 function meta::external::language::java::generation::essential::lang::castCoder(ctx:FuncCoderContext[1], collection:Code[1], exmpl:Code[1]) : Code[1]
 {
    let type   = resolveHackedUnit($ctx, $ctx.params->at(1));
-
-   let castTo = if(isJavaList($collection.type),
-                   | javaList($type),
-                   | $type
-                );
-
-   $collection->j_cast($castTo);
+   if(isJavaList($collection.type),
+      | $collection->j_listOf(javaList($type)),
+      | $collection->j_cast($type)
+   );
 }
 
 function <<access.private>> meta::external::language::java::generation::essential::lang::resolveHackedUnit(ctx:FuncCoderContext[1], exmpl:ValueSpecification[1]) : meta::external::language::java::metamodel::Type[1]

--- a/legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-pure/src/main/resources/core_java_platform_binding/legendJavaPlatformBinding/planConventions/test/langLibraryTests.pure
+++ b/legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-pure/src/main/resources/core_java_platform_binding/legendJavaPlatformBinding/planConventions/test/langLibraryTests.pure
@@ -27,6 +27,10 @@ meta::pure::executionPlan::platformBinding::legendJava::library::lang::tests::te
          ->assert('(%s).intValue() == 5')
       ->addTest('cast empty', {|[]->cast(@Integer)}, '(Long) null', javaLong()->toBoxed())
          ->assert('(%s) == null')
+      ->addTest('cast collection', {|[1, 2]->cast(@Number)}, 'java.util.Arrays.asList(1L, 2L).stream().map(Number.class::cast).collect(java.util.stream.Collectors.toList())', javaList(javaNumber()))
+         ->assert('(%s).size() == 2')
+         ->assert('((Number)(%s).get(0)).intValue() == 1')
+         ->assert('((Number)(%s).get(1)).intValue() == 2')
       ->runTests();
 }
 


### PR DESCRIPTION
#### What type of PR is this?
- Bug Fix


#### What does this PR do / why is it needed ?
This PR fixes casting of a variable of type collection (e.g. `String[*]`). Currently, those cast within an M2M mapping result in Java compilation errors.


