### PR TITLE
Publish the release to Central in two waves so bundles can validate

### DIFF
--- a/.github/scripts/await-wave.sh
+++ b/.github/scripts/await-wave.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# Copyright 2026 Goldman Sachs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Wait for every deployment in a wave to reach a target state.
+#
+#   await-wave.sh <ids-file> [target-state]
+#
+# Every deployment is awaited even after one of them fails. The failed 4.139.1
+# release aborted on the first bundle, so the outcome of the other two was
+# never reported and the post-mortem had a third of the evidence it needed.
+
+set -euo pipefail
+
+IDS_FILE=${1:?usage: await-wave.sh <ids-file> [target-state]}
+TARGET=${2:-VALIDATED}
+PUBLISH="$(cd "$(dirname "$0")" && pwd)/central-publish.sh"
+
+[ -s "$IDS_FILE" ] || { echo "ERROR: $IDS_FILE is empty or missing" >&2; exit 1; }
+
+failed=0
+while read -r id; do
+  [ -n "$id" ] || continue
+  "$PUBLISH" await "$id" "$TARGET" < /dev/null || failed=$((failed + 1))
+done < "$IDS_FILE"
+
+if [ "$failed" -ne 0 ]; then
+  echo "ERROR: $failed of $(grep -c . "$IDS_FILE") deployment(s) did not reach $TARGET" >&2
+  exit 1
+fi
+
+echo "all deployments in $IDS_FILE reached $TARGET"

--- a/.github/scripts/central-publish.sh
+++ b/.github/scripts/central-publish.sh
@@ -21,6 +21,8 @@
 #   central-publish.sh state  <deployment-id>                 -> prints current state
 #   central-publish.sh publish <deployment-id>
 #   central-publish.sh drop    <deployment-id>
+#   central-publish.sh cleanup <deployment-id>                -> drop if droppable
+#   central-publish.sh await-central <artifactId> <version>   -> wait for repo1
 #
 # Uploads are always USER_MANAGED. With AUTOMATIC, a release split across N
 # bundles has no safe failure mode: if bundle 5 fails validation, bundles 1-4
@@ -33,12 +35,19 @@
 #   CENTRAL_API_BASE                        override for testing
 #   CENTRAL_POLL_INTERVAL                   seconds between status polls (60)
 #   CENTRAL_POLL_TIMEOUT                    seconds before giving up (3600)
+#   CENTRAL_REPO_BASE                       read-side repository (repo1)
+#   CENTRAL_GROUP_PATH                      group as a path, for await-central
+#   CENTRAL_STATUS_DIR                      if set, raw status JSON is kept here
+#   CENTRAL_ERROR_LINES                     max validation errors printed (200)
 
 set -euo pipefail
 
 CENTRAL_API_BASE=${CENTRAL_API_BASE:-https://central.sonatype.com/api/v1/publisher}
 CENTRAL_POLL_INTERVAL=${CENTRAL_POLL_INTERVAL:-60}
 CENTRAL_POLL_TIMEOUT=${CENTRAL_POLL_TIMEOUT:-3600}
+CENTRAL_REPO_BASE=${CENTRAL_REPO_BASE:-https://repo1.maven.org/maven2}
+CENTRAL_GROUP_PATH=${CENTRAL_GROUP_PATH:-org/finos/legend/engine}
+CENTRAL_ERROR_LINES=${CENTRAL_ERROR_LINES:-200}
 
 : "${CI_DEPLOY_USERNAME:?CI_DEPLOY_USERNAME is not set}"
 : "${CI_DEPLOY_PASSWORD:?CI_DEPLOY_PASSWORD is not set}"
@@ -52,6 +61,41 @@ auth_token() {
 
 urlencode() {
   jq -rn --arg v "$1" '$v|@uri'
+}
+
+save_status() {
+  local id=$1 response=$2
+  [ -n "${CENTRAL_STATUS_DIR:-}" ] || return 0
+  mkdir -p "$CENTRAL_STATUS_DIR"
+  printf '%s' "$response" > "$CENTRAL_STATUS_DIR/$id.json"
+}
+
+# The Portal returns every validation error in a single JSON blob. Echoing that
+# raw produces one enormous line, which the Actions runner drops outright: the
+# 4.139.1 release failed validation and the log said only "FAILED", with no
+# indication of why. Print one error per line, capped, and keep the raw
+# response so a post-mortem has the whole thing.
+report_errors() {
+  local id=$1 response=$2 formatted total
+  save_status "$id" "$response"
+  formatted=$(jq -r '
+    if (.errors | type) == "object" then
+      .errors | to_entries[] as $e | $e.value[] | "\($e.key): \(.)"
+    elif (.errors | type) == "array" then
+      .errors[] | tostring
+    else empty end' <<< "$response" 2>/dev/null || true)
+
+  if [ -z "$formatted" ]; then
+    echo "ERROR: the Portal returned no error detail for $id" >&2
+    return 0
+  fi
+
+  total=$(printf '%s\n' "$formatted" | wc -l)
+  printf '%s\n' "$formatted" | awk -v n="$CENTRAL_ERROR_LINES" 'NR <= n { print "ERROR:   " $0 }' >&2
+  if [ "$total" -gt "$CENTRAL_ERROR_LINES" ]; then
+    echo "ERROR:   ... and $((total - CENTRAL_ERROR_LINES)) more errors;" >&2
+    echo "ERROR:   the full response is in the central-bundle-report artifact." >&2
+  fi
 }
 
 cmd_upload() {
@@ -116,8 +160,8 @@ cmd_await() {
         return 0
         ;;
       FAILED)
-        echo "ERROR: deployment $id FAILED" >&2
-        echo "$response" >&2
+        echo "ERROR: deployment $id FAILED validation:" >&2
+        report_errors "$id" "$response"
         # Deliberately not dropped: Sonatype support needs a FAILED
         # deployment's files to diagnose it.
         exit 1
@@ -141,6 +185,65 @@ cmd_state() {
     "$CENTRAL_API_BASE/status?id=$(urlencode "$id")" || true)
   state=$(jq -r 'if type == "object" then (.deploymentState // empty) else empty end' <<< "$response" 2>/dev/null || true)
   echo "${state:-UNKNOWN}"
+}
+
+# Wave 2 bundles can only validate once their parent POMs are resolvable from
+# Central, so the release has to wait for wave 1 to become readable on the
+# read side (repo1) -- reaching PUBLISHED on the Portal happens first, and is
+# not the same thing.
+cmd_await_central() {
+  local artifact=$1 version=$2 url code
+  local deadline=$((SECONDS + CENTRAL_POLL_TIMEOUT))
+  url="$CENTRAL_REPO_BASE/$CENTRAL_GROUP_PATH/$artifact/$version/$artifact-$version.pom"
+
+  while :; do
+    code=$(curl -sS -o /dev/null -w '%{http_code}' "$url" || echo 000)
+    if [ "$code" = "200" ]; then
+      echo "$artifact:$version is readable on Central"
+      return 0
+    fi
+    if [ "$SECONDS" -ge "$deadline" ]; then
+      echo "ERROR: $artifact:$version did not appear on Central within" >&2
+      echo "ERROR: ${CENTRAL_POLL_TIMEOUT}s (last HTTP $code, $url)" >&2
+      exit 1
+    fi
+    echo "$artifact:$version not yet on Central (HTTP $code)"
+    sleep "$CENTRAL_POLL_INTERVAL"
+  done
+}
+
+# `drop` answers HTTP 400 while a deployment is still validating -- that is what
+# happened to bundle 3 of the failed release, which was left behind. Wait for a
+# terminal state, then drop only what is safe to drop. This never returns
+# non-zero: it runs in a failure handler and must not mask the original error.
+cmd_cleanup() {
+  local id=$1 state
+  local deadline=$((SECONDS + CENTRAL_POLL_TIMEOUT))
+
+  while :; do
+    state=$(cmd_state "$id")
+    case "$state" in
+      VALIDATED)
+        cmd_drop "$id"
+        return 0
+        ;;
+      FAILED)
+        # Kept on purpose: Sonatype support needs a FAILED deployment's files.
+        echo "leaving deployment $id in state FAILED"
+        return 0
+        ;;
+      PUBLISHED|PUBLISHING|UNKNOWN)
+        echo "leaving deployment $id in state $state"
+        return 0
+        ;;
+    esac
+    if [ "$SECONDS" -ge "$deadline" ]; then
+      echo "warning: deployment $id still $state after ${CENTRAL_POLL_TIMEOUT}s, not dropped" >&2
+      return 0
+    fi
+    echo "deployment $id is $state, waiting for a terminal state before dropping"
+    sleep "$CENTRAL_POLL_INTERVAL"
+  done
 }
 
 cmd_publish() {
@@ -179,8 +282,11 @@ case "${1:-}" in
   state)   cmd_state   "${2:?missing deployment id}" ;;
   publish) cmd_publish "${2:?missing deployment id}" ;;
   drop)    cmd_drop    "${2:?missing deployment id}" ;;
