### PR TITLE
M2M: Exclude qualified properties from source tree back-edge candidates

### DIFF
--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/graphFetch/graphExtension.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/graphFetch/graphExtension.pure
@@ -572,10 +572,14 @@ function <<access.private>> meta::pure::graphFetch::enrichSourceTreeNodeForPrope
          // the current owner: during union/operation processing the algorithm dispatches
          // one branch's set impl into a sibling subtree, where srcClass != owner is the
          // normal cross-branch shape and the legacy fallback's empty output is correct.
+         // Exclude qualified properties: they are functions (potentially with parameters),
+         // not stored slots, so they must never be synthesized into the source tree as
+         // back-edges - the query/mapping never asked for them and downstream serialize
+         // code generation would call them with no arguments.
          let childProperties = $owner->meta::pure::functions::meta::allNestedProperties()
-                                       ->filter(p | let pt = $p->functionReturnType();
-                                                    $pt.rawType->isNotEmpty()
-                                                    && $pt.rawType->toOne()->instanceOf(Class););
+                                       ->filter(p | !$p->instanceOf(QualifiedProperty)
+                                                    && $p->functionReturnType().rawType->isNotEmpty()
+                                                    && $p->functionReturnType().rawType->toOne()->instanceOf(Class));
          let childPropertiesMap = $childProperties->groupBy(p | $p.genericType.rawType->toOne());
          let propertyTreesBelongingToOwner = meta::pure::graphFetch::findSubTreeWithOwnerOrPropertyTreesFromOwner($inlinedPropertyTree, $owner, $childPropertiesMap);
          let treeClasses = $inlinedPropertyTree->meta::pure::graphFetch::collectPropertyTreeClasses()->removeDuplicates();

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/graphFetch/tests/sourceTreeCalc/testSourceTreeCalc.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/graphFetch/tests/sourceTreeCalc/testSourceTreeCalc.pure
@@ -3008,6 +3008,96 @@ Mapping meta::pure::graphFetch::tests::sourceTreeCalc::intermediateAssoc::CEAsso
 )
 
 ###Pure
+import meta::pure::graphFetch::tests::sourceTreeCalc::intermediateQualified::*;
+import meta::pure::graphFetch::*;
+import meta::pure::graphFetch::routing::*;
+
+// Regression: the intermediate back-edge machinery (calculateSourceTree ->
+// buildPropertyPathUptoOwner) builds its candidate map from allNestedProperties(),
+// which includes qualified properties. A qualified property that takes a parameter
+// must never be synthesized into the source tree - it is not present in the query
+// or the mapping, and downstream Java serialize generation would call it with no
+// arguments. Here QCompanyEmployee.aBetterEmployee(String[1]) returns the same
+// class as the real back-edge property `employee` and sorts alphabetically before
+// it, so pickIntermediateProperty selects it if qualified properties are not
+// filtered out.
+Class meta::pure::graphFetch::tests::sourceTreeCalc::intermediateQualified::QPerson
+{
+  firstName : String[1];
+  lastName  : String[1];
+}
+
+Class meta::pure::graphFetch::tests::sourceTreeCalc::intermediateQualified::QAddress
+{
+  street : String[1];
+  zip    : String[1];
+}
+
+Association meta::pure::graphFetch::tests::sourceTreeCalc::intermediateQualified::QPerson_QAddress
+{
+  resident : meta::pure::graphFetch::tests::sourceTreeCalc::intermediateQualified::QPerson[1];
+  address  : meta::pure::graphFetch::tests::sourceTreeCalc::intermediateQualified::QAddress[0..1];
+}
+
+Class meta::pure::graphFetch::tests::sourceTreeCalc::intermediateQualified::QCompanyEmployee
+{
+  employee : QPerson[1];
+
+  aBetterEmployee(suffix : String[1])
+  {
+    $this.employee
+  } : QPerson[1];
+}
+
+Class meta::pure::graphFetch::tests::sourceTreeCalc::intermediateQualified::QCompanyEmployeeIntermediate
+{
+  ce : QCompanyEmployee[1];
+  person : QPerson[1];
+}
+
+Class meta::pure::graphFetch::tests::sourceTreeCalc::intermediateQualified::QCompanyEmployeeTarget
+{
+  employeeStreet : String[1];
+}
+
+function meta::pure::graphFetch::tests::sourceTreeCalc::intermediateQualified::qwrap(ce:QCompanyEmployee[1]) : QCompanyEmployeeIntermediate[*]
+{
+  ^QCompanyEmployeeIntermediate(ce = $ce, person = $ce.employee)
+}
+
+function <<test.Test>>
+  meta::pure::graphFetch::tests::sourceTreeCalc::intermediateQualified::testIntermediateBackEdgeIgnoresQualifiedProperties():Boolean[1]
+{
+  let tree = #{QCompanyEmployeeTarget {employeeStreet}}#;
+  let sourceTree = meta::pure::graphFetch::calculateSourceTree(
+                      $tree,
+                      meta::pure::graphFetch::tests::sourceTreeCalc::intermediateQualified::QualifiedBackEdgeMapping,
+                      meta::pure::extension::defaultExtensions());
+
+  let expected = #{
+    QCompanyEmployee
+    {
+      employee
+      {
+        address { street }
+      }
+    }
+  }#;
+  assertEquals($expected->meta::pure::graphFetch::sortTree()->meta::pure::graphFetch::treeToString(),
+               $sourceTree->meta::pure::graphFetch::sortTree()->meta::pure::graphFetch::treeToString());
+}
+
+###Mapping
+Mapping meta::pure::graphFetch::tests::sourceTreeCalc::intermediateQualified::QualifiedBackEdgeMapping
+(
+  *meta::pure::graphFetch::tests::sourceTreeCalc::intermediateQualified::QCompanyEmployeeTarget : Pure
+  {
+    ~src meta::pure::graphFetch::tests::sourceTreeCalc::intermediateQualified::QCompanyEmployee
+    employeeStreet : $src->meta::pure::graphFetch::tests::sourceTreeCalc::intermediateQualified::qwrap().person.address.street->toOne()
+  }
+)
+
+###Pure
 import meta::pure::graphFetch::tests::sourceTreeCalc::collide::*;
 import meta::pure::graphFetch::*;
 import meta::pure::graphFetch::routing::*;


