### PR TITLE
m2m: fix null opt return type

### DIFF
--- a/legend-engine-xts-java/legend-engine-xt-javaGeneration-pure/src/main/resources/core_external_language_java/generation/expressionGeneration.pure
+++ b/legend-engine-xts-java/legend-engine-xt-javaGeneration-pure/src/main/resources/core_external_language_java/generation/expressionGeneration.pure
@@ -33,10 +33,21 @@ function meta::external::language::java::transform::generateJavaMethodBody(vses:
 function meta::external::language::java::transform::generateJavaMethodBody(vses:ValueSpecification[*], conventions: Conventions[1], debug: DebugContext[1]):Code[1]
 {
    assert($vses->isNotEmpty(), 'Method body must have at least one expression');
-   $vses->statementsForBlock($conventions, $debug)->j_block();
+   $vses->statementsForBlock($conventions, [], $debug)->j_block();
 }
 
-function <<access.private>> meta::external::language::java::transform::statementsForBlock(vses:ValueSpecification[*], conventions: Conventions[1], debug: DebugContext[1]):Code[*]
+function meta::external::language::java::transform::generateJavaMethodBody(vses:ValueSpecification[*], conventions: Conventions[1], returnType: meta::external::language::java::metamodel::Type[0..1]):Code[1]
+{
+   generateJavaMethodBody($vses, $conventions, $returnType, noDebug());
+}
+
+function meta::external::language::java::transform::generateJavaMethodBody(vses:ValueSpecification[*], conventions: Conventions[1], returnType: meta::external::language::java::metamodel::Type[0..1], debug: DebugContext[1]):Code[1]
+{
+   assert($vses->isNotEmpty(), 'Method body must have at least one expression');
+   $vses->statementsForBlock($conventions, $returnType, $debug)->j_block();
+}
+
+function <<access.private>> meta::external::language::java::transform::statementsForBlock(vses:ValueSpecification[*], conventions: Conventions[1], returnType: meta::external::language::java::metamodel::Type[0..1], debug: DebugContext[1]):Code[*]
 {
    let generated = $vses->toIndexed()
       			->map(z| print(if($debug.debug,|$debug.space+'statementsForBlock - processing expression '+$z.first->toString()+'\n',|''));
@@ -49,15 +60,31 @@ function <<access.private>> meta::external::language::java::transform::statement
             let last   = $cs->last()->toOne();
 
             if($last->isAssignment(),
-               | $toLast->add($last)->add($last->variableAssigned()->j_return()),
+               | $toLast->add($last)->add($last->variableAssigned()->prepareMethodReturnExpression($returnType)->j_return()),
                |
             if($last->isDeclaration(),
-               | $toLast->add($last)->add($last->variableDeclared()->j_return()),
-               | $toLast->add($last->j_return())
+               | $toLast->add($last)->add($last->variableDeclared()->prepareMethodReturnExpression($returnType)->j_return()),
+               | $toLast->add($last->prepareMethodReturnExpression($returnType)->j_return())
             ));
          }
       ])
       ->toStatements();
+}
+
+function <<access.private>> meta::external::language::java::transform::prepareMethodReturnExpression(expression: Code[1], returnType: meta::external::language::java::metamodel::Type[0..1]): Code[1]
+{
+   if($returnType->isEmpty(),
+      | $expression,
+      {| let type = $returnType->toOne();
+         if($type->isJavaList(),
+            | $expression->j_listOf($type),
+            | if($expression.type->isJavaList() && !$expression->isCollectionsEmptyList(),
+               | $expression->j_streamOf()->js_resolve(javaObject())->j_cast($type),
+               | $expression->j_cast($type)
+            )
+         );
+      }
+   );
 }
 
 function meta::external::language::java::transform::generateJava(vs:ValueSpecification[1], conventions: Conventions[1]):Code[1]
