### PR TITLE
M2M : Fix local variable shadowing in generated Java

### DIFF
--- a/legend-engine-core/legend-engine-core-query-pure-http-api/src/test/java/org/finos/legend/engine/query/pure/api/test/inMemory/TestM2MGrammarCompileAndExecute.java
+++ b/legend-engine-core/legend-engine-core-query-pure-http-api/src/test/java/org/finos/legend/engine/query/pure/api/test/inMemory/TestM2MGrammarCompileAndExecute.java
@@ -456,6 +456,56 @@ public class TestM2MGrammarCompileAndExecute
         assertEquals("{\"builder\":{\"_type\":\"json\"},\"values\":{\"count\":10}}", json);
     }
 
+    @Test
+    public void testM2MNestedLambdaParamNameCollidingWithCalleeFunctionParam() throws IOException
+    {
+        PureModelContextData contextData = PureGrammarParser.newInstance().parseModel("" +
+                "Class test::Swap\n" +
+                "{\n" +
+                "   name : String[1];\n" +
+                "}\n" +
+                "Class test::SrcHolder\n" +
+                "{\n" +
+                "   swaps : test::Swap[*];\n" +
+                "}\n" +
+                "Class test::TgtRow\n" +
+                "{\n" +
+                "   label : String[0..1];\n" +
+                "}\n" +
+                "function test::first(swap: test::Swap[1]): String[1]\n" +
+                "{\n" +
+                "   $swap.name\n" +
+                "}\n" +
+                "function test::labelOf(h: test::SrcHolder[1]): String[0..1]\n" +
+                "{\n" +
+                "   $h.swaps->map(swap | $h.swaps->map(swap | $swap->test::first()))->first()\n" +
+                "}\n" +
+                "\n" +
+                "###Mapping\n" +
+                "Mapping test::TestMapping\n" +
+                "(\n" +
+                "   *test::TgtRow : Pure\n" +
+                "   {\n" +
+                "     ~src test::SrcHolder\n" +
+                "     label : $src->test::labelOf()\n" +
+                "   }\n" +
+                ")\n"
+        );
+
+        ClassInstance fetchTree = rootGFT("test::TgtRow", propertyGFT("label"));
+        LambdaFunction lambda = lambda(apply(SERIALIZE, apply(GRAPH_FETCH, apply(GET_ALL, clazz("test::TgtRow")), fetchTree), fetchTree));
+
+        ExecuteInput input = new ExecuteInput();
+        input.clientVersion = "vX_X_X";
+        input.model = contextData;
+        input.mapping = "test::TestMapping";
+        input.function = lambda;
+        input.runtime = runtimeValue(jsonModelConnection("test::SrcHolder", "{\"swaps\":[{\"name\":\"A\"},{\"name\":\"B\"}]}"));
+        input.context = context();
+        String json = responseAsString(runTest(input));
+        assertEquals("{\"builder\":{\"_type\":\"json\"},\"values\":{\"label\":\"A\"}}", json);
+    }
+
     private Response runTest(ExecuteInput input)
     {
         ModelManager modelManager = new ModelManager(DeploymentMode.TEST);

--- a/legend-engine-core/legend-engine-core-query-pure-http-api/src/test/java/org/finos/legend/engine/query/pure/api/test/inMemory/TestM2MGrammarCompileAndExecute.java
+++ b/legend-engine-core/legend-engine-core-query-pure-http-api/src/test/java/org/finos/legend/engine/query/pure/api/test/inMemory/TestM2MGrammarCompileAndExecute.java
@@ -405,6 +405,57 @@ public class TestM2MGrammarCompileAndExecute
         assertEquals("{\"builder\":{\"_type\":\"json\"},\"values\":{\"labels\":[\"alpha\",\"beta\"]}}", json);
     }
 
