### PR TITLE
Add mappingProvider to dataspace execution contexts and make defaultRuntime optional

### DIFF
--- a/legend-engine-xts-analytics/legend-engine-xts-analytics-search/legend-engine-xt-analytics-search-pure/src/main/resources/core_analytics_search/metamodel.pure
+++ b/legend-engine-xts-analytics/legend-engine-xts-analytics-search/legend-engine-xt-analytics-search-pure/src/main/resources/core_analytics_search/metamodel.pure
@@ -79,7 +79,7 @@ Class meta::analytics::search::metamodel::dataspace::ExecutionContext
 {
   name: String[1];
   mappingPath: String[1];
-  runtimePath: String[1];
+  runtimePath: String[0..1];
   classes: meta::analytics::search::metamodel::class::SimpleClassElement[*];
   databaseColumns: meta::analytics::search::metamodel::mapping::DatabaseColumn[*];
 }

--- a/legend-engine-xts-analytics/legend-engine-xts-analytics-search/legend-engine-xt-analytics-search-pure/src/main/resources/core_analytics_search/trans.pure
+++ b/legend-engine-xts-analytics/legend-engine-xts-analytics-search/legend-engine-xt-analytics-search-pure/src/main/resources/core_analytics_search/trans.pure
@@ -107,7 +107,9 @@ function meta::analytics::search::transformation::dataspace::buildExecutionConte
   ^meta::analytics::search::metamodel::dataspace::ExecutionContext(
     name = $executionContext.name,
     mappingPath = $executionContext.mapping->elementToPath(),
-    runtimePath = $executionContext.defaultRuntime->elementToPath(),
+    runtimePath = if($executionContext.defaultRuntime->isEmpty(),
+                     | [],
+                     | $executionContext.defaultRuntime->toOne()->elementToPath()),
     classes = $executionContext.mapping->meta::analytics::search::transformation::dataspace::buildClassDocuments()
   )
 }

--- a/legend-engine-xts-data-space/legend-engine-xt-data-space-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/DataSpaceCompilerExtension.java
+++ b/legend-engine-xts-data-space/legend-engine-xt-data-space-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/DataSpaceCompilerExtension.java
@@ -67,6 +67,7 @@ import org.finos.legend.pure.generated.Root_meta_pure_metamodel_dataSpace_DataSp
 import org.finos.legend.pure.generated.Root_meta_pure_metamodel_dataSpace_DataSpaceDiagram_Impl;
 import org.finos.legend.pure.generated.Root_meta_pure_metamodel_dataSpace_DataSpaceExecutionContext;
 import org.finos.legend.pure.generated.Root_meta_pure_metamodel_dataSpace_DataSpaceExecutionContext_Impl;
+import org.finos.legend.pure.generated.Root_meta_pure_metamodel_dataSpace_DataSpaceMappingProvider_Impl;
 import org.finos.legend.pure.generated.Root_meta_pure_metamodel_dataSpace_DataSpacePackageableElementExecutable_Impl;
 import org.finos.legend.pure.generated.Root_meta_pure_metamodel_dataSpace_DataSpaceSupportCombinedInfo_Impl;
 import org.finos.legend.pure.generated.Root_meta_pure_metamodel_dataSpace_DataSpaceSupportEmail_Impl;