@@ -157,7 +184,7 @@ function <<access.private>> meta::external::language::java::transform::processVa
 function meta::external::language::java::transform::processLambda(l:LambdaFunction<Any>[1], conventions: Conventions[1], debug: meta::pure::tools::DebugContext[1]):Code[1]
 {
     let parameters = $l.classifierGenericType.typeArguments.rawType->cast(@meta::pure::metamodel::type::FunctionType).parameters->map(p|$p->processVariableExpressionAsParameter($conventions, $debug->indent()));
-    let expression = $l.expressionSequence->evaluateAndDeactivate()->statementsForBlock($conventions->addProvidedVariables($parameters), $debug)->j_block();
+    let expression = $l.expressionSequence->evaluateAndDeactivate()->statementsForBlock($conventions->addProvidedVariables($parameters), [], $debug)->j_block();
     j_lambda($parameters, $expression, javaFunctionType($parameters.type, $expression.type));
 }
 function <<access.private>> meta::external::language::java::transform::processInstanceValue(i: InstanceValue[1], conventions: Conventions[1], debug: meta::pure::tools::DebugContext[1]):Code[1]
@@ -303,7 +330,7 @@ function <<access.private>> meta::external::language::java::transform::processCo
            |print(if($debug.debug,|$debug.space+'Implementation of: \''+$fe.func->elementToPath()+'\'\n',|''));
            let updatedState = $state->addDependencyVisitedFunction($fe.func->elementToPath());
             
-            let implBody    = $fe.func->cast(@ConcreteFunctionDefinition<Any>).expressionSequence->evaluateAndDeactivate()->generateJavaMethodBody($newCon, $debug->indent());
+            let implBody    = $fe.func->cast(@ConcreteFunctionDefinition<Any>).expressionSequence->evaluateAndDeactivate()->generateJavaMethodBody($newCon, $signature.method.returnType, $debug->indent());
             let classesUsed = $signature.method->typesUsed()
                                 ->typesToClasses()
                                 ->filter(c | !meta::external::language::java::factory::isKnownPackage($c.package))

--- a/legend-engine-xts-java/legend-engine-xt-javaGeneration-pure/src/main/resources/core_external_language_java/generation/expressionGeneration.pure
+++ b/legend-engine-xts-java/legend-engine-xt-javaGeneration-pure/src/main/resources/core_external_language_java/generation/expressionGeneration.pure
@@ -33,21 +33,21 @@ function meta::external::language::java::transform::generateJavaMethodBody(vses:
 function meta::external::language::java::transform::generateJavaMethodBody(vses:ValueSpecification[*], conventions: Conventions[1], debug: DebugContext[1]):Code[1]
 {
    assert($vses->isNotEmpty(), 'Method body must have at least one expression');
-   $vses->statementsForBlock($conventions, [], $debug)->j_block();
+   $vses->statementsForBlock($conventions, $debug)->j_block();
 }
 
-function meta::external::language::java::transform::generateJavaMethodBody(vses:ValueSpecification[*], conventions: Conventions[1], returnType: meta::external::language::java::metamodel::Type[0..1]):Code[1]
-{
-   generateJavaMethodBody($vses, $conventions, $returnType, noDebug());
-}
-
-function meta::external::language::java::transform::generateJavaMethodBody(vses:ValueSpecification[*], conventions: Conventions[1], returnType: meta::external::language::java::metamodel::Type[0..1], debug: DebugContext[1]):Code[1]
+function <<access.private>>  meta::external::language::java::transform::generateJavaMethodBody(vses: ValueSpecification[*], conventions: Conventions[1], returnType:meta::external::language::java::metamodel::Type[1], debug: DebugContext[1]):Code[1]
 {
    assert($vses->isNotEmpty(), 'Method body must have at least one expression');
    $vses->statementsForBlock($conventions, $returnType, $debug)->j_block();
 }
 
-function <<access.private>> meta::external::language::java::transform::statementsForBlock(vses:ValueSpecification[*], conventions: Conventions[1], returnType: meta::external::language::java::metamodel::Type[0..1], debug: DebugContext[1]):Code[*]
+function <<access.private>> meta::external::language::java::transform::statementsForBlock(vses:ValueSpecification[*], conventions: Conventions[1], debug: DebugContext[1]):Code[*]
+{
+   $vses->statementsForBlock($conventions,[], $debug);
+}
+
+function <<access.private>> meta::external::language::java::transform::statementsForBlock(vses:ValueSpecification[*], conventions: Conventions[1], returnType:meta::external::language::java::metamodel::Type[0..1], debug: DebugContext[1]):Code[*]
 {
    let generated = $vses->toIndexed()
       			->map(z| print(if($debug.debug,|$debug.space+'statementsForBlock - processing expression '+$z.first->toString()+'\n',|''));
@@ -58,33 +58,35 @@ function <<access.private>> meta::external::language::java::transform::statement
          {cs: Code[*] |
             let toLast = $cs->init();
             let last   = $cs->last()->toOne();
+            let lastValueSpecification = $vses->last()->toOne();
 
             if($last->isAssignment(),
-               | $toLast->add($last)->add($last->variableAssigned()->prepareMethodReturnExpression($returnType)->j_return()),
+               | $toLast->add($last)->add($last->variableAssigned()->j_return()),
                |
             if($last->isDeclaration(),
-               | $toLast->add($last)->add($last->variableDeclared()->prepareMethodReturnExpression($returnType)->j_return()),
-               | $toLast->add($last->prepareMethodReturnExpression($returnType)->j_return())
+               | $toLast->add($last)->add($last->variableDeclared()->j_return()),
+               | $toLast->add($last->j_return())
             ));
          }
       ])
       ->toStatements();
 }
 
