### PR TITLE
Fix release workflow to handle large artefacts

### DIFF
--- a/.github/scripts/central-publish.sh
+++ b/.github/scripts/central-publish.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+#
+# Copyright 2026 Goldman Sachs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Central Publisher Portal API driver.
+#
+#   central-publish.sh upload <bundle.zip> <deployment-name>  -> prints deployment id
+#   central-publish.sh await  <deployment-id> [target-state]  -> default VALIDATED
+#   central-publish.sh state  <deployment-id>                 -> prints current state
+#   central-publish.sh publish <deployment-id>
+#   central-publish.sh drop    <deployment-id>
+#
+# Uploads are always USER_MANAGED. With AUTOMATIC, a release split across N
+# bundles has no safe failure mode: if bundle 5 fails validation, bundles 1-4
+# are already irreversibly on Central. USER_MANAGED lets every bundle reach
+# VALIDATED before any of them is published, and lets a failed run drop the
+# validated-but-unpublished ones.
+#
+# Env:
+#   CI_DEPLOY_USERNAME, CI_DEPLOY_PASSWORD  Portal token (required)
+#   CENTRAL_API_BASE                        override for testing
+#   CENTRAL_POLL_INTERVAL                   seconds between status polls (60)
+#   CENTRAL_POLL_TIMEOUT                    seconds before giving up (3600)
+
+set -euo pipefail
+
+CENTRAL_API_BASE=${CENTRAL_API_BASE:-https://central.sonatype.com/api/v1/publisher}
+CENTRAL_POLL_INTERVAL=${CENTRAL_POLL_INTERVAL:-60}
+CENTRAL_POLL_TIMEOUT=${CENTRAL_POLL_TIMEOUT:-3600}
+
+: "${CI_DEPLOY_USERNAME:?CI_DEPLOY_USERNAME is not set}"
+: "${CI_DEPLOY_PASSWORD:?CI_DEPLOY_PASSWORD is not set}"
+
+# -w0 because base64 wraps at 76 columns and a token longer than that would put
+# a newline inside the Authorization header. '%s:%s' because the credentials
+# are data, not a printf format string -- a '%' in the password corrupts it.
+auth_token() {
+  printf '%s:%s' "$CI_DEPLOY_USERNAME" "$CI_DEPLOY_PASSWORD" | base64 -w0
+}
+
+urlencode() {
+  jq -rn --arg v "$1" '$v|@uri'
+}
+
+cmd_upload() {
+  local bundle=$1 name=$2 body code
+  [ -f "$bundle" ] || { echo "ERROR: no such bundle: $bundle" >&2; exit 1; }
+  body=$(mktemp)
+  code=$(curl -sS -o "$body" -w '%{http_code}' -X POST \
+    -H "Authorization: Bearer $(auth_token)" \
+    --form "bundle=@$bundle" \
+    "$CENTRAL_API_BASE/upload?publishingType=USER_MANAGED&name=$(urlencode "$name")")
+
+  if [[ "$code" != 2* ]]; then
+    echo "ERROR: upload of $bundle failed with HTTP $code" >&2
+    echo "--- response body ---" >&2
+    cat "$body" >&2
+    echo >&2
+    rm -f "$body"
+    exit 1
+  fi
+
+  # The API returns the deployment id as a bare string, not JSON.
+  tr -d '[:space:]' < "$body"
+  echo
+  rm -f "$body"
+}
+
+cmd_await() {
+  local id=$1 target=${2:-VALIDATED}
+  local deadline=$((SECONDS + CENTRAL_POLL_TIMEOUT))
+  local state response consecutive_errors=0
+
+  while :; do
+    if [ "$SECONDS" -ge "$deadline" ]; then
+      echo "ERROR: deployment $id did not reach $target within ${CENTRAL_POLL_TIMEOUT}s" >&2
+      echo "ERROR: last observed state: ${state:-<none>}" >&2
+      exit 1
+    fi
+
+    response=$(curl -sS -X POST -H "Authorization: Bearer $(auth_token)" \
+      "$CENTRAL_API_BASE/status?id=$(urlencode "$id")" || true)
+
+    # A transient API error yields an empty or non-JSON body. Retrying is
+    # correct; treating it as a state is not -- jq would emit "null" and the
+    # loop would spin against it until the job timed out.
+    state=$(jq -r 'if type == "object" then (.deploymentState // empty) else empty end' <<< "$response" 2>/dev/null || true)
+    if [ -z "$state" ]; then
+      consecutive_errors=$((consecutive_errors + 1))
+      echo "warning: unreadable status response for $id (attempt $consecutive_errors)" >&2
+      if [ "$consecutive_errors" -ge 10 ]; then
+        echo "ERROR: 10 consecutive unreadable status responses for $id" >&2
+        echo "ERROR: last response: $response" >&2
+        exit 1
+      fi
+      sleep "$CENTRAL_POLL_INTERVAL"
+      continue
+    fi
+    consecutive_errors=0
+
+    echo "deployment $id is $state"
+    case "$state" in
+      "$target")
+        return 0
+        ;;
+      FAILED)
+        echo "ERROR: deployment $id FAILED" >&2
+        echo "$response" >&2
+        # Deliberately not dropped: Sonatype support needs a FAILED
+        # deployment's files to diagnose it.
+        exit 1
+        ;;
+      PUBLISHED)
+        # Only reachable when waiting for something else; PUBLISHED is terminal.
+        echo "ERROR: deployment $id is already PUBLISHED, cannot reach $target" >&2
+        exit 1
+        ;;
+    esac
+
+    sleep "$CENTRAL_POLL_INTERVAL"
+  done
+}
+
+# Single status read, no waiting. Used by failure cleanup to tell a
+# droppable VALIDATED deployment from a FAILED one that must be kept.
+cmd_state() {
+  local id=$1 response state
+  response=$(curl -sS -X POST -H "Authorization: Bearer $(auth_token)" \
+    "$CENTRAL_API_BASE/status?id=$(urlencode "$id")" || true)
+  state=$(jq -r 'if type == "object" then (.deploymentState // empty) else empty end' <<< "$response" 2>/dev/null || true)
+  echo "${state:-UNKNOWN}"
+}
+
+cmd_publish() {
+  local id=$1 body code
+  body=$(mktemp)
+  code=$(curl -sS -o "$body" -w '%{http_code}' -X POST \
+    -H "Authorization: Bearer $(auth_token)" \
+    "$CENTRAL_API_BASE/deployment/$(urlencode "$id")")
+  if [[ "$code" != 2* ]]; then
+    echo "ERROR: publish of $id failed with HTTP $code" >&2
+    cat "$body" >&2
+    rm -f "$body"
+    exit 1
+  fi
+  rm -f "$body"
+  echo "requested publish of $id"
+}
+
+cmd_drop() {
+  local id=$1 body code
+  body=$(mktemp)
+  code=$(curl -sS -o "$body" -w '%{http_code}' -X DELETE \
+    -H "Authorization: Bearer $(auth_token)" \
+    "$CENTRAL_API_BASE/deployment/$(urlencode "$id")")
+  rm -f "$body"
+  if [[ "$code" != 2* ]]; then
+    echo "warning: could not drop deployment $id (HTTP $code)" >&2
+    return 0
+  fi
+  echo "dropped deployment $id"
+}
+
+case "${1:-}" in
+  upload)  cmd_upload  "${2:?missing bundle}" "${3:?missing deployment name}" ;;
+  await)   cmd_await   "${2:?missing deployment id}" "${3:-VALIDATED}" ;;
+  state)   cmd_state   "${2:?missing deployment id}" ;;
+  publish) cmd_publish "${2:?missing deployment id}" ;;
+  drop)    cmd_drop    "${2:?missing deployment id}" ;;
+  *)
+    echo "usage: central-publish.sh {upload <zip> <name>|await <id> [state]|state <id>|publish <id>|drop <id>}" >&2
+    exit 2
+    ;;
+esac