@@ -137,14 +138,21 @@ public class DataSpaceCompilerExtension implements CompilerExtension, EmbeddedDa
                     {
                         if (executionContextSet.add(executionContext.name))
                         {
-                            Root_meta_pure_runtime_PackageableRuntime runtime = context.resolvePackageableRuntime(executionContext.defaultRuntime.path, executionContext.defaultRuntime.sourceInformation);
-                            Mapping mapping = context.resolveMapping(executionContext.mapping.path, executionContext.mapping.sourceInformation);
-                            return new Root_meta_pure_metamodel_dataSpace_DataSpaceExecutionContext_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::dataSpace::DataSpaceExecutionContext"))
+                            Root_meta_pure_runtime_PackageableRuntime runtime = executionContext.defaultRuntime != null ? context.resolvePackageableRuntime(executionContext.defaultRuntime.path, executionContext.defaultRuntime.sourceInformation) : null;
+                            Mapping mapping = executionContext.mapping != null
+                                    ? context.resolveMapping(executionContext.mapping.path, executionContext.mapping.sourceInformation)
+                                    : null;
+                            Root_meta_pure_metamodel_dataSpace_DataSpaceExecutionContext impl = new Root_meta_pure_metamodel_dataSpace_DataSpaceExecutionContext_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::dataSpace::DataSpaceExecutionContext"))
                                     ._name(executionContext.name)
                                     ._title(executionContext.title)
                                     ._description(executionContext.description)
-                                    ._mapping(mapping)
                                     ._defaultRuntime(runtime);
+                            // mappingProvider is resolved in the third pass
+                            if (mapping != null)
+                            {
+                                impl._mapping(mapping);
+                            }
+                            return impl;
                         }
                         else
                         {
@@ -180,11 +188,20 @@ public class DataSpaceCompilerExtension implements CompilerExtension, EmbeddedDa
 
                     dataSpace.executionContexts.forEach(executionContext ->
                     {
-                        Mapping mapping = context.resolveMapping(executionContext.mapping.path, executionContext.mapping.sourceInformation);
-                        Root_meta_pure_runtime_PackageableRuntime runtime = context.resolvePackageableRuntime(executionContext.defaultRuntime.path, executionContext.defaultRuntime.sourceInformation);
-                        if (!HelperRuntimeBuilder.isRuntimeCompatibleWithMapping(runtime._runtimeValue(), mapping, context.pureModel.extensions.getExtraRuntimeCompilerHandler()))
+                        Root_meta_pure_metamodel_dataSpace_DataSpaceExecutionContext compiled = metamodel._executionContexts().toList().stream().filter(ec -> executionContext.name.equals(ec._name())).findFirst().orElseThrow(() -> new EngineException("Missing compiled execution context '" + executionContext.name + "'", executionContext.sourceInformation, EngineErrorType.COMPILATION));
+                        Mapping mapping;
+                        if (executionContext.mappingProvider != null && compiled._mapping() == null)
                         {
-                            throw new EngineException("Execution context '" + executionContext.name + "' default runtime is not compatible with mapping", dataSpace.sourceInformation, EngineErrorType.COMPILATION);
+                            setMappingProviderAndResolvedMapping(compiled, executionContext.mappingProvider, context);
+                        }
+                        mapping = compiled._mapping();
+                        if (executionContext.defaultRuntime != null)
+                        {
+                            Root_meta_pure_runtime_PackageableRuntime runtime = context.resolvePackageableRuntime(executionContext.defaultRuntime.path, executionContext.defaultRuntime.sourceInformation);
+                            if (!HelperRuntimeBuilder.isRuntimeCompatibleWithMapping(runtime._runtimeValue(), mapping, context.pureModel.extensions.getExtraRuntimeCompilerHandler()))
+                            {
+                                throw new EngineException("Execution context '" + executionContext.name + "' default runtime is not compatible with mapping", dataSpace.sourceInformation, EngineErrorType.COMPILATION);
+                            }
                         }
                     });
 
@@ -357,7 +374,9 @@ public class DataSpaceCompilerExtension implements CompilerExtension, EmbeddedDa
                                                 if (mappingImpl instanceof Root_meta_pure_mapping_Mapping_Impl)
                                                 {
                                                     String mappingPath = platform_pure_essential_meta_graph_elementToPath.Root_meta_pure_functions_meta_elementToPath_PackageableElement_1__String_1__String_1_((Root_meta_pure_mapping_Mapping_Impl) mappingImpl, "::", context.pureModel.getExecutionSupport());
-                                                    if (!mappingPath.equals(executionContext.mapping.path))
+                                                    Root_meta_pure_metamodel_dataSpace_DataSpaceExecutionContext compiledCtx = metamodel._executionContexts().toList().stream().filter(ec -> executionContext.name.equals(ec._name())).findFirst().orElse(null);
+                                                    String expectedMappingPath = compiledCtx == null ? null : effectiveMappingPath(executionContext, compiledCtx, context);
+                                                    if (expectedMappingPath != null && !mappingPath.equals(expectedMappingPath))
                                                     {
                                                         throw new EngineException("The mapping utilized in the function within the curated template query does not align with the mapping applied in the execution context `" + executionContext.name + "`.");
                                                     }
@@ -380,7 +399,7 @@ public class DataSpaceCompilerExtension implements CompilerExtension, EmbeddedDa
                                                 if (runtimeImpl != null)
                                                 {
                                                     String runtimePath = context.pureModel.getRuntimePath(runtimeImpl);
-                                                    if (!runtimePath.equals(executionContext.defaultRuntime.path))
+                                                    if (executionContext.defaultRuntime != null && !runtimePath.equals(executionContext.defaultRuntime.path))
                                                     {
                                                         throw new EngineException("The runtime utilized in the function within the curated template query does not align with the runtime applied in the execution context `" + executionContext.name + "`.");
                                                     }
@@ -397,13 +416,57 @@ public class DataSpaceCompilerExtension implements CompilerExtension, EmbeddedDa
         ));
     }
 
+
+    private static void setMappingProviderAndResolvedMapping(Root_meta_pure_metamodel_dataSpace_DataSpaceExecutionContext executionContext, org.finos.legend.engine.protocol.pure.v1.model.packageableElement.dataSpace.DataSpaceMappingProvider provider, CompileContext context)
+    {
+        PackageableElement element = context.resolvePackageableElement(provider.element.path, provider.element.sourceInformation);
+        for (DataSpaceMappingProviderCompilerExtension ext : DataSpaceMappingProviderCompilerExtensionLoader.extensions())
+        {
+            Optional<Mapping> resolved = ext.resolveMapping(element, provider, context);
+            if (resolved.isPresent())
+            {
+                executionContext._mappingProvider(new Root_meta_pure_metamodel_dataSpace_DataSpaceMappingProvider_Impl("", null, context.pureModel.getClass("meta::pure::metamodel::dataSpace::DataSpaceMappingProvider"))
+                        ._element(element)
+                        ._keys(Lists.immutable.withAll(provider.keys == null ? java.util.Collections.emptyList() : provider.keys)));
+                executionContext._mapping(resolved.get());
+                return;
+            }
+        }
+        throw new EngineException(
+                "'" + provider.element.path
+                        + (provider.keys == null || provider.keys.isEmpty() ? "" : "." + String.join(".", provider.keys))
+                        + "' is not a valid mapping provider",
+                provider.sourceInformation,
+                EngineErrorType.COMPILATION);
+    }
+
+    private static String effectiveMappingPath(DataSpaceExecutionContext executionContext, Root_meta_pure_metamodel_dataSpace_DataSpaceExecutionContext compiled, CompileContext context)
+    {
+        if (executionContext.mapping != null)
+        {
+            return executionContext.mapping.path;
+        }
+        Mapping m = compiled._mapping();
+        return platform_pure_essential_meta_graph_elementToPath.Root_meta_pure_functions_meta_elementToPath_PackageableElement_1__String_1__String_1_(m, "::", context.pureModel.getExecutionSupport());
+    }
+
     private Set<PackageableElementPointer> dataSpacePrerequisiteElementsPass(DataSpace dataSpace, CompileContext context)
     {
         Set<PackageableElementPointer> prerequisiteElements = Sets.mutable.empty();
         dataSpace.executionContexts.forEach(executionContext ->
         {
-            prerequisiteElements.add(executionContext.mapping);
-            prerequisiteElements.add(executionContext.defaultRuntime);
+            if (executionContext.mapping != null)
+            {
+                prerequisiteElements.add(executionContext.mapping);
+            }
+            if (executionContext.mappingProvider != null && executionContext.mappingProvider.element != null)
+            {
+                prerequisiteElements.add(executionContext.mappingProvider.element);
+            }
+            if (executionContext.defaultRuntime != null)
+            {
+                prerequisiteElements.add(executionContext.defaultRuntime);
+            }
         });
 
         if (dataSpace.elements != null)

--- a/legend-engine-xts-data-space/legend-engine-xt-data-space-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/DataSpaceMappingProviderCompilerExtension.java
+++ b/legend-engine-xts-data-space/legend-engine-xt-data-space-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/DataSpaceMappingProviderCompilerExtension.java
@@ -1,0 +1,28 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.language.pure.compiler.toPureGraph;
+
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.dataSpace.DataSpaceMappingProvider;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.Mapping;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement;
+
+import java.util.Optional;
+
+public interface DataSpaceMappingProviderCompilerExtension
+{
+    Optional<Mapping> resolveMapping(PackageableElement element, DataSpaceMappingProvider provider, CompileContext context);
+}
+
+

--- a/legend-engine-xts-data-space/legend-engine-xt-data-space-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/DataSpaceMappingProviderCompilerExtensionLoader.java
+++ b/legend-engine-xts-data-space/legend-engine-xt-data-space-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/DataSpaceMappingProviderCompilerExtensionLoader.java
@@ -1,0 +1,45 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.language.pure.compiler.toPureGraph;
+
+import org.eclipse.collections.api.factory.Lists;
+
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.concurrent.atomic.AtomicReference;
+
+public final class DataSpaceMappingProviderCompilerExtensionLoader
+{
+    private static final AtomicReference<List<DataSpaceMappingProviderCompilerExtension>> INSTANCE = new AtomicReference<>();
+
+    private DataSpaceMappingProviderCompilerExtensionLoader()
+    {
+    }
+
+    public static List<DataSpaceMappingProviderCompilerExtension> extensions()
+    {
+        return INSTANCE.updateAndGet(v ->
+        {
+            if (v != null)
+            {
+                return v;
+            }
+            List<DataSpaceMappingProviderCompilerExtension> loaded = Lists.mutable.empty();
+            ServiceLoader.load(DataSpaceMappingProviderCompilerExtension.class).forEach(loaded::add);
+            return loaded;
+        });
+    }
+}
+

--- a/legend-engine-xts-data-space/legend-engine-xt-data-space-compiler/src/test/java/org/finos/legend/engine/language/pure/compiler/test/TestDataSpaceCompilationFromGrammar.java
+++ b/legend-engine-xts-data-space/legend-engine-xt-data-space-compiler/src/test/java/org/finos/legend/engine/language/pure/compiler/test/TestDataSpaceCompilationFromGrammar.java
@@ -1411,4 +1411,26 @@ public class TestDataSpaceCompilationFromGrammar extends TestCompilationFromGram
                 "  executables: [{ title: 'MyExec'; executable: model::MyService; }, { title: 'MyExec1'; executable: model::Mine; }];\n" +
                 "}\n", "COMPILATION error at [43:1-55:1]: Error in 'model::dataSpace': Can't find the packageable element 'model::Mine'");
     }