+  cleanup) cmd_cleanup "${2:?missing deployment id}" ;;
+  await-central)
+           cmd_await_central "${2:?missing artifactId}" "${3:?missing version}" ;;
   *)
-    echo "usage: central-publish.sh {upload <zip> <name>|await <id> [state]|state <id>|publish <id>|drop <id>}" >&2
+    echo "usage: central-publish.sh {upload <zip> <name>|await <id> [state]|state <id>|publish <id>|drop <id>|cleanup <id>|await-central <artifactId> <version>}" >&2
     exit 2
     ;;
 esac

--- a/.github/scripts/stage-and-split.sh
+++ b/.github/scripts/stage-and-split.sh
@@ -86,6 +86,56 @@ if [ ${#COORDS[@]} -eq 0 ]; then
   exit 1
 fi
 
+# Central validates every deployment independently and builds an effective POM
+# for each artifact, which means resolving its <parent>. A parent that is
+# neither in the same bundle nor already on Central cannot be resolved and the
+# whole deployment fails validation -- which is exactly how the 4.139.1 release
+# failed once the bundle was first split.
+#
+# So the release goes out in two waves. Wave 1 is every coordinate that is
+# somebody's parent (aggregator POMs, a few hundred KB in total). Once it is
+# published, wave 2 can be split arbitrarily: each bundle resolves its parents
+# from Central instead of from a sibling bundle.
+PARENTS=$(mktemp)
+list=$(mktemp)
+coordlist=$(mktemp)
+sorted_coords=""
+trap 'rm -f "$list" "$coordlist" "$PARENTS"; [ -n "${sorted_coords:-}" ] && rm -f "$sorted_coords"' EXIT
+
+while IFS= read -r pom; do
+  # awk rather than head so the upstream greps never take SIGPIPE under pipefail
+  # `|| true` because a POM without a <parent> makes grep exit 1, which under
+  # `set -e` with pipefail would abort the whole run. The root POM is exactly
+  # such a POM, so this is the normal case, not an edge case.
+  tr '\n' ' ' < "$pom" \
+    | grep -o '<parent>.*</parent>' \
+    | grep -o '<artifactId>[^<]*</artifactId>' \
+    | awk 'NR == 1' \
+    | sed 's|<[^>]*>||g' || true
+done < <(find "$ROOT" -mindepth 3 -maxdepth 3 -type f -name '*.pom') | sort -u > "$PARENTS"
+
+WAVE1=()
+WAVE2=()
+for dir in "${COORDS[@]}"; do
+  artifact=$(basename "$(dirname "$dir")")
+  if grep -qxF "$artifact" "$PARENTS"; then
+    WAVE1+=("$dir")
+  else
+    WAVE2+=("$dir")
+  fi
+done
+
+# With more than one coordinate there is always at least a root POM that others
+# inherit from. An empty wave 1 means the parent scan broke, and publishing on
+# that basis would repeat the validation failure this split exists to avoid.
+if [ ${#WAVE1[@]} -eq 0 ] && [ ${#COORDS[@]} -gt 1 ]; then
+  echo "ERROR: no parent coordinates found among ${#COORDS[@]} coordinates." >&2
+  echo "ERROR: refusing to split, every bundle would fail parent resolution." >&2
+  exit 1
+fi
+
+echo "wave 1: ${#WAVE1[@]} parent coordinates; wave 2: ${#WAVE2[@]} coordinates"
+
 # Central requires md5 and sha1; sha256 and sha512 are optional but are already
 # published for prior releases, so they are kept for parity.
 while IFS= read -r -d '' file; do
@@ -116,18 +166,14 @@ printf 'coordinate\tbytes\n' > "$COORDS_TSV"
 
 idx=1
 size=0
-list=$(mktemp)
-coordlist=$(mktemp)
-sorted_coords=""
-trap 'rm -f "$list" "$coordlist"; [ -n "${sorted_coords:-}" ] && rm -f "$sorted_coords"' EXIT
-
+wave=wave1
 mb()  { awk -v b="$1" 'BEGIN { printf "%.1f", b / 1000000 }'; }
 pct() { awk -v a="$1" -v b="$2" 'BEGIN { printf "%.1f", 100 * a / b }'; }
 
 flush() {
   [ -s "$list" ] || return 0
   local name out zipsize sha files
-  name="central-bundle-$(printf '%02d' "$idx")"
+  name="$wave-bundle-$(printf '%02d' "$idx")"
   out="$BUNDLES/$name.zip"
   zip -q -X "$out" -@ < "$list"
   zipsize=$(stat -c%s "$out")
@@ -143,38 +189,50 @@ flush() {
   printf '%s\t%s\t%s\t%s\t%s\n' "$name" "$files" "$zipsize" "$size" "$sha" >> "$BUNDLES_TSV"
   awk -v b="$name" -F'\t' '{ printf "%s\t%s\t%s\n", b, $1, $2 }' "$coordlist" >> "$CONTENTS_TSV"
 
-  echo "bundle $idx: $files files, $(mb "$zipsize") MB zipped ($(pct "$zipsize" "$HARD_LIMIT")% of Portal limit), sha256 $sha"
+  echo "$name: $files files, $(mb "$zipsize") MB zipped ($(pct "$zipsize" "$HARD_LIMIT")% of Portal limit), sha256 $sha"
   idx=$((idx + 1))
   size=0
   : > "$list"
   : > "$coordlist"
 }
 
-for dir in "${COORDS[@]}"; do
-  dirsize=$(du -sb "$dir" | cut -f1)
-  printf '%s\t%s\n' "$dir" "$dirsize" >> "$COORDS_TSV"
+pack() { # pack <wave-name> <coordinate-dir>...
+  wave=$1
+  shift
+  idx=1
+  size=0
+  : > "$list"
+  : > "$coordlist"
 
-  if [ "$dirsize" -gt "$MAX_BYTES" ]; then
-    echo "ERROR: $dir alone is $(mb "$dirsize") MB, above the ${MAX_BYTES}-byte" >&2
-    echo "ERROR: bundle target. A single coordinate cannot be split across bundles." >&2
-    echo "ERROR: shrink the artifact, stop publishing it, or request a Portal limit" >&2
-    echo "ERROR: increase from central-support@sonatype.com." >&2
-    exit 1
-  fi
-  if [ $((dirsize * 100)) -gt $((MAX_BYTES * 80)) ]; then
-    echo "WARNING: $dir is $(mb "$dirsize") MB, $(pct "$dirsize" "$MAX_BYTES")% of the bundle target." >&2
-    echo "WARNING: it will hard-fail the release once it exceeds $((MAX_BYTES / 1000000)) MB." >&2
-  fi
-  if [ "$size" -gt 0 ] && [ $((size + dirsize)) -gt "$MAX_BYTES" ]; then
-    flush
-  fi
-  find "$dir" -type f >> "$list"
-  printf '%s\t%s\n' "$dir" "$dirsize" >> "$coordlist"
-  size=$((size + dirsize))
-done
-flush
+  for dir in "$@"; do
+    dirsize=$(du -sb "$dir" | cut -f1)
+    printf '%s\t%s\n' "$dir" "$dirsize" >> "$COORDS_TSV"
 
-NBUNDLES=$((idx - 1))
+    if [ "$dirsize" -gt "$MAX_BYTES" ]; then
+      echo "ERROR: $dir alone is $(mb "$dirsize") MB, above the ${MAX_BYTES}-byte" >&2
+      echo "ERROR: bundle target. A single coordinate cannot be split across bundles." >&2
+      echo "ERROR: shrink the artifact, stop publishing it, or request a Portal limit" >&2
+      echo "ERROR: increase from central-support@sonatype.com." >&2
+      exit 1
+    fi
+    if [ $((dirsize * 100)) -gt $((MAX_BYTES * 80)) ]; then
+      echo "WARNING: $dir is $(mb "$dirsize") MB, $(pct "$dirsize" "$MAX_BYTES")% of the bundle target." >&2
+      echo "WARNING: it will hard-fail the release once it exceeds $((MAX_BYTES / 1000000)) MB." >&2
+    fi
+    if [ "$size" -gt 0 ] && [ $((size + dirsize)) -gt "$MAX_BYTES" ]; then
+      flush
+    fi
+    find "$dir" -type f >> "$list"
+    printf '%s\t%s\n' "$dir" "$dirsize" >> "$coordlist"
+    size=$((size + dirsize))
+  done
+  flush
+}
+
+pack wave1 "${WAVE1[@]}"
+[ ${#WAVE2[@]} -eq 0 ] || pack wave2 "${WAVE2[@]}"
+
+NBUNDLES=$(($(wc -l < "$BUNDLES_TSV") - 1))
 TOTAL_ZIP=$(awk -F'\t' 'NR > 1 { s += $3 } END { print s + 0 }' "$BUNDLES_TSV")
 LARGEST_ZIP=$(awk -F'\t' 'NR > 1 && $3 > m { m = $3 } END { print m + 0 }' "$BUNDLES_TSV")
 
@@ -188,6 +246,8 @@ LARGEST_ZIP=$(awk -F'\t' 'NR > 1 && $3 > m { m = $3 } END { print m + 0 }' "$BUN
   echo "| Files staged | $STAGED_FILES |"
   echo "| Staged size | $(mb "$STAGED_BYTES") MB |"
   echo "| Bundles produced | $NBUNDLES |"
+  echo "| Wave 1 (parent POMs) | ${#WAVE1[@]} coordinates |"
+  echo "| Wave 2 (everything else) | ${#WAVE2[@]} coordinates |"
   echo "| Total upload size | $(mb "$TOTAL_ZIP") MB |"
   echo "| Largest bundle | $(mb "$LARGEST_ZIP") MB ($(pct "$LARGEST_ZIP" "$HARD_LIMIT")% of the ${HARD_LIMIT}-byte Portal limit) |"
   echo "| Packing target | $(mb "$MAX_BYTES") MB per bundle |"
@@ -215,6 +275,10 @@ LARGEST_ZIP=$(awk -F'\t' 'NR > 1 && $3 > m { m = $3 } END { print m + 0 }' "$BUN
   echo
   echo "A coordinate cannot be split across bundles, so any single one reaching"
   echo "$(mb "$MAX_BYTES") MB fails the release outright."
+  echo
+  echo "Wave 1 must be published to Central before wave 2 is uploaded: every"
+  echo "wave-2 bundle resolves its parent POMs from Central, not from a sibling"
+  echo "bundle."
 } > "$REPORT"
 
 echo

--- a/.github/scripts/test-central-publish.sh
+++ b/.github/scripts/test-central-publish.sh
@@ -41,6 +41,7 @@ import base64, http.server, json, os, re, sys, threading, urllib.parse
 EXPECTED = os.environ["EXPECTED_AUTH"]
 errors = []
 deploys = {}
+repo_reads = {}
 counter = [0]
 lock = threading.Lock()
 
@@ -95,6 +96,15 @@ class Handler(http.server.BaseHTTPRequestHandler):
     def do_GET(self):
         if self.path == "/_report":
             return self.send(200, json.dumps({"errors": errors, "deploys": deploys}), "application/json")
+        # Stands in for repo1.maven.org: a freshly published artifact is not
+        # readable immediately, so the first two reads 404.
+        if self.path.startswith("/repo/"):
+            with lock:
+                repo_reads[self.path] = repo_reads.get(self.path, 0) + 1
+                n = repo_reads[self.path]
+            if "never" in self.path or n <= 2:
+                return self.send(404, "not found")
+            return self.send(200, "<project/>", "text/xml")
         return self.send(404, "not found")
 
     def do_POST(self):
@@ -137,7 +147,18 @@ class Handler(http.server.BaseHTTPRequestHandler):
                 # What a proxy hiccup actually looks like: HTML, not JSON.
                 return self.send(502, "<html><body><center><h1>502 Bad Gateway</h1></center></body></html>", "text/html")
             if "fail" in name:
-                return self.send(200, json.dumps({"deploymentState": "FAILED", "errors": ["missing signature"]}), "application/json")
+                return self.send(200, json.dumps({
+                    "deploymentId": deployment_id,
+                    "deploymentState": "FAILED",
+                    "errors": {
+                        "org/finos/legend/engine/legend-engine-core/4.100.0/legend-engine-core-4.100.0.pom": [
+                            "Parent POM not found: org.finos.legend.engine:legend-engine:4.100.0",
+                        ],
+                        "org/finos/legend/engine/legend-engine-config/4.100.0/legend-engine-config-4.100.0.pom": [
+                            "Parent POM not found: org.finos.legend.engine:legend-engine:4.100.0",
+                        ],
+                    },
+                }), "application/json")
             if "hang" in name:
                 return self.send(200, json.dumps({"deploymentState": "VALIDATING"}), "application/json")
 
@@ -175,6 +196,7 @@ for _ in $(seq 1 50); do [ -s "$TMP/port" ] && break; sleep 0.1; done
 export CENTRAL_API_BASE="http://127.0.0.1:$(cat "$TMP/port")"
 export CENTRAL_POLL_INTERVAL=1
 export CENTRAL_POLL_TIMEOUT=30
+export CENTRAL_STATUS_DIR="$TMP/status"
 
 printf 'PK\x03\x04fake zip content' > "$TMP/bundle.zip"
 
@@ -209,6 +231,100 @@ if bash "$SCRIPT" await "$id3" VALIDATED > "$TMP/await4.log" 2>&1; then
 else
   echo "ok   FAILED deployment aborts"
 fi
+
+# The 4.139.1 post-mortem: the raw status JSON was echoed as one enormous line
+# and the runner dropped it, so the log said only "FAILED" and the release was
+# undiagnosable. Every validation error must appear as its own line.
+check "failure log names the failing file" \
+  "$(grep -c 'legend-engine-core-4.100.0.pom' "$TMP/await4.log")" 1
+check "failure log carries the Portal's message" \
+  "$(grep -c 'Parent POM not found' "$TMP/await4.log")" 2
+check "failure log puts each error on its own line" \
+  "$(awk 'length > 200' "$TMP/await4.log" | wc -l)" 0
+check "raw status JSON kept for post-mortem" \
+  "$([ -s "$CENTRAL_STATUS_DIR/$id3.json" ] && echo yes || echo no)" yes
+check "kept JSON is the untouched API response" \
+  "$(jq -r '.deploymentState' "$CENTRAL_STATUS_DIR/$id3.json")" FAILED
+
+# --- wave 1 must be readable on Central before wave 2 is uploaded ---------
+export CENTRAL_REPO_BASE="$CENTRAL_API_BASE/repo"
+bash "$SCRIPT" await-central legend-engine 4.100.0 > "$TMP/repo1.log" 2>&1 \
+  && echo "ok   await-central waits for the artifact to appear" \
+  || { echo "FAIL await-central never saw the artifact"; cat "$TMP/repo1.log"; fail=1; }
+check "await-central polled past the initial 404s" \
+  "$(grep -c 'not yet on Central' "$TMP/repo1.log")" 2
+
+if CENTRAL_POLL_TIMEOUT=3 bash "$SCRIPT" await-central legend-engine-never 4.100.0 \
+     > "$TMP/repo2.log" 2>&1; then
+  echo "FAIL await-central succeeded on an artifact that never appeared"; fail=1
+else
+  echo "ok   await-central times out rather than hanging"
+fi
+
+# --- cleanup ---------------------------------------------------------------
+# `drop` on a deployment still VALIDATING returns HTTP 400, which is what
+# happened to bundle 3 of the failed release. Cleanup must wait for a terminal
+# state, and must never turn a real failure into a cleanup failure.
+id7=$(bash "$SCRIPT" upload "$TMP/bundle.zip" "legend-engine-4.100.0-bundle-07")
+bash "$SCRIPT" cleanup "$id7" > "$TMP/cleanup1.log" 2>&1 \
+  && echo "ok   cleanup succeeds on a droppable deployment" \
+  || { echo "FAIL cleanup errored"; cat "$TMP/cleanup1.log"; fail=1; }
+
+bash "$SCRIPT" cleanup "$id3" > "$TMP/cleanup2.log" 2>&1 \
+  && echo "ok   cleanup succeeds on a FAILED deployment" \
+  || { echo "FAIL cleanup errored on FAILED deployment"; cat "$TMP/cleanup2.log"; fail=1; }
+
+id8=$(bash "$SCRIPT" upload "$TMP/bundle.zip" "legend-engine-4.100.0-bundle-hang-2")
+if CENTRAL_POLL_TIMEOUT=3 bash "$SCRIPT" cleanup "$id8" > "$TMP/cleanup3.log" 2>&1; then
+  echo "ok   cleanup of a stuck deployment does not fail the job"
+else
+  echo "FAIL cleanup of a stuck deployment returned non-zero"; cat "$TMP/cleanup3.log"; fail=1
+fi
+
+# --- the wave drivers the workflow calls ----------------------------------
+SCRIPTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+WORK="$TMP/work"
+mkdir -p "$WORK/central-publishing"
+export GITHUB_STEP_SUMMARY="$WORK/summary.md"
+for n in 01 02; do cp "$TMP/bundle.zip" "$WORK/central-publishing/wave2-bundle-$n.zip"; done
+cp "$TMP/bundle.zip" "$WORK/central-publishing/wave1-bundle-01.zip"
+: > "$WORK/deployment-ids.txt"
+: > "$WORK/bundle-deployments.tsv"
+
+(cd "$WORK" && bash "$SCRIPTS_DIR/upload-wave.sh" wave2 4.100.0) > "$TMP/uw.log" 2>&1 \
+  && echo "ok   upload-wave uploads a wave" \
+  || { echo "FAIL upload-wave errored"; cat "$TMP/uw.log"; fail=1; }
+check "upload-wave records one id per bundle" \
+  "$(wc -l < "$WORK/wave2-ids.txt")" 2
+check "upload-wave appends to the combined id list" \
+  "$(wc -l < "$WORK/deployment-ids.txt")" 2
+check "upload-wave names the deployment after the bundle" \
+  "$(curl -sS "$CENTRAL_API_BASE/_report" | jq -r '[.deploys[] | select(.name == "legend-engine-4.100.0-wave2-bundle-01")] | length')" 1
+
+# An empty wave would otherwise upload nothing and silently "succeed",
+# publishing a release that is missing every artifact in it.
+if (cd "$WORK" && bash "$SCRIPTS_DIR/upload-wave.sh" wave9 4.100.0) > /dev/null 2>&1; then
+  echo "FAIL upload-wave accepted a wave with no bundles"; fail=1
+else
+  echo "ok   upload-wave aborts when a wave has no bundles"
+fi
+
+# The failed release only ever reported bundle 1: the loop aborted on the first
+# failure, so the states of bundles 2 and 3 were never learned.
+idf1=$(bash "$SCRIPT" upload "$TMP/bundle.zip" "legend-engine-4.100.0-bundle-fail-a")
+idf2=$(bash "$SCRIPT" upload "$TMP/bundle.zip" "legend-engine-4.100.0-bundle-fail-b")
+printf '%s\n%s\n' "$idf1" "$idf2" > "$TMP/failing-ids.txt"
+if bash "$SCRIPTS_DIR/await-wave.sh" "$TMP/failing-ids.txt" VALIDATED > "$TMP/aw.log" 2>&1; then
+  echo "FAIL await-wave succeeded despite failing bundles"; fail=1
+else
+  echo "ok   await-wave fails when a bundle fails"
+fi
+check "await-wave reports every failing bundle, not just the first" \
+  "$(grep -c 'FAILED validation' "$TMP/aw.log")" 2
+
+bash "$SCRIPTS_DIR/await-wave.sh" "$WORK/wave2-ids.txt" VALIDATED > "$TMP/aw2.log" 2>&1 \
+  && echo "ok   await-wave succeeds when every bundle validates" \
+  || { echo "FAIL await-wave failed on healthy bundles"; cat "$TMP/aw2.log"; fail=1; }
 
 # a deployment that never validates must hit the deadline, not spin forever
 start=$SECONDS

--- a/.github/scripts/test-stage-and-split.sh
+++ b/.github/scripts/test-stage-and-split.sh
@@ -31,16 +31,27 @@ MAX=$((30 * 1000 * 1000))   # 30MB so the test runs fast
 fail=0
 check() { if [ "$2" = "$3" ]; then echo "ok   $1"; else echo "FAIL $1: expected '$3' got '$2'"; fail=1; fi; }
 
-mk() { # mk <artifact> <version> <jar-size-mb>
+pom_xml() { # pom_xml <artifact> <parent-artifact-or-empty>
+  local a=$1
+  local p=${2:-}
+  if [ -n "$p" ]; then
+    printf '<project><parent><groupId>org.finos.legend.engine</groupId><artifactId>%s</artifactId></parent><artifactId>%s</artifactId></project>' "$p" "$a"
+  else
+    printf '<project><artifactId>%s</artifactId></project>' "$a"
+  fi
+}
+
+mk() { # mk <artifact> <version> <jar-size-mb> [parent-artifact]
   # NB: separate `local` statements on purpose -- bash declares all names in a
   # single `local` before assigning, so `local a=$1 d="$M2/$a"` breaks under set -u.
   local a=$1
   local v=$2
   local mb=$3
+  local p=${4:-}
   local d="$M2/$a/$v"
   mkdir -p "$d"
   head -c $((mb * 1000 * 1000)) /dev/urandom > "$d/$a-$v.jar"
-  printf '<project><artifactId>%s</artifactId></project>' "$a" > "$d/$a-$v.pom"
+  pom_xml "$a" "$p" > "$d/$a-$v.pom"
   head -c 2000 /dev/urandom > "$d/$a-$v-sources.jar"
   head -c 2000 /dev/urandom > "$d/$a-$v-javadoc.jar"
   for f in "$d/$a-$v".*; do echo sig > "$f.asc"; done
@@ -48,13 +59,31 @@ mk() { # mk <artifact> <version> <jar-size-mb>
   printf '<metadata/>' > "$d/maven-metadata-local.xml"
 }
 
+mkagg() { # mkagg <artifact> <version> [parent-artifact] -- a pom-only aggregator
+  local a=$1
+  local v=$2
+  local p=${3:-}
+  local d="$M2/$a/$v"
+  mkdir -p "$d"
+  pom_xml "$a" "$p" > "$d/$a-$v.pom"
+  echo sig > "$d/$a-$v.pom.asc"
+  echo '{}' > "$d/_remote.repositories"
+}
+
+# The parent chain. Central validates each deployment independently and cannot
+# build an effective POM for a module whose parent is neither in the bundle nor
+# already published, so these must all land in wave 1.
+mkagg legend-engine        "$VERSION"
+mkagg legend-engine-xts    "$VERSION" legend-engine
+mkagg legend-engine-config "$VERSION" legend-engine
+
 # 12 normal modules at 8MB -> must span multiple 30MB bundles
-for i in $(seq -w 1 12); do mk "legend-engine-xt-mod$i" "$VERSION" 8; done
+for i in $(seq -w 1 12); do mk "legend-engine-xt-mod$i" "$VERSION" 8 legend-engine-xts; done
 # stale version that must be pruned
-mk legend-engine-xt-mod01 "$STALE" 8
+mk legend-engine-xt-mod01 "$STALE" 8 legend-engine-xts
 # the server module: carries a large shaded jar plus a tests jar, both of which
 # are published to Central today and must survive staging untouched
-mk legend-engine-server-http-server "$VERSION" 1
+mk legend-engine-server-http-server "$VERSION" 1 legend-engine-config
 head -c $((20 * 1000 * 1000)) /dev/urandom > "$M2/legend-engine-server-http-server/$VERSION/legend-engine-server-http-server-$VERSION-shaded.jar"
 head -c 3000 /dev/urandom > "$M2/legend-engine-server-http-server/$VERSION/legend-engine-server-http-server-$VERSION-tests.jar"
 
@@ -141,11 +170,51 @@ check "report sha256 matches the zips on disk" \
        [ "$(sha256sum "$BUNDLES/$name.zip" | cut -d' ' -f1)" = "$sha" ] || echo bad
      done | wc -l)" 0
 check "every coordinate accounted for in the report" \
-  "$(tail -n +2 "$BUNDLES/coordinates.tsv" | wc -l)" 13
+  "$(tail -n +2 "$BUNDLES/coordinates.tsv" | wc -l)" 16
 check "every coordinate assigned to exactly one bundle" \
   "$(tail -n +2 "$BUNDLES/bundle-contents.tsv" | cut -f2 | sort | uniq -d | wc -l)" 0
 check "bundle-contents covers all coordinates" \
-  "$(tail -n +2 "$BUNDLES/bundle-contents.tsv" | cut -f2 | sort -u | wc -l)" 13
+  "$(tail -n +2 "$BUNDLES/bundle-contents.tsv" | cut -f2 | sort -u | wc -l)" 16
+
+# --- two-wave split ------------------------------------------------------
+# Wave 1 carries every coordinate that is somebody's parent. Once it is on
+# Central, wave 2 can be split any way at all: each bundle resolves its
+# parents from Central rather than from a sibling bundle.
+check "wave 1 bundle produced" \
+  "$(find "$BUNDLES" -name 'wave1-bundle-*.zip' | wc -l)" 1
+nwave2=$(find "$BUNDLES" -name 'wave2-bundle-*.zip' | wc -l)
+if [ "$nwave2" -gt 1 ]; then echo "ok   wave 2 split into $nwave2 bundles"; else echo "FAIL wave 2 produced $nwave2 bundles"; fail=1; fi
+
+wave_coords() { # wave_coords <wave1|wave2>
+  awk -F'\t' -v w="$1" 'NR > 1 && $1 ~ "^"w"-bundle-" { n = split($2, p, "/"); print p[n - 1] }' \
+    "$BUNDLES/bundle-contents.tsv" | sort -u
+}
+wave_coords wave1 > "$TMP/wave1.txt"
+wave_coords wave2 > "$TMP/wave2.txt"
+
+check "wave 1 holds exactly the parent coordinates" \
+  "$(tr '\n' ' ' < "$TMP/wave1.txt")" "legend-engine legend-engine-config legend-engine-xts "
+check "wave 2 holds every remaining coordinate" \
+  "$(wc -l < "$TMP/wave2.txt")" 13
+check "no coordinate appears in both waves" \
+  "$(comm -12 "$TMP/wave1.txt" "$TMP/wave2.txt" | wc -l)" 0
+
+# The invariant the whole scheme rests on: nothing in wave 2 may depend on a
+# parent that is also in wave 2, or that bundle cannot validate on its own.
+orphans=0
+while IFS= read -r coord; do
+  pom=$(find "$STAGING" -path "*/$coord/$VERSION/*.pom" | head -1)
+  parent=$(grep -o '<parent>.*</parent>' "$pom" | grep -o '<artifactId>[^<]*' | head -1 | cut -d'>' -f2)
+  [ -n "$parent" ] || continue
+  grep -qx "$parent" "$TMP/wave1.txt" && continue
+  grep -qx "$parent" "$TMP/wave2.txt" || continue
+  echo "  $coord has parent $parent in wave 2"
+  orphans=$((orphans + 1))
+done < "$TMP/wave2.txt"
+check "no wave-2 coordinate has its parent in wave 2" "$orphans" 0
+
+check "report records the wave for every bundle" \
+  "$(tail -n +2 "$BUNDLES/bundles.tsv" | awk -F'\t' '$1 !~ /^wave[12]-bundle-/' | wc -l)" 0
 check "report header names the release version" \
   "$(grep -cF '| Release version | `'"$VERSION"'` |' "$BUNDLES/bundle-report.md")" 1
 # the server module carries the 20MB shaded jar, so it must head the table

--- a/.github/scripts/upload-wave.sh
+++ b/.github/scripts/upload-wave.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#
+# Copyright 2026 Goldman Sachs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Upload every bundle of one wave to the Central Publisher Portal.
+#
+#   upload-wave.sh <wave> <release-version>
+#
+# Reads   central-publishing/<wave>-bundle-*.zip
+# Writes  <wave>-ids.txt          deployment ids for this wave
+#         deployment-ids.txt      appended: every deployment, for cleanup
+#         bundle-deployments.tsv  appended: bundle -> size -> deployment id
+
+set -euo pipefail
+
+WAVE=${1:?usage: upload-wave.sh <wave> <release-version>}
+RELEASE_VERSION=${2:?missing release version}
+PUBLISH="$(cd "$(dirname "$0")" && pwd)/central-publish.sh"
+SUMMARY=${GITHUB_STEP_SUMMARY:-/dev/null}
+
+shopt -s nullglob
+bundles=(central-publishing/"$WAVE"-bundle-*.zip)
+
+# A wave that matches nothing would upload nothing and exit 0, and the release
+# would be declared successful with those artifacts missing from Central.
+if [ ${#bundles[@]} -eq 0 ]; then
+  echo "ERROR: no bundles matched central-publishing/$WAVE-bundle-*.zip" >&2
+  exit 1
+fi
+
+: > "$WAVE-ids.txt"
+
+for bundle in "${bundles[@]}"; do
+  base=$(basename "$bundle" .zip)
+  bytes=$(stat -c%s "$bundle")
+  echo "uploading $bundle ($bytes bytes)"
+  id=$("$PUBLISH" upload "$bundle" "legend-engine-${RELEASE_VERSION}-${base}" < /dev/null)
+  echo "$id" >> "$WAVE-ids.txt"
+  echo "$id" >> deployment-ids.txt
+  printf '%s\t%s\t%s\n' "$base.zip" "$bytes" "$id" >> bundle-deployments.tsv
+  echo "uploaded $bundle as deployment $id"
+  # shellcheck disable=SC2016  # the backticks are markdown, not a subshell
+  printf '| %s | %s MB | `%s` |\n' "$base.zip" "$((bytes / 1000000))" "$id" >> "$SUMMARY"
+done
+
+echo "uploaded ${#bundles[@]} bundle(s) for $WAVE"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -234,6 +234,10 @@ jobs:
   release:
     name: Create and Publish Release Bundle
     runs-on: ubuntu-latest
+    # Raw Portal responses land here and are uploaded with the bundle report:
+    # validation errors are far too large to survive the Actions log.
+    env:
+      CENTRAL_STATUS_DIR: ${{ github.workspace }}/central-publishing/status
     needs:
       - build
       - test
@@ -255,8 +259,14 @@ jobs:
 
       # The full artifact set is over 1.7GB, well past the Portal's 1GiB
       # per-bundle cap, which nginx rejects with a bare "413 Payload Too Large"
-      # before the API sees it. Split it, never separating a jar from its pom,
-      # signature and checksums.
+      # before the API sees it. So it ships as several bundles -- but Central
+      # validates each deployment independently and has to resolve every POM's
+      # <parent> to build an effective POM. A parent sitting in a sibling
+      # bundle is resolvable from neither, which is how 4.139.1 failed.
+      #
+      # Hence two waves. Wave 1 is every coordinate that is somebody's parent
+      # (a few hundred KB of aggregator POMs) and is published first; wave 2 is
+      # everything else and resolves its parents from Central.
       - name: Stage and split bundles
         env:
           RELEASE_VERSION: ${{ github.event.inputs.releaseVersion }}
@@ -264,11 +274,6 @@ jobs:
           .github/scripts/stage-and-split.sh \
             ~/.m2/repository/org/finos/legend/engine "$RELEASE_VERSION" "$PWD"
           cat central-publishing/bundle-report.md >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Upload bundles to Central
-        env:
-          RELEASE_VERSION: ${{ github.event.inputs.releaseVersion }}
-        run: |
           : > deployment-ids.txt
           : > bundle-deployments.tsv
           {
@@ -278,21 +283,70 @@ jobs:
             echo "| Bundle | Upload size | Deployment ID |"
             echo "|---|---:|---|"
           } >> "$GITHUB_STEP_SUMMARY"
-          for bundle in central-publishing/central-bundle-*.zip; do
-            suffix=$(basename "$bundle" .zip | sed 's/^central-bundle-//')
-            bytes=$(stat -c%s "$bundle")
-            echo "uploading $bundle ($bytes bytes)"
-            id=$(.github/scripts/central-publish.sh upload "$bundle" \
-                   "legend-engine-${RELEASE_VERSION}-central-bundle-${suffix}")
-            echo "$id" >> deployment-ids.txt
-            printf '%s\t%s\t%s\n' "$(basename "$bundle")" "$bytes" "$id" >> bundle-deployments.tsv
-            echo "uploaded $bundle as deployment $id"
-            printf '| %s | %s MB | `%s` |\n' \
-              "$(basename "$bundle")" "$((bytes / 1000000))" "$id" >> "$GITHUB_STEP_SUMMARY"
-          done
 
-      # Kept even when the release fails: the sizes and the bundle-to-deployment
-      # mapping are exactly what a post-mortem needs, and the runner is gone.
+      - name: Upload wave 1 (parent POMs)
+        env:
+          RELEASE_VERSION: ${{ github.event.inputs.releaseVersion }}
+        run: .github/scripts/upload-wave.sh wave1 "$RELEASE_VERSION"
+
+      - name: Validate wave 1
+        run: .github/scripts/await-wave.sh wave1-ids.txt VALIDATED
+
+      # Wave 2 cannot validate until these are resolvable, so a dry run stops
+      # here: there is no way to rehearse wave 2 without really publishing
+      # wave 1, and Central is immutable.
+      - name: Publish wave 1
+        if: ${{ github.event.inputs.dryRun != 'true' }}
+        run: |
+          while read -r id; do
+            .github/scripts/central-publish.sh publish "$id" < /dev/null
+          done < wave1-ids.txt
+          .github/scripts/await-wave.sh wave1-ids.txt PUBLISHED
+
+      # Reaching PUBLISHED on the Portal is not the same as being readable on
+      # repo1, and it is the read side that wave 2's validation resolves against.
+      - name: Wait for wave 1 to be readable on Central
+        if: ${{ github.event.inputs.dryRun != 'true' }}
+        env:
+          RELEASE_VERSION: ${{ github.event.inputs.releaseVersion }}
+        run: |
+          awk -F'\t' '$1 ~ /^wave1-bundle-/ { n = split($2, p, "/"); print p[n - 1] }' \
+            central-publishing/bundle-contents.tsv | sort -u > wave1-coords.txt
+          echo "waiting for $(wc -l < wave1-coords.txt) parent coordinates"
+          while read -r artifact; do
+            .github/scripts/central-publish.sh await-central "$artifact" "$RELEASE_VERSION" < /dev/null
+          done < wave1-coords.txt
+
+      - name: Upload wave 2
+        if: ${{ github.event.inputs.dryRun != 'true' }}
+        env:
+          RELEASE_VERSION: ${{ github.event.inputs.releaseVersion }}
+        run: .github/scripts/upload-wave.sh wave2 "$RELEASE_VERSION"
+
+      # Every wave-2 bundle must validate before any is published: publishing
+      # bundle 1 and then finding bundle 3 invalid leaves a partial release,
+      # and nothing on Central can be changed or withdrawn.
+      - name: Validate wave 2
+        if: ${{ github.event.inputs.dryRun != 'true' }}
+        run: .github/scripts/await-wave.sh wave2-ids.txt VALIDATED
+
+      - name: Publish wave 2
+        if: ${{ github.event.inputs.dryRun != 'true' }}
+        run: |
+          while read -r id; do
+            .github/scripts/central-publish.sh publish "$id" < /dev/null
+          done < wave2-ids.txt
+          .github/scripts/await-wave.sh wave2-ids.txt PUBLISHED
+
+      - name: Note that a dry run stops after wave 1
+        if: ${{ github.event.inputs.dryRun == 'true' }}
+        run: |
+          echo "Dry run: wave 1 validated and will be dropped. Wave 2 was not"
+          echo "uploaded -- it can only validate once wave 1 is really published."
+
+      # Kept even when the release fails: sizes, the bundle-to-deployment
+      # mapping and the raw Portal responses are exactly what a post-mortem
+      # needs, and the runner is gone by then.
       - name: Upload bundle size report
         if: always()
         uses: actions/upload-artifact@v7
@@ -301,43 +355,15 @@ jobs:
           path: |
             central-publishing/bundle-report.md
             central-publishing/*.tsv
+            central-publishing/status/*.json
             bundle-deployments.tsv
           retention-days: 30
           if-no-files-found: warn
 
-      # Every bundle must validate before any of them is published. Publishing
-      # bundle 1 and then discovering bundle 5 is invalid leaves a partial
-      # release on Central, and Central is immutable.
-      - name: Wait for all bundles to validate
-        run: |
-          while read -r id; do
-            .github/scripts/central-publish.sh await "$id" VALIDATED < /dev/null
-          done < deployment-ids.txt
-
-      - name: Publish all bundles
-        if: ${{ github.event.inputs.dryRun != 'true' }}
-        run: |
-          while read -r id; do
-            .github/scripts/central-publish.sh publish "$id" < /dev/null
-          done < deployment-ids.txt
-          while read -r id; do
-            .github/scripts/central-publish.sh await "$id" PUBLISHED < /dev/null
-          done < deployment-ids.txt
-
       - name: Drop unpublished deployments
         if: ${{ always() && (failure() || cancelled() || github.event.inputs.dryRun == 'true') }}
         run: |
-          [ -f deployment-ids.txt ] || exit 0
+          [ -s deployment-ids.txt ] || exit 0
           while read -r id; do
-            state=$(.github/scripts/central-publish.sh state "$id" < /dev/null)
-            case "$state" in
-              VALIDATED|PENDING|VALIDATING)
-                .github/scripts/central-publish.sh drop "$id" < /dev/null
-                ;;
-              *)
-                # FAILED deployments are left in place on purpose: Sonatype
-                # support needs their files to diagnose the failure.
-                echo "leaving deployment $id in state $state"
-                ;;
-            esac
+            .github/scripts/central-publish.sh cleanup "$id" < /dev/null
           done < deployment-ids.txt


### PR DESCRIPTION
# Publish the release to Central in two waves so bundles can validate

Follows [#5051](https://github.com/finos/legend-engine/pull/5051) and
[#5055](https://github.com/finos/legend-engine/pull/5055).

## Problem

The 4.139.1 release ([run 31373520942](https://github.com/finos/legend-engine/actions/runs/31373520942/job/93429667218))
uploaded cleanly — the split fixed the `413`, all three bundles reached the
Portal — and then **every bundle failed validation**:

```
deployment 4f696ef5… is VALIDATING
ERROR: deployment 4f696ef5… FAILED            ← bundle 01
leaving deployment 353d0c9a… in state FAILED  ← bundle 02
warning: could not drop deployment ec0d3b17… (HTTP 400)  ← bundle 03, still VALIDATING
```

Central validates each deployment **independently** and builds an effective POM
for every artifact, which requires resolving its `<parent>`. `stage-and-split.sh`
packed coordinates in sorted directory order, blind to parent relationships, so
a module could land in bundle 1 while its parent sat in bundle 3. That parent is
in neither the bundle nor on Central — 4.139.1 is a new version — so it cannot
be resolved and the whole deployment fails.

Cross-referencing `bundle-contents.tsv` from the failed run against the parent
graph of all 602 POMs at tag `legend-engine-4.139.1`:

| Bundle | Coordinates | Parent in a *different* bundle | Portal result |
|---|---:|---:|---|
| 01 | 142 | **19** | FAILED |
| 02 | 62 | **57** | FAILED |
| 03 | 397 | **0** | not failed |

Bundle 03 happens to contain the root POM and every `-xts-*` aggregator, because
they sort last. Sonatype's own plugin documentation states the constraint
directly: *"the parent pom is needed to resolve the bundle artifacts that point
to the parent pom."*

## Approach

**A parent-closed partition is not constructible here.** Every module's ancestor
chain terminates at the single root POM, so any parent-closed split would have to
duplicate that POM into every bundle — and Central rejects republishing a
coordinate. Better packing cannot fix this.

**Size is not what is still broken.** The per-bundle cap was already satisfied:
261 / 895 / 542 MB, all under 1 GiB, all uploaded successfully. Only independent
validation was broken.

So the release goes out in two waves:

| | Coordinates | Size |
|---|---:|---:|
| **Wave 1** — every coordinate that is somebody's parent | 115 | **0.5 MB** |
| **Wave 2** — everything else | 486 | 1892.3 MB |

Wave 1 is published first. Once it is readable on `repo1`, every wave-2 bundle
resolves its parents from Central rather than from a sibling bundle, and wave 2
splits arbitrarily — unchanged at 3 bundles, largest 83.4% of the cap.

**Nothing is removed from Central and no coordinate changes**, so there is no
downstream impact and no consumer coordination needed.

Also checked: `<scope>import</scope>` BOMs must resolve to build an effective POM
too, but all five in the repo are third-party (`libraries-bom`,
`opentelemetry-bom`, `testcontainers-bom`, `awssdk bom`, `netty-bom`) and already
on Central. Parents are the only cross-bundle constraint.

### Alternative considered and rejected

Excluding `legend-engine-server-http-server:shaded` (971.6 MB, **51.3%** of the
release) would bring the whole release to ~826 MB — one bundle, no waves. It is
a real option and remains a follow-up, but it is a breaking change for consumers
resolving that classifier (`finos/pylegend` downloads it from `repo1` by direct
URL), so it should not be bundled into an urgent release fix.

## Changes

### `stage-and-split.sh` — wave partitioning

Scans every staged `.pom` for `<parent><artifactId>`; any coordinate that is
somebody's parent goes to wave 1. Bundles are named `wave1-bundle-NN.zip` /
`wave2-bundle-NN.zip` and the report carries the wave breakdown.

Refuses to run if wave 1 comes out empty while there is more than one
coordinate — that means the parent scan broke, and splitting on that basis
would reproduce exactly the failure this change exists to prevent.

### `central-publish.sh` — two new commands, and readable failures

| | |
|---|---|
| `await-central <artifactId> <version>` | Polls `repo1` until the POM is readable. Reaching `PUBLISHED` on the Portal is **not** the same as being resolvable on the read side, and it is the read side that wave 2's validation resolves against. |
| `cleanup <id>` | Waits for a terminal state before dropping. `drop` returns HTTP 400 while a deployment is still validating, which is why bundle 03 was left behind. Never returns non-zero: it runs in a failure handler and must not mask the original error. |

**The failure diagnostics are the other half of this PR.** The old code did
`echo "$response" >&2` — the entire status JSON on one line. For a 2,898-file
bundle that is megabytes, and the runner dropped it: the log for the failed run
contains no `deploymentState`, no `errors`, nothing. The release was
undiagnosable from its own log. Errors now print one per line (capped at 200,
with a count of the remainder) and the raw response is written to
`CENTRAL_STATUS_DIR` and uploaded with the bundle report.

### `upload-wave.sh`, `await-wave.sh` — new

The workflow's two loops, extracted so they can be tested.

- `upload-wave` **aborts when a wave's glob matches nothing**, rather than
  uploading nothing, exiting 0, and declaring a release successful with those
  artifacts missing from Central.
- `await-wave` awaits **every** deployment even after one fails, then exits
  non-zero. The old loop ran under `bash -e` and aborted on the first failure,
  so bundle 03's outcome was never learned and the post-mortem had a third of
  the evidence it needed.

### `release.yml` — sequencing

upload wave 1 → validate → publish → wait for readability on `repo1` → upload
wave 2 → validate all → publish all. Failure and cancellation route through
`cleanup`.

## Verification

| | |
|---|---|
| `test-stage-and-split.sh` | **36 assertions, ALL PASS** — offline, synthetic repository, seconds |
| `test-central-publish.sh` | **34 assertions, ALL PASS** — drives the script against a local mock of the Portal API, no credentials, no network |
| `shellcheck` | clean on all four production scripts |

12 assertions are new, each watched fail before the code was written. The
load-bearing ones:

- **`no wave-2 coordinate has its parent in wave 2`** — the invariant the whole
  scheme rests on. Checked by re-reading the staged POMs, not by trusting the
  splitter's own bookkeeping.
- **`failure log carries the Portal's message`** — asserts 2 lines, which is
  precisely what the old one-line-JSON code got wrong (it produced 1). The mock
  returns a realistic `errors` object keyed by file.
- **`await-wave reports every failing bundle, not just the first`**
- **`cleanup of a stuck deployment does not fail the job`**
- **`upload-wave aborts when a wave has no bundles`**

The pre-existing `bundles cover every staged file exactly once` check now spans
both waves, so nothing can be silently dropped in the partition.

Parent extraction was also validated against real published POMs from
`repo1.maven.org`: `legend-engine-server-http-server-4.138.2.pom` →
`legend-engine-server`, and the root `legend-engine-4.138.2.pom` → `finos`
(outside the group, correctly ignored).

## Behaviour change reviewers should know about

**`dryRun` now stops after wave 1.** It validates and drops wave 1 and does not
upload wave 2 at all. This is inherent rather than an oversight: wave 2 cannot
validate until wave 1 is genuinely published, and Central is immutable, so there
is nothing to rehearse. The workflow says so explicitly in a step.

**The release is no longer strictly all-or-nothing.** If wave 2 fails after
wave 1 published, 4.139.x has 115 parent POMs on Central with no modules under
them. They are inert — nothing resolves them, nothing breaks, and the next
release is unaffected. That is a far smaller blast radius than half the modules
publishing, which is what the previous design risked.

## Follow-ups, not in this PR

**The shaded jar is still the deadline.** `legend-engine-server-http-server` is
a single **971.6 MB** coordinate — **97.2%** of the packing target and of the
per-artifact 1 GiB ceiling. A coordinate cannot be split across bundles, so once
it crosses, *no* bundling strategy works. Two waves buys time; it is not a fix.
The options are to shrink it, publish it as a GitHub Release asset instead of a
Maven classifier (with a PR to `finos/pylegend`, the one consumer that resolves
it from Central), or request an exemption from central-support@sonatype.com.

**Stop bundling from `~/.m2` at all** — unchanged from #5051; the `build` job
runs `install`, not `deploy`, so the bundle is the whole local-repo subtree
rather than the deployable set.

**`stage-and-split.sh` requires an absolute output directory.** It `cd`s into
the staging directory and then reuses `$STAGING`. Pre-existing; the workflow
passes `$PWD` and the tests pass absolute paths, so nothing is broken today.

## Reviewing this

```bash
bash .github/scripts/test-stage-and-split.sh   # expect ALL PASS, offline, seconds
bash .github/scripts/test-central-publish.sh   # expect ALL PASS, no network
```

To see the real wave split without a fresh build, against any local `~/.m2`
containing a built version:

```bash
.github/scripts/stage-and-split.sh ~/.m2/repository/org/finos/legend/engine <version> "$PWD/out"
cat out/central-publishing/bundle-report.md
awk -F'\t' '$1 ~ /^wave1-bundle-/ { n = split($2, p, "/"); print p[n-1] }' \
  out/central-publishing/bundle-contents.tsv | sort -u | wc -l   # parent coordinates
```
