### PR TITLE
Default LEGACY_SQL_NULL_UNSAFE_EQUALS on the in-flow execution path

### DIFF
--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/functions/tests/testFilters.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/functions/tests/testFilters.pure
@@ -203,10 +203,26 @@ function <<test.Test>> meta::relational::tests::query::filter::equal::testBuildF
    let result = execute(buildQuery([]), simpleRelationalMapping, meta::external::store::relational::tests::testRuntime(), meta::relational::extension::relationalExtensions());
    assertSize($result.values, 1);
    assertEquals('Elena', $result.values->toOne().firstName);
-   assertEquals('select "root".ID as "pk_0", "root".FIRSTNAME as "firstName", "root".AGE as "age", "root".LASTNAME as "lastName" from personTable as "root" where "root".LASTNAME like \'F%\' and (null is null or "root".FIRSTNAME is null)', $result->sqlRemoveFormatting());
 
    let result2 = execute(buildQuery('Peter'), simpleRelationalMapping, meta::external::store::relational::tests::testRuntime(), meta::relational::extension::relationalExtensions());
    assertSize($result2.values, 0);
+}
+
+function <<test.Test, test.ExcludeAlloy>> meta::relational::tests::query::filter::equal::testBuildFilterWithValueThatCanBeNullInFlowSql():Boolean[1]
+{
+   let result = execute(buildQuery([]), simpleRelationalMapping, meta::external::store::relational::tests::testRuntime(), meta::relational::extension::relationalExtensions());
+   assertEquals(expectedSqlForValueThatCanBeNull('= null'), $result->sqlRemoveFormatting());
+}
+
+function <<test.Test, test.AlloyOnly>> meta::relational::tests::query::filter::equal::testBuildFilterWithValueThatCanBeNullPlanSql():Boolean[1]
+{
+   let result = execute(buildQuery([]), simpleRelationalMapping, meta::external::store::relational::tests::testRuntime(), meta::relational::extension::relationalExtensions());
+   assertEquals(expectedSqlForValueThatCanBeNull('is null'), $result->sqlRemoveFormatting());
+}
+
+function <<access.private>> meta::relational::tests::query::filter::equal::expectedSqlForValueThatCanBeNull(comparison:String[1]):String[1]
+{
+   'select "root".ID as "pk_0", "root".FIRSTNAME as "firstName", "root".AGE as "age", "root".LASTNAME as "lastName" from personTable as "root" where "root".LASTNAME like \'F%\' and (null is null or "root".FIRSTNAME ' + $comparison + ')'
 }
 
 function <<access.private>> meta::relational::tests::query::filter::equal::buildQuery(value:String[0..1]):FunctionDefinition<{->Person[*]}>[1]

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/relationalMappingExecution.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/relationalMappingExecution.pure
@@ -381,7 +381,8 @@ function meta::relational::mapping::execution(store: Database[1], f:ValueSpecifi
 
    let relationalExecutionContext = $exeCtx->match([r:RelationalExecutionContext[1]|$r, a:Any[0..1]|[]]);
 
-   let originalQuery = $f->toSQLQuery($m, $inScopeVars, $debug, $relationalExecutionContext->relationalExecutionContextToState(defaultState($m, $inScopeVars, $exeCtx, $extensions)), $extensions);
+   let sqlGenerationState = $relationalExecutionContext->relationalExecutionContextToState(defaultState($m, $inScopeVars, $exeCtx, $extensions));
+   let originalQuery = $f->toSQLQuery($m, $inScopeVars, $debug, ^$sqlGenerationState(legacyNullUnsafeEquals = true), $extensions);
    let toSqlQueryDurationMilliseconds = ($toSqlQueryStart->dateDiff(now(),DurationUnit.MILLISECONDS));
 
    let connections = $runtime.connectionStores->filter(c | $c.connection->instanceOf(meta::external::store::relational::runtime::DatabaseConnection));

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/tests/query/testLegacyNullUnsafeEquals.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/tests/query/testLegacyNullUnsafeEquals.pure
@@ -30,16 +30,26 @@ function <<test.Test>> meta::relational::tests::query::legacyNullUnsafeEquals::t
    let fn = {|Person.all()
                 ->project([col(p|$p.firstName, 'name'), col(p|$p.age == $p.manager.age, 'match')])
                 ->withFeatureFlags(meta::pure::executionPlan::features::Feature.LEGACY_SQL_NULL_UNSAFE_EQUALS)};
-   let result = execute($fn, simpleRelationalMapping, meta::external::store::relational::tests::testRuntime(), meta::relational::extension::relationalExtensions());
-   assertSameSQL('select "root".FIRSTNAME as "name", "root".AGE = "persontable_1".AGE as "match" from personTable as "root" left outer join personTable as "persontable_1" on ("root".MANAGERID = "persontable_1".ID)', $result);
+   let plan = executionPlan($fn, simpleRelationalMapping, meta::external::store::relational::tests::testRuntime(), meta::relational::extension::relationalExtensions());
+   let planString = $plan->planToString(meta::relational::extension::relationalExtensions());
+   assert($planString->contains('"root".AGE = "persontable_1".AGE as "match"'), |'expected plain equals in plan, got: ' + $planString);
 }
 
 function <<test.Test>> meta::relational::tests::query::legacyNullUnsafeEquals::testDefaultProjectionIsNullSafe():Boolean[1]
 {
    let fn = {|Person.all()
                 ->project([col(p|$p.firstName, 'name'), col(p|$p.age == $p.manager.age, 'match')])};
+   let plan = executionPlan($fn, simpleRelationalMapping, meta::external::store::relational::tests::testRuntime(), meta::relational::extension::relationalExtensions());
+   let planString = $plan->planToString(meta::relational::extension::relationalExtensions());
+   assert($planString->contains('"root".AGE is not distinct from "persontable_1".AGE as "match"'), |'expected null-safe comparison in plan, got: ' + $planString);
+}
+
+function <<test.Test, test.ExcludeAlloy>> meta::relational::tests::query::legacyNullUnsafeEquals::testInFlowExecutionForcesLegacyEquals():Boolean[1]
+{
+   let fn = {|Person.all()
+                ->project([col(p|$p.firstName, 'name'), col(p|$p.age == $p.manager.age, 'match')])};
    let result = execute($fn, simpleRelationalMapping, meta::external::store::relational::tests::testRuntime(), meta::relational::extension::relationalExtensions());
-   assertSameSQL('select "root".FIRSTNAME as "name", "root".AGE is not distinct from "persontable_1".AGE as "match" from personTable as "root" left outer join personTable as "persontable_1" on ("root".MANAGERID = "persontable_1".ID)', $result);
+   assertSameSQL('select "root".FIRSTNAME as "name", "root".AGE = "persontable_1".AGE as "match" from personTable as "root" left outer join personTable as "persontable_1" on ("root".MANAGERID = "persontable_1".ID)', $result);
 }
 
 function <<test.Test>> meta::relational::tests::query::legacyNullUnsafeEquals::testLegacyFlagRestoresOptionalParamFreeMarkerSelector():Boolean[1]


