### PR TITLE
Have each Databricks suite tidy up the workspace it shares

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -281,6 +281,12 @@ jobs:
   test-modules:
     name: Test Module - ${{ matrix.name }}
     runs-on: ubuntu-latest
+    # Cloud PCT modules share one fixed workspace per store, so runs on different refs
+    # corrupt each other's fixtures. Scope the group per module - a group constant across
+    # the matrix would serialise every module against every other one.
+    concurrency:
+      group: test-module-${{ matrix.name }}
+      cancel-in-progress: false
     if: "!cancelled() && needs.build.result == 'success'"
     needs:
       - build

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-databricks/legend-engine-xt-relationalStore-databricks-PCT/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-databricks/legend-engine-xt-relationalStore-databricks-PCT/pom.xml
@@ -316,6 +316,15 @@
             <artifactId>commons-lang3</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-identity-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
         <!-- TEST -->
         <dependency>
             <groupId>junit</groupId>

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-databricks/legend-engine-xt-relationalStore-databricks-PCT/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/databricks/DatabricksCleanupResource.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-databricks/legend-engine-xt-relationalStore-databricks-PCT/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/databricks/DatabricksCleanupResource.java
@@ -1,0 +1,93 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.plan.execution.stores.relational.test.databricks;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.list.MutableList;
+import org.finos.legend.engine.plan.execution.stores.relational.connection.manager.ConnectionManagerSelector;
+import org.finos.legend.engine.plan.execution.stores.relational.connection.tests.api.TestConnectionIntegration;
+import org.finos.legend.engine.plan.execution.stores.relational.plugin.RelationalStoreExecutorBuilder;
+import org.finos.legend.engine.shared.core.identity.Identity;
+import org.finos.legend.engine.test.shared.framework.TestServerResource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Runs a suite's own tidy-up against the shared Databricks workspace before its tests start.
+ *
+ * <p>Add one after the connection integration in the {@code wrapSuite} resource list -
+ * {@code ServersState.start()} runs resources in order, and this needs the connection the
+ * integration builds in its own {@code start()}.
+ *
+ * <p>Each suite cleans up only what it creates. Nothing here may touch another suite's fixtures:
+ * the pct-cloud-test profile sets {@code forkCount=2}, so suites run in parallel JVMs that cannot
+ * coordinate with each other.
+ */
+public abstract class DatabricksCleanupResource implements TestServerResource
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(DatabricksCleanupResource.class);
+
+    private final TestConnectionIntegration integration;
+
+    protected DatabricksCleanupResource(TestConnectionIntegration integration)
+    {
+        this.integration = integration;
+    }
+
+    @Override
+    public void start()
+    {
+        try
+        {
+            ConnectionManagerSelector connectionManager = new RelationalStoreExecutorBuilder().build()
+                    .getStoreState().getRelationalExecutor().getConnectionManager();
+
+            try (Connection connection = connectionManager.getDatabaseConnection(new Identity("legend-pct-cleanup"), this.integration.getConnection());
+                 Statement statement = connection.createStatement())
+            {
+                this.clean(statement);
+            }
+        }
+        catch (Exception e)
+        {
+            // Never fatal - a tidy-up that throws would turn a recoverable workspace into a hard suite failure.
+            LOGGER.warn("Databricks cleanup [{}] skipped", this.getClass().getSimpleName(), e);
+        }
+    }
+
+    protected abstract void clean(Statement statement) throws SQLException;
+
+    protected static MutableList<String> query(Statement statement, String sql, int column) throws SQLException
+    {
+        MutableList<String> values = Lists.mutable.empty();
+        try (ResultSet resultSet = statement.executeQuery(sql))
+        {
+            while (resultSet.next())
+            {
+                values.add(resultSet.getString(column));
+            }
+        }
+        return values;
+    }
+
+    @Override
+    public void shutDown()
+    {
+    }
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-databricks/legend-engine-xt-relationalStore-databricks-PCT/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/databricks/pct/DatabricksLeakedTableSweep.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-databricks/legend-engine-xt-relationalStore-databricks-PCT/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/databricks/pct/DatabricksLeakedTableSweep.java
@@ -1,0 +1,96 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.plan.execution.stores.relational.test.databricks.pct;
+
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Duration;
+import org.eclipse.collections.api.list.MutableList;
+import org.finos.legend.engine.plan.execution.stores.relational.connection.tests.api.TestConnectionIntegration;
+import org.finos.legend.engine.plan.execution.stores.relational.test.databricks.DatabricksCleanupResource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Drops tables this suite left behind on earlier runs.
+ *
+ * <p>meta::relational::tests::pct::process::setupDatabase registers each table's drop as an
+ * on-connection-close commit query, but those do not run when the block connection is locked, when
+ * an earlier drop in the batch throws, or when the JVM dies - and the schema itself is deliberately
+ * never dropped. The residue had reached 2617 tables at a steady ~165 a month since 2025-05 before
+ * anything started removing it.
+ *
+ * <p>Selection is by age, not by run. A suite takes about half an hour, so a table older than
+ * {@link #MIN_AGE} cannot belong to a run still in flight - not this one, and not a concurrent CI
+ * run against the same workspace. That is what makes it safe to do from inside a test rather than
+ * from a job that owns the workspace.
+ */
+class DatabricksLeakedTableSweep extends DatabricksCleanupResource
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(DatabricksLeakedTableSweep.class);
+
+    private static final String PCT_SCHEMA = "leschema";
+
+    private static final Duration MIN_AGE = Duration.ofDays(2);
+
+    // Bounds what any one run adds to start-up. The leak is a few tables a day and the suite runs
+    // many times a day, so this drains a backlog without ever costing much on a single run.
+    private static final int SWEEP_LIMIT = 100;
+
+    // PCT names its tables <prefix><random>_<epochMillis>.
+    private static final int EPOCH_MILLIS_LENGTH = 13;
+
+    DatabricksLeakedTableSweep(TestConnectionIntegration integration)
+    {
+        super(integration);
+    }
+
+    @Override
+    protected void clean(Statement statement) throws SQLException
+    {
+        long cutoff = System.currentTimeMillis() - MIN_AGE.toMillis();
+        MutableList<String> leaked = query(statement, "Show tables in " + PCT_SCHEMA, 2)
+                .select(table -> createdBefore(table, cutoff))
+                .take(SWEEP_LIMIT);
+
+        int swept = 0;
+        for (String table : leaked)
+        {
+            try
+            {
+                statement.execute("Drop table if exists " + PCT_SCHEMA + ".`" + table + "`");
+                swept++;
+            }
+            catch (Exception e)
+            {
+                LOGGER.warn("Could not sweep leaked table [{}.{}]", PCT_SCHEMA, table, e);
+            }
+        }
+        LOGGER.info("Swept {} leaked table(s) from [{}]", swept, PCT_SCHEMA);
+    }
+
+    /**
+     * A name we cannot parse is left alone rather than guessed at.
+     */
+    private static boolean createdBefore(String table, long cutoff)
+    {
+        String suffix = table.substring(table.lastIndexOf('_') + 1);
+        if (suffix.length() != EPOCH_MILLIS_LENGTH || !suffix.chars().allMatch(Character::isDigit))
+        {
+            return false;
+        }
+        return Long.parseLong(suffix) < cutoff;
+    }
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-databricks/legend-engine-xt-relationalStore-databricks-PCT/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/databricks/pct/Test_Relational_Databricks_PCT.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-databricks/legend-engine-xt-relationalStore-databricks-PCT/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/databricks/pct/Test_Relational_Databricks_PCT.java
@@ -18,6 +18,7 @@ import junit.framework.Test;
 import junit.framework.TestSuite;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.MutableList;
+import org.finos.legend.engine.plan.execution.stores.relational.connection.tests.api.TestConnectionIntegration;
 import org.finos.legend.engine.plan.execution.stores.relational.connection.tests.api.TestConnectionIntegrationLoader;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.DatabaseType;
 import org.finos.legend.engine.pure.code.core.CoreScenarioQuantCodeRepositoryProvider;
@@ -84,7 +85,10 @@ public class Test_Relational_Databricks_PCT
 
     private static MutableList<TestServerResource> databricksTestServerResources()
     {
-        return Lists.mutable.with((TestServerResource) TestConnectionIntegrationLoader.extensions().select(c -> c.getDatabaseType() == DatabaseType.Databricks).getFirst());
+        TestConnectionIntegration databricks = TestConnectionIntegrationLoader.extensions().select(c -> c.getDatabaseType() == DatabaseType.Databricks).getFirst();
+        // The sweep must follow the integration: ServersState.start() runs the resources in order,
+        // and it needs the connection the integration builds in start().
+        return Lists.mutable.with((TestServerResource) databricks, new DatabricksLeakedTableSweep(databricks));
     }
 
     private abstract static class DatabricksPCTReportConfiguration extends PCTReportConfiguration

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-databricks/legend-engine-xt-relationalStore-databricks-PCT/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/databricks/semistructured/DatabricksFixtureSchemaReset.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-databricks/legend-engine-xt-relationalStore-databricks-PCT/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/databricks/semistructured/DatabricksFixtureSchemaReset.java
@@ -1,0 +1,88 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.plan.execution.stores.relational.test.databricks.semistructured;
+
+import java.sql.SQLException;
+import java.sql.Statement;
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.list.MutableList;
+import org.finos.legend.engine.plan.execution.stores.relational.connection.tests.api.TestConnectionIntegration;
+import org.finos.legend.engine.plan.execution.stores.relational.test.databricks.DatabricksCleanupResource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Drops the fixture schemas of meta::relational::tests::semistructured before the suite runs.
+ *
+ * <p>Unlike the PCT suite, which randomises its table names, these tests use hardcoded schema/table
+ * names against a single shared Databricks workspace. When two CI runs overlap, one run's
+ * `Drop table if exists` can delete `_delta_log/0.json` after the other has written later versions.
+ * That leaves a managed table directory whose Delta log cannot be reconstructed - and because the
+ * metastore entry is gone with it, the table is invisible to `Show tables`, so no `Drop table` can
+ * reach it and every later `Create Table` fails with DELTA_TRUNCATED_TRANSACTION_LOG. Dropping the
+ * schema deletes its warehouse directory, orphan included, which is the only repair available over
+ * JDBC.
+ *
+ * <p>The set is derived from `Show schemas` rather than listed, so a new fixture schema needs no
+ * change here. See {@link #PROTECTED_SCHEMAS} for what is spared.
+ */
+class DatabricksFixtureSchemaReset extends DatabricksCleanupResource
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(DatabricksFixtureSchemaReset.class);
+
+    // Everything Show schemas returns is dropped except these.
+    //
+    //   default            - the database the JDBC URL connects to
+    //   leschema           - the PCT suite's, and it sweeps its own leaked tables by age. Dropping
+    //                        it here would race the tables that suite creates in a parallel fork.
+    //   information_schema - metastore-owned
+    //   inflows/lcr/legend - unknown provenance, no reference anywhere in this repo. Quarantined
+    //                        until someone claims them; delete these three entries once they are
+    //                        confirmed to be junk.
+    private static final MutableList<String> PROTECTED_SCHEMAS = Lists.mutable.with(
+            "default",
+            "leschema",
+            "information_schema",
+            "inflows",
+            "lcr",
+            "legend"
+    );
+
+    DatabricksFixtureSchemaReset(TestConnectionIntegration integration)
+    {
+        super(integration);
+    }
+
+    @Override
+    protected void clean(Statement statement) throws SQLException
+    {
+        for (String schema : query(statement, "Show schemas", 1))
+        {
+            if (PROTECTED_SCHEMAS.contains(schema.toLowerCase()))
+            {
+                continue;
+            }
+            try
+            {
+                statement.execute("Drop schema if exists " + schema + " cascade");
+                LOGGER.info("Reset Databricks schema [{}]", schema);
+            }
+            catch (Exception e)
+            {
+                LOGGER.warn("Could not reset Databricks schema [{}]", schema, e);
+            }
+        }
+    }
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-databricks/legend-engine-xt-relationalStore-databricks-PCT/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/databricks/semistructured/Test_Relational_Databricks_Semistructured.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-databricks/legend-engine-xt-relationalStore-databricks-PCT/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/databricks/semistructured/Test_Relational_Databricks_Semistructured.java
@@ -22,6 +22,7 @@ import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.impl.tuple.Tuples;
+import org.finos.legend.engine.plan.execution.stores.relational.connection.tests.api.TestConnectionIntegration;
 import org.finos.legend.engine.plan.execution.stores.relational.connection.tests.api.TestConnectionIntegrationLoader;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.DatabaseType;
 import org.finos.legend.engine.test.shared.framework.TestServerResource;
@@ -128,6 +129,8 @@ public class Test_Relational_Databricks_Semistructured
             }
         };
 