--- a/.github/scripts/stage-and-split.sh
+++ b/.github/scripts/stage-and-split.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+#
+# Copyright 2026 Goldman Sachs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Stage legend-engine artifacts from a local Maven repository and split them
+# into Central Publisher Portal bundles that fit under the Portal's 1GiB
+# upload limit. A single oversized bundle is rejected by nginx with a bare
+# "413 Payload Too Large" before the API ever sees it.
+#
+# Usage: stage-and-split.sh <m2-engine-dir> <release-version> <out-dir> [max-bytes]
+#
+# Env:
+#   CENTRAL_EXCLUDE_GLOBS  space-separated find(1) -name globs to drop from the
+#                          bundle. EMPTY BY DEFAULT ON PURPOSE: every artifact
+#                          currently in the local repo is also currently on
+#                          Central, and Central is immutable, so dropping one
+#                          silently removes a coordinate consumers already
+#                          resolve. Only populate this once the coordinate has
+#                          been confirmed unused downstream.
+
+set -euo pipefail
+
+M2_ENGINE_DIR=${1:?usage: stage-and-split.sh <m2-engine-dir> <version> <out-dir> [max-bytes]}
+RELEASE_VERSION=${2:?missing release version}
+OUT_DIR=${3:?missing output dir}
+MAX_BYTES=${4:-1000000000}
+
+# The Portal rejects anything above 1GiB at the proxy. MAX_BYTES is the packing
+# target; this is the backstop checked against the produced zip.
+HARD_LIMIT=$((1024 * 1024 * 1024))
+
+STAGING="$OUT_DIR/central-staging"
+BUNDLES="$OUT_DIR/central-publishing"
+ROOT=org/finos/legend/engine
+
+[ -d "$M2_ENGINE_DIR" ] || { echo "ERROR: $M2_ENGINE_DIR does not exist" >&2; exit 1; }
+
+rm -rf "$STAGING" "$BUNDLES"
+mkdir -p "$STAGING/$ROOT" "$BUNDLES"
+cp -R "$M2_ENGINE_DIR/." "$STAGING/$ROOT/"
+
+# Keep only directories whose name is exactly the release version. Defensive:
+# the build job already purges the local repo before building the release tag,
+# but a stale version leaking in here would be published irreversibly.
+find "$STAGING/$ROOT" -mindepth 2 -type d \
+  -regextype posix-extended \
+  -regex '.*/[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.+-]+)?$' \
+  ! -name "$RELEASE_VERSION" -prune -exec rm -rf {} +
+
+# Local-repo bookkeeping, never part of a deployment. Targeted by name rather
+# than by "*.xml" so a real .xml artifact could never be swept up.
+find "$STAGING" -type f \
+  \( -name '_remote.repositories' \
+     -o -name 'maven-metadata-local.xml' \
+     -o -name 'maven-metadata-*.xml' \
+     -o -name '*.lastUpdated' \
+     -o -name 'resolver-status.properties' \) -delete
+
+for glob in ${CENTRAL_EXCLUDE_GLOBS:-}; do
+  echo "excluding: $glob"
+  find "$STAGING" -type f -name "$glob" -delete
+done
+
+find "$STAGING/$ROOT" -mindepth 1 -type d -empty -delete
+
+# An artifact coordinate is one <artifactId>/<version> directory. It is the
+# unit of splitting: a jar must never be separated from its .pom, .asc and
+# checksums, or the bundle validates but leaves a broken artifact on Central.
+cd "$STAGING"
+mapfile -t COORDS < <(find "$ROOT" -mindepth 2 -maxdepth 2 -type d -name "$RELEASE_VERSION" | sort)
+
+if [ ${#COORDS[@]} -eq 0 ]; then
+  echo "ERROR: no artifacts found for version $RELEASE_VERSION under $M2_ENGINE_DIR" >&2
+  exit 1
+fi
+
+# Central requires md5 and sha1; sha256 and sha512 are optional but are already
+# published for prior releases, so they are kept for parity.
+find "$STAGING" -type f \
+  ! -name '*.md5' ! -name '*.sha1' ! -name '*.sha256' \
+  ! -name '*.sha512' ! -name '*.asc' -print0 | while IFS= read -r -d '' file; do
+  md5sum    "$file" | awk '{print $1}' > "$file.md5"
+  sha1sum   "$file" | awk '{print $1}' > "$file.sha1"
+  sha256sum "$file" | awk '{print $1}' > "$file.sha256"
+  sha512sum "$file" | awk '{print $1}' > "$file.sha512"
+done
+
+STAGED_BYTES=$(du -sb "$STAGING" | cut -f1)
+STAGED_FILES=$(find "$STAGING" -type f | wc -l)
+echo "staged ${#COORDS[@]} coordinates: $((STAGED_BYTES / 1000000)) MB, $STAGED_FILES files"
+
+# --- split ---------------------------------------------------------------
+# Everything measured here is written to bundle-report.md / *.tsv as well as
+# the log. When a release fails at the Portal the first question is always
+# "how big was it and what was in it", and the runner is gone by then.
+BUNDLES_TSV="$BUNDLES/bundles.tsv"
+CONTENTS_TSV="$BUNDLES/bundle-contents.tsv"
+COORDS_TSV="$BUNDLES/coordinates.tsv"
+REPORT="$BUNDLES/bundle-report.md"
+
+printf 'bundle\tfiles\tzip_bytes\tstaged_bytes\tsha256\n' > "$BUNDLES_TSV"
+printf 'bundle\tcoordinate\tbytes\n' > "$CONTENTS_TSV"
+printf 'coordinate\tbytes\n' > "$COORDS_TSV"
+
+idx=1
+size=0
+list=$(mktemp)
+coordlist=$(mktemp)
+trap 'rm -f "$list" "$coordlist"' EXIT
+
+mb()  { awk -v b="$1" 'BEGIN { printf "%.1f", b / 1000000 }'; }
+pct() { awk -v a="$1" -v b="$2" 'BEGIN { printf "%.1f", 100 * a / b }'; }
+
+flush() {
+  [ -s "$list" ] || return 0
+  local name out zipsize sha files
+  name="central-bundle-$(printf '%02d' "$idx")"
+  out="$BUNDLES/$name.zip"
+  zip -q -X "$out" -@ < "$list"
+  zipsize=$(stat -c%s "$out")
+  files=$(wc -l < "$list")
+  sha=$(sha256sum "$out" | cut -d' ' -f1)
+
+  if [ "$zipsize" -gt "$HARD_LIMIT" ]; then
+    echo "ERROR: $out is $zipsize bytes ($(mb "$zipsize") MB), above the Portal's" >&2
+    echo "ERROR: ${HARD_LIMIT}-byte limit. Lower max-bytes (currently $MAX_BYTES) and re-run." >&2
+    exit 1
+  fi
+
+  printf '%s\t%s\t%s\t%s\t%s\n' "$name" "$files" "$zipsize" "$size" "$sha" >> "$BUNDLES_TSV"
+  awk -v b="$name" -F'\t' '{ printf "%s\t%s\t%s\n", b, $1, $2 }' "$coordlist" >> "$CONTENTS_TSV"
+
+  echo "bundle $idx: $files files, $(mb "$zipsize") MB zipped ($(pct "$zipsize" "$HARD_LIMIT")% of Portal limit), sha256 $sha"
+  idx=$((idx + 1))
+  size=0
+  : > "$list"
+  : > "$coordlist"
+}
+
+for dir in "${COORDS[@]}"; do
+  dirsize=$(du -sb "$dir" | cut -f1)
+  printf '%s\t%s\n' "$dir" "$dirsize" >> "$COORDS_TSV"
+
+  if [ "$dirsize" -gt "$MAX_BYTES" ]; then
+    echo "ERROR: $dir alone is $(mb "$dirsize") MB, above the ${MAX_BYTES}-byte" >&2
+    echo "ERROR: bundle target. A single coordinate cannot be split across bundles." >&2
+    echo "ERROR: shrink the artifact, stop publishing it, or request a Portal limit" >&2
+    echo "ERROR: increase from central-support@sonatype.com." >&2
+    exit 1
+  fi
+  if [ $((dirsize * 100)) -gt $((MAX_BYTES * 80)) ]; then
+    echo "WARNING: $dir is $(mb "$dirsize") MB, $(pct "$dirsize" "$MAX_BYTES")% of the bundle target." >&2
+    echo "WARNING: it will hard-fail the release once it exceeds $((MAX_BYTES / 1000000)) MB." >&2
+  fi
+  if [ "$size" -gt 0 ] && [ $((size + dirsize)) -gt "$MAX_BYTES" ]; then
+    flush
+  fi
+  find "$dir" -type f >> "$list"
+  printf '%s\t%s\n' "$dir" "$dirsize" >> "$coordlist"
+  size=$((size + dirsize))
+done
+flush
+
+NBUNDLES=$((idx - 1))
+TOTAL_ZIP=$(awk -F'\t' 'NR > 1 { s += $3 } END { print s + 0 }' "$BUNDLES_TSV")
+LARGEST_ZIP=$(awk -F'\t' 'NR > 1 && $3 > m { m = $3 } END { print m + 0 }' "$BUNDLES_TSV")
+
+{
+  echo "## Central bundle report"
+  echo
+  echo "| | |"
+  echo "|---|---|"
+  echo "| Release version | \`$RELEASE_VERSION\` |"
+  echo "| Coordinates staged | ${#COORDS[@]} |"
+  echo "| Files staged | $STAGED_FILES |"
+  echo "| Staged size | $(mb "$STAGED_BYTES") MB |"
+  echo "| Bundles produced | $NBUNDLES |"
+  echo "| Total upload size | $(mb "$TOTAL_ZIP") MB |"
+  echo "| Largest bundle | $(mb "$LARGEST_ZIP") MB ($(pct "$LARGEST_ZIP" "$HARD_LIMIT")% of the ${HARD_LIMIT}-byte Portal limit) |"
+  echo "| Packing target | $(mb "$MAX_BYTES") MB per bundle |"
+  echo
+  echo "### Bundles"
+  echo
+  echo "| Bundle | Files | Upload size | % of Portal limit | SHA-256 |"
+  echo "|---|---:|---:|---:|---|"
+  awk -F'\t' -v lim="$HARD_LIMIT" 'NR > 1 {
+    printf "| %s.zip | %s | %.1f MB | %.1f%% | `%s` |\n", $1, $2, $3 / 1000000, 100 * $3 / lim, $5
+  }' "$BUNDLES_TSV"
+  echo
+  echo "### 20 largest coordinates"
+  echo
+  echo "| Coordinate | Size | % of packing target |"
+  echo "|---|---:|---:|"
+  tail -n +2 "$COORDS_TSV" | sort -t$'\t' -k2 -rn | head -20 |
+    awk -F'\t' -v tgt="$MAX_BYTES" '{
+      flag = (100 * $2 / tgt >= 80) ? " :warning:" : ""
+      printf "| `%s` | %.1f MB | %.1f%%%s |\n", $1, $2 / 1000000, 100 * $2 / tgt, flag
+    }'
+  echo
+  echo "A coordinate cannot be split across bundles, so any single one reaching"
+  echo "$(mb "$MAX_BYTES") MB fails the release outright."
+} > "$REPORT"
+
+echo
+cat "$REPORT"
+echo
+echo "wrote $NBUNDLES bundle(s) to $BUNDLES"
+echo "report: $REPORT"

