### PR TITLE
enclose values in quotes for snowflake csv upload

### DIFF
--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-executionPlan-execution/legend-engine-executionPlan-execution/src/main/java/org/finos/legend/engine/plan/execution/result/object/StreamingObjectResultCSVSerializer.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-executionPlan-execution/legend-engine-executionPlan-execution/src/main/java/org/finos/legend/engine/plan/execution/result/object/StreamingObjectResultCSVSerializer.java
@@ -36,11 +36,18 @@ public class StreamingObjectResultCSVSerializer extends CsvSerializer
 {
     private final StreamingObjectResult streamingObjectResult;
     private final boolean withHeader;
+    private final CSVFormat csvFormat;
 
     public StreamingObjectResultCSVSerializer(StreamingObjectResult streamingObjectResult, boolean withHeader)
     {
+        this(streamingObjectResult, withHeader, CSVFormat.DEFAULT);
+    }
+
+    public StreamingObjectResultCSVSerializer(StreamingObjectResult streamingObjectResult, boolean withHeader, CSVFormat csvFormat)
+    {
         this.streamingObjectResult = streamingObjectResult;
         this.withHeader = withHeader;
+        this.csvFormat = csvFormat;
     }
 
     @Override
@@ -48,7 +55,7 @@ public class StreamingObjectResultCSVSerializer extends CsvSerializer
     {
         ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
         Writer out = new BufferedWriter(new OutputStreamWriter(byteArrayOutputStream));
-        final CSVPrinter csvPrinter = new CSVPrinter(out, withHeader ? CSVFormat.DEFAULT.withFirstRecordAsHeader() : CSVFormat.DEFAULT);
+        final CSVPrinter csvPrinter = new CSVPrinter(out, withHeader ? this.csvFormat.withFirstRecordAsHeader() : this.csvFormat);
         final ObjectMapper objectMapper = ExecutionResultObjectMapperFactory.getNewObjectMapper();
         try
         {

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-execution/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-execution/pom.xml
@@ -133,6 +133,10 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-csv</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <scope>test</scope>

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-execution/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/driver/vendors/snowflake/SnowflakeCommands.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-execution/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/driver/vendors/snowflake/SnowflakeCommands.java
@@ -14,6 +14,8 @@
 
 package org.finos.legend.engine.plan.execution.stores.relational.connection.driver.vendors.snowflake;
 
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.QuoteMode;
 import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.api.map.ImmutableMap;
 import org.finos.legend.engine.plan.execution.stores.relational.connection.driver.commands.Column;
@@ -28,6 +30,13 @@ import java.util.stream.Collectors;
 public class SnowflakeCommands extends RelationalDatabaseCommands
 {
     private static final ImmutableMap<String, String> columnTypeToSqlTextMap = Maps.immutable.of("BIT", "BOOLEAN");
+    public static final CSVFormat TEMP_FILE_CSV_FORMAT = CSVFormat.DEFAULT.withQuoteMode(QuoteMode.ALL_NON_NULL);
+
+    @Override
+    public CSVFormat getCsvFormatForTempFile()
+    {
+        return TEMP_FILE_CSV_FORMAT;
+    }
 
     @Override
     public String processTempTableName(String tempTableName)

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-execution/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/connection/ds/TestSnowflakeCommands.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-execution/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/connection/ds/TestSnowflakeCommands.java
@@ -14,6 +14,9 @@
 
 package org.finos.legend.engine.plan.execution.stores.relational.connection.ds;
 
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
+import org.apache.commons.csv.QuoteMode;
 import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.impl.factory.Lists;
 import org.finos.legend.engine.plan.execution.stores.relational.connection.driver.commands.Column;
@@ -21,9 +24,12 @@ import org.finos.legend.engine.plan.execution.stores.relational.connection.drive
 import org.junit.Test;
 
 import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class TestSnowflakeCommands
 {
@@ -47,5 +53,33 @@ public class TestSnowflakeCommands
                 "DROP STAGE LEGEND_TEMP_DB.LEGEND_TEMP_SCHEMA.LEGEND_TEMP_STAGE"
         );
         assertEquals(expectedSQLStatements, sqlStatements);
+    }
+
+    @Test
+    public void testCsvFormatForTempFileUsesAllNonNullQuoteMode()
+    {
+        CSVFormat format = new SnowflakeCommands().getCsvFormatForTempFile();
+
+        assertNotNull(format);
+        assertEquals(QuoteMode.ALL_NON_NULL, format.getQuoteMode());
+        assertEquals(Character.valueOf('"'), format.getQuoteCharacter());
+    }
+
+    @Test
+    public void testCsvFormatForTempFileQuotesNonNullValuesAndPreservesEmbeddedNewlines() throws IOException
+    {
+        CSVFormat format = new SnowflakeCommands().getCsvFormatForTempFile();
+
+        StringWriter out = new StringWriter();
+        try (CSVPrinter printer = new CSVPrinter(out, format))
+        {
+            printer.printRecord(Arrays.asList("hello", "", null, 42, "line1\nline2,\"still one field\""));
+            printer.printRecord(Arrays.asList("x", "y", "z", 0, "plain"));
+        }
+
+        String expected =
+                "\"hello\",\"\",,\"42\",\"line1\nline2,\"\"still one field\"\"\"\r\n"
+                        + "\"x\",\"y\",\"z\",\"0\",\"plain\"\r\n";
+        assertEquals(expected, out.toString());
     }
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan-connection/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan-connection/pom.xml
@@ -240,6 +240,13 @@
         </dependency>
         <!-- COMMONS CODEC -->
 
+        <!-- COMMONS CSV (temp-table load CSV format) -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-csv</artifactId>
+        </dependency>
+        <!-- COMMONS CSV -->
+
         <!-- LOGGING -->
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan-connection/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/driver/commands/RelationalDatabaseCommands.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan-connection/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/driver/commands/RelationalDatabaseCommands.java
@@ -14,6 +14,8 @@
 
 package org.finos.legend.engine.plan.execution.stores.relational.connection.driver.commands;
 
+import org.apache.commons.csv.CSVFormat;
+
 import java.util.List;
 
 public abstract class RelationalDatabaseCommands
@@ -49,6 +51,11 @@ public abstract class RelationalDatabaseCommands
     public boolean supportsHeaderOnCsvFile()
     {
         return true;
+    }
+
+    public CSVFormat getCsvFormatForTempFile()
+    {
+        return CSVFormat.DEFAULT;
     }
 
     public String createTempTable(String tableName, List<Column> columns)

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/StreamResultToTempTableVisitor.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/StreamResultToTempTableVisitor.java
@@ -17,6 +17,7 @@ package org.finos.legend.engine.plan.execution.stores.relational;
 import com.google.common.collect.Iterators;
 import io.opentracing.Scope;
 import io.opentracing.util.GlobalTracer;
+import org.apache.commons.csv.CSVFormat;
 import org.finos.legend.engine.plan.execution.result.ResultNormalizer;
 import org.finos.legend.engine.plan.execution.result.StreamingResult;
 import org.finos.legend.engine.plan.execution.result.builder.tds.TDSBuilder;
@@ -86,13 +87,14 @@ public class StreamResultToTempTableVisitor implements RelationalDatabaseCommand
     {
         if (ingestionMethod == IngestionMethod.CLIENT_FILE)
         {
+            CSVFormat csvFormat = dbCommands.getCsvFormatForTempFile();
             try (TemporaryFile tempFile = new TemporaryFile(config.tempPath))
             {
                 CsvSerializer csvSerializer;
                 boolean withHeader = dbCommands.supportsHeaderOnCsvFile();
                 if (result instanceof RelationalResult)
                 {
-                    csvSerializer = new RelationalResultToCSVSerializer((RelationalResult) result, withHeader);
+                    csvSerializer = new RelationalResultToCSVSerializer((RelationalResult) result, withHeader, csvFormat);
                     tempFile.writeFile(csvSerializer);
                     try (Statement statement = connection.createStatement())
                     {
@@ -112,7 +114,7 @@ public class StreamResultToTempTableVisitor implements RelationalDatabaseCommand
                 }
                 else if (result instanceof RealizedRelationalResult)
                 {
-                    csvSerializer = new RealizedRelationalResultCSVSerializer((RealizedRelationalResult) result, this.databaseTimeZone, withHeader, false);
+                    csvSerializer = new RealizedRelationalResultCSVSerializer((RealizedRelationalResult) result, this.databaseTimeZone, withHeader, false, csvFormat);
                     tempFile.writeFile(csvSerializer);
                     try (Statement statement = connection.createStatement())
                     {
@@ -123,7 +125,7 @@ public class StreamResultToTempTableVisitor implements RelationalDatabaseCommand
                 }
                 else if (result instanceof StreamingObjectResult)
                 {
-                    csvSerializer = new StreamingObjectResultCSVSerializer((StreamingObjectResult) result, withHeader);
+                    csvSerializer = new StreamingObjectResultCSVSerializer((StreamingObjectResult) result, withHeader, csvFormat);
                     tempFile.writeFile(csvSerializer);
                     try (Statement statement = connection.createStatement())
                     {
@@ -133,7 +135,7 @@ public class StreamResultToTempTableVisitor implements RelationalDatabaseCommand
                 }
                 else if (result instanceof TempTableStreamingResult)
                 {
-                    csvSerializer = new StreamingTempTableResultCSVSerializer((TempTableStreamingResult) result, withHeader);
+                    csvSerializer = new StreamingTempTableResultCSVSerializer((TempTableStreamingResult) result, withHeader, csvFormat);
                     tempFile.writeFile(csvSerializer);
                     try (Statement statement = connection.createStatement())
                     {

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/serialization/RelationalResultToCSVSerializer.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/serialization/RelationalResultToCSVSerializer.java
@@ -41,14 +41,19 @@ public class RelationalResultToCSVSerializer extends CsvSerializer
 
     public RelationalResultToCSVSerializer(RelationalResult relationalResult, boolean withHeader)
     {
+        this(relationalResult, withHeader, CSVFormat.DEFAULT);
+    }
+
+    public RelationalResultToCSVSerializer(RelationalResult relationalResult, boolean withHeader, CSVFormat csvFormat)
+    {
         this.relationalResult = relationalResult;
         if (withHeader)
         {
-            this.csvFormat = CSVFormat.DEFAULT.withHeader(relationalResult.getColumnListForSerializer().toArray(new String[0]));
+            this.csvFormat = csvFormat.withHeader(relationalResult.getColumnListForSerializer().toArray(new String[0]));
         }
         else
         {
-            this.csvFormat = CSVFormat.DEFAULT;
+            this.csvFormat = csvFormat;
         }
     }
 


### PR DESCRIPTION
#### What type of PR is this?

- Bug Fix

#### What does this PR do / why is it needed ?

When streaming a result set into a snowflake table we now enclose values with ".

This solves a bug where if a value enda with \\, it will escape the , in the csv and interpret as a literal , instead of a delimeter 