-function <<access.private>> meta::external::language::java::transform::prepareMethodReturnExpression(expression: Code[1], returnType: meta::external::language::java::metamodel::Type[0..1]): Code[1]
+function <<access.private>> meta::external::language::java::transform::prepareMethodReturnExpression(expression: Code[1], valueSpecification: ValueSpecification[1], returnType: meta::external::language::java::metamodel::Type[0..1]): Code[1]
 {
-   if($returnType->isEmpty(),
-      | $expression,
-      {| let type = $returnType->toOne();
+   if($returnType->isEmpty() || !$valueSpecification->isNil(), 
+      | $expression, 
+      {
+         |let type = $returnType->toOne();
          if($type->isJavaList(),
             | $expression->j_listOf($type),
             | if($expression.type->isJavaList() && !$expression->isCollectionsEmptyList(),
-               | $expression->j_streamOf()->js_resolve(javaObject())->j_cast($type),
-               | $expression->j_cast($type)
-            )
+                 | $expression->j_streamOf()->js_resolve(javaObject())->j_cast($type),
+                 | $expression->j_cast($type)
+              )
          );
       }
-   );
+   )
 }
 
 function meta::external::language::java::transform::generateJava(vs:ValueSpecification[1], conventions: Conventions[1]):Code[1]
@@ -184,7 +186,7 @@ function <<access.private>> meta::external::language::java::transform::processVa
 function meta::external::language::java::transform::processLambda(l:LambdaFunction<Any>[1], conventions: Conventions[1], debug: meta::pure::tools::DebugContext[1]):Code[1]
 {
     let parameters = $l.classifierGenericType.typeArguments.rawType->cast(@meta::pure::metamodel::type::FunctionType).parameters->map(p|$p->processVariableExpressionAsParameter($conventions, $debug->indent()));
-    let expression = $l.expressionSequence->evaluateAndDeactivate()->statementsForBlock($conventions->addProvidedVariables($parameters), [], $debug)->j_block();
+    let expression = $l.expressionSequence->evaluateAndDeactivate()->statementsForBlock($conventions->addProvidedVariables($parameters), $debug)->j_block();
     j_lambda($parameters, $expression, javaFunctionType($parameters.type, $expression.type));
 }
 function <<access.private>> meta::external::language::java::transform::processInstanceValue(i: InstanceValue[1], conventions: Conventions[1], debug: meta::pure::tools::DebugContext[1]):Code[1]