--- a/.github/scripts/test-central-publish.sh
+++ b/.github/scripts/test-central-publish.sh
@@ -1,0 +1,250 @@
+#!/usr/bin/env bash
+#
+# Copyright 2026 Goldman Sachs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Drives central-publish.sh against a local mock of the Central Publisher
+# Portal API. No network, no credentials, nothing reaches Central. The mock
+# asserts on the Authorization header and the publishingType, which is what
+# makes the base64/printf and USER_MANAGED fixes actually verifiable.
+
+set -euo pipefail
+
+SCRIPT="$(cd "$(dirname "$0")" && pwd)/central-publish.sh"
+TMP=$(mktemp -d)
+trap 'kill "${SERVER_PID:-}" 2>/dev/null || true; rm -rf "$TMP"' EXIT
+
+# Deliberately awkward credentials:
+#  - a '%' in the password catches using it as a printf format string
+#  - 76 combined bytes push base64 past its 76-column wrap point
+export CI_DEPLOY_USERNAME='finos-ci-deploy-user-0123456789'
+export CI_DEPLOY_PASSWORD='tok%en-abcdefghijklmnopqrstuvwxyz-0123456789'
+export EXPECTED_AUTH="$CI_DEPLOY_USERNAME:$CI_DEPLOY_PASSWORD"
+
+fail=0
+check() { if [ "$2" = "$3" ]; then echo "ok   $1"; else echo "FAIL $1: expected '$3' got '$2'"; fail=1; fi; }
+
+cat > "$TMP/mock.py" <<'PY'
+import base64, http.server, json, os, re, sys, threading, urllib.parse
+
+EXPECTED = os.environ["EXPECTED_AUTH"]
+errors = []
+deploys = {}
+counter = [0]
+lock = threading.Lock()
+
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, *a):
+        pass
+
+    def send(self, code, body, ctype="text/plain"):
+        raw = body.encode()
+        self.send_response(code)
+        self.send_header("Content-Type", ctype)
+        self.send_header("Content-Length", str(len(raw)))
+        self.end_headers()
+        self.wfile.write(raw)
+
+    def check_auth(self):
+        header = self.headers.get("Authorization", "")
+        if not header.startswith("Bearer "):
+            errors.append("Authorization header missing or not Bearer: %r" % header)
+            return False
+        token = header[len("Bearer "):]
+        if re.search(r"\s", token):
+            errors.append("whitespace inside base64 token: %r" % token)
+            return False
+        try:
+            decoded = base64.b64decode(token, validate=True).decode()
+        except Exception:
+            errors.append("token is not valid base64: %r" % token)
+            return False
+        if decoded != EXPECTED:
+            errors.append("token decodes to %r, expected %r" % (decoded, EXPECTED))
+            return False
+        return True
+
+    def body(self):
+        n = int(self.headers.get("Content-Length", 0))
+        return self.rfile.read(n) if n else b""
+
+    def do_DELETE(self):
+        path = urllib.parse.urlparse(self.path).path
+        if not self.check_auth():
+            return self.send(401, "unauthorized")
+        m = re.match(r"^/deployment/(.+)$", path)
+        if m and m.group(1) in deploys:
+            deploys[m.group(1)]["dropped"] = True
+            return self.send(204, "")
+        return self.send(404, "not found")
+
+    def do_GET(self):
+        if self.path == "/_report":
+            return self.send(200, json.dumps({"errors": errors, "deploys": deploys}), "application/json")
+        return self.send(404, "not found")
+
+    def do_POST(self):
+        parsed = urllib.parse.urlparse(self.path)
+        query = urllib.parse.parse_qs(parsed.query)
+        payload = self.body()
+        if not self.check_auth():
+            return self.send(401, "unauthorized")
+
+        if parsed.path == "/upload":
+            publishing_type = (query.get("publishingType") or [None])[0]
+            if publishing_type != "USER_MANAGED":
+                errors.append("publishingType was %r, expected USER_MANAGED" % publishing_type)
+            name = (query.get("name") or [None])[0]
+            if b"PK\x03\x04" not in payload:
+                errors.append("uploaded body for %r contains no zip" % name)
+            with lock:
+                counter[0] += 1
+                deployment_id = "deployment-%02d" % counter[0]
+            deploys[deployment_id] = {
+                "name": name,
+                "publishingType": publishing_type,
+                "polls": 0,
+                "publishRequested": False,
+                "dropped": False,
+                "bytes": len(payload),
+            }
+            return self.send(201, deployment_id)
+
+        if parsed.path == "/status":
+            deployment_id = (query.get("id") or [None])[0]
+            deployment = deploys.get(deployment_id)
+            if deployment is None:
+                return self.send(404, "unknown deployment")
+            deployment["polls"] += 1
+            name = deployment["name"] or ""
+            polls = deployment["polls"]
+
+            if "flaky" in name and polls <= 3:
+                # What a proxy hiccup actually looks like: HTML, not JSON.
+                return self.send(502, "<html><body><center><h1>502 Bad Gateway</h1></center></body></html>", "text/html")
+            if "fail" in name:
+                return self.send(200, json.dumps({"deploymentState": "FAILED", "errors": ["missing signature"]}), "application/json")
+            if "hang" in name:
+                return self.send(200, json.dumps({"deploymentState": "VALIDATING"}), "application/json")
+
+            if deployment["publishRequested"]:
+                state = "PUBLISHING" if polls % 2 == 0 else "PUBLISHED"
+            elif polls <= 1:
+                state = "PENDING"
+            else:
+                state = "VALIDATED"
+            return self.send(200, json.dumps({"deploymentState": state}), "application/json")
+
+        m = re.match(r"^/deployment/(.+)$", parsed.path)
+        if m:
+            deployment = deploys.get(m.group(1))
+            if deployment is None:
+                return self.send(404, "unknown deployment")
+            deployment["publishRequested"] = True
+            deployment["polls"] = 0
+            return self.send(204, "")
+
+        return self.send(404, "not found")
+
+
+server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+with open(sys.argv[1], "w") as fh:
+    fh.write(str(server.server_address[1]))
+server.serve_forever()
+PY
+
+python3 "$TMP/mock.py" "$TMP/port" &
+SERVER_PID=$!
+for _ in $(seq 1 50); do [ -s "$TMP/port" ] && break; sleep 0.1; done
+[ -s "$TMP/port" ] || { echo "FAIL mock server did not start"; exit 1; }
+
+export CENTRAL_API_BASE="http://127.0.0.1:$(cat "$TMP/port")"
+export CENTRAL_POLL_INTERVAL=1
+export CENTRAL_POLL_TIMEOUT=30
+
+printf 'PK\x03\x04fake zip content' > "$TMP/bundle.zip"
+
+echo "=== assertions ==="
+
+id1=$(bash "$SCRIPT" upload "$TMP/bundle.zip" "legend-engine-4.100.0-bundle-01")
+check "upload returns a deployment id" "$id1" "deployment-01"
+
+bash "$SCRIPT" await "$id1" VALIDATED > "$TMP/await1.log" 2>&1 \
+  && echo "ok   await reaches VALIDATED" \
+  || { echo "FAIL await did not reach VALIDATED"; cat "$TMP/await1.log"; fail=1; }
+check "await tolerates non-terminal states first" \
+  "$(grep -c 'is PENDING' "$TMP/await1.log")" 1
+
+bash "$SCRIPT" publish "$id1" > /dev/null
+bash "$SCRIPT" await "$id1" PUBLISHED > "$TMP/await2.log" 2>&1 \
+  && echo "ok   await reaches PUBLISHED after publish" \
+  || { echo "FAIL await did not reach PUBLISHED"; cat "$TMP/await2.log"; fail=1; }
+
+# transient 502s with an HTML body must be retried, not parsed as a state
+id2=$(bash "$SCRIPT" upload "$TMP/bundle.zip" "legend-engine-4.100.0-bundle-flaky")
+bash "$SCRIPT" await "$id2" VALIDATED > "$TMP/await3.log" 2>&1 \
+  && echo "ok   await survives transient API errors" \
+  || { echo "FAIL await died on a transient error"; cat "$TMP/await3.log"; fail=1; }
+check "transient errors were retried, not treated as state" \
+  "$(grep -c 'unreadable status response' "$TMP/await3.log")" 3
+
+# a FAILED deployment must abort, and must not be dropped
+id3=$(bash "$SCRIPT" upload "$TMP/bundle.zip" "legend-engine-4.100.0-bundle-fail")
+if bash "$SCRIPT" await "$id3" VALIDATED > "$TMP/await4.log" 2>&1; then
+  echo "FAIL await returned success on a FAILED deployment"; fail=1
+else
+  echo "ok   FAILED deployment aborts"
+fi
+
+# a deployment that never validates must hit the deadline, not spin forever
+start=$SECONDS
+if CENTRAL_POLL_TIMEOUT=3 bash "$SCRIPT" await \
+     "$(bash "$SCRIPT" upload "$TMP/bundle.zip" "legend-engine-4.100.0-bundle-hang")" \
+     VALIDATED > "$TMP/await5.log" 2>&1; then
+  echo "FAIL stuck deployment did not time out"; fail=1
+else
+  elapsed=$((SECONDS - start))
+  if [ "$elapsed" -le 20 ]; then
+    echo "ok   stuck deployment times out after ${elapsed}s"
+  else
+    echo "FAIL timeout took ${elapsed}s, deadline not honoured"; fail=1
+  fi
+fi
+check "timeout message names the deadline" \
+  "$(grep -c 'did not reach VALIDATED within' "$TMP/await5.log")" 1
+
+# drop must work for cleanup on failure
+id6=$(bash "$SCRIPT" upload "$TMP/bundle.zip" "legend-engine-4.100.0-bundle-06")
+bash "$SCRIPT" drop "$id6" > /dev/null
+report=$(curl -sS "$CENTRAL_API_BASE/_report")
+check "drop marks the deployment dropped" \
+  "$(jq -r --arg id "$id6" '.deploys[$id].dropped' <<< "$report")" true
+check "FAILED deployment was NOT dropped" \
+  "$(jq -r --arg id "$id3" '.deploys[$id].dropped' <<< "$report")" false
+
+# the assertions the mock itself made
+check "every request carried a well-formed auth header" \
+  "$(jq -r '[.errors[] | select(test("token|Authorization"))] | length' <<< "$report")" 0
+check "no server-side protocol errors at all" \
+  "$(jq -r '.errors | length' <<< "$report")" 0
+check "every upload was USER_MANAGED" \
+  "$(jq -r '[.deploys[] | select(.publishingType != "USER_MANAGED")] | length' <<< "$report")" 0
+check "deployment name reached the API" \
+  "$(jq -r --arg id "$id1" '.deploys[$id].name' <<< "$report")" "legend-engine-4.100.0-bundle-01"
+
+echo
+if [ "$fail" -eq 0 ]; then echo "ALL PASS"; else echo "FAILURES"; exit 1; fi

