### PR TITLE
[Backport release-legend-release-4.98] Reduce thread count for release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,7 @@ jobs:
         run: rm -rf ~/.m2/repository/org/finos/legend/engine
 
       - name: Build Release Tag
-        run: mvn -B -e -T5 -DskipTests -Dorg.slf4j.simpleLogger.showThreadName=true install -P release,docker,pct-cloud-test
+        run: mvn -B -e -T3 -DskipTests -Dorg.slf4j.simpleLogger.showThreadName=true install -P release,docker,pct-cloud-test
         env:
           MAVEN_OPTS: -Xmx36g
 


### PR DESCRIPTION
Backport of #5031 to `release-legend-release-4.98`.

Created automatically by the backport workflow. If this PR has
conflicts or CI failures, the assignee (the original author) is
responsible for resolving them.