### PR TITLE
[Backport release-legend-release-4.98] Harden `stage-and-split.sh` report generation against `pipefail`/SIGPIPE failures

### DIFF
--- a/.github/scripts/stage-and-split.sh
+++ b/.github/scripts/stage-and-split.sh
@@ -88,14 +88,14 @@ fi
 
 # Central requires md5 and sha1; sha256 and sha512 are optional but are already
 # published for prior releases, so they are kept for parity.
-find "$STAGING" -type f \
-  ! -name '*.md5' ! -name '*.sha1' ! -name '*.sha256' \
-  ! -name '*.sha512' ! -name '*.asc' -print0 | while IFS= read -r -d '' file; do
+while IFS= read -r -d '' file; do
   md5sum    "$file" | awk '{print $1}' > "$file.md5"
   sha1sum   "$file" | awk '{print $1}' > "$file.sha1"
   sha256sum "$file" | awk '{print $1}' > "$file.sha256"
   sha512sum "$file" | awk '{print $1}' > "$file.sha512"
-done
+done < <(find "$STAGING" -type f \
+  ! -name '*.md5' ! -name '*.sha1' ! -name '*.sha256' \
+  ! -name '*.sha512' ! -name '*.asc' -print0)
 
 STAGED_BYTES=$(du -sb "$STAGING" | cut -f1)
 STAGED_FILES=$(find "$STAGING" -type f | wc -l)
@@ -118,7 +118,8 @@ idx=1
 size=0
 list=$(mktemp)
 coordlist=$(mktemp)
-trap 'rm -f "$list" "$coordlist"' EXIT
+sorted_coords=""
+trap 'rm -f "$list" "$coordlist"; [ -n "${sorted_coords:-}" ] && rm -f "$sorted_coords"' EXIT
 
 mb()  { awk -v b="$1" 'BEGIN { printf "%.1f", b / 1000000 }'; }
 pct() { awk -v a="$1" -v b="$2" 'BEGIN { printf "%.1f", 100 * a / b }'; }
@@ -203,11 +204,14 @@ LARGEST_ZIP=$(awk -F'\t' 'NR > 1 && $3 > m { m = $3 } END { print m + 0 }' "$BUN
   echo
   echo "| Coordinate | Size | % of packing target |"
   echo "|---|---:|---:|"
-  tail -n +2 "$COORDS_TSV" | sort -t$'\t' -k2 -rn | head -20 |
-    awk -F'\t' -v tgt="$MAX_BYTES" '{
-      flag = (100 * $2 / tgt >= 80) ? " :warning:" : ""
-      printf "| `%s` | %.1f MB | %.1f%%%s |\n", $1, $2 / 1000000, 100 * $2 / tgt, flag
-    }'
+  sorted_coords=$(mktemp)
+  tail -n +2 "$COORDS_TSV" | sort -t$'\t' -k2 -rn > "$sorted_coords"
+  head -20 "$sorted_coords" | awk -F'\t' -v tgt="$MAX_BYTES" '{
+    flag = (100 * $2 / tgt >= 80) ? " :warning:" : ""
+    printf "| `%s` | %.1f MB | %.1f%%%s |\n", $1, $2 / 1000000, 100 * $2 / tgt, flag
+  }'
+  rm -f "$sorted_coords"
+  sorted_coords=""
   echo
   echo "A coordinate cannot be split across bundles, so any single one reaching"
   echo "$(mb "$MAX_BYTES") MB fails the release outright."


### PR DESCRIPTION
Backport of #5055 to `release-legend-release-4.98`.

Created automatically by the backport workflow. If this PR has
conflicts or CI failures, the assignee (the original author) is
responsible for resolving them.