--- a/.github/scripts/test-stage-and-split.sh
+++ b/.github/scripts/test-stage-and-split.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+#
+# Copyright 2026 Goldman Sachs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Builds a synthetic ~/.m2 engine tree with known sizes and asserts the
+# invariants that matter for a Central release. No network, runs in seconds.
+
+set -euo pipefail
+
+SCRIPT="$(cd "$(dirname "$0")" && pwd)/stage-and-split.sh"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+VERSION=4.100.0
+STALE=4.99.0
+M2="$TMP/m2/org/finos/legend/engine"
+MAX=$((30 * 1000 * 1000))   # 30MB so the test runs fast
+
+fail=0
+check() { if [ "$2" = "$3" ]; then echo "ok   $1"; else echo "FAIL $1: expected '$3' got '$2'"; fail=1; fi; }
+
+mk() { # mk <artifact> <version> <jar-size-mb>
+  # NB: separate `local` statements on purpose -- bash declares all names in a
+  # single `local` before assigning, so `local a=$1 d="$M2/$a"` breaks under set -u.
+  local a=$1
+  local v=$2
+  local mb=$3
+  local d="$M2/$a/$v"
+  mkdir -p "$d"
+  head -c $((mb * 1000 * 1000)) /dev/urandom > "$d/$a-$v.jar"
+  printf '<project><artifactId>%s</artifactId></project>' "$a" > "$d/$a-$v.pom"
+  head -c 2000 /dev/urandom > "$d/$a-$v-sources.jar"
+  head -c 2000 /dev/urandom > "$d/$a-$v-javadoc.jar"
+  for f in "$d/$a-$v".*; do echo sig > "$f.asc"; done
+  echo '{}' > "$d/_remote.repositories"
+  printf '<metadata/>' > "$d/maven-metadata-local.xml"
+}
+
+# 12 normal modules at 8MB -> must span multiple 30MB bundles
+for i in $(seq -w 1 12); do mk "legend-engine-xt-mod$i" "$VERSION" 8; done
+# stale version that must be pruned
+mk legend-engine-xt-mod01 "$STALE" 8
+# the server module: carries a large shaded jar plus a tests jar, both of which
+# are published to Central today and must survive staging untouched
+mk legend-engine-server-http-server "$VERSION" 1
+head -c $((20 * 1000 * 1000)) /dev/urandom > "$M2/legend-engine-server-http-server/$VERSION/legend-engine-server-http-server-$VERSION-shaded.jar"
+head -c 3000 /dev/urandom > "$M2/legend-engine-server-http-server/$VERSION/legend-engine-server-http-server-$VERSION-tests.jar"
+
+echo "=== running ==="
+bash "$SCRIPT" "$M2" "$VERSION" "$TMP/out" "$MAX"
+
+STAGING="$TMP/out/central-staging"
+BUNDLES="$TMP/out/central-publishing"
+
+echo "=== assertions ==="
+
+check "stale version pruned" \
+  "$(find "$STAGING" -type d -name "$STALE" | wc -l)" 0
+check "no _remote.repositories staged" \
+  "$(find "$STAGING" -name '_remote.repositories' | wc -l)" 0
+check "no maven-metadata-local.xml staged" \
+  "$(find "$STAGING" -name 'maven-metadata-local.xml' | wc -l)" 0
+
+# Parity with what is already on Central: these are published coordinates today.
+check "shaded jar preserved" \
+  "$(find "$STAGING" -name '*-shaded.jar' | wc -l)" 1
+check "tests jar preserved" \
+  "$(find "$STAGING" -name '*-tests.jar' | wc -l)" 1
+check "sources jars preserved" \
+  "$(find "$STAGING" -name '*-sources.jar' | wc -l)" 13
+check "signatures preserved" \
+  "$(find "$STAGING" -name '*.asc' | wc -l)" "$(find "$M2" -path "*/$VERSION/*" -name '*.asc' | wc -l)"
+
+# every artifact file has all four checksums alongside it
+missing=0
+while IFS= read -r f; do
+  for ext in md5 sha1 sha256 sha512; do
+    [ -f "$f.$ext" ] || { echo "  missing .$ext for $f"; missing=$((missing + 1)); }
+  done
+done < <(find "$STAGING" -type f \( -name '*.jar' -o -name '*.pom' \))
+check "every artifact has md5+sha1+sha256+sha512" "$missing" 0
+
+check "no checksums of signatures" \
+  "$(find "$STAGING" -name '*.asc.md5' | wc -l)" 0
+check "no checksums of checksums" \
+  "$(find "$STAGING" -name '*.sha1.md5' -o -name '*.md5.md5' | wc -l)" 0
+
+# more than one bundle was produced
+nbundles=$(find "$BUNDLES" -name '*.zip' | wc -l)
+if [ "$nbundles" -gt 1 ]; then echo "ok   split into $nbundles bundles"; else echo "FAIL only $nbundles bundle"; fail=1; fi
+
+for z in "$BUNDLES"/*.zip; do
+  s=$(stat -c%s "$z")
+  if [ "$s" -gt "$MAX" ]; then echo "FAIL $z is $s bytes > $MAX"; fail=1; fi
+done
+echo "ok   all bundles under limit"
+
+# union of bundle contents == staged files, with no duplicates
+for z in "$BUNDLES"/*.zip; do unzip -Z1 "$z"; done | grep -v '/$' | sort > "$TMP/in-bundles.txt"
+(cd "$STAGING" && find . -type f | sed 's|^\./||' | sort) > "$TMP/staged.txt"
+check "no file duplicated across bundles" \
+  "$(uniq -d < "$TMP/in-bundles.txt" | wc -l)" 0
+if diff -q "$TMP/staged.txt" "$TMP/in-bundles.txt" >/dev/null; then
+  echo "ok   bundles cover every staged file exactly once"
+else
+  echo "FAIL bundle contents differ from staging:"; diff "$TMP/staged.txt" "$TMP/in-bundles.txt" | head; fail=1
+fi
+
+# no coordinate is split across two bundles
+for z in "$BUNDLES"/*.zip; do unzip -Z1 "$z" | grep -v '/$' | xargs -r -n1 dirname; done | sort -u > "$TMP/dirs-all.txt"
+for z in "$BUNDLES"/*.zip; do unzip -Z1 "$z" | grep -v '/$' | xargs -r -n1 dirname | sort -u; done | sort > "$TMP/dirs-per-bundle.txt"
+check "no coordinate split across bundles" \
+  "$(wc -l < "$TMP/dirs-per-bundle.txt")" "$(wc -l < "$TMP/dirs-all.txt")"
+
+check "maven layout preserved at zip root" \
+  "$(head -1 "$TMP/in-bundles.txt" | cut -d/ -f1-4)" "org/finos/legend/engine"
+
+# --- size report ---------------------------------------------------------
+check "report written" \
+  "$([ -f "$BUNDLES/bundle-report.md" ] && echo yes || echo no)" yes
+check "report row per bundle" \
+  "$(tail -n +2 "$BUNDLES/bundles.tsv" | wc -l)" "$nbundles"
+check "report bundle sizes match the zips on disk" \
+  "$(tail -n +2 "$BUNDLES/bundles.tsv" | while IFS=$'\t' read -r name _ bytes _; do
+       [ "$(stat -c%s "$BUNDLES/$name.zip")" = "$bytes" ] || echo bad
+     done | wc -l)" 0
+check "report sha256 matches the zips on disk" \
+  "$(tail -n +2 "$BUNDLES/bundles.tsv" | while IFS=$'\t' read -r name _ _ _ sha; do
+       [ "$(sha256sum "$BUNDLES/$name.zip" | cut -d' ' -f1)" = "$sha" ] || echo bad
+     done | wc -l)" 0
+check "every coordinate accounted for in the report" \
+  "$(tail -n +2 "$BUNDLES/coordinates.tsv" | wc -l)" 13
+check "every coordinate assigned to exactly one bundle" \
+  "$(tail -n +2 "$BUNDLES/bundle-contents.tsv" | cut -f2 | sort | uniq -d | wc -l)" 0
+check "bundle-contents covers all coordinates" \
+  "$(tail -n +2 "$BUNDLES/bundle-contents.tsv" | cut -f2 | sort -u | wc -l)" 13
+check "report header names the release version" \
+  "$(grep -cF '| Release version | `'"$VERSION"'` |' "$BUNDLES/bundle-report.md")" 1
+# the server module carries the 20MB shaded jar, so it must head the table
+check "report ranks the largest coordinate first" \
+  "$(grep -A4 '20 largest coordinates' "$BUNDLES/bundle-report.md" | tail -1 | grep -c 'legend-engine-server-http-server')" 1
+check "report flags coordinates near the packing target" \
+  "$(grep -c ':warning:' "$BUNDLES/bundle-report.md")" 0
+
+# opt-in exclusions must actually drop files when configured
+CENTRAL_EXCLUDE_GLOBS='*-tests.jar' bash "$SCRIPT" "$M2" "$VERSION" "$TMP/out-excl" "$MAX" >/dev/null
+check "CENTRAL_EXCLUDE_GLOBS drops matching files" \
+  "$(find "$TMP/out-excl/central-staging" -name '*-tests.jar' | wc -l)" 0
+
+# a single oversized coordinate must fail loudly rather than emit a bad bundle
+head -c $((40 * 1000 * 1000)) /dev/urandom > "$M2/legend-engine-xt-mod01/$VERSION/big.jar"
+if bash "$SCRIPT" "$M2" "$VERSION" "$TMP/out2" "$MAX" >/dev/null 2>&1; then
+  echo "FAIL oversized coordinate did not abort"; fail=1
+else
+  echo "ok   oversized single coordinate aborts"
+fi
+rm -f "$M2/legend-engine-xt-mod01/$VERSION/big.jar"
+
+# an unknown release version must fail rather than publish an empty bundle
+if bash "$SCRIPT" "$M2" 9.9.9 "$TMP/out3" "$MAX" >/dev/null 2>&1; then
+  echo "FAIL unknown version did not abort"; fail=1
+else
+  echo "ok   unknown release version aborts"
+fi
+
+echo
+if [ "$fail" -eq 0 ]; then echo "ALL PASS"; else echo "FAILURES"; exit 1; fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,11 @@ on:
       releaseVersion:
         description: "New release version"
         required: true
+      dryRun:
+        description: "Upload and validate bundles, then drop them without publishing to Central"
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build:
@@ -236,7 +241,7 @@ jobs:
     steps:
 
       - name: Checkout Release Tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.repository.name }}-${{ github.event.inputs.releaseVersion }}
           fetch-depth: 1
@@ -248,66 +253,91 @@ jobs:
           name: m2-repo
           path: ~/.m2/repository/org/finos/legend/engine
 
-      - name: Create bundle to publish
+      # The full artifact set is over 1.7GB, well past the Portal's 1GiB
+      # per-bundle cap, which nginx rejects with a bare "413 Payload Too Large"
+      # before the API sees it. Split it, never separating a jar from its pom,
+      # signature and checksums.
+      - name: Stage and split bundles
         env:
           RELEASE_VERSION: ${{ github.event.inputs.releaseVersion }}
         run: |
-          # Defensive guard: keep only directories whose name is exactly the
-          # release version under each artifact path. Should be a no-op when
-          # the build job already purged stale artifacts, but protects the
-          # publish step against any future regression that lets prior-release
-          # jars slip into ~/.m2/repository/org/finos/legend/engine.
-          find ~/.m2/repository/org/finos/legend/engine -mindepth 2 -type d \
-            -regextype posix-extended \
-            -regex '.*/[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.+-]+)?$' \
-            ! -name "$RELEASE_VERSION" -prune -exec rm -rf {} +
+          .github/scripts/stage-and-split.sh \
+            ~/.m2/repository/org/finos/legend/engine "$RELEASE_VERSION" "$PWD"
+          cat central-publishing/bundle-report.md >> "$GITHUB_STEP_SUMMARY"
 