### PR DESCRIPTION
### Summary

`meta::relational::mapping::execution` now sets `legacyNullUnsafeEquals` on the `State` it hands to `toSQLQuery`, so the null-safe equality SQL generation added in #4900 is scoped to **execution plans** and the **in-flow (router) execution path keeps the pre-existing `=` shape**. Legacy consumers of the in-flow path were affected by the new rendering.

```pure
let sqlGenerationState = $relationalExecutionContext->relationalExecutionContextToState(defaultState($m, $inScopeVars, $exeCtx, $extensions));
let originalQuery = $f->toSQLQuery($m, $inScopeVars, $debug, ^$sqlGenerationState(legacyNullUnsafeEquals = true), $extensions);
```

Set on the `State` rather than on the `ExecutionContext` so `postProcessQuery` — which also receives `$exeCtx` — is unaffected. Plan generation, `toSQLString` and the SQL API all go through their own `defaultState` call and are untouched.

### Scope — what this does and does not revert

#4900 made two distinct kinds of change, and this flag gates exactly one of them.

**Semantic changes** - null-safety where there was none before. `Feature.LEGACY_SQL_NULL_UNSAFE_EQUALS` gates all of these via `processEquals`, so the in-flow path is fully restored to pre-#4900 results:

| Case | In-flow rendering with the flag |
|---|---|
| projected equality, e.g. `col(p \| $p.age == $p.manager.age, 'match')` | `=` |
| optional bind parameter, e.g. `filter(p \| $p.age == $age)` with `age:Integer[0..1]` | FreeMarker `optionalVarPlaceHolderOperationSelector` |
| `[] == column` | `= null` |

