### PR TITLE
Omit empty relational taggedValues from the serialized protocol

### DIFF
--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/RelationalParseTreeWalker.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/RelationalParseTreeWalker.java
@@ -135,10 +135,7 @@ public class RelationalParseTreeWalker
         }
         database.schemas = ListIterate.collect(ctx.schema(), schemaCtx -> this.visitSchema(schemaCtx, scopeInfo));
         database.stereotypes = ctx.stereotypes() == null ? Lists.mutable.empty() : this.visitStereotypes(ctx.stereotypes());
-        database.taggedValues = PureGrammarParserUtility.taggedValuesWithDocumentation(
-                ctx.documentation() == null ? null : ctx.documentation().STRING().getSymbol(),
-                ctx.taggedValues() == null ? Lists.mutable.empty() : this.visitTaggedValues(ctx.taggedValues()),
-                this.walkerSourceInformation);
+        database.taggedValues = this.visitTaggedValues(ctx.documentation(), ctx.taggedValues());
         // NOTE: if tables and views are defined without a schema, create a default schema to hold these
         List<Table> tables = ListIterate.collect(ctx.table(), this::visitTable);
         List<View> views = ListIterate.collect(ctx.view(), viewCtx -> this.visitView(viewCtx, scopeInfo));
@@ -178,6 +175,18 @@ public class RelationalParseTreeWalker
         });
     }
 
+    /**
+     * The element's tagged values, with a documentation block promoted into a doc tagged value. An element with
+     * neither yields an empty list, which the protocol omits from the serialized model.
+     */
+    private List<TaggedValue> visitTaggedValues(RelationalParserGrammar.DocumentationContext documentationCtx, RelationalParserGrammar.TaggedValuesContext taggedValuesCtx)
+    {
+        return PureGrammarParserUtility.taggedValuesWithDocumentation(
+                documentationCtx == null ? null : documentationCtx.STRING().getSymbol(),
+                taggedValuesCtx == null ? Lists.mutable.empty() : this.visitTaggedValues(taggedValuesCtx),
+                this.walkerSourceInformation);
+    }
+
     private List<TaggedValue> visitTaggedValues(RelationalParserGrammar. TaggedValuesContext ctx)
     {
         return ListIterate.collect(ctx.taggedValue(), taggedValueContext ->
@@ -209,10 +218,7 @@ public class RelationalParseTreeWalker
         {
             schema.stereotypes = this.visitStereotypes(ctx.stereotypes());
         }
-        schema.taggedValues = PureGrammarParserUtility.taggedValuesWithDocumentation(
-                ctx.documentation() == null ? null : ctx.documentation().STRING().getSymbol(),
-                ctx.taggedValues() == null ? Lists.mutable.empty() : this.visitTaggedValues(ctx.taggedValues()),
-                this.walkerSourceInformation);
+        schema.taggedValues = this.visitTaggedValues(ctx.documentation(), ctx.taggedValues());
         return schema;
     }
 
@@ -234,10 +240,7 @@ public class RelationalParseTreeWalker
         {
             table.stereotypes = this.visitStereotypes(ctx.stereotypes());
         }
-        table.taggedValues = PureGrammarParserUtility.taggedValuesWithDocumentation(
-                ctx.documentation() == null ? null : ctx.documentation().STRING().getSymbol(),
-                ctx.taggedValues() == null ? Lists.mutable.empty() : this.visitTaggedValues(ctx.taggedValues()),
-                this.walkerSourceInformation);
+        table.taggedValues = this.visitTaggedValues(ctx.documentation(), ctx.taggedValues());
         return table;
     }
 
@@ -250,10 +253,7 @@ public class RelationalParseTreeWalker
         {
             column.stereotypes = this.visitStereotypes(ctx.stereotypes());
         }
