### PR TITLE
Add label-driven backport workflow for release branches

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,72 @@
+# Copyright 2026 Goldman Sachs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Backport Merged PR
+
+# pull_request_target is safe here: no step checks out or executes code from
+# the PR. actions/checkout below checks out the BASE ref (master), and the
+# backport action only cherry-picks commits already merged to master.
+on:
+  pull_request_target:
+    types: [closed, labeled]
+    branches:
+      - master
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  backport:
+    name: Create Backport PRs
+    runs-on: ubuntu-latest
+    # Two ways in: PR merged while carrying backport label(s), or a backport
+    # label added to an already-merged PR (retroactive backport).
+    #
+    # Known limitation: on the 'labeled' path, the action re-evaluates ALL of
+    # the PR's labels (label_pattern has no way to scope to just the label
+    # from this event), not only the one just added. If a PR already has a
+    # completed backport (e.g. "backport legend-release-4.98") and a second
+    # backport label is added later (e.g. "backport legend-release-4.97"),
+    # this run retries 4.98 too. That retry fails, because the branch/PR for
+    # it already exists, so the action posts a failure comment on the
+    # original PR even though the newly requested 4.97 backport succeeds.
+    # This is expected, not a bug — see the design spec's edge cases.
+    if: >
+      github.event.pull_request.merged == true &&
+      (
+        (github.event.action == 'closed' && contains(toJSON(github.event.pull_request.labels.*.name), '"backport ')) ||
+        (github.event.action == 'labeled' && startsWith(github.event.label.name, 'backport '))
+      )
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Create backport pull requests
+        uses: korthout/backport-action@2e830a1d0b8269505846ddd407a70876913ad1f8 # v4.6.0
+        with:
+          # Must be a PAT, not the default github.token: GitHub does not fire
+          # workflow runs (e.g. build.yml) for pushes/PRs created by the
+          # default GITHUB_TOKEN (recursion prevention). Using the default
+          # here would silently leave every backport PR with zero CI checks.
+          github_token: ${{ secrets.FINOS_GITHUB_TOKEN }}
+          add_author_as_assignee: true
+          label_pattern: '^backport ([^ ]+)$'
+          pull_title: '[Backport ${target_branch}] ${pull_title}'
+          pull_description: |-
+            Backport of #${pull_number} to `${target_branch}`.
+
+            Created automatically by the backport workflow. If this PR has
+            conflicts or CI failures, the assignee (the original author) is
+            responsible for resolving them.

--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -18,7 +18,7 @@ on:
   workflow_dispatch:
     inputs:
       releaseVersion:
-        description: "Release version (used to create branch legend-release-<version>)"
+        description: "Release version (used to create branch release-legend-release-<version>)"
         required: true
       gitRef:
         description: "Git ref to branch from (commit hash, tag, or branch). Defaults to head of master if not provided."
@@ -29,6 +29,14 @@ jobs:
   create-branch:
     name: Create Release Branch
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+    # Defined once here so the branch that gets pushed and the backport label
+    # that names it can never drift apart. Mapping the input through env also
+    # keeps it out of the shell command lines below.
+    env:
+      BRANCH_NAME: release-legend-release-${{ github.event.inputs.releaseVersion }}
     steps:
       - name: Determine base ref
         id: base
@@ -49,8 +57,20 @@ jobs:
 
       - name: Create and push release branch
         run: |
-          BRANCH_NAME="legend-release-${{ github.event.inputs.releaseVersion }}"
           echo "Creating branch: ${BRANCH_NAME}"
           git checkout -b "${BRANCH_NAME}"
           git push origin "${BRANCH_NAME}"
           echo "Successfully created and pushed branch: ${BRANCH_NAME}"
+
+      - name: Create backport label
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          LABEL_NAME="backport ${BRANCH_NAME}"
+          echo "Creating label: ${LABEL_NAME}"
+          gh label create "${LABEL_NAME}" \
+            --repo "${{ github.repository }}" \
+            --color "0E8A16" \
+            --description "Apply to a PR to auto-open a backport PR against ${BRANCH_NAME} when merged" \
+            --force \
+            || echo "::warning::Could not create label '${LABEL_NAME}' - create it manually with: gh label create '${LABEL_NAME}'"


### PR DESCRIPTION
#### What type of PR is this?

  Improvement

#### What does this PR do / why is it needed ?

  Automates patching changes into release branches.

  Today, a developer whose fix needs to land on both `master` and a cut release
  branch has to hand-craft two PRs, manually cherry-picking the second one. It's
  repetitive and easy to forget, so fixes get missed on release branches.

  With this change, a developer adds a label to their master PR:

      backport legend-release-4.98

  When the PR merges, a workflow cherry-picks it onto that release branch and
  opens a PR titled `[Backport legend-release-4.98] <original title>`, assigned to
  the original author. The label can be added *after* the merge too, which covers
  the common "we only realised later that this needs backporting" case. Multiple
  labels produce one backport PR per target. If the cherry-pick conflicts, the
  action comments on the original PR with the manual steps instead of opening a
  broken PR.

  Two files change:
  
  - **`.github/workflows/backport.yml`** (new) — the backport workflow. The
    cherry-pick and PR creation are delegated to `korthout/backport-action`
    (MIT, purpose-built), pinned to the v4.6.0 commit SHA.
  - **`.github/workflows/create-release-branch.yml`** — cutting a release branch
    now also creates the matching `backport legend-release-<version>` label, so
    the label always exists for every branch this workflow cuts. Label creation is
    idempotent and cannot fail the branch cut.