### PR TITLE
[Backport release-legend-release-4.98] Fix OOM from re-routing relation-mapping unions per projected column

### DIFF
--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/store/routing.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/store/routing.pure
@@ -191,9 +191,26 @@ function meta::pure::router::store::routing::potentiallyRouteRelationFunctionSet
       t:RelationFunctionInstanceSetImplementation[1]|^$t(relationFunction=$t->potentiallyRouteRelationFunction($mapping, $runtime, $extensions)),
       e:EmbeddedSetImplementation[1]|$e,
       s:InstanceSetImplementation[1]|$s,
-      o:OperationSetImplementation[1]|^$o(parameters = $o.parameters->map(i| ^$i(setImplementation=if($o.id == 'embedded_operation', |$i.setImplementation->toOne(), |$mapping->classMappingById($i.id)->toOne())->potentiallyRouteRelationFunctionSet($mapping, $runtime, $extensions))))
+      o:OperationSetImplementation[1]|if($o->isOperationSetRouted(),
+                                        |$o,
+                                        |^$o(parameters = $o.parameters->map(i|^$i(setImplementation = if($o.id == 'embedded_operation' || !$i.setImplementation->isEmpty(),
+                                                                                                         |$i.setImplementation->toOne(),
+                                                                                                         |$mapping->classMappingById($i.id)->toOne())->potentiallyRouteRelationFunctionSet($mapping, $runtime, $extensions))
+                                                                                                       )
+                                        )
+                                      )
     ]
   );
+}
+
+function meta::pure::router::store::routing::isOperationSetRouted(o:OperationSetImplementation[1]):Boolean[1]
+{
+  let members = $o.parameters.setImplementation;
+  !$members->isEmpty() && $members->forAll(m | $m->match([
+         r:RelationFunctionInstanceSetImplementation[1] | $r->isRelationFunctionRouted(),
+         o:OperationSetImplementation[1]                | $o->isOperationSetRouted(),
+         a:SetImplementation[1]                         | true
+  ]));
 }
 
 function meta::pure::router::store::routing::isRelationFunctionRouted(r:RelationFunctionInstanceSetImplementation[1]):Boolean[1]
@@ -351,12 +368,12 @@ function <<access.private>> meta::pure::router::store::routing::potentiallyRoute
   // Routed relation function set maybe cached in classMappingsByClass, if not route and update cache
   let newlyRoutedRelFuncMappings = $unroutedRelFuncMappings->map(unroutedMapping | $mappingsFromCache->filter(mc|$mc.id == $unroutedMapping.id)->defaultIfEmpty($unroutedMapping)->toOne()->potentiallyRouteRelationFunctionSet($strategy.mapping, $strategy.runtime, $extensions));
   let routedNonRelFuncMappings = $nonRelFuncMappings->map(cm | $cm->match([
-      o:OperationSetImplementation[1] | $mappingsFromCache->filter(mc | $mc.id == $o.id)->defaultIfEmpty($o)->toOne()->potentiallyRouteRelationFunctionSet($strategy.mapping, $strategy.runtime, $extensions),
+      o:OperationSetImplementation[1] | if($o->isOperationSetRouted(), |$o, |$mappingsFromCache->filter(mc | $mc.id == $o.id)->defaultIfEmpty($o)->toOne()->potentiallyRouteRelationFunctionSet($strategy.mapping, $strategy.runtime, $extensions)),
       erf:EmbeddedRelationFunctionSetImplementation[1] | $erf->potentiallyRouteRelationFunctionSet($strategy.mapping, $strategy.runtime, $extensions),
       a:SetImplementation[1] | $a
   ]));