-        column.taggedValues = PureGrammarParserUtility.taggedValuesWithDocumentation(
-                ctx.documentation() == null ? null : ctx.documentation().STRING().getSymbol(),
-                ctx.taggedValues() == null ? Lists.mutable.empty() : this.visitTaggedValues(ctx.taggedValues()),
-                this.walkerSourceInformation);
+        column.taggedValues = this.visitTaggedValues(ctx.documentation(), ctx.taggedValues());
         boolean nullable = true;
         if (ctx.PRIMARY_KEY() != null)
         {
@@ -553,10 +553,7 @@ public class RelationalParseTreeWalker
         {
             view.stereotypes = this.visitStereotypes(ctx.stereotypes());
         }
-        view.taggedValues = PureGrammarParserUtility.taggedValuesWithDocumentation(
-                ctx.documentation() == null ? null : ctx.documentation().STRING().getSymbol(),
-                ctx.taggedValues() == null ? Lists.mutable.empty() : this.visitTaggedValues(ctx.taggedValues()),
-                this.walkerSourceInformation);
+        view.taggedValues = this.visitTaggedValues(ctx.documentation(), ctx.taggedValues());
         return view;
     }
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestRelationalGrammarParser.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestRelationalGrammarParser.java
@@ -14,6 +14,8 @@
 
 package org.finos.legend.engine.language.pure.grammar.test;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.antlr.v4.runtime.Vocabulary;
 import org.eclipse.collections.impl.list.mutable.ListAdapter;
 import org.finos.legend.engine.language.pure.grammar.from.antlr4.RelationalParserGrammar;
@@ -22,6 +24,7 @@ import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextDa
 import org.finos.legend.engine.protocol.pure.m3.PackageableElement;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.Mapping;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model.Database;
+import org.finos.legend.engine.shared.core.ObjectMapperFactory;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -566,5 +569,91 @@ public class TestRelationalGrammarParser extends TestGrammarParser.TestGrammarPa
         Assert.assertEquals(103, mapping.associationMappings.get(0).association.sourceInformation.startLine);
         Assert.assertEquals(103, mapping.associationMappings.get(0).association.sourceInformation.endLine);
         Assert.assertEquals(20, mapping.associationMappings.get(0).association.sourceInformation.endColumn);