--- a/legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-pure/src/main/resources/core_java_platform_binding/legendJavaPlatformBinding/planConventions/test/langLibraryTests.pure
+++ b/legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-pure/src/main/resources/core_java_platform_binding/legendJavaPlatformBinding/planConventions/test/langLibraryTests.pure
@@ -73,6 +73,27 @@ meta::pure::executionPlan::platformBinding::legendJava::library::lang::tests::te
       ->runTests();
 }
 
+
+function meta::pure::executionPlan::platformBinding::legendJava::library::lang::tests::optionalFromListShape(cond: Boolean[1]) : String[0..1]
+{
+   if($cond, |[], |'FOUND')
+}
+
+function meta::pure::executionPlan::platformBinding::legendJava::library::lang::tests::doTestOptionalFromListShape() : Boolean[1]
+{
+   assertEquals('FOUND', optionalFromListShape(false));
+   assertEquals([], optionalFromListShape(true));
+}
+
+function <<meta::pure::profiles::test.Test, meta::pure::profiles::test.AlloyOnly>>
+{  meta::pure::executionPlan::profiles::serverVersion.start='v1_11_0' }
+meta::pure::executionPlan::platformBinding::legendJava::library::lang::tests::testOptionalFromListShape() : Boolean[1]
+{
+   javaPureTests(engineConventions([]), [
+      doTestOptionalFromListShape__Boolean_1_
+   ])->runTests();
+}
+
 function <<meta::pure::profiles::test.Test, meta::pure::profiles::test.AlloyOnly>>
 {  meta::pure::executionPlan::profiles::serverVersion.start='v1_11_0' }
 meta::pure::executionPlan::platformBinding::legendJava::library::lang::tests::testNot() : Boolean[1]

--- a/legend-engine-xts-service/legend-engine-test-runner-service/src/test/java/org/finos/legend/engine/testable/service/TestServiceTestSuite.java
+++ b/legend-engine-xts-service/legend-engine-test-runner-service/src/test/java/org/finos/legend/engine/testable/service/TestServiceTestSuite.java
@@ -2802,6 +2802,26 @@ public class TestServiceTestSuite
     }
 
     @Test