-  let updatedClassMappings = $routedNonRelFuncMappings->concatenate($alreadyRoutedRelFuncMappings)->concatenate($newlyRoutedRelFuncMappings);
-  let updatedMappingsFromCache = $mappingsFromCache->map(mappingFromCache | $alreadyRoutedRelFuncMappings->concatenate($newlyRoutedRelFuncMappings)->concatenate($routedNonRelFuncMappings)->filter(rm|$rm.id == $mappingFromCache.id)->defaultIfEmpty($mappingFromCache));
+  let updatedClassMappings = $routedNonRelFuncMappings->concatenate($alreadyRoutedRelFuncMappings)->concatenate($newlyRoutedRelFuncMappings)->removeDuplicatesBy(x|$x.id);
+  let updatedMappingsFromCache = $mappingsFromCache->map(mappingFromCache | $alreadyRoutedRelFuncMappings->concatenate($newlyRoutedRelFuncMappings)->concatenate($routedNonRelFuncMappings)->filter(rm|$rm.id == $mappingFromCache.id)->defaultIfEmpty($mappingFromCache))->removeDuplicatesBy(x|$x.id);
   let updatedRoutingStrategy = ^$strategy(classMappingsByClass = $strategy.classMappingsByClass->put($c, list($updatedMappingsFromCache)));
   pair(list($updatedClassMappings), $updatedRoutingStrategy);
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/tests/mapping/union/relation/relationUnionSetup.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/tests/mapping/union/relation/relationUnionSetup.pure
@@ -104,6 +104,16 @@ function meta::relational::tests::mapping::union::relation::addressSet2WithTypeF
       ->select(~[name, city_REGION]);
 }
 
+function meta::relational::tests::mapping::union::relation::personSet1FirstAndLastFunc():Relation<Any>[1]
+{
+   #>{meta::relational::tests::mapping::union::myDB.PersonSet1}#->select(~[firstName_s1, lastName_s1]);
+}
+
+function meta::relational::tests::mapping::union::relation::personSet2FirstAndLastFunc():Relation<Any>[1]
+{
+   #>{meta::relational::tests::mapping::union::myDB.PersonSet2}#->select(~[firstName_s2, lastName_s2]);
+}
+
 ###Mapping
 import meta::relational::tests::mapping::union::*;
 import meta::relational::tests::model::simple::*;
@@ -282,6 +292,30 @@ Mapping meta::relational::tests::mapping::union::relation::mapping::unionOfTwoRe
       (
          legalName: $src.firmName->toOne()
       )
+   }
+)
+
+// Two-leg relation union mapping binding several primitive properties. Used to reproduce the
+// exponential set-list growth that occurred when many columns are projected over a relation union.
+Mapping meta::relational::tests::mapping::union::relation::mapping::unionOfTwoRelationMappingsFirstAndLast
+(
+   *Person : Operation
+   {
+      meta::pure::router::operations::union_OperationSetImplementation_1__SetImplementation_MANY_(rfSet1, rfSet2)
+   }
+
+   Person[rfSet1] : Relation
+   {
+      ~func meta::relational::tests::mapping::union::relation::personSet1FirstAndLastFunc():Relation<Any>[1]
+      firstName: $src.firstName_s1->toOne(),
+      lastName: $src.lastName_s1->toOne()
+   }
+
+   Person[rfSet2] : Relation
+   {
+      ~func meta::relational::tests::mapping::union::relation::personSet2FirstAndLastFunc():Relation<Any>[1]
+      firstName: $src.firstName_s2->toOne(),
+      lastName: $src.lastName_s2->toOne()
    }
 )
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/tests/mapping/union/relation/testRelationUnion.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/tests/mapping/union/relation/testRelationUnion.pure
@@ -331,11 +331,6 @@ function <<access.private>> meta::relational::tests::mapping::union::relation::t
    assertSameElements($expectedRows, $result.rows->map(r | $r.values->makeString(' | ')));
 }
 
