### PR TITLE
Add optional annotations field to PowerBI Table metamodel

### DIFF
--- a/legend-engine-xts-powerbi/legend-engine-xt-powerbi-pure/src/main/resources/core_external_format_powerbi/metamodel/metamodel.pure
+++ b/legend-engine-xts-powerbi/legend-engine-xt-powerbi-pure/src/main/resources/core_external_format_powerbi/metamodel/metamodel.pure
@@ -107,6 +107,7 @@ Class meta::external::powerbi::metamodel::Table
   lineageTag : String[1];
   columns : Column[*];
   partition : Partition[1];
+  annotations : Map<String,String>[0..1];
 }
 
 Class meta::external::powerbi::metamodel::Database


### PR DESCRIPTION
#### What type of PR is this?
- Improvement

#### What does this PR do / why is it needed ?
Enhancing Power BI metamodel to include annotations.
Generic Map<String,String>[0..1] field for attaching arbitrary key/value metadata to a generated table; optional and absent by default so existing Table construction sites are unaffected.

#### Which issue(s) this PR fixes:
N/A

#### Does this PR introduce a user-facing change?
No