+    public void testM2MMappingCallingFunctionReturningOptionalFromListExpression()
+    {
+        ServiceTestableRunnerExtension runner = new ServiceTestableRunnerExtension();
+        String grammar = getResourceAsString("testable/m2m-optional-from-list/legend-testable-m2m-optional-from-list.pure");
+        PureModelContextData modelData = PureGrammarParser.newInstance().parseModel(grammar);
+        PureModel pureModel = Compiler.compile(modelData, DeploymentMode.TEST, Identity.getAnonymousIdentity().getName());
+        Root_meta_legend_service_metamodel_Service service = (Root_meta_legend_service_metamodel_Service) pureModel.getPackageableElement("testM2MOptionalFromList::service::OptionalFromListService");
+        List<TestResult> results = runner.executeAllTest(service, pureModel, modelData);
+
+        Assert.assertEquals(1, results.size());
+        TestResult result = results.get(0);
+        Assert.assertFalse("Expected a TestExecuted, got: " + result, result instanceof TestError);
+        Assert.assertTrue(result instanceof TestExecuted);
+        Assert.assertEquals(TestExecutionStatus.PASS, ((TestExecuted) result).testExecutionStatus);
+        Assert.assertEquals("testM2MOptionalFromList::service::OptionalFromListService", result.testable);
+        Assert.assertEquals("testSuite1", result.testSuiteId);
+        Assert.assertEquals("test1", result.atomicTestId);
+    }
+
+    @Test
     public void testServiceTestKeysWithMultipleTestBlocks()
     {
         List<TestResult> MultiKeyTestResult = executeServiceTest("testable/service/", "serviceGrammarModel.pure", "serviceGrammarWithTestKeys1.pure", "testModelStoreTestSuites::service::DocM2MService");

--- a/legend-engine-xts-service/legend-engine-test-runner-service/src/test/resources/testable/m2m-optional-from-list/legend-testable-m2m-optional-from-list.pure
+++ b/legend-engine-xts-service/legend-engine-test-runner-service/src/test/resources/testable/m2m-optional-from-list/legend-testable-m2m-optional-from-list.pure
@@ -1,0 +1,133 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+Class testM2MOptionalFromList::model::SourceEvent
+{
+  id: String[1];
+  attributes: testM2MOptionalFromList::model::SourceAttribute[*];
+}
+
+Class testM2MOptionalFromList::model::SourceAttribute
+{
+  code: String[1];
+}
+
+Class testM2MOptionalFromList::model::TargetEvent
+{
+  id: String[1];
+  firstCode: String[0..1];
+}
+
+function testM2MOptionalFromList::model::firstCodeOrEmpty(src: testM2MOptionalFromList::model::SourceEvent[1]): String[0..1]
+{
+  if($src.attributes->isEmpty(),
+    |[],
+    |'FOUND'
+  )
+}
+
+
+###Mapping
+Mapping testM2MOptionalFromList::mapping::SourceToTargetMapping
+(
+  *testM2MOptionalFromList::model::TargetEvent: Pure
+  {
+    ~src testM2MOptionalFromList::model::SourceEvent
+    id: $src.id,
+    firstCode: $src->testM2MOptionalFromList::model::firstCodeOrEmpty()
+  }
+)
+
+
+###Runtime
+Runtime testM2MOptionalFromList::runtime::SourceToTargetRuntime
+{
+  mappings:
+  [
+    testM2MOptionalFromList::mapping::SourceToTargetMapping
+  ];
+  connections:
+  [
+    ModelStore:
+    [
+      connection_1:
+      #{
+        JsonModelConnection
+        {
+          class: testM2MOptionalFromList::model::SourceEvent;
+          url: 'executor:default';
+        }
+      }#
+    ]
+  ];
+}
+
+
+###Service
+Service testM2MOptionalFromList::service::OptionalFromListService
+{
+  pattern: '/testM2MOptionalFromList/optionalFromList';
+  owners:
+  [
+    'dummy',
+    'dummy1'
+  ];
+  documentation: 'M2M mapping calling a user function returning [0..1] whose body ends in a [*] expression.';
+  autoActivateUpdates: true;
+  execution: Single
+  {
+    query: |testM2MOptionalFromList::model::TargetEvent.all()->graphFetch(#{testM2MOptionalFromList::model::TargetEvent{id,firstCode}}#)->serialize(#{testM2MOptionalFromList::model::TargetEvent{id,firstCode}}#);
+    mapping: testM2MOptionalFromList::mapping::SourceToTargetMapping;
+    runtime: testM2MOptionalFromList::runtime::SourceToTargetRuntime;
+  }
+  testSuites:
+  [
+    testSuite1:
+    {
+      data:
+      [
+        connections:
+        [
+          connection_1:
+            ExternalFormat
+            #{
+              contentType: 'application/json';
+              data: '[{"id":"withOneValue","attributes":[{"code":"A"}]},{"id":"empty","attributes":[]}]';
+            }#
+        ]
+      ]
+      tests:
+      [
+        test1:
+        {
+          serializationFormat: PURE;
+          asserts:
+          [
+            assert1:
+              EqualToJson
+              #{
+                expected :
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '[{"id":"withOneValue","firstCode":"FOUND"},{"id":"empty"}]';
+                  }#;
+              }#
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
#### What type of PR is this?
- Bug Fix

#### What does this PR do / why is it needed ?
This PR fixes in M2M transformations functions that return null (i.e. []) in a function whose signature returns an optional type (e.g. String[0..1]).

Currently, the java generator does not have information about the outer scope and would generate non-compilable Java code by assuming the bull refers to a property with multiplicity *.

The fix targets narrowly this case to provide correct Java generation.