### PR DESCRIPTION
#### What type of PR is this?

  Bug Fix

  #### What does this PR do / why is it needed ?

  `calculateSourceTree`'s intermediate-object handling (introduced in #4996) builds its
  back-edge candidate map from `allNestedProperties()`, which includes qualified
  properties. When a mapping wraps its source in an intermediate class, a qualified
  property could be picked as the synthesized back-edge and appear in the calculated
  source tree — even though it is referenced nowhere in the query or the mapping.

  For a qualified property that takes parameters, this breaks execution: the generated
  serialize code calls the property with no arguments.

  Example — given a source class with both a stored property and a parameterized
  qualified property returning the same class:
  qualified property returning the same class:

  Class QCompanyEmployee
  {
    employee : QPerson[1];
    aBetterEmployee(suffix : String[1]) { $this.employee } : QPerson[1];
  }

  the source tree for a mapping routed through an intermediate came out as

  QCompanyEmployee ( aBetterEmployee() ( address ( street ) ) )   // broken

  instead of

  QCompanyEmployee ( employee ( address ( street ) ) )

  The fix filters `QualifiedProperty` out of the back-edge candidate map in
  `graphExtension.pure`: qualified properties are functions, not stored slots, so they
  must never be synthesized into a source tree the query/mapping did not ask for.

  Adds a regression test (`testIntermediateBackEdgeIgnoresQualifiedProperties`) where
  the qualified property returns the same class as the real back-edge property and
  sorts alphabetically before it, so it would win candidate selection without the
  filter. Full `legend-engine-pure-code-compiled-core` suite passes (1206 tests).

  #### Which issue(s) this PR fixes:

  Fixes #

  #### Other notes for reviewers:

  - The sibling `allNestedProperties()` call feeding the unreachable-owner diagnostic
    (`ownerClassTypedReturnTypes`) intentionally still includes qualified properties:
    it only influences when the diagnostic assert stays inert, never the tree content,
    and keeping them there keeps the diagnostic conservative.

  #### Does this PR introduce a user-facing change?

  No — fixes incorrect source trees (and consequent Java generation failures) for M2M
  mappings with intermediate objects when the source model declares parameterized
  qualified properties.