+        TestConnectionIntegration databricks = TestConnectionIntegrationLoader.extensions().select(c -> c.getDatabaseType() == DatabaseType.Databricks).getFirst();
+
         return wrapSuite(
                 () -> true,
                 () -> PureTestBuilder.buildSuite(
@@ -139,7 +142,9 @@ public class Test_Relational_Databricks_Semistructured
                         executionSupport
                 ),
                 () -> false,
-                Lists.mutable.with((TestServerResource) TestConnectionIntegrationLoader.extensions().select(c -> c.getDatabaseType() == DatabaseType.Databricks).getFirst())
+                // The reset must follow the integration in this list: ServersState.start() runs the
+                // resources in order, and it needs the connection the integration builds in start().
+                Lists.mutable.with((TestServerResource) databricks, new DatabricksFixtureSchemaReset(databricks))
         );
     }
 }


### PR DESCRIPTION
## Problem

`Test Module - databricks` was failing on every run — PR branches and `master` alike — with 130 errors in `Test_Relational_Databricks_Semistructured`, while `Test_Relational_Databricks_PCT` stayed green at 1225/1225:

```
DeltaFileNotFoundException: [DELTA_TRUNCATED_TRANSACTION_LOG]
dbfs:/user/hive/warehouse/person_schema.db/person_table/_delta_log/00000000000000000000.json:
Unable to reconstruct state at version 1 ...
```