+    }
+
+    /**
+     * The relational protocol omits `taggedValues` from the database, schema, table, column and view when the
+     * declaration carries none. The grammar round trips never see the intermediate protocol, so the shape is pinned
+     * here: an extra `"taggedValues": []` on every table and column of every model is a protocol change, and it broke
+     * legend-studio's round-trip suite once already.
+     */
+    @Test
+    public void testAbsentAnnotationsAreOmittedFromTheProtocol() throws Exception
+    {
+        JsonNode database = parsedDatabase("###Relational\n" +
+                "Database model::store::ProductDatabase\n" +
+                "(\n" +
+                "  Schema productSchema\n" +
+                "  (\n" +
+                "    Table productTable\n" +
+                "    (\n" +
+                "      ID INTEGER PRIMARY KEY\n" +
+                "    )\n" +
+                "  )\n" +
+                "  View productView\n" +
+                "  (\n" +
+                "    id: productSchema.productTable.ID PRIMARY KEY\n" +
+                "  )\n" +
+                ")\n");
+        JsonNode schema = database.get("schemas").get(0);
+        JsonNode table = schema.get("tables").get(0);
+        // a view declared outside a schema lands in the synthesized `default` schema
+        JsonNode view = database.get("schemas").get(1).get("views").get(0);
+        Assert.assertFalse(database.toString(), database.has("taggedValues"));
+        Assert.assertFalse(database.toString(), schema.has("taggedValues"));
+        Assert.assertFalse(database.toString(), schema.has("stereotypes"));
+        Assert.assertFalse(database.toString(), table.has("taggedValues"));
+        Assert.assertFalse(database.toString(), table.has("stereotypes"));
+        Assert.assertFalse(database.toString(), table.get("columns").get(0).has("taggedValues"));
+        Assert.assertFalse(database.toString(), table.get("columns").get(0).has("stereotypes"));
+        Assert.assertFalse(database.toString(), view.has("taggedValues"));
+        Assert.assertFalse(database.toString(), view.has("stereotypes"));
+    }
+
+    /**
+     * A `'''...'''` documentation block desugars into a doc tagged value flagged as authored multi-line, which is what
+     * the composer reads back to decide it renders as a block rather than as an ordinary tagged value.
+     */
+    @Test
+    public void testDocumentationIsRecordedAsAMultiLineDocTaggedValue() throws Exception
+    {
+        JsonNode database = parsedDatabase("###Relational\n" +
+                "Database model::store::ProductDatabase\n" +
+                "(\n" +
+                "  Schema productSchema\n" +
+                "  (\n" +
+                "    '''\n" +
+                "    One row per product.\n" +
+                "    Keyed by ID.\n" +
+                "    '''\n" +
+                "    Table productTable\n" +
+                "    (\n" +
+                "      ID INTEGER PRIMARY KEY\n" +
+                "    )\n" +
+                "  )\n" +
+                ")\n");
+        JsonNode schema = database.get("schemas").get(0);
+        JsonNode taggedValue = schema.get("tables").get(0).get("taggedValues").get(0);
+        Assert.assertEquals("meta::pure::profiles::doc", taggedValue.get("tag").get("profile").asText());
+        Assert.assertEquals("doc", taggedValue.get("tag").get("value").asText());
+        Assert.assertEquals("One row per product.\nKeyed by ID.", taggedValue.get("value").get("value").asText());
+        Assert.assertTrue(taggedValue.get("value").get("multiLine").asBoolean());
+        // the field appears only where the documentation was written
+        Assert.assertFalse(database.toString(), database.has("taggedValues"));
+        Assert.assertFalse(database.toString(), schema.has("taggedValues"));
+    }
+
+    private static JsonNode parsedDatabase(String code) throws Exception
+    {
+        ObjectMapper objectMapper = ObjectMapperFactory.getNewStandardObjectMapperWithPureProtocolExtensionSupports();
+        JsonNode elements = objectMapper.readTree(objectMapper.writeValueAsString(test(code))).get("elements");
+        for (JsonNode element : elements)
+        {
+            if ("relational".equals(element.get("_type").asText()))
+            {
+                return element;
+            }
+        }
+        throw new AssertionError("No database in " + elements);
     }
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestRelationalGrammarRoundtrip.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestRelationalGrammarRoundtrip.java
@@ -989,6 +989,73 @@ public class TestRelationalGrammarRoundtrip extends TestToPureGrammarRoundtrip
                 ")\n");
     }
 