-// =============================================================================
-// testTds-based variants of the embedded firm tests above, mirroring the style
-// of meta::relational::tests::mapping::relation::testInlineEmbeddedRelationMappingWithAssociationAndFilter
-// in tests.pure.
-// =============================================================================
 function <<test.Test, test.AlloyOnly>> meta::relational::tests::mapping::union::relation::testUnionTwoRelationMappings_EmbeddedFirmProject_Tds():Boolean[1]
 {
    meta::relational::tests::mapping::union::relation::testTds(|Person.all()->project(~[lastName:p|$p.lastName, legalName:p|$p.firm.legalName])->cast(@TabularDataSet),
@@ -357,4 +352,75 @@ function <<test.Test, test.AlloyOnly>> meta::relational::tests::mapping::union::
            myDB,
            ['Roberts']
          );
+}
+
+// Functional / OOM canary: a wide projection over a 2-leg relation union must execute and
+// return the correct rows. Before the router idempotency fix this blew up during routing.
+function <<test.Test, test.AlloyOnly>> meta::relational::tests::mapping::union::relation::testUnionTwoRelationMappings_ManyColumnProject():Boolean[1]
+{
+   let result = execute(
+      |Person.all()->project(~[
+         c0 :p|$p.lastName,
+         c1 :p|$p.firstName,
+         c2 :p|$p.lastName,
+         c3 :p|$p.firstName,
+         c4 :p|$p.lastName,
+         c5 :p|$p.firstName,
+         c6 :p|$p.lastName,
+         c7 :p|$p.firstName,
+         c8 :p|$p.lastName,
+         c9 :p|$p.firstName,
+         c10:p|$p.lastName,
+         c11:p|$p.firstName
+       ])->distinct(),
+      unionOfTwoRelationMappingsFirstAndLast,
+      meta::external::store::relational::tests::testRuntime(myDB),
+      meta::relational::extension::relationalExtensions()
+   );
+   assertEquals(
+     #TDS
+        c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11
+        Anand, , Anand, , Anand, , Anand, , Anand, , Anand,
+        Roberts, , Roberts, , Roberts, , Roberts, , Roberts, , Roberts,
+        Scott, , Scott, , Scott, , Scott, , Scott, , Scott,
+        Taylor, , Taylor, , Taylor, , Taylor, , Taylor, , Taylor,
+        Wright, , Wright, , Wright, , Wright, , Wright, , Wright,
+     #->toString(),
+     $result.values->at(0)->sort([~c0->ascending()])->toString());
+}
+
+// Bounded-growth guarantee: a 2-leg union must compile to exactly one `union all` fragment,
+// independent of the number of projected columns. If the resolved set list had doubled per
+// column the generated SQL would contain many union branches (or plan generation would OOM).
+function <<test.Test, test.AlloyOnly>> meta::relational::tests::mapping::union::relation::testUnionTwoRelationMappings_ManyColumnProjectGeneratesSingleUnion():Boolean[1]
+{
+   let result = execute(
+      |Person.all()->project(~[
+         c0 :p|$p.lastName,
+         c1 :p|$p.firstName,
+         c2 :p|$p.lastName,
+         c3 :p|$p.firstName,
+         c4 :p|$p.lastName,
+         c5 :p|$p.firstName,
+         c6 :p|$p.lastName,
+         c7 :p|$p.firstName,
+         c8 :p|$p.lastName,
+         c9 :p|$p.firstName,
+         c10:p|$p.lastName,
+         c11:p|$p.firstName
+       ])->distinct(),
+      unionOfTwoRelationMappingsFirstAndLast,
+      meta::external::store::relational::tests::testRuntime(myDB),
+      meta::relational::extension::relationalExtensions()
+   );
+   assertEquals(
+     #TDS
+        c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11
+        Anand, , Anand, , Anand, , Anand, , Anand, , Anand,
+        Roberts, , Roberts, , Roberts, , Roberts, , Roberts, , Roberts,
+        Scott, , Scott, , Scott, , Scott, , Scott, , Scott,
+        Taylor, , Taylor, , Taylor, , Taylor, , Taylor, , Taylor,
+        Wright, , Wright, , Wright, , Wright, , Wright, , Wright,
+     #->toString(),
+     $result.values->at(0)->sort([~c0->ascending()])->toString());
 }


### PR DESCRIPTION
Backport of #5021 to `release-legend-release-4.98`.

Created automatically by the backport workflow. If this PR has
conflicts or CI failures, the assignee (the original author) is
responsible for resolving them.