-          mkdir -p central-staging/org/finos/legend
-          cp -R ~/.m2/repository/org/finos/legend/engine central-staging/org/finos/legend
-          find central-staging -type f \( -name "*.xml" -o -name "*.repositories" \) -delete
-          find central-staging -type f ! -name "*.md5" ! -name "*.sha1" ! -name "*.sha256" ! -name "*.sha512" ! -name "*.asc" | while read -r file; do
-            md5sum "$file" | awk '{print $1}' > "$file.md5"
-            sha1sum "$file" | awk '{print $1}' > "$file.sha1"
-            sha256sum "$file" | awk '{print $1}' > "$file.sha256"
-            sha512sum "$file" | awk '{print $1}' > "$file.sha512"
-          done
-          
-          mkdir central-publishing
-          cd central-staging && zip -r ../central-publishing/central-bundle.zip org
-
-      - name: Publish bundle
-        working-directory: central-publishing
+      - name: Upload bundles to Central
+        env:
+          RELEASE_VERSION: ${{ github.event.inputs.releaseVersion }}
         run: |
-          token=$(printf "$CI_DEPLOY_USERNAME:$CI_DEPLOY_PASSWORD" | base64)
-          httpCode=$(curl -s -o response.json -w "%{http_code}" -X POST -H "Authorization: Bearer $token" --form bundle=@central-bundle.zip https://central.sonatype.com/api/v1/publisher/upload?publishingType=AUTOMATIC)
-          
-          if [[ "$httpCode" == 2* ]]; then
-            deploymentId=$(cat response.json)
-            echo "Uploaded bundle. Deployment id is: $deploymentId"
-            echo "DEVELOPMENT_ID=${deploymentId}" >> $GITHUB_ENV
-          else
-            echo "Failed to upload bundle. Got status code $httpCode"
-            echo "Got the following response body:"
-            cat response.json
-            exit 1
-          fi
-
-      - name: Verify deployment status
-        run: |
-          token=$(printf "$CI_DEPLOY_USERNAME:$CI_DEPLOY_PASSWORD" | base64)
-          deploymentId=${{ env.DEVELOPMENT_ID }}
-          
-          deploymentState=""
-          
-          while [ "$deploymentState" != "PUBLISHED" ]; do
-            sleep 1m
-            response=$(curl -s -X POST -H "Authorization: Bearer $token" https://central.sonatype.com/api/v1/publisher/status?id=$deploymentId)
-            deploymentState=$(echo "$response" | jq -r '.deploymentState')
-            echo "Deployment state for id $deploymentId is $deploymentState"
-          
-            if [[ "$deploymentState" == "FAILED" ]]; then
-              echo "The deployment failed with the following response"
-              echo "$response"
-              exit 1
-            fi
+          : > deployment-ids.txt
+          : > bundle-deployments.tsv
+          {
+            echo
+            echo "### Central deployments"
+            echo
+            echo "| Bundle | Upload size | Deployment ID |"
+            echo "|---|---:|---|"
+          } >> "$GITHUB_STEP_SUMMARY"
+          for bundle in central-publishing/central-bundle-*.zip; do
+            suffix=$(basename "$bundle" .zip | sed 's/^central-bundle-//')
+            bytes=$(stat -c%s "$bundle")
+            echo "uploading $bundle ($bytes bytes)"
+            id=$(.github/scripts/central-publish.sh upload "$bundle" \
+                   "legend-engine-${RELEASE_VERSION}-central-bundle-${suffix}")
+            echo "$id" >> deployment-ids.txt
+            printf '%s\t%s\t%s\n' "$(basename "$bundle")" "$bytes" "$id" >> bundle-deployments.tsv
+            echo "uploaded $bundle as deployment $id"
+            printf '| %s | %s MB | `%s` |\n' \
+              "$(basename "$bundle")" "$((bytes / 1000000))" "$id" >> "$GITHUB_STEP_SUMMARY"
           done
+
+      # Kept even when the release fails: the sizes and the bundle-to-deployment
+      # mapping are exactly what a post-mortem needs, and the runner is gone.
+      - name: Upload bundle size report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: central-bundle-report
+          path: |
+            central-publishing/bundle-report.md
+            central-publishing/*.tsv
+            bundle-deployments.tsv
+          retention-days: 30
+          if-no-files-found: warn
+
+      # Every bundle must validate before any of them is published. Publishing
+      # bundle 1 and then discovering bundle 5 is invalid leaves a partial
+      # release on Central, and Central is immutable.
+      - name: Wait for all bundles to validate
+        run: |
+          while read -r id; do
+            .github/scripts/central-publish.sh await "$id" VALIDATED < /dev/null
+          done < deployment-ids.txt
+
+      - name: Publish all bundles
+        if: ${{ github.event.inputs.dryRun != 'true' }}
+        run: |
+          while read -r id; do
+            .github/scripts/central-publish.sh publish "$id" < /dev/null
+          done < deployment-ids.txt
+          while read -r id; do
+            .github/scripts/central-publish.sh await "$id" PUBLISHED < /dev/null
+          done < deployment-ids.txt
+
+      - name: Drop unpublished deployments
+        if: ${{ always() && (failure() || cancelled() || github.event.inputs.dryRun == 'true') }}
+        run: |
+          [ -f deployment-ids.txt ] || exit 0
+          while read -r id; do
+            state=$(.github/scripts/central-publish.sh state "$id" < /dev/null)
+            case "$state" in
+              VALIDATED|PENDING|VALIDATING)
+                .github/scripts/central-publish.sh drop "$id" < /dev/null
+                ;;
+              *)
+                # FAILED deployments are left in place on purpose: Sonatype
+                # support needs their files to diagnose the failure.
+                echo "leaving deployment $id in state $state"
+                ;;
+            esac
+          done < deployment-ids.txt


### PR DESCRIPTION
# Fix `413 Payload Too Large` when publishing to Maven Central

## Problem

The `release` workflow has been failing at the upload step with a bare
`<center><h1>413 Payload Too Large</h1></center>`. The response is HTML rather
than the Publisher Portal API's usual JSON because the rejection happens at
nginx, before the API ever sees the request.

The Portal caps a single bundle at **1 GiB**. A full legend-engine release is
**~1.74 GB** across **600 coordinates / 5,610 files**, uploaded as one zip.
Presto hit the same wall at 4.3GB ([prestodb/presto#25856](https://github.com/prestodb/presto/issues/25856)).

## Approach

Split the upload into multiple bundles, and make the release recoverable first,
because splitting without that is more dangerous than the bug.

**The published artifact set is unchanged.** Dropping the obvious weight is
tempting and wrong. The 971MB `legend-engine-server-http-server:shaded` jar,
the `-tests.jar`s, sources and javadoc are all on Central today (verified
against `repo1.maven.org` for 4.138.0), and Central is immutable, so removing
any of them silently breaks consumers that resolve those coordinates. `.par`
and `-jar-with-dependencies.jar` artifacts — sometimes assumed to be the bulk
here — do not exist in the local repository at all; excluding them is a no-op.
Exclusions are therefore opt-in via `CENTRAL_EXCLUDE_GLOBS`, empty by default.

Splitting happens only on whole `<artifactId>/<version>` directories. A jar
must never be separated from its pom, signature and checksums, or the bundle
validates while leaving a permanently broken artifact on Central.

## Changes

Three commits, ordered so that all behaviour change is isolated in the last one.

### 1. `.github/scripts/central-publish.sh` — Portal API driver

The workflow drove the API inline with three bugs that only surface during a
release:

| | |
|---|---|
| `publishingType=AUTOMATIC` | With N bundles, if bundle 5 fails validation, bundles 1–4 are already irreversibly on Central. Now `USER_MANAGED`, so every bundle reaches `VALIDATED` before any is published. |
| `printf "$u:$p" \| base64` | `base64` wraps at 76 columns, putting a newline inside the `Authorization` header for a token over 57 bytes; and the credentials were used as a printf *format string*, so a `%` in the password corrupted them. Now `printf '%s:%s' "$u" "$p" \| base64 -w0`. |
| Unbounded status poll | No deadline, and a transient API error made `jq -r '.deploymentState'` yield the string `"null"`, so it spun against that until the 6-hour job limit. Now bounded by `CENTRAL_POLL_TIMEOUT`, with unreadable responses retried rather than parsed as a state. |

`FAILED` deployments are deliberately never dropped — Sonatype support needs
their files to diagnose the failure.

### 2. `.github/scripts/stage-and-split.sh` — staging, splitting, reporting

Bin-packs coordinates into bundles under a configurable target (1e9 bytes by
default), with a 1 GiB backstop check on each produced zip.

Because a coordinate cannot be split, a single one over the target is a **hard
error** rather than a silently oversized bundle, and one over 80% warns.

Also narrows the local-repo cleanup: it previously deleted every `*.xml`, which
would have swept up a genuine `.xml` artifact. It now targets the specific
bookkeeping filenames (`_remote.repositories`, `maven-metadata-*.xml`,
`*.lastUpdated`, `resolver-status.properties`).

### 3. `.github/workflows/release.yml` — wiring

Sequence is now: stage and split → upload every bundle → wait for **all** to
reach `VALIDATED` → only then publish any. A failed or cancelled run drops the
deployments still at `VALIDATED` and leaves `FAILED` ones in place.

Also adds a `dryRun` input, fixes the `DEVELOPMENT_ID` typo, and pins
`actions/checkout` to `v6` to match every other job.

## Observability

This failure was hard to diagnose because nothing recorded what was uploaded.
Every run now writes, **before** anything is uploaded:

- `bundle-report.md` — totals, per-bundle size as a percentage of the Portal
  limit, and the 20 largest coordinates, flagged at ≥80% of the target
- `bundles.tsv` — bundle / files / zip bytes / staged bytes / sha256
- `bundle-contents.tsv` — which coordinate landed in which bundle
- `coordinates.tsv` — every coordinate and its size

The upload step adds a **bundle → deployment-ID** table. That mapping was
previously impossible to reconstruct: when Sonatype says "deployment X failed",
you can now say which zip, which sha256, and which artifacts were in it.

All of it goes to the job summary and uploads as an artifact under
`if: always()` with 30-day retention, so a failed release keeps its evidence
after the runner is gone.

## Verification

Run against the real artifact tree (600 coordinates, 1.74GB):

| | |
|---|---|
| Bundles | 3 — 202.1 / **895.7** / 465.2 MB |
| Largest | **83.4%** of the 1 GiB limit |
| Coverage | 5,610 staged files = 5,610 bundled files, 0 duplicated, 0 coordinates spanning bundles |

- `test-stage-and-split.sh` — **29 assertions, ALL PASS.** Offline, synthetic
  repository, seconds. The two that matter most are that no file is duplicated
  across bundles and that the bundles cover every staged file exactly once — a
  split that drops a `.pom` or `.asc` produces bundles that validate
  individually but leave a permanently broken artifact on Central.
- `test-central-publish.sh` — **15 assertions, ALL PASS.** Drives the script
  against a local mock of the Portal API that decodes the `Authorization`
  header and asserts on `publishingType`, so the auth and polling fixes are
  verifiable without credentials or network. Mutation-checked: reintroducing
  the original `base64` line makes it fail with HTTP 401 on the first call.

Not done locally: `shellcheck` and `actionlint` were unavailable in the
environment. `bash -n` was run on all four scripts and the workflow YAML was
parsed. Worth running both in CI.

## Follow-ups, not in this PR

**The shaded jar is the real deadline.** `legend-engine-server-http-server` is
a single 968MB coordinate — **96.8% of the packing target**. A coordinate
cannot be split across bundles, so once it passes 1000MB the release hard-fails
and no amount of splitting helps. The fix is to shrink it, stop publishing it
after a downstream audit (legend-sdlc, legend-studio, legend-depot), or request
a bundle-size exemption from central-support@sonatype.com. The report now
prints this on every run rather than leaving it to be rediscovered.

**Stop bundling from `~/.m2` at all.** The `build` job runs `mvn install`, not
`deploy`, so the bundle is the whole local-repo subtree rather than the
deployable set. Deploying to a file-based staging repo with
`-DaltDeploymentRepository` would honour per-module `maven.deploy.skip` and
drop local-repo bookkeeping automatically. Worth noting that **no module
currently sets `maven.deploy.skip`**, so this is a smaller win than it sounds
until modules are audited.

**`central-publishing-maven-plugin` is dead config.** It is declared in the
root `pom.xml` with `autoPublish=true` and `waitMaxTime=3600`, but the workflow
never runs `deploy`, so it never executes. Left alone here to keep the diff
focused, but it should be removed or actually used.

**Release-count metric.** Many small deployments inflate the tracked "release
count"; Portal rate limiting begins 2026-10-01. Worth checking FINOS's standing
at https://central.sonatype.com/publishing/usage before a permanently split
release process becomes the norm — another argument for the follow-ups above.

## Reviewing this

```bash
bash .github/scripts/test-stage-and-split.sh   # expect ALL PASS, offline, seconds
bash .github/scripts/test-central-publish.sh   # expect ALL PASS, no network
```

To see real numbers without a fresh build, against any local `~/.m2` that has a
built version in it:

```bash
.github/scripts/stage-and-split.sh ~/.m2/repository/org/finos/legend/engine <version> /tmp/out
cat /tmp/out/central-publishing/bundle-report.md
```

Note that `dryRun` still runs the full `build` job, including
`release:prepare`, which tags and bumps versions. It rehearses the *publish*
path, not the release as a whole — it is not a no-op on `master`.