+    /**
+     * Documentation (`'''...'''`) is sugar over the doc.doc tagged value on every declaration that carries
+     * annotations. Relational is the one place where the block is not at column 0 - it is emitted at the
+     * declaration's own indentation, which is also the indentation the parser strips back off.
+     */
+    @Test
+    public void testRelationalElementsWithDocumentation()
+    {
+        test("###Relational\n" +
+                "'''\n" +
+                "Product reference data.\n" +
+                "Loaded nightly.\n" +
+                "'''\n" +
+                "Database model::store::ProductDatabase\n" +
+                "(\n" +
+                "  '''\n" +
+                "  The product schema.\n" +
+                "  Owned by reference data.\n" +
+                "  '''\n" +
+                "  Schema productSchema\n" +
+                "  (\n" +
+                "    '''\n" +
+                "    One row per product.\n" +
+                "    Keyed by ID.\n" +
+                "    '''\n" +
+                "    Table productTable\n" +
+                "    (\n" +
+                "      '''\n" +
+                "      The product identifier.\n" +
+                "      Assigned upstream.\n" +
+                "      '''\n" +
+                "      ID INTEGER PRIMARY KEY,\n" +
+                "      NAME VARCHAR(200)\n" +
+                "    )\n" +
+                "  )\n" +
+                "\n" +
+                "  '''\n" +
+                "  Products, flattened.\n" +
+                "  For reporting only.\n" +
+                "  '''\n" +
+                "  View productView\n" +
+                "  (\n" +
+                "    id: productSchema.productTable.ID PRIMARY KEY\n" +
+                "  )\n" +
+                ")\n");
+    }
+
+    @Test
+    public void testRelationalElementsWithDocumentationAndOtherAnnotations()
+    {
+        test("###Relational\n" +
+                "'''\n" +
+                "Product reference data.\n" +
+                "Loaded nightly.\n" +
+                "'''\n" +
+                "Database <<equality.Key>> {doc.version = '1.0'} model::store::ProductDatabase\n" +
+                "(\n" +
+                "  Schema productSchema\n" +
+                "  (\n" +
+                "    Table productTable\n" +
+                "    (\n" +
+                "      ID INTEGER PRIMARY KEY\n" +
+                "    )\n" +
+                "  )\n" +
+                ")\n");
+    }
+
 
     @Test
     public void testFunctionTest()

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-protocol/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/store/relational/model/Column.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-protocol/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/store/relational/model/Column.java
@@ -14,10 +14,12 @@
 
 package org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import org.finos.legend.engine.protocol.pure.m3.extension.StereotypePtr;
 import org.finos.legend.engine.protocol.pure.m3.extension.TaggedValue;
 import org.finos.legend.engine.protocol.pure.m3.SourceInformation;
 
+import java.util.Collections;
 import java.util.List;
 
 public class Column
@@ -27,5 +29,6 @@ public class Column
     public boolean nullable;
     public SourceInformation sourceInformation;
     public List<StereotypePtr> stereotypes;
-    public List<TaggedValue> taggedValues;
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public List<TaggedValue> taggedValues = Collections.emptyList();
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-protocol/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/store/relational/model/Database.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-protocol/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/store/relational/model/Database.java
@@ -14,6 +14,7 @@
 
 package org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import org.finos.legend.engine.protocol.pure.m3.extension.TaggedValue;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElementVisitor;
 import org.finos.legend.engine.protocol.pure.m3.extension.StereotypePtr;
@@ -28,8 +29,10 @@ public class Database extends Store
     public List<Schema> schemas = Collections.emptyList();
     public List<Join> joins = Collections.emptyList();
     public List<Filter> filters = Collections.emptyList();
+    // deliberately not NON_EMPTY: a database has always serialized `"stereotypes": []`, and clients round trip it
     public List<StereotypePtr> stereotypes = Collections.emptyList();
-    public List<TaggedValue> taggedValues;
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public List<TaggedValue> taggedValues = Collections.emptyList();
     public List<IncludeStore> includedStoreSpecifications;
 
     @Override

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-protocol/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/store/relational/model/Schema.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-protocol/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/store/relational/model/Schema.java
@@ -14,6 +14,7 @@
 
 package org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import org.finos.legend.engine.protocol.pure.m3.extension.StereotypePtr;
 import org.finos.legend.engine.protocol.pure.m3.extension.TaggedValue;
 import org.finos.legend.engine.protocol.pure.m3.SourceInformation;
@@ -30,5 +31,6 @@ public class Schema
     public SourceInformation sourceInformation;
 
     public List<StereotypePtr> stereotypes;
-    public List<TaggedValue> taggedValues;
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public List<TaggedValue> taggedValues = Collections.emptyList();
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-protocol/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/store/relational/model/Table.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-protocol/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/store/relational/model/Table.java
@@ -14,6 +14,7 @@
 
 package org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import org.finos.legend.engine.protocol.pure.m3.extension.StereotypePtr;
 import org.finos.legend.engine.protocol.pure.m3.extension.TaggedValue;
 import org.finos.legend.engine.protocol.pure.m3.SourceInformation;