+    @Test
+    public void testM2MNestedMatchDefaultArms() throws IOException
+    {
+        PureModelContextData contextData = PureGrammarParser.newInstance().parseModel("" +
+                "Class test::Src\n" +
+                "{\n" +
+                "   items : test::Item[*];\n" +
+                "}\n" +
+                "Class test::Item\n" +
+                "{\n" +
+                "}\n" +
+                "Class test::ItemA extends test::Item\n" +
+                "{\n" +
+                "}\n" +
+                "Class test::Tgt\n" +
+                "{\n" +
+                "   count : Integer[0..1];\n" +
+                "}\n" +
+                "function test::classify(s: test::Src[1]): Integer[1]\n" +
+                "{\n" +
+                "   $s.items->at(0)->match([\n" +
+                "      a1: test::ItemA[1] | 10,\n" +
+                "      default: Any[*] | $s.items->map(c | $c->match([ a2: test::ItemA[1] | 20, default: Any[*] | 0 ]))->at(0)\n" +
+                "   ])\n" +
+                "}\n" +
+                "\n" +
+                "###Mapping\n" +
+                "Mapping test::TestMapping\n" +
+                "(\n" +
+                "   *test::Tgt : Pure\n" +
+                "   {\n" +
+                "     ~src test::Src\n" +
+                "     count : $src->test::classify()\n" +
+                "   }\n" +
+                ")\n"
+        );
+
+        ClassInstance fetchTree = rootGFT("test::Tgt", propertyGFT("count"));
+        LambdaFunction lambda = lambda(apply(SERIALIZE, apply(GRAPH_FETCH, apply(GET_ALL, clazz("test::Tgt")), fetchTree), fetchTree));
+
+        ExecuteInput input = new ExecuteInput();
+        input.clientVersion = "vX_X_X";
+        input.model = contextData;
+        input.mapping = "test::TestMapping";
+        input.function = lambda;
+        input.runtime = runtimeValue(jsonModelConnection("test::Src", "{\"items\":[{\"@type\":\"ItemA\"}]}"));
+        input.context = context();
+        String json = responseAsString(runTest(input));
+        assertEquals("{\"builder\":{\"_type\":\"json\"},\"values\":{\"count\":10}}", json);
+    }
+
     private Response runTest(ExecuteInput input)
     {
         ModelManager modelManager = new ModelManager(DeploymentMode.TEST);

--- a/legend-engine-xts-java/legend-engine-xt-javaGeneration-pure/src/main/resources/core_external_language_java/generation/conventions.pure
+++ b/legend-engine-xts-java/legend-engine-xt-javaGeneration-pure/src/main/resources/core_external_language_java/generation/conventions.pure
@@ -55,6 +55,7 @@ Class meta::external::language::java::transform::Conventions
    libraries                   : ConventionsLibrary[*];
    newFunctionProhibitedList   : meta::pure::metamodel::type::Class<Any>[*];
    providedVariables           : Map<String, Code>[1];
+   variablesInScope            : String[*];
    visitedFunctions            : FunctionExpression[*];
 
    extensions : meta::pure::extension::Extension[*];
@@ -1162,6 +1163,23 @@ function meta::external::language::java::transform::addProvidedVariables(convent
    assert($codes->forAll(c|$c->isVariable()));
    let namesToCodes = $codes->map(c|pair($c->variableName(), $c));
    ^$conventions(providedVariables=$conventions.providedVariables->putAll($namesToCodes));
+}
+
+function meta::external::language::java::transform::addProvidedVariablesRenamed(conventions:Conventions[1], keyed:Pair<String, Code>[*]): Conventions[1]
+{
+   assert($keyed->forAll(kp|$kp.second->isVariable()));
+   ^$conventions(
+      providedVariables = $conventions.providedVariables->putAll($keyed),
+      variablesInScope  = $conventions.variablesInScope->concatenate($keyed->map(kp|$kp.second->variableName()))->removeDuplicates()
+   );
+}
+
+function <<access.private>> meta::external::language::java::transform::uniqueVariableName(base:String[1], taken:String[*]):String[1]
+{
+   if(!$taken->contains($base),
+      | $base,
+      | range($taken->size() + 1)->map(i | $base + '_' + ($i + 1)->toString())->filter(c | !$taken->contains($c))->first()->toOne()
+   );
 }
 
 function meta::external::language::java::transform::registerClassCoder(conventions: Conventions[1], purpose: Any[1], coder: Function<{meta::pure::metamodel::type::Type[1],Conventions[1],DebugContext[1]->meta::external::language::java::metamodel::Class[1]}>[1]): Conventions[1]

--- a/legend-engine-xts-java/legend-engine-xt-javaGeneration-pure/src/main/resources/core_external_language_java/generation/expressionGeneration.pure
+++ b/legend-engine-xts-java/legend-engine-xt-javaGeneration-pure/src/main/resources/core_external_language_java/generation/expressionGeneration.pure
@@ -156,8 +156,15 @@ function <<access.private>> meta::external::language::java::transform::processVa
 
 function meta::external::language::java::transform::processLambda(l:LambdaFunction<Any>[1], conventions: Conventions[1], debug: meta::pure::tools::DebugContext[1]):Code[1]
 {
-    let parameters = $l.classifierGenericType.typeArguments.rawType->cast(@meta::pure::metamodel::type::FunctionType).parameters->map(p|$p->processVariableExpressionAsParameter($conventions, $debug->indent()));
-    let expression = $l.expressionSequence->evaluateAndDeactivate()->statementsForBlock($conventions->addProvidedVariables($parameters), $debug)->j_block();
+    let keyedParameters = $l.classifierGenericType.typeArguments.rawType->cast(@meta::pure::metamodel::type::FunctionType).parameters->map(p|
+       let baseParam  = $p->processVariableExpressionAsParameter($conventions, $debug->indent());
+       let key        = $baseParam->variableName();
+       let emitted    = if($key == 'this', |$key, |uniqueVariableName($key, $conventions.variablesInScope));
+       let finalParam = if($emitted == $key, |$baseParam, |j_parameter($baseParam.type, $emitted));
+       pair($key, $finalParam);
+    );
+    let parameters = $keyedParameters->map(kp|$kp.second);
+    let expression = $l.expressionSequence->evaluateAndDeactivate()->statementsForBlock($conventions->addProvidedVariablesRenamed($keyedParameters), $debug)->j_block();
     j_lambda($parameters, $expression, javaFunctionType($parameters.type, $expression.type));
 }
 function <<access.private>> meta::external::language::java::transform::processInstanceValue(i: InstanceValue[1], conventions: Conventions[1], debug: meta::pure::tools::DebugContext[1]):Code[1]

--- a/legend-engine-xts-java/legend-engine-xt-javaGeneration-pure/src/main/resources/core_external_language_java/generation/expressionGeneration.pure
+++ b/legend-engine-xts-java/legend-engine-xt-javaGeneration-pure/src/main/resources/core_external_language_java/generation/expressionGeneration.pure
@@ -33,7 +33,11 @@ function meta::external::language::java::transform::generateJavaMethodBody(vses:
 function meta::external::language::java::transform::generateJavaMethodBody(vses:ValueSpecification[*], conventions: Conventions[1], debug: DebugContext[1]):Code[1]
 {
    assert($vses->isNotEmpty(), 'Method body must have at least one expression');
-   $vses->statementsForBlock($conventions, $debug)->j_block();
+   let cleanConventions = ^$conventions(
+      providedVariables = ^Map<String,Code>(),
+      variablesInScope  = []
+   );
+   $vses->statementsForBlock($cleanConventions, $debug)->j_block();
 }
 
 function <<access.private>> meta::external::language::java::transform::statementsForBlock(vses:ValueSpecification[*], conventions: Conventions[1], debug: DebugContext[1]):Code[*]


### PR DESCRIPTION
#### What type of PR is this?
- Bug Fix


#### What does this PR do / why is it needed ?
This PR fixes in M2M compilation issues caused by the shadowing of an outer declared variable with a lambda function. Fix consists of tracking variables in local scope and generate unique names for new variables in lambda functions so that generated Java is correct.