**SQL-text refactors** - identical semantics, different rendering. These were *already* null-safe before #4900 via hand-rolled expansions, which #4900 centralized onto the `nullSafeEqual` / `nullSafeNotEqual` dynafunctions (rendered as `IS [NOT] DISTINCT FROM` on capable dialects):

| Site | pre-#4900 | today, both paths |
|---|---|---|
| `processEqualFromFilter` / `convertEqualFromFilter` (store-authored `Database` filters and joins; also rescues router filter `==` between two nullable columns) | `(a = b OR (a is null AND b is null))` | `a is not distinct from b` |
| `processNotEqual` (any non-literal-vs-literal `!=`) | `orNull` expansion | `a is distinct from b` |
| union bridge joins (`pureToSQLQuery_union.pure`) | hand-rolled expansion | `nullSafeEqual` |

The flag deliberately does not touch these - reverting them would regress below pre-#4900 behaviour. They are also structurally out of its reach: `State.legacyNullUnsafeEquals` exists only in the Pure -> relational algebra stage (`pureToSQLQuery.pure`), while these render in the relational algebra -> SQL text stage (`sqlQueryToString/dbExtension.pure`, `sqlDialectTranslation/toPostgresModel.pure`), which carries `SqlGenerationContext` / `ModelConversionState` and never sees `State`.

Consequence worth noting: consumers sensitive to SQL *text* rather than results (a dialect that cannot parse `IS NOT DISTINCT FROM`, golden-SQL fixtures) still see the new form from those three sites on the in-flow path. Changing that would mean threading the flag through stage 2 - a separate change.

`testConsistencyWithNullsInColumnToColumnComparison` illustrates the filter rescue: it executes in-flow and still asserts `where "root".STREET is not distinct from "root".STREET`, unchanged by this PR.

### Tests

One expectation diverged across the 2708-test relational suite: a `[] == column` comparison renders `= null` in-flow and `is null` under plan generation. `testBuildFilterWithValueThatCanBeNull` keeps its value assertions on both paths; its SQL assertion is split into `ExcludeAlloy` / `AlloyOnly` variants sharing one expected-string builder so the two shapes differ visibly at the call site.

In `testLegacyNullUnsafeEquals`, the flag-on/flag-off projection pair moves from `execute(...)` to `executionPlan(...)` — `execute(...)` no longer discriminates now that the in-flow path forces the flag — and a new `testInFlowExecutionForcesLegacyEquals` locks the in-flow shape.

Verified locally:

| Suite | Path | Result |
|---|---|---|
| `Test_Pure_Relational` (core-pure) | in-flow | 2708/2708 |
| `Test_Pure_Relational` (relationalStore-test, H2) | plan | 4/4 |
| `Test_Relational_UsingPureClientTestSuite` | plan | 2298/2298 |

Dialect-module SQL locks are `toSQLString`-based and unaffected; PCT, `TestServiceRunner` and `TestPlanExecutionForIn` are plan-path.