Four managed Delta directories had an orphaned `_delta_log` — `0.json` deleted, later versions still present:

| directory | needed version |
|---|---|
| `person_schema.db/person_table` | 1 |
| `firm_schema.db/firm_table` | 1 |
| `order_schema.db/order_table` | 1 |
| `semistructured.db/blocks` | 2 |

**Root cause.** The semi-structured fixtures use hardcoded schema/table names against one shared workspace, hardcoded in `DatabricksTestConnectionIntegration` for every branch and PR, while `build.yml` scopes concurrency per PR ref so runs on different refs overlap. One run's `Drop table if exists` deleted `_delta_log/0.json` after another had written `1.json`/`2.json`. Three runs overlapped that night, and the `master` push run failed identically on the same four paths.

The metastore entry goes with the directory, so the table is invisible to `Show tables` — no `Drop table` can reach it, and every later `Create Table` fails. Confirmed on the workspace: all four schemas reported zero tables while the directories were still present.

The workspace has been recovered manually (`DROP SCHEMA ... CASCADE`, which deletes the warehouse directory, orphan included). Two Databricks CI jobs have since passed on unmodified branches, confirming the repair. This PR stops it recurring.

## Change

Each suite gets a cleanup resource for the state it creates, wired after the connection integration so it runs with a live connection (`ServersState.start()` runs resources in order).