+
+    @Test
+    public void testDataSpaceExecutionContextWithInvalidMappingProvider()
+    {
+        test("###Mapping\n" +
+                        "Mapping model::plainMapping3\n" +
+                        "(\n" +
+                        ")\n" +
+                        "###DataSpace\n" +
+                        "DataSpace model::mySpace3\n" +
+                        "{\n" +
+                        "  executionContexts:\n" +
+                        "  [\n" +
+                        "    {\n" +
+                        "      name: 'default';\n" +
+                        "      mappingProvider: model::plainMapping3.someKey;\n" +
+                        "    }\n" +
+                        "  ];\n" +
+                        "  defaultExecutionContext: 'default';\n" +
+                        "}\n",
+                "COMPILATION error at [12:7-52]: 'model::plainMapping3.someKey' is not a valid mapping provider");
+    }
 }

--- a/legend-engine-xts-data-space/legend-engine-xt-data-space-generation/src/main/java/org/finos/legend/engine/generation/analytics/DataSpaceAnalyticsHelper.java
+++ b/legend-engine-xts-data-space/legend-engine-xt-data-space-generation/src/main/java/org/finos/legend/engine/generation/analytics/DataSpaceAnalyticsHelper.java
@@ -144,7 +144,7 @@ public class DataSpaceAnalyticsHelper
                         executableAnalysisResult.result = buildExecutableResult(PlanGenerator.generateExecutionPlan(
                                 ((Root_meta_pure_metamodel_dataSpace_DataSpaceTemplateExecutable) executable)._query(),
                                 executionContext._mapping(),
-                                executionContext._defaultRuntime()._runtimeValue(),
+                                executionContext._defaultRuntime() == null ? null : executionContext._defaultRuntime()._runtimeValue(),
                                 HelperValueSpecificationBuilder.processExecutionContext(new BaseExecutionContext(), pureModel.getContext()),
                                 pureModel,
                                 PureClientVersions.production,
@@ -233,7 +233,7 @@ public class DataSpaceAnalyticsHelper
                             Root_meta_pure_metamodel_dataSpace_DataSpaceExecutionContext executionContext = executable._executionContextKey() == null ? dataSpace._defaultExecutionContext() :
                                     dataSpace._executionContexts().toList().stream().filter(c -> c._name().equals(executable._executionContextKey())).findFirst().get();
                             mapping = executionContext._mapping();
-                            runtime = executionContext._defaultRuntime()._runtimeValue();
+                            runtime = executionContext._defaultRuntime() == null ? null : executionContext._defaultRuntime()._runtimeValue();
                             LambdaFunction lambda = new LambdaFunction();
                             lambda.body = new ArrayList<>();
                             lambda.body.addAll(((Function) _el).body);
@@ -279,7 +279,7 @@ public class DataSpaceAnalyticsHelper
         try
         {
             MappingModelCoverageAnalysisResult mappingModelCoverageAnalysisResultProtocol = DataSpaceAnalyticsHelper.objectMapper.readValue(core_analytics_mapping_modelCoverage_serializer.Root_meta_analytics_mapping_modelCoverage_serialization_json_getSerializedMappingModelCoverageAnalysisResult_MappingModelCoverageAnalysisResult_1__String_1_(mappingModelCoverageAnalysisResult, pureModel.getExecutionSupport()), MappingModelCoverageAnalysisResult.class);
-            if (returnDataSets)
+            if (returnDataSets && excResult.defaultRuntime != null)
             {
                 excResult.datasets = LazyIterate.flatCollect(entitlementServiceExtensions, extension -> extension.generateDatasetSpecifications(null, excResult.defaultRuntime, pureModel.getRuntime(excResult.defaultRuntime), excResult.mapping, pureModel.getMapping(excResult.mapping), pureModelContextData, pureModel)).toList();
             }
@@ -342,7 +342,14 @@ public class DataSpaceAnalyticsHelper
             excResult.title = executionContext._title();
             excResult.description = executionContext._description();
             excResult.mapping = HelperModelBuilder.getElementFullPath(executionContext._mapping(), pureModel.getExecutionSupport());
-            excResult.defaultRuntime = HelperModelBuilder.getElementFullPath(executionContext._defaultRuntime(), pureModel.getExecutionSupport());
+            if (executionContext._mappingProvider() != null)
+            {
+                DataSpaceMappingProviderAnalysisResult mappingProvider = new DataSpaceMappingProviderAnalysisResult();
+                mappingProvider.element = HelperModelBuilder.getElementFullPath(executionContext._mappingProvider()._element(), pureModel.getExecutionSupport());
+                mappingProvider.keys = ListIterate.collect(executionContext._mappingProvider()._keys().toList(), key -> key);
+                excResult.mappingProvider = mappingProvider;
+            }
+            excResult.defaultRuntime = executionContext._defaultRuntime() == null ? null : HelperModelBuilder.getElementFullPath(executionContext._defaultRuntime(), pureModel.getExecutionSupport());
             excResult.compatibleRuntimes = ListIterate.collect(executionContextAnalysisResult._compatibleRuntimes().toList(), runtime -> HelperModelBuilder.getElementFullPath(runtime, pureModel.getExecutionSupport()));
             Optional<org.finos.legend.engine.protocol.pure.m3.PackageableElement> packageableRuntime = pureModelContextData.getElements().stream().filter(e -> e.getPath().equals(excResult.defaultRuntime) && e instanceof PackageableRuntime).findFirst();
             if (packageableRuntime.isPresent() && packageableRuntime.get() instanceof PackageableRuntime)
@@ -446,7 +453,14 @@ public class DataSpaceAnalyticsHelper
             excResult.title = executionContext._title();
             excResult.description = executionContext._description();
             excResult.mapping = HelperModelBuilder.getElementFullPath(executionContext._mapping(), pureModel.getExecutionSupport());
-            excResult.defaultRuntime = HelperModelBuilder.getElementFullPath(executionContext._defaultRuntime(), pureModel.getExecutionSupport());
+            if (executionContext._mappingProvider() != null)
+            {
+                DataSpaceMappingProviderAnalysisResult mappingProvider = new DataSpaceMappingProviderAnalysisResult();
+                mappingProvider.element = HelperModelBuilder.getElementFullPath(executionContext._mappingProvider()._element(), pureModel.getExecutionSupport());
+                mappingProvider.keys = ListIterate.collect(executionContext._mappingProvider()._keys().toList(), key -> key);
+                excResult.mappingProvider = mappingProvider;
+            }
+            excResult.defaultRuntime = executionContext._defaultRuntime() == null ? null : HelperModelBuilder.getElementFullPath(executionContext._defaultRuntime(), pureModel.getExecutionSupport());
             Optional<org.finos.legend.engine.protocol.pure.m3.PackageableElement> packageableRuntime = pureModelContextData.getElements().stream().filter(e -> e.getPath().equals(excResult.defaultRuntime) && e instanceof PackageableRuntime).findFirst();
             if (packageableRuntime.isPresent() && packageableRuntime.get() instanceof PackageableRuntime)
             {

--- a/legend-engine-xts-data-space/legend-engine-xt-data-space-generation/src/main/java/org/finos/legend/engine/generation/analytics/model/DataSpaceExecutionContextAnalysisResult.java
+++ b/legend-engine-xts-data-space/legend-engine-xt-data-space-generation/src/main/java/org/finos/legend/engine/generation/analytics/model/DataSpaceExecutionContextAnalysisResult.java
@@ -25,6 +25,7 @@ public class DataSpaceExecutionContextAnalysisResult
     public String title;
     public String description;
     public String mapping;
+    public DataSpaceMappingProviderAnalysisResult mappingProvider;
     public List<String> compatibleRuntimes;
     public String defaultRuntime;
     public DataSpaceExecutionContextRuntimeMetadata runtimeMetadata;

--- a/legend-engine-xts-data-space/legend-engine-xt-data-space-generation/src/main/java/org/finos/legend/engine/generation/analytics/model/DataSpaceMappingProviderAnalysisResult.java
+++ b/legend-engine-xts-data-space/legend-engine-xt-data-space-generation/src/main/java/org/finos/legend/engine/generation/analytics/model/DataSpaceMappingProviderAnalysisResult.java
@@ -1,0 +1,23 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.generation.analytics.model;
+
+import java.util.List;
+
+public class DataSpaceMappingProviderAnalysisResult
+{
+    public String element;
+    public List<String> keys;
+}

--- a/legend-engine-xts-data-space/legend-engine-xt-data-space-grammar/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/DataSpaceLexerGrammar.g4
+++ b/legend-engine-xts-data-space/legend-engine-xt-data-space-grammar/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/DataSpaceLexerGrammar.g4
@@ -22,6 +22,7 @@ DATA_SPACE_EXECUTION_CONTEXTS:              'executionContexts';
 DATA_SPACE_DEFAULT_EXECUTION_CONTEXT:       'defaultExecutionContext';
 
 DATA_SPACE_MAPPING:                         'mapping';
+DATA_SPACE_MAPPING_PROVIDER:                'mappingProvider';
 DATA_SPACE_DEFAULT_RUNTIME:                 'defaultRuntime';
 DATA_SPACE_TEST_DATA:                       'testData';
 

--- a/legend-engine-xts-data-space/legend-engine-xt-data-space-grammar/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/DataSpaceParserGrammar.g4
+++ b/legend-engine-xts-data-space/legend-engine-xt-data-space-grammar/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/DataSpaceParserGrammar.g4
@@ -19,6 +19,7 @@ identifier:                         VALID_STRING | STRING
                                     | DATA_SPACE_EXECUTION_CONTEXTS
                                     | DATA_SPACE_DEFAULT_EXECUTION_CONTEXT
                                     | DATA_SPACE_MAPPING
+                                    | DATA_SPACE_MAPPING_PROVIDER
                                     | DATA_SPACE_DEFAULT_RUNTIME
                                     | DATA_SPACE_TEST_DATA
                                     | DATA_SPACE_DIAGRAMS
@@ -84,6 +85,7 @@ executionContext:                   BRACE_OPEN
                                             | executionContextTitle
                                             | executionContextDescription
                                             | executionContextMapping
+                                            | executionContextMappingProvider
                                             | executionContextDefaultRuntime
                                             | executionContextTestData
                                         )*
@@ -96,6 +98,8 @@ executionContextTitle:              DATA_SPACE__TITLE COLON STRING SEMI_COLON
 executionContextDescription:        DATA_SPACE__DESCRIPTION COLON STRING SEMI_COLON
 ;
 executionContextMapping:            DATA_SPACE_MAPPING COLON qualifiedName SEMI_COLON
+;
+executionContextMappingProvider:    DATA_SPACE_MAPPING_PROVIDER COLON qualifiedName (DOT identifier (COMMA identifier)*)? SEMI_COLON
 ;
 executionContextTestData:           DATA_SPACE_TEST_DATA COLON embeddedData SEMI_COLON
 ;

--- a/legend-engine-xts-data-space/legend-engine-xt-data-space-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/DataSpaceParseTreeWalker.java
+++ b/legend-engine-xts-data-space/legend-engine-xt-data-space-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/DataSpaceParseTreeWalker.java
@@ -171,20 +171,51 @@ public class DataSpaceParseTreeWalker
         executionContext.description = descriptionContext != null ? PureGrammarParserUtility.fromGrammarString(descriptionContext.STRING().getText(), true) : null;
 
         // Mapping
-        DataSpaceParserGrammar.ExecutionContextMappingContext mappingContext = PureGrammarParserUtility.validateAndExtractRequiredField(ctx.executionContextMapping(), "mapping", executionContext.sourceInformation);
-        executionContext.mapping = new PackageableElementPointer(
-                PackageableElementType.MAPPING,
-                PureGrammarParserUtility.fromQualifiedName(mappingContext.qualifiedName().packagePath() == null ? Collections.emptyList() : mappingContext.qualifiedName().packagePath().identifier(), mappingContext.qualifiedName().identifier())
-        );
-        executionContext.mapping.sourceInformation = walkerSourceInformation.getSourceInformation(mappingContext);
+        DataSpaceParserGrammar.ExecutionContextMappingContext mappingContext = PureGrammarParserUtility.validateAndExtractOptionalField(ctx.executionContextMapping(), "mapping", executionContext.sourceInformation);
+        if (mappingContext != null)
+        {
+            executionContext.mapping = new PackageableElementPointer(
+                    PackageableElementType.MAPPING,
+                    PureGrammarParserUtility.fromQualifiedName(mappingContext.qualifiedName().packagePath() == null ? Collections.emptyList() : mappingContext.qualifiedName().packagePath().identifier(), mappingContext.qualifiedName().identifier())
+            );
+            executionContext.mapping.sourceInformation = walkerSourceInformation.getSourceInformation(mappingContext);
+        }
+
+        DataSpaceParserGrammar.ExecutionContextMappingProviderContext mappingProviderContext = PureGrammarParserUtility.validateAndExtractOptionalField(ctx.executionContextMappingProvider(), "mappingProvider", executionContext.sourceInformation);
+        if (mappingProviderContext != null)
+        {
+            org.finos.legend.engine.protocol.pure.v1.model.packageableElement.dataSpace.DataSpaceMappingProvider provider =
+                    new org.finos.legend.engine.protocol.pure.v1.model.packageableElement.dataSpace.DataSpaceMappingProvider();
+            provider.sourceInformation = walkerSourceInformation.getSourceInformation(mappingProviderContext);
+            provider.element = new PackageableElementPointer(
+                    null,
+                    PureGrammarParserUtility.fromQualifiedName(mappingProviderContext.qualifiedName().packagePath() == null ? Collections.emptyList() : mappingProviderContext.qualifiedName().packagePath().identifier(), mappingProviderContext.qualifiedName().identifier())
+            );
+            provider.element.sourceInformation = walkerSourceInformation.getSourceInformation(mappingProviderContext.qualifiedName());
+            provider.keys = mappingProviderContext.identifier() == null ? null :
+                    ListIterate.collect(mappingProviderContext.identifier(), id -> PureGrammarParserUtility.fromIdentifier(id));
+            executionContext.mappingProvider = provider;
+        }
+
+        if (executionContext.mapping == null && executionContext.mappingProvider == null)
+        {
+            throw new EngineException("Data space execution context must define either 'mapping' or 'mappingProvider'", executionContext.sourceInformation, EngineErrorType.PARSER);
+        }
+        if (executionContext.mapping != null && executionContext.mappingProvider != null)
+        {
+            throw new EngineException("Data space execution context cannot define both 'mapping' and 'mappingProvider'", executionContext.sourceInformation, EngineErrorType.PARSER);
+        }
 
         // Runtime
-        DataSpaceParserGrammar.ExecutionContextDefaultRuntimeContext defaultRuntimeContext = PureGrammarParserUtility.validateAndExtractRequiredField(ctx.executionContextDefaultRuntime(), "defaultRuntime", executionContext.sourceInformation);
-        executionContext.defaultRuntime = new PackageableElementPointer(
-                PackageableElementType.RUNTIME,
-                PureGrammarParserUtility.fromQualifiedName(defaultRuntimeContext.qualifiedName().packagePath() == null ? Collections.emptyList() : defaultRuntimeContext.qualifiedName().packagePath().identifier(), defaultRuntimeContext.qualifiedName().identifier())
-        );
-        executionContext.defaultRuntime.sourceInformation = walkerSourceInformation.getSourceInformation(defaultRuntimeContext);
+        DataSpaceParserGrammar.ExecutionContextDefaultRuntimeContext defaultRuntimeContext = PureGrammarParserUtility.validateAndExtractOptionalField(ctx.executionContextDefaultRuntime(), "defaultRuntime", executionContext.sourceInformation);
+        if (defaultRuntimeContext != null)
+        {
+            executionContext.defaultRuntime = new PackageableElementPointer(
+                    PackageableElementType.RUNTIME,
+                    PureGrammarParserUtility.fromQualifiedName(defaultRuntimeContext.qualifiedName().packagePath() == null ? Collections.emptyList() : defaultRuntimeContext.qualifiedName().packagePath().identifier(), defaultRuntimeContext.qualifiedName().identifier())
+            );
+            executionContext.defaultRuntime.sourceInformation = walkerSourceInformation.getSourceInformation(defaultRuntimeContext);
+        }
 
         // TestData
         DataSpaceParserGrammar.ExecutionContextTestDataContext data = PureGrammarParserUtility.validateAndExtractOptionalField(ctx.executionContextTestData(), "testData", executionContext.sourceInformation);

--- a/legend-engine-xts-data-space/legend-engine-xt-data-space-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/DataSpaceGrammarComposerExtension.java
+++ b/legend-engine-xts-data-space/legend-engine-xt-data-space-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/DataSpaceGrammarComposerExtension.java
@@ -108,10 +108,21 @@ public class DataSpaceGrammarComposerExtension implements PureGrammarComposerExt
                 (getTabString(3) + "name: " + convertString(executionContext.name, true) + ";\n") +
                 (executionContext.title != null ? (getTabString(3) + "title: " + convertString(executionContext.title, true) + ";\n") : "") +
                 (executionContext.description != null ? (getTabString(3) + "description: " + convertString(executionContext.description, true) + ";\n") : "") +
-                getTabString(3) + "mapping: " + PureGrammarComposerUtility.convertPath(executionContext.mapping.path) + ";\n" +
-                getTabString(3) + "defaultRuntime: " + PureGrammarComposerUtility.convertPath(executionContext.defaultRuntime.path) + ";\n" +
+                (executionContext.mapping != null ? (getTabString(3) + "mapping: " + PureGrammarComposerUtility.convertPath(executionContext.mapping.path) + ";\n") : "") +
+                (executionContext.mappingProvider != null ? (getTabString(3) + "mappingProvider: " + renderMappingProvider(executionContext.mappingProvider) + ";\n") : "") +
+                (executionContext.defaultRuntime != null ? (getTabString(3) + "defaultRuntime: " + PureGrammarComposerUtility.convertPath(executionContext.defaultRuntime.path) + ";\n") : "") +
                 (executionContext.testData == null ? "" : (renderTestData(executionContext.testData, 3, context) + "\n")) +
                 getTabString(2) + "}";
+    }
+
+    private static String renderMappingProvider(org.finos.legend.engine.protocol.pure.v1.model.packageableElement.dataSpace.DataSpaceMappingProvider provider)
+    {
+        String base = PureGrammarComposerUtility.convertPath(provider.element.path);
+        if (provider.keys == null || provider.keys.isEmpty())
+        {
+            return base;
+        }
+        return base + "." + String.join(",", provider.keys);
     }
 
     private static String renderTestData(EmbeddedData embeddedData, int baseIndentation, PureGrammarComposerContext context)

--- a/legend-engine-xts-data-space/legend-engine-xt-data-space-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestDataSpaceGrammarParser.java
+++ b/legend-engine-xts-data-space/legend-engine-xt-data-space-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestDataSpaceGrammarParser.java
@@ -78,7 +78,7 @@ public class TestDataSpaceGrammarParser extends TestGrammarParser.TestGrammarPar
                 "    }\n" +
                 "  ];\n" +
                 "  defaultExecutionContext: 'Context 1';\n" +
-                "}\n", "PARSER error at [5:5-8:5]: Field 'mapping' is required");
+                "}\n", "PARSER error at [5:5-8:5]: Data space execution context must define either 'mapping' or 'mappingProvider'");
         test("###DataSpace\n" +
                 "DataSpace model::dataSpace" +
                 "{\n" +
@@ -87,10 +87,11 @@ public class TestDataSpaceGrammarParser extends TestGrammarParser.TestGrammarPar
                 "    {\n" +
                 "      name: 'Context 1';\n" +
                 "      mapping: model::String;\n" +
+                "      mappingProvider: model::product.key;\n" +
                 "    }\n" +
                 "  ];\n" +
                 "  defaultExecutionContext: 'Context 1';\n" +
-                "}\n", "PARSER error at [5:5-8:5]: Field 'defaultRuntime' is required");
+                "}\n", "PARSER error at [5:5-9:5]: Data space execution context cannot define both 'mapping' and 'mappingProvider'");
 
         // Executables
         test("###DataSpace\n" +

--- a/legend-engine-xts-data-space/legend-engine-xt-data-space-protocol/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/dataSpace/DataSpaceMappingProvider.java
+++ b/legend-engine-xts-data-space/legend-engine-xt-data-space-protocol/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/dataSpace/DataSpaceMappingProvider.java
@@ -1,4 +1,4 @@
-//  Copyright 2022 Goldman Sachs
+//  Copyright 2026 Goldman Sachs
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -16,17 +16,15 @@ package org.finos.legend.engine.protocol.pure.v1.model.packageableElement.dataSp
 
 import org.finos.legend.engine.protocol.pure.m3.SourceInformation;
 import org.finos.legend.engine.protocol.pure.v1.model.context.PackageableElementPointer;
-import org.finos.legend.engine.protocol.pure.v1.model.data.DataElementReference;
 
-public class DataSpaceExecutionContext
+import java.util.Collections;
+import java.util.List;
+
+public class DataSpaceMappingProvider
 {
-    public String name;
-    public String title;
-    public String description;
-    public PackageableElementPointer mapping;
-    public PackageableElementPointer defaultRuntime;
-    public DataElementReference testData;
-    // TODO: see if we can remove mapping after deserializing mapping to mappingProvider. Check clients taking in dataspaces
-    public DataSpaceMappingProvider mappingProvider;
+    public PackageableElementPointer element;
+    public List<String> keys = Collections.emptyList();
     public SourceInformation sourceInformation;
 }
+
+

--- a/legend-engine-xts-data-space/legend-engine-xt-data-space-pure-metamodel/src/main/resources/core_data_space_metamodel/metamodel.pure
+++ b/legend-engine-xts-data-space/legend-engine-xt-data-space-pure-metamodel/src/main/resources/core_data_space_metamodel/metamodel.pure
@@ -46,8 +46,15 @@ Class meta::pure::metamodel::dataSpace::DataSpaceExecutionContext
   title: String[0..1];
   description: String[0..1];
   mapping: meta::pure::mapping::Mapping[1];
-  defaultRuntime: meta::pure::runtime::PackageableRuntime[1];
+  mappingProvider: meta::pure::metamodel::dataSpace::DataSpaceMappingProvider[0..1];
+  defaultRuntime: meta::pure::runtime::PackageableRuntime[0..1];
   testData: meta::pure::data::EmbeddedData[0..1];
+}
+
+Class meta::pure::metamodel::dataSpace::DataSpaceMappingProvider
+{
+  element: PackageableElement[1];
+  keys: String[*];
 }
 
 Class meta::pure::metamodel::dataSpace::DataSpaceDiagram