@@ -30,5 +31,6 @@ public class Table
     public List<Milestoning> milestoning = Collections.emptyList();
     public SourceInformation sourceInformation;
     public List<StereotypePtr> stereotypes;
-    public List<TaggedValue> taggedValues;
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public List<TaggedValue> taggedValues = Collections.emptyList();
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-protocol/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/store/relational/model/View.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-protocol/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/store/relational/model/View.java
@@ -14,6 +14,7 @@
 
 package org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import org.finos.legend.engine.protocol.pure.m3.extension.StereotypePtr;
 import org.finos.legend.engine.protocol.pure.m3.extension.TaggedValue;
 import org.finos.legend.engine.protocol.pure.m3.SourceInformation;
@@ -35,5 +36,6 @@ public class View
     public List<ColumnMapping> columnMappings = Collections.emptyList();
     public SourceInformation sourceInformation;
     public List<StereotypePtr> stereotypes;
-    public List<TaggedValue> taggedValues;
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public List<TaggedValue> taggedValues = Collections.emptyList();
 }


### PR DESCRIPTION
### What

`#5008` (documentation as sugar over `doc.doc`) moved the five `###Relational` tagged value sites — database, schema, table, column and view — from

```java
if (ctx.taggedValues() != null) { table.taggedValues = this.visitTaggedValues(ctx.taggedValues()); }
```

to an unconditional assignment through `PureGrammarParserUtility.taggedValuesWithDocumentation`, which returns an empty list when the element carries neither documentation nor tagged values.

Every other DSL already did exactly that. Relational is the one whose protocol classes leave these fields **null** rather than defaulting to an empty list, so the field went from absent to `"taggedValues": []` on every table and column of every model — a protocol change, which `#5008` explicitly claimed not to make.

It broke legend-studio's grammar round-trip suite ([run](https://github.com/finos/legend-studio/actions/runs/31051543136/job/92459599824)): 40 failing tests, every one containing a relational database, each differing on nothing but the extra key that studio's own serializer omits.

### Fix

In the protocol rather than the parser, so the invariant holds for any producer of these POJOs and not only for the grammar walker:

```java
@JsonInclude(JsonInclude.Include.NON_EMPTY)
public List<TaggedValue> taggedValues = Collections.emptyList();
```

on `Database`, `Schema`, `Table`, `Column` and `View` — the same pattern `m3/relation/Column` and `ColSpec` already use. The parser keeps the unconditional assignment and the five call sites collapse onto one shared helper.

`Database.stereotypes` is deliberately left alone: it has always defaulted to an empty list and always serialized as `"stereotypes": []`, and clients round trip that key, so annotating it would move the wire shape in the opposite direction. There is a comment on the field saying so.

### Why it escaped CI

The relational round-trip tests are grammar→grammar; an extra field in the intermediate `PureModelContextData` is invisible to them, and `###Relational` had no documentation tests at all.

- `TestRelationalGrammarParser` — serializes the parsed `PureModelContextData` and pins that an element without annotations has no `taggedValues` key, and that a documentation block becomes a doc tagged value flagged `multiLine`.
- `TestRelationalGrammarRoundtrip` — documentation round trips on all five declarations, and alongside other annotations.

Negative control: stripping the five annotations fails exactly those two parser tests, with output matching studio's CI byte for byte.

### Scope

Only `###Relational` was affected — the other ten DSLs emitted `[]` before this feature and still do, so studio's expectations for those were never disturbed. The parser is the only writer of these five fields (`HelperRelationalBuilder` reads them; the other `taggedValues` writers in the repo target unrelated types), and nothing mutates them in place, so defaulting to the immutable `Collections.emptyList()` is safe.

Relational grammar 271 tests pass, relational http-api 8 pass (including `TestRelationalElementApi`, the graph→protocol producer), checkstyle clean on both modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