- **`DatabricksFixtureSchemaReset`** (semi-structured suite) — drops its fixture schemas, so an orphaned directory is removed and the next run heals itself instead of needing manual DBFS surgery. The set is derived from `Show schemas` minus an explicit protect list, so adding a fixture schema to the models needs no change here.
- **`DatabricksLeakedTableSweep`** (PCT suite) — drops tables this suite leaked on earlier runs. `setupDatabase` registers each drop as an on-connection-close commit query, but those do not run when the block connection is locked, when an earlier drop in the batch throws, or when the JVM dies — and the schema is deliberately never dropped. That had accumulated **2617 tables at a steady ~165/month since 2025-05** with nothing removing them (swept to 52 manually; this keeps it there).
- **`DatabricksCleanupResource`** — shared connection plumbing for both.

Selection in the sweep is by the epoch-millis suffix, not by run: a suite takes about half an hour, so a table older than the cutoff cannot belong to a run still in flight. That is what makes it safe with `forkCount=2` and with concurrent CI runs on the same workspace. A per-run limit keeps it off the critical path.

**Neither suite touches the other's state** — `forkCount=2` means parallel JVMs that cannot coordinate. This is why `leschema` is in the semi-structured protect list: the PCT suite sweeps it instead.

Also adds a per-module `concurrency` group to `test-modules`. This narrows the cross-ref race but cannot close it, since `release.yml` runs the same profile from a separate workflow.

## Trade-off

The destructive window is now wider than the per-fixture drop it supplements, so an overlapping run may report `TABLE_OR_VIEW_NOT_FOUND` more often. That is expected: a red run that heals itself beats a workspace that stays broken until someone intervenes.

## Testing

`mvn clean test-compile` and `checkstyle:check@verify` pass on the module.

The cleanup code has **not** executed against Databricks yet — the `pct-cloud-test` profile only runs in CI. Both resources log and swallow failures by design rather than failing the suite, so the signals to look for in this PR's Databricks job are `Reset Databricks schema [...]` and `Swept N leaked table(s) from [leschema]`. Absence of those lines, rather than a red build, is what would indicate a problem.

## Note for reviewers

`PROTECTED_SCHEMAS` quarantines `inflows`, `lcr` and `legend` — three schemas holding 4 tables between them, with zero references anywhere in this repo. They are spared until someone claims them. If you know their owner, those entries can be dropped.