--- a/legend-engine-xts-data-space/legend-engine-xt-data-space-pure/src/main/resources/core_data_space/analytics/analytics.pure
+++ b/legend-engine-xts-data-space/legend-engine-xt-data-space-pure/src/main/resources/core_data_space/analytics/analytics.pure
@@ -65,7 +65,7 @@ function <<access.private>> meta::pure::metamodel::dataSpace::analytics::analyze
 {
   $dataSpace.executionContexts->map(context|^DataSpaceExecutionContextAnalysisResult(
     name = $context.name,
-    compatibleRuntimes = getMappingCompatibleRuntimes($context.mapping, $allAvailableRuntimes),
+    compatibleRuntimes = getMappingCompatibleRuntimes($context.mapping, $allAvailableRuntimes)->concatenate($context.defaultRuntime)->removeDuplicatesBy(r | $r->elementToPath()),
     mappingCoverage = if($mappingCoverageMap->get($context.mapping)->isEmpty()
                 ,|meta::analytics::mapping::modelCoverage::analyze($context.mapping, $returnLightGraph, false, $returnLightGraph)
                 ,|$mappingCoverageMap->get($context.mapping)->toOne()

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure/src/main/resources/core_dataquality/generation/dataquality.pure
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure/src/main/resources/core_dataquality/generation/dataquality.pure
@@ -400,7 +400,8 @@ function meta::external::dataquality::getMappingAndRuntime(context: DataQualityE
         ^Pair<Mapping, Runtime>(first=$mappingAndRuntimeContext.mapping, second=$mappingAndRuntimeContext.runtime);,
       | let dataSpaceDataQualityExecutionContext = $context->cast(@DataSpaceDataQualityExecutionContext);
         let dataSpaceExecutionContext = $dataSpaceDataQualityExecutionContext.dataSpace.executionContexts->filter(execContext| $execContext.name == $dataSpaceDataQualityExecutionContext.contextName)->toOne();
-        ^Pair<Mapping, Runtime>(first=$dataSpaceExecutionContext.mapping, second=$dataSpaceExecutionContext.defaultRuntime.runtimeValue);
+        let dataSpaceExecutionContextRuntime = $dataSpaceExecutionContext.defaultRuntime->toOne('Data quality execution requires a default runtime on execution context \'' + $dataSpaceExecutionContext.name + '\' of data space \'' + $dataSpaceDataQualityExecutionContext.dataSpace->elementToPath() + '\'. Runtime-less execution contexts are not yet supported.').runtimeValue;
+        ^Pair<Mapping, Runtime>(first=$dataSpaceExecutionContext.mapping, second=$dataSpaceExecutionContextRuntime);
     );
 }
 

--- a/legend-engine-xts-graphQL/legend-engine-xt-graphQL-http-api/src/main/java/org/finos/legend/engine/query/graphQL/api/execute/GraphQLExecute.java
+++ b/legend-engine-xts-graphQL/legend-engine-xt-graphQL-http-api/src/main/java/org/finos/legend/engine/query/graphQL/api/execute/GraphQLExecute.java
@@ -493,6 +493,10 @@ public class GraphQLExecute extends GraphQL
 
         Root_meta_pure_metamodel_dataSpace_DataSpaceExecutionContext executionContextPureElement = getDataspaceExecutionContext(dataspacePath, executionContext, pureModel);
         Mapping mapping = executionContextPureElement._mapping();
+        if (executionContextPureElement._defaultRuntime() == null)
+        {
+            throw new RuntimeException("GraphQL execution requires a default runtime on execution context '" + executionContextPureElement._name() + "' of data space '" + dataspacePath + "'. Runtime-less execution contexts are not yet supported.");
+        }
         Root_meta_core_runtime_Runtime runtime = executionContextPureElement._defaultRuntime()._runtimeValue();
         return getSerializedNamedPlans(pureModel, extensions, _class, mapping, runtime, document, query, queryDoc, graphQLCacheKey);
     }

--- a/legend-engine-xts-hostedService/legend-engine-xt-hostedService-pure/src/main/resources/core_hostedservice/generation/generation.pure
+++ b/legend-engine-xts-hostedService/legend-engine-xt-hostedService-pure/src/main/resources/core_hostedservice/generation/generation.pure
@@ -202,7 +202,8 @@ function meta::external::function::activator::hostedService::generation::rebuild
                                                              rebuildFromExpressionForExecutionEnv($func, $e->cast(@ExecutionEnvironmentInstance)->toOne());,
                        d : DataSpace[*]                    | assert($d->size() == 1, 'Found too many/ not enough dataSpaces, Size =' + $d->size()->toString());
                                                               $d.executionContexts->map(
-                                                                ec | let newFunc = rebuildFromExpression($func, $ec.mapping, $ec.defaultRuntime.runtimeValue);
+                                                                ec | let ecRuntime = $ec.defaultRuntime->toOne('Hosted service generation requires a default runtime on execution context \'' + $ec.name + '\'. Runtime-less execution contexts are not yet supported by this generator.').runtimeValue;
+                                                                let newFunc = rebuildFromExpression($func, $ec.mapping, $ecRuntime);
                                                                 pair($ec.name, $newFunc);
                                                               );,
                        a : Any[1]                          | fail('unexpected type'); [];

--- a/legend-engine-xts-powerbi/legend-engine-xt-powerbi-pure/src/main/resources/core_external_format_powerbi/transformation/fromPure/pureToPBIP.pure
+++ b/legend-engine-xts-powerbi/legend-engine-xt-powerbi-pure/src/main/resources/core_external_format_powerbi/transformation/fromPure/pureToPBIP.pure
@@ -146,26 +146,33 @@ function <<access.private>> meta::external::powerbi::transformation::fromPure::g
 function <<access.private>> meta::external::powerbi::transformation::fromPure::getExecutionPlan(dataspaceTemplateExecutable: DataSpaceTemplateExecutable[1], dataspace: DataSpace[1], extensions: meta::pure::extension::Extension[*]): ExecutionPlan[1]
 {
   let dataspaceExecutionContext=$dataspaceTemplateExecutable.executionContextKey->getDataSpaceExecutionContext($dataspace.executionContexts, $dataspace.defaultExecutionContext);
+  let runtime=$dataspaceExecutionContext->getDefaultRuntimeForPowerBI($dataspaceTemplateExecutable.id);
 
-  $dataspaceTemplateExecutable.query->executionPlan($dataspaceExecutionContext.mapping, $dataspaceExecutionContext.defaultRuntime.runtimeValue, $dataspaceExecutionContext.defaultRuntime.runtimeValue->getCustomExecutionContext($extensions), $extensions);
+  $dataspaceTemplateExecutable.query->executionPlan($dataspaceExecutionContext.mapping, $runtime, $runtime->getCustomExecutionContext($extensions), $extensions);
 }
 
 function <<access.private>> meta::external::powerbi::transformation::fromPure::getExecutionPlan(dataspacePackageableElementExecutable: DataSpacePackageableElementExecutable[1], dataspace: DataSpace[1], extensions: meta::pure::extension::Extension[*]): ExecutionPlan[1]
 {
   let dataspaceExecutionContext=$dataspacePackageableElementExecutable.executionContextKey->getDataSpaceExecutionContext($dataspace.executionContexts, $dataspace.defaultExecutionContext);
+  let runtime=$dataspaceExecutionContext->getDefaultRuntimeForPowerBI($dataspacePackageableElementExecutable.id);
 
   $dataspacePackageableElementExecutable.executable->match([
-    f: PackageableFunction<Any>[1] | $f->cast(@ConcreteFunctionDefinition<Any>)->executionPlan($dataspaceExecutionContext.mapping, $dataspaceExecutionContext.defaultRuntime.runtimeValue, $dataspaceExecutionContext.defaultRuntime.runtimeValue->getCustomExecutionContext($extensions), $extensions),
-    s: Service[1] | $s->getExecutionPlan($dataspaceExecutionContext, $dataspaceExecutionContext.defaultRuntime.runtimeValue->getCustomExecutionContext($extensions), $extensions);
+    f: PackageableFunction<Any>[1] | $f->cast(@ConcreteFunctionDefinition<Any>)->executionPlan($dataspaceExecutionContext.mapping, $runtime, $runtime->getCustomExecutionContext($extensions), $extensions),
+    s: Service[1] | $s->getExecutionPlan($dataspaceExecutionContext, $runtime, $runtime->getCustomExecutionContext($extensions), $extensions);
   ]);
 }
 
-function <<access.private>> meta::external::powerbi::transformation::fromPure::getExecutionPlan(s: Service[1], dataSpaceExecutionContext: DataSpaceExecutionContext[1], customExecutionContext: ExecutionContext[1], extensions: meta::pure::extension::Extension[*]): ExecutionPlan[1]
+function <<access.private>> meta::external::powerbi::transformation::fromPure::getExecutionPlan(s: Service[1], dataSpaceExecutionContext: DataSpaceExecutionContext[1], runtime: EngineRuntime[1], customExecutionContext: ExecutionContext[1], extensions: meta::pure::extension::Extension[*]): ExecutionPlan[1]
 {
   //Support only single execution services
   assert($s.execution->instanceOf(PureSingleExecution), 'Only single execution services are supported for Power BI artifact generation. Service with pattern \"' + $s.pattern + '\" is not a single execution service.');
 
-  $s.execution->cast(@PureSingleExecution).func->executionPlan($dataSpaceExecutionContext.mapping, $dataSpaceExecutionContext.defaultRuntime.runtimeValue, $customExecutionContext, $extensions);
+  $s.execution->cast(@PureSingleExecution).func->executionPlan($dataSpaceExecutionContext.mapping, $runtime, $customExecutionContext, $extensions);
+}
+
+function <<access.private>> meta::external::powerbi::transformation::fromPure::getDefaultRuntimeForPowerBI(dataSpaceExecutionContext: DataSpaceExecutionContext[1], executableId: String[1]): EngineRuntime[1]
+{
+  $dataSpaceExecutionContext.defaultRuntime->toOne('Power BI artifact generation requires a default runtime on execution context \'' + $dataSpaceExecutionContext.name + '\' (executable \'' + $executableId + '\'). Runtime-less execution contexts are not yet supported by this generator.').runtimeValue;
 }
 
 function <<access.private>> meta::external::powerbi::transformation::fromPure::getDataSpaceExecutionContext(executionContextKey: String[0..1], executionContexts: DataSpaceExecutionContext[1..*], defaultExecutionContext: DataSpaceExecutionContext[1]): DataSpaceExecutionContext[1]


### PR DESCRIPTION
Add mappingProvider to dataspace execution contexts and make defaultRuntime optional

#### What type of PR is this?

<!--
Choose one of the following labels :
- Improvement
- Bug Fix
-->

#### What does this PR do / why is it needed ?

<!--
Describe change being introduced by this PR.
-->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
