### PR TITLE
Document every PCT function in legend-engine

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -325,6 +325,20 @@ jobs:
           name: test-results-${{ matrix.name }}
           path: ${{ github.workspace }}/surefire-reports-aggregate/*.xml
 
+      - name: Stage SQL Parity Report
+        if: ${{ matrix.name == 'sql' }}
+        shell: bash
+        run: |
+          mkdir -p ${GITHUB_WORKSPACE}/sql-parity
+          cp -v legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/target/*.html ${GITHUB_WORKSPACE}/sql-parity/
+
+      - name: Upload SQL Parity Report
+        if: ${{ matrix.name == 'sql' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: sql-parity-report
+          path: ${{ github.workspace }}/sql-parity/*.html
+
   benchmark:
     name: Pipeline Benchmark
     runs-on: ubuntu-latest
@@ -480,6 +494,41 @@ jobs:
           name: pct-html-report
           path: target/ok.html
 
+      - name: Upload PCT Report
+        uses: actions/upload-artifact@v7
+        with:
+          name: pct-report
+          path: target/pct
+
+  legend-docs:
+    name: Update Legend Docs
+    runs-on: ubuntu-latest
+    if: "!cancelled() && needs.pct-report.result == 'success' && github.ref == 'refs/heads/master'"
+    needs:
+      - pct-report
+    steps:
+      # This job carries no build setup, so it configures the commit identity that before-test
+      # would otherwise have set.
+      - name: Configure git
+        shell: bash
+        run: |
+          git config --global committer.email "infra@finos.org"
+          git config --global committer.name "FINOS Admin"
+          git config --global author.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          git config --global author.name "${GITHUB_ACTOR}"
+
+      - name: Download PCT Report
+        uses: actions/download-artifact@v8
+        with:
+          name: pct-report
+          path: pct
+
+      - name: Download SQL Parity Report
+        uses: actions/download-artifact@v8
+        with:
+          name: sql-parity-report
+          path: sql-parity
+
       - name: Checkout Legend Docs
         uses: actions/checkout@v6
         with:
@@ -494,7 +543,15 @@ jobs:
         shell: bash
         run: |
           mkdir -p legend-docs/website/static/pct/
-          cp -rvT target/pct/. legend-docs/website/static/pct/
+          cp -rvT pct/. legend-docs/website/static/pct/
+          mkdir -p legend-docs/website/static/sql-parity/
+          cp -rvT sql-parity/. legend-docs/website/static/sql-parity/
+          cat > legend-docs/website/static/sql-parity/git-info.json <<EOF
+          {
+            "git.commit.id": "${{ github.sha }}",
+            "git.build.time": "$(date -u +%Y-%m-%dT%H:%M:%S%z)"
+          }
+          EOF
 
       - name: Check for new documentation files
         id: newFiles

--- a/docs/pct/composition-tests.md
+++ b/docs/pct/composition-tests.md
@@ -1,0 +1,410 @@
+# PCT composition tests
+
+Most PCT tests exercise **one** function. A handful exercise the way functions behave **together**,
+and those live in dedicated `composition.pure` files. This page is the reference for them, because —
+as [Why they are not in the function reference](#why-they-are-not-in-the-function-reference)
+explains — they are the one category of PCT test that the generated function documentation cannot
+show you.
+
+- [Why composition tests exist](#why-composition-tests-exist)
+- [Where they live](#where-they-live)
+- [Why they are not in the function reference](#why-they-are-not-in-the-function-reference)
+- [Anatomy of a composition test](#anatomy-of-a-composition-test)
+- [The relation suite by theme](#the-relation-suite-by-theme)
+  - [Operator order](#1-operator-order)
+  - [Which SQL clause a filter becomes](#2-which-sql-clause-a-filter-becomes)
+  - [Pivot and cast](#3-pivot-and-cast)
+  - [Window compositions](#4-window-compositions)
+  - [Null semantics](#5-null-semantics)
+  - [Variant columns](#6-variant-columns)
+  - [Identifiers and aliases](#7-identifiers-and-aliases)
+  - [Expression shapes](#8-expression-shapes)
+- [The variant suite](#the-variant-suite)
+- [The stale `TO FIX` banner](#the-stale-to-fix-banner)
+- [Portability](#portability)
+- [Adding a composition test](#adding-a-composition-test)
+
+## Why composition tests exist
+
+A store passes a per-function PCT test by implementing that function correctly in isolation. That is
+not enough. Relational execution translates a **whole expression tree** into one SQL statement, and
+the translation decisions are contextual:
+
+- `filter` becomes `WHERE`, `HAVING`, or `QUALIFY` depending on what precedes it and what it
+  references.
+- `pivot` produces a column set that is not known until the data is read, which changes the type of
+  everything downstream.
+- A window aggregate and a filter can commute or not, depending on which columns the filter touches.
+- Two adjacent operations may collapse into one `SELECT`, or force a sub-select or a CTE.
+
+Every one of those is a property of the *pair*, not of either function. `groupBy` and `filter` can
+both be perfect on their own and still produce wrong SQL when adjacent. Composition tests pin down
+the pair.
+
+## Where they live
+
+| File | Tests |
+|---|---|
+| `core_functions_relation/relation/tests/composition.pure` | 72 |
+| `core_functions_variant/functions/tests/composition.pure` | 21 |
+
+Two other files carry the same name but are not PCT suites:
+`core_external_query_sql_reverse_pct/relation/composition.pure` records the expected results of
+**reverse** (Pure → SQL → Pure) translation for the relation suite, and the pandas reverse-PCT
+module holds an equivalent list. When you add or rename a composition test, those files may need the
+matching entry.
+
+## Why they are not in the function reference
+
+PCT tests are attached to a function **by source file**. `FunctionsGeneration.addPCTTestToFunctionsDB`
+looks up a `FunctionDefinition` keyed on the test's `sourceId`; that map is populated only from
+`<<PCT.function>>` declarations. A `composition.pure` declares none, so the lookup misses and the
+test is discarded — along with any documentation on it:
+
+```java
+FunctionDefinition functionInfo = functionsDB.get(_function.getSourceInformation().getSourceId());
+// FunctionDefinition can be null if the PCT Tests are meant to test functions composition.
+// Documentation on such a test is dropped here, just as its count is.
+if (functionInfo != null)
+```
+
+That comment was added by legend-pure's own documentation pass (finos/legend-pure#1305), so this is
+a known and accepted gap rather than a bug in our wiring. The effect is visible in the generated
+report: `FUNCTIONS_relation.json` contains 46 `functionDefinitions` and **no entry** for
+`composition.pure`, and none of the 72 test names appear anywhere in it.
+
+Two practical consequences:
+
+1. **A `'''…'''` literal on a composition test does not publish.** Every test in both files carries
+   one, and each parses and lands as a `doc.doc` tagged value that Pure can query and that a reader
+   of the source sees immediately — but none of them reach the generated function documentation.
+   Until the drop is fixed upstream, the literal is for people reading the `.pure` file and this page
+   is for everything cross-cutting: the themes below, the shared conventions, the divergences.
+2. **Coverage percentages exclude these tests.** An adapter that fails every composition test still
+   reports full coverage of `filter`, `groupBy` and `pivot`.
+
+## Anatomy of a composition test
+
+```pure
+'''
+The filter runs against the narrowed relation, so it may only name columns that `distinct` kept.
+'''
+function <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.aggregation>>
+meta::pure::functions::relation::tests::composition::test_Distinct_Filter<T|m>(
+    f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {
+               | #TDS
+                  val, str, str2
+                  2, a, b
+                  3, a, b
+                #->distinct(~[val, str])->filter(x|$x.val > 2)
+              };
+
+    let res =  $f->eval($expr);
+
+    assertEquals( '#TDS\n'+
+                  '   val,str\n'+
+                  '   3,a\n'+
+                  '#', $res->sort(~val->ascending())->toString());
+}
+```
+
+- **The `'''…'''` literal** says what the test pins down, in a sentence or two — not what it does,
+  which the body already shows. See [Why they are not in the function
+  reference](#why-they-are-not-in-the-function-reference) for where it does and does not surface.
+- **`f` is the adapter.** Each store supplies an evaluator; the test hands it the *unevaluated*
+  lambda `$expr` so every store gets the identical expression tree and translates it its own way.
+  This is why the pipeline is built inside `{| … }` rather than executed directly.
+- **`#TDS … #` is the source relation**, written inline. Columns are untyped unless annotated
+  (`payload:meta::pure::metamodel::variant::Variant`, `fromDate:Date[1]`), and `null` is a literal.
+- **`->sort(…)` before `->toString()`** is a convention, not part of what is being tested: row order
+  out of a relational store is not guaranteed, so the assertion sorts first. A test that omits the
+  sort is asserting that the pipeline itself determines the order.
+- **`assertTdsEquivalent(expected, actual, tolerance)`** replaces `assertEquals` where floats or
+  dates are involved; the trailing numbers are tolerances.
+- **Qualifier stereotypes** (`PCTRelationQualifier.relation` / `.aggregation` / `.olap`,
+  `PCTCoreQualifier.variant`) classify the test by feature area and are carried into the PCT report.
+
+## The relation suite by theme
+
+### 1. Operator order
+
+The suite is deliberately a matrix: the same two or three operators in each order, so a routing bug
+that only shows up in one arrangement is caught.
+
+| Test | Pipeline | What it pins down |
+|---|---|---|
+| `test_Distinct_GroupBy` | `distinct` → `groupBy` | Deduplication happens before aggregation, so the sums differ from the reverse order |
+| `test_GroupBy_Distinct` | `groupBy` → `distinct` | `distinct` on a subset of the grouped keys collapses the aggregate away |
+| `test_GroupBy_GroupBy` | `groupBy` → `groupBy` | An aggregate column can itself be aggregated |
+| `test_Distinct_Filter` | `distinct` → `filter` | |
+| `testProjectDistinct` | `project` → `distinct` | `distinct` sees the *projected* values — two rows differing only in case collapse once `toLower` is applied |
+| `test_Extend_GroupBy_Project` / `test_Extend_GroupBy_Extend_Select` | | Renaming a `groupBy` result two ways — via `project`, and via `extend`+`select` |
+| `test_Extend_Sort_Project` / `test_Extend_Sort_Extend_Select` | | The same pairing after a `sort` instead |
+| `testExtendFilter` | `extend` → `filter` | A filter may reference a column that `extend` just created |
+| `testFilterPostProject` | `project` → `filter` | Filtering a projection built from class instances rather than a `#TDS` |
+| `testProjectJoinWithProjectProject` | `project` → `join` → `project` | Projections either side of a join, re-projected |
+
+### 2. Which SQL clause a filter becomes
+
+Where a `filter` sits, and which columns it names, decides what it compiles to. Two tests say so in
+their own `doc.doc`:
+
+| Test | Filter references | Recorded intent |
+|---|---|---|
+| `testExtendWindowFilter` | a window (`over`) output column | *"Qualify grammar should be produced instead of subselect."* |
+| `testGroupByFilterExtendFilter` | a `groupBy` output **and** a window output, in one pipeline | *"Produces qualify and having grammar together."* |
+
+`test_GroupBy_Filter` is the minimal version of the first half — `groupBy` then a filter on the
+aggregate column, nothing else — and `test_GroupBy_Distinct_Filter` and `test_Distinct_GroupBy_Filter`
+add a `distinct` on either side of the aggregation.
+
+`testExtendFilterOutNull` is the case that goes the other way, and it is the surprising one — see
+[Null semantics](#5-null-semantics).
+
+### 3. Pivot and cast
+
+**Every `pivot` in the suite is followed by `->cast(@Relation<(…)>)`.** This is not decoration.
+`pivot` turns row values into columns, so its output type depends on the data and cannot be inferred
+at compile time; the `cast` is how you tell the compiler what the shape will be, and without it
+nothing downstream can reference a column.
+
+The generated column name is `<pivoted value>__|__<aggregate column>`, and **the name itself
+contains quote characters**, which is why the cast has to double them up:
+
+```pure
+->pivot(~[year], ~['newCol' : x | $x.treePlanted : y | $y->plus()])
+->cast(@Relation<(city:String, country:String, '\'2011__|__newCol\'':Integer)>)
+```
+
+`test_Extend_Filter_Select_ComplexGroupBy_Pivot` produces columns named `2011`, `4022` and `6035`,
+which looks like corruption and is not. The pipeline groups by city and country while **summing the
+year column**, so SAN's two 2011 rows become `4022` and NYC's `2011 + 2012 + 2012` becomes `6035`.
+Those sums are then the values that get pivoted into column names. The test is checking that pivot
+handles a computed pivot column; the arithmetic is incidental.
+
+| Test | Shape |
+|---|---|
+| `test_Pivot_Filter` | Dynamic pivot, then filter on a pass-through column |
+| `test_Extend_Filter_Select_ComplexGroupBy_Pivot` | The summed-year case above |
+| `test_Extend_Filter_Select_GroupBy_Pivot_Extend_Sort_Limit` | Seven operators; `extend` after the cast |
+| `test_Extend_Filter_Select_Pivot_GroupBy_Extend_Sort` | Pivot **before** groupBy — the group-by then has to name the generated quoted columns |
+| `test_Static_Pivot_Filter` | Static pivot: `pivot(~year, [2000, 2011], …)` fixes the value list up front |
+| `test_Project_Filter_Before_Static_Pivot` | Static pivot fed by a projection |
+| `testStaticPivot_AfterConcatenate` | Pivot over a `concatenate`; with no grouping key collapsed, each source row stays its own row |
+| `testStaticPivot_AfterExtendConcatenate` | The left arm carries a window column, the right arm supplies it as a literal |
+
+### 4. Window compositions
+
+`over(~grp)` with **no sort** frames the whole partition, so the aggregate is the partition total and
+identical on every row of that partition — 16 for all three rows of group 1 in
+`testOLAPCastAggWithPartitionWindow`. Add an order and the default frame changes; that is a property
+of `over` itself and is documented on `over.pure`.
+
+| Test | Pins down |
+|---|---|
+| `testWindowFunctionsAfterProject` | `lead`/`lag` over a projection built from class instances; the first and last row of each partition come back `null` |
+| `testGroupByCastBeforeAgg` / `testGroupByCastAfterAgg` | `cast` is a no-op whether applied to the values or the aggregate result |
+| `testOLAPCastAggWithPartitionWindow` and three siblings | The same no-op property in all four positions available in a windowed aggregate |
+| `testProjectExtendNestedIfLeadAdjust` | `lead` inside a nested `if`, with `adjust` on dates |
+| `testExtendLeadAdjustDerivedOffset` | An `adjust` whose offset is itself read from the `lead` row |
+
+### 5. Null semantics
+
+The most load-bearing cluster in the file. Two things are worth knowing before reading any of it.
+
+**Equality is null-safe.** `null == null` is **true** and `null == 5` is **false** — never unknown.
+This is not SQL's three-valued logic, and it is visible directly in the assertions:
+
+- `testFilterEqualOnNullableColumns` keeps the `BothNull` row.
+- `testFilterNotEqualOnNullableColumns` keeps `LeftNull` and `RightNull` but drops `BothNull`.
+- `testProjectEqualityOnNullableColumns` projects the comparison into a column: every row gets
+  `true` or `false`, none get `null`.
+- `testJoinOnNullKey` is the consequence — an **INNER** join on `$x.id == $y.id2` matches the two
+  null-keyed left rows against the two null-keyed right rows and emits all four combinations. Under
+  SQL's default semantics that join would emit nothing for those rows.
+
+Relational execution gets this by emitting null-safe equality rather than a bare `=`; the SQL API can
+opt back into three-valued semantics per query with
+`Feature.LEGACY_SQL_NULL_UNSAFE_EQUALS` (see `pureToSQLQuery.pure` and
+`testLegacyNullUnsafeEquals.pure`).
+
+**`groupBy` gives null its own group.** `testGroupByOnNull` sums the three null-group rows to 12 and
+returns `null` as a group key, matching SQL's `GROUP BY`.
+
+| Test | Behaviour asserted |
+|---|---|
+| `testExtendAddOnNull` | A window `sum` over a partition whose values are **all** null returns `null`, not `0` |
+| `testExtendJoinStringOnNull` | `joinStrings` over a window containing nulls; the assertion re-splits and re-sorts the result, so what it pins down is which values survive, not the order they arrive in |
+| `testMultiCoalesceInProject` | Multi-argument `coalesce` in a projection, including an all-empty row falling through to the literal default |
+| `testCoalesceInPreFilter` | `coalesce` on the left of a comparison inside `filter` |
+
+#### Two divergences that are excluded rather than fixed
+
+`testExtendAddOnNull` and `testExtendFilterOutNull` are excluded on **`core-compiled` and
+`core-interpreted`** — the in-memory Pure engines — and the recorded diffs say exactly why.
+
+For `testExtendAddOnNull`, the in-memory engines return `0` where the relational stores return
+`null` for a sum over an all-null partition.
+
+`testExtendFilterOutNull` is the more consequential one. The pipeline is
+`extend(over(~p), sum(i)) → filter(o->isNotEmpty())`, and the two families disagree about **order**:
+
+| | Partition `p = 100` | Reading |
+|---|---|---|
+| Relational stores (asserted) | `60` | Filter first, then window — SQL applies `WHERE` before window functions |
+| `core-compiled` / `core-interpreted` | `110` | Window first, then filter — the pipeline read literally |
+
+Both readings are defensible; the suite asserts the SQL one. Note the contrast with
+`testExtendWindowFilter`, where the filter references the *window output* and therefore cannot be
+pushed below it — there the two families agree, and that test is excluded nowhere.
+
+### 6. Variant columns
+
+Fifteen tests covering `Variant`-typed relation columns. The governing rule: **`toMany(@T)` on a
+variant holding JSON `null` yields an empty collection**, and every downstream function then behaves
+as it does for any empty collection.
+
+| Test | Behaviour |
+|---|---|
+| `testVariantColumn_isEmpty` / `_isNotEmpty` | `'[]'` and `'null'` are both empty; `'[1]'` is not |
+| `testVariantColumn_indexOf` | `-1` when absent, and `-1` for a `'null'` payload |
+| `testVariantColumn_contains` | `false` for a `'null'` payload |
+| `testVariantArrayColumn_joinStrings` | Empty output for a `'null'` payload |
+| `testVariantColumn_slice` | `slice(2,3)` → one element; **negative bounds yield `[]`**, they do not index from the end |
+| `testVariantArrayColumn_sort` / `_reverse` | Round-trip through `toMany(@Integer)` and back via `toVariant` |
+| `testVariantColumn_distinct_removeDuplicates` | The two deduplication functions agree |
+| `testVariant_if` | A variant column as either branch of an `if` |
+| `testVariantColumn_extend_indexExtraction_filter` | `get(0)` in an `extend`, then filtered on |
+| `testVariantColumn_functionComposition` | The filter predicate calls a user-defined function over the extracted collection |
+| `testVariantColumn_modelOutputNotSupported` | `to(@SomeClass)` as a **projected column** is an error — asserted, not worked around |
+| `testVariantColumn_projectModelProperty` | …but `to(@SomeClass).name` — projecting a *property* — works |
+| `testVariantMapColumn_keys_LateralFlatten` / `_values_LateralFlatten` | `lateral` + `flatten` over `Map<String, Variant>` keys and values, the row-multiplying case |
+
+### 7. Identifiers and aliases
+
+| Test | Pins down |
+|---|---|
+| `testMixColumnNamesRenameFilter` | Five chained `rename`s over names differing only in case and leading underscores, then a filter referencing all three final names |
+| `testMixColumnNamesRenameExtend` | The same with an `extend` and a `select` interleaved |
+| `testGroupBy_Conflicting_Alias_With_Table_Columns` | A projection alias colliding with a real column name on the other side of a join |
+
+### 8. Expression shapes
+
+Regression tests for specific code-generation shapes rather than for a semantic rule.
+
+| Test | Shape |
+|---|---|
+| `testTDSPlusTimesMinus` | Binary `+ * -` inside a `project` |
+| `testProjectNumbersPlusTimesMinus` | The variadic `plus([…])` / `times([…])` / `minus([…])` forms over mixed Integer and Float |
+| `testFilterArithmeticComparisonExpression` | Arithmetic on both sides of a comparison inside `filter` |
+| `testNestedJoinArithmeticComparisonExpression` | A join condition combining an equality with an arithmetic inequality |
+| `testProjectOfComputedColumn_withCast` | `cast` narrowing a computed column to `Integer[1]` |
+| `testMultiIfTDS` | The `if([pair(…), pair(…)], |default)` multi-branch form |
+| `TestJoin_CurrentUserId` | `currentUserId()` inside a join condition — a value the store supplies, not the data |
+| `testConcatenateWithJoinOnOneSide` | A `concatenate` whose left arm is a join and whose right arm is not; the two arms reach the CTE with different column representations, which is what the inline comments in the test are about |
+
+## The variant suite
+
+`core_functions_variant/functions/tests/composition.pure` holds 21 tests in two groups.
+
+**Variant collections through platform iteration functions** — `map`, `fold` and `filter` applied to
+`toMany(@Variant)` and to `toMany(@Integer)`. Each function is tested both ways because the two take
+different paths: `@Variant` keeps every element boxed and needs an explicit `to(@Integer)` inside the
+lambda, while `@Integer` converts up front and lets the lambda use plain arithmetic. Both must give
+the same answer.
+
+**Variant to model** — `to(@Person)` / `toMany(@Person)` followed by property access. What is being
+tested is the *combination*: conversion alone is covered by `to.pure`, but conversion followed by a
+nested property, a qualified property, or a `[*]` traversal exercises paths that conversion alone
+does not. `testToClassAndAccessNestedProperty_manyToMany` walks `[*] → [*]` and asserts the exact
+flattening order.
+
+Three tests cover subtype discrimination: the default `_type` key, a custom key
+(`to(@Pet, '__type', [])`), and a custom key with a value-to-class lookup table
+(`[pair('gato', Cat), pair('perro', Dog)]`).
+
+The classes these tests need — `Person`, `Address`, `Pet`, `Dog`, `Cat` — are declared
+`<<access.private>>` at the bottom of the same file.
+
+## The stale `TO FIX` banner
+
+Line 338 of the relation file reads:
+
+```pure
+// ------------------------------------- TO FIX -------------------------------------
+```
+
+It has no closing marker, so it visually captures the remaining 60 tests. It does not mean that.
+It was added by finos/legend-engine#2979 (`relation: add support for pivot()`) when it sat at the
+**end** of the file and covered exactly the three tests written directly beneath it:
+`test_GroupBy_Filter`, `test_GroupBy_Distinct_Filter`, `test_Distinct_GroupBy_Filter`. Everything
+after them was appended later.
+
+Those three now pass on every relational store — they are excluded only on `java` and `deephaven`,
+in both cases with the generic `Instance of type 'meta::pure::metamodel::relation::TDS' can't be
+translated` that those adapters apply to essentially every relation test. Their assertions are also
+arithmetically correct under standard SQL semantics. The banner is stale; treat it as history, and
+do not read the tests under it as recording known-wrong behaviour.
+
+## Portability
+
+How many of the 72 relation composition tests each adapter excludes, from the `*_manifest.json`
+files:
+
+| Adapter | Excluded |
+|---|---|
+| `java` | 71 |
+| `deephaven` | 70 |
+| `relational-spanner` | 42 |
+| `relational-clickhouse` | 34 |
+| `relational-sqlserver` | 32 |
+| `relational-trino` | 31 |
+| `relational-memsql`, `relational-oracle` | 26 |
+| `relational-h2`, `relational-postgres` | 23 |
+| `relational-databricks` | 14 |
+| `core-interpreted` | 4 |
+| `core-compiled` | 3 |
+| `relational-duckdb`, `relational-snowflake` | 1 |
+
+`java` and `deephaven` exclude nearly the whole suite for one structural reason each
+(`Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated`), so their counts say
+nothing about the individual tests — `java` runs exactly one, `testCoalesceInPreFilter`. Among the
+relational stores the exclusions are mostly feature gaps rather than disagreements: Spanner has no
+window columns, ClickHouse has no `concatWithSeparator` aggregate, SQL Server and Trino have no
+`joinStrings` in a select position.
+
+When counting these yourself, note that `test_Slice_Size`, `test_Limit_Size` and `test_Distinct_Size`
+also sit in the `tests::composition::` **package** but are declared in `size.pure`. Because that file
+does declare a `<<PCT.function>>`, they attach to `size` and do publish normally — grepping the
+manifests by package name picks them up and overstates the counts above by three.
+
+## Adding a composition test
+
+1. **Only if it is genuinely about a pair.** If one function is wrong, the test belongs in that
+   function's own file, where it will be counted and published. `composition.pure` is for behaviour
+   that neither function exhibits alone.
+2. **Name it for the pipeline**, in order: `test_Extend_Sort_Project`, `testGroupByFilterExtendFilter`.
+   The existing names use both `test_A_B` and `testAB` styles; match the neighbours in the section
+   you are adding to.
+3. **Keep the source `#TDS` minimal** but large enough that the orders being contrasted give
+   *different* answers — a composition test whose two orderings agree proves nothing.
+4. **Sort before asserting**, unless the ordering is the thing under test.
+5. **Tag it** with the right `PCTRelationQualifier` stereotypes.
+6. **Give it a `'''…'''` literal**, like every one of its neighbours — one or two sentences saying
+   what the test pins down, not what it does. Add it to the matching theme table here too; the
+   literal will not publish, so this page is where a reader outside the file will find it.
+7. **Run it, then record honest exclusions** per
+   [expected-failures-howto.md](expected-failures-howto.md). The runner prints a copy-paste snippet
+   on failure.
+8. **Check the reverse-PCT files** (`core_external_query_sql_reverse_pct`, and the pandas equivalent)
+   for whether an entry is needed.
+
+## See also
+
+- [Writing PCT function documentation](pct-documentation.md) — the `'''…'''` standard for function
+  signatures and for tests that *do* publish.
+- [PCT conventions](conventions.md) — naming, file layout, one function per file.
+- [Expected failures](expected-failures-howto.md) — how to record an exclusion.
+- [PCT overview](overview.md) and [taxonomy](taxonomy.md).

--- a/docs/pct/composition-tests.md
+++ b/docs/pct/composition-tests.md
@@ -148,13 +148,13 @@ that only shows up in one arrangement is caught.
 
 ### 2. Which SQL clause a filter becomes
 
-Where a `filter` sits, and which columns it names, decides what it compiles to. Two tests say so in
-their own `doc.doc`:
+Where a `filter` sits, and which columns it names, decides what it compiles to. Two tests were
+written to pin exactly that, and say so in their own documentation:
 
 | Test | Filter references | Recorded intent |
 |---|---|---|
-| `testExtendWindowFilter` | a window (`over`) output column | *"Qualify grammar should be produced instead of subselect."* |
-| `testGroupByFilterExtendFilter` | a `groupBy` output **and** a window output, in one pipeline | *"Produces qualify and having grammar together."* |
+| `testExtendWindowFilter` | a window (`over`) output column | *"Filtering on a window column produces qualify grammar rather than a sub-select."* |
+| `testGroupByFilterExtendFilter` | a `groupBy` output **and** a window output, in one pipeline | *"A pipeline that filters an aggregate and then filters a window column produces having and qualify grammar together."* |
 
 `test_GroupBy_Filter` is the minimal version of the first half — `groupBy` then a filter on the
 aggregate column, nothing else — and `test_GroupBy_Distinct_Filter` and `test_Distinct_GroupBy_Filter`

--- a/docs/pct/conventions.md
+++ b/docs/pct/conventions.md
@@ -34,6 +34,7 @@ meta::pure::functions::date::tests::testTimeBucketSeconds_Function_1__Boolean_1_
 - [ ] Test organization - tests should be granular such that a failure can be easily isolated. E.g. testing Float inputs should be declared in a separate
 test from one that tests for Integer inputs. That way, the test failure clearly isolates what may be wrong.
 - [ ] Did you account for edge cases? e.g. if testing Number inputs, did you try very large/small numbers?
+- [ ] Is the test really about one function? A test that only fails when two functions are combined belongs in a `composition.pure` file instead — see [Composition Tests](composition-tests.md). Those tests still carry a `'''...'''` literal, but note that they are neither counted nor published, so record anything cross-cutting on that page as well.
 
 #### Error Messages
 PCT measure the level of cross-target support for a given Platform Function. When contributing to PCT on Legend, keep this preference order in mind:

--- a/docs/pct/conventions.md
+++ b/docs/pct/conventions.md
@@ -12,7 +12,7 @@ It is critical that utmost care is taken when deciding on:
     - All PCT tests for the PCT function belong in the same file
 - package names are all lower-case
 - function names are camelCase, with the first letter lower-case
-- function signatures **must be documented** with a `'''...'''` documentation literal — see [Writing PCT function documentation](pct-documentation.md) for the template and rules. The older `doc.doc` tagged value form is being replaced; a declaration may not carry both.
+- function signatures **must be documented** with a `'''...'''` documentation literal — see [Writing PCT function documentation](pct-documentation.md) for the template and rules. The older `doc.doc` tagged value form has been converted across every PCT declaration in the engine repositories; a declaration may not carry both, so adding a literal to a signature that still has one means deleting the tagged value in the same edit. `grep -rn "doc\.doc" --include='*.pure' <module>/src/main/resources` should come back empty for a converted repository.
 
 ### Practices
 #### PCT Tests

--- a/docs/pct/conventions.md
+++ b/docs/pct/conventions.md
@@ -12,7 +12,7 @@ It is critical that utmost care is taken when deciding on:
     - All PCT tests for the PCT function belong in the same file
 - package names are all lower-case
 - function names are camelCase, with the first letter lower-case
-- function signatures **must have docstring (doc.doc)**
+- function signatures **must be documented** with a `'''...'''` documentation literal — see [Writing PCT function documentation](pct-documentation.md) for the template and rules. The older `doc.doc` tagged value form is being replaced; a declaration may not carry both.
 
 ### Practices
 #### PCT Tests

--- a/docs/pct/native-howto.md
+++ b/docs/pct/native-howto.md
@@ -21,14 +21,26 @@ For "**cosh**", we created a *.pure file here:
 ![cosh-file-taxonomy](assets/howto-cosh.pure.PNG)
 
 The function signature in the file looks like this:
-```Java
+````Java
+'''
+The hyperbolic cosine of a number.
+
+**Parameters**
+- `number` — the angle, in radians.
+
+**Returns** the hyperbolic cosine.
+
+**Examples**
+```pure
+cosh(0)   // 1.0
+```
+'''
 native function
     <<PCT.function>>
-        {
-            doc.doc='cosh returns the hyperbolic cosine of a number'
-        }
 meta::pure::functions::math::trigonometry::cosh(number:Number[1]):Float[1];
-```
+````
+
+See [Writing PCT function documentation](pct-documentation.md) for the full template and rules.
 
 ## How to Run your Native Function
 Before we dig into the implementation of the function, it is important to know how can use Pure to call your native function

--- a/docs/pct/overview.md
+++ b/docs/pct/overview.md
@@ -32,6 +32,28 @@ The final step involves running PCT Tests against database targets for the funct
 to run the tests and record expected failures in the adapter's JSON manifest file.
 
 -------------
+# Published Reports
+Two reports are generated from the same aggregated data (`DocumentationGeneration.buildDocumentation()`, served as
+`pct-docs.json`), and both are published to the Legend docs site by the `pct-report` job in `.github/workflows/build.yml`:
+
+| Report | Served at | Reads best as |
+|---|---|---|
+| `PCT_Report_Compatibility.html` | `/api/pct/form` | One matrix — every function against every adapter |
+| `PCT_Report_Functions.html` | `/api/pct/functions` | A javadoc-style reference — browse by package, then one page per function |
+
+The function reference page shows, for a single function: every overload with its documentation, every test case with its
+documentation and qualifiers, and per-adapter results with the failure message behind each `×`. It counts every reported test —
+unlike the compatibility matrix, it gives no qualifier (including `unsupportedFeature`) special treatment.
+
+Regenerate both locally with:
+```bash
+mvn exec:java -pl org.finos.legend.engine:legend-engine-pure-ide-light-http-server \
+    -Dexec.mainClass="org.finos.legend.engine.server.core.pct.GeneratePCTFiles"
+```
+The output lands in `target/pct/`; serve that directory over HTTP (the pages fetch `pct-docs.json` alongside themselves).
+Adapters appear only when their PCT module is on the classpath, so a local run shows fewer stores than CI.
+
+-------------
 # References
 ## Conventions
 For conventions and best practices, see [this page](conventions.md)

--- a/docs/pct/overview.md
+++ b/docs/pct/overview.md
@@ -10,6 +10,8 @@ we specify expectations around the api. This guide enables you to contribute pla
 | Add a function implemented in Java (native) | [Native How-To](native-howto.md) |
 | Make my function work on databases | [Wiring How-To](wiring-howto.md) |
 | Run PCT tests and handle failures | [Expected Failures How-To](expected-failures-howto.md) |
+| Document a function I added | [PCT Function Documentation](pct-documentation.md) |
+| Understand a test in a `composition.pure` file | [Composition Tests](composition-tests.md) |
 | Understand concepts like routing, DynaFunction | [Concepts & Glossary](concepts-glossary.md) |
 
 ## Development Setup

--- a/docs/pct/overview.md
+++ b/docs/pct/overview.md
@@ -46,8 +46,9 @@ documentation and qualifiers, and per-adapter results with the failure message b
 unlike the compatibility matrix, it gives no qualifier (including `unsupportedFeature`) special treatment.
 
 Each function is addressable as `PCT_Report_Functions.html#f/<name>` (for example `#f/tan`), so a single function can be linked
-directly. Names used in several packages resolve to a chooser listing them; the `link` in each function's header gives the
-shortest URL that opens that page.
+directly. Adding the parameter types picks out one overload — `#f/times(Decimal)`, or `#f/max(Date[1..*])` where multiplicity is
+what separates them. Names used in several packages resolve to a chooser listing them, unless the overload settles which one was
+meant. The `link` in a function's header and the `#` beside each signature give the shortest URL that opens that page.
 
 Regenerate both locally with:
 ```bash

--- a/docs/pct/overview.md
+++ b/docs/pct/overview.md
@@ -45,6 +45,10 @@ The function reference page shows, for a single function: every overload with it
 documentation and qualifiers, and per-adapter results with the failure message behind each `×`. It counts every reported test —
 unlike the compatibility matrix, it gives no qualifier (including `unsupportedFeature`) special treatment.
 
+Each function is addressable as `PCT_Report_Functions.html#f/<name>` (for example `#f/tan`), so a single function can be linked
+directly. Names used in several packages resolve to a chooser listing them; the `link` in each function's header gives the
+shortest URL that opens that page.
+
 Regenerate both locally with:
 ```bash
 mvn exec:java -pl org.finos.legend.engine:legend-engine-pure-ide-light-http-server \

--- a/docs/pct/pct-documentation.md
+++ b/docs/pct/pct-documentation.md
@@ -224,6 +224,22 @@ both `meta::pure::functions::variant::navigation` and `meta::pure::functions::co
 separated, return type after the colon. Strip the package when the target is in the same package as the
 function you are documenting; keep it otherwise.
 
+**Exception — you may drop to a fully qualified path when the signature is unwieldy.** The signature
+exists to disambiguate, and a path already does that when nothing shares the name. Some relation
+functions take a wide row type: `simpleMovingAverage5Days`'s `simple` field runs past 300 characters,
+and pasting it into a `See also` line buries the reference it is supposed to make. `core_scenario_quant`
+therefore references by path alone — `meta::external::scenario::quant::sma::simpleMovingAverage5Days`.
+This is a readability escape hatch, not a second convention: keep full signatures wherever they fit on a
+line, as `core_dataquality` does with `rowCountEqual(Relation<T>[1], Number[1]):Boolean[1]`. Confirm the
+name really is unique rather than assuming it:
+
+```bash
+python3 -c "
+import json,collections; d=json.load(open('<module>/target/classes/pct-reports/FUNCTIONS_<repository>.json'))
+c=collections.Counter(s['simple'].split('(')[0] for f in d['functionDefinitions'] for s in f['signatures'])
+print([n for n,k in c.items() if k>1] or 'all unique')"
+```
+
 **Do not hand-write signatures.** Copy them from the generated JSON:
 
 ```bash

--- a/docs/pct/pct-documentation.md
+++ b/docs/pct/pct-documentation.md
@@ -3,18 +3,26 @@
 This standard governs the `'''…'''` documentation on `<<PCT.function>>` declarations and
 `<<PCT.test>>` cases in the engine-side Pure function repositories:
 
-| Repository | Module |
-|---|---|
-| `core_functions_standard` | `legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure` |
-| `core_functions_relation` | `legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure` |
-| `core_functions_unclassified` | `legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-functions-unclassified-pure` |
-| `core_functions_variant` | `legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-variant/legend-engine-pure-functions-variant-pure` |
-| `core_scenario_quant` | `legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-scenario-quant-pure` |
-| `core` | `legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core` |
-| `core_dataquality` | `legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure` |
+| Repository | Signatures | Module | Emits a report |
+|---|---|---|---|
+| `core_functions_standard` | 115 | `legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure` | yes |
+| `core_functions_relation` | 95 | `legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure` | yes |
+| `core_functions_unclassified` | 37 | `legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-functions-unclassified-pure` | yes |
+| `core_functions_variant` | 9 | `legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-variant/legend-engine-pure-functions-variant-pure` | yes |
+| `core_scenario_quant` | 6 | `legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-scenario-quant-pure` | yes |
+| `core_dataquality` | 7 | `legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure` | **no** |
+| `core` | 1 | `legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core` | **no** |
 
 These strings are **published to end users**. Write for someone using Pure to get work done, not for
 someone maintaining the compiler.
+
+> **The last two modules declare no `generate-pct-functions` execution**, so their eight signatures are
+> documented but never reach a `FUNCTIONS_*.json`. Document them anyway — the text is right where a
+> reader of the source will look, and it costs nothing to be ready — but do not expect to verify them
+> through the report. Wiring `core_dataquality` up is not just a `pom.xml` line: all seven of its
+> functions share `dataquality_relation_helper.pure`, and `FunctionsGeneration` permits only one PCT
+> function name per source file, so the file would have to be split first. The same gap affects
+> composition tests for a different reason — see [Composition Tests](composition-tests.md).
 
 For the language mechanics — where documentation attaches, how content is processed, the conflict
 with an explicit `doc.doc` — see
@@ -316,3 +324,30 @@ print(json.dumps([f for f in d['functionDefinitions'] if f.get('name')=='toJson'
 
 Confirm `signatures[].documentation` holds the intended Markdown with newlines preserved, and — at
 `legend.pure.version` ≥ 5.94.0 — that tests appear under `tests` with their documentation attached.
+
+> **A populated `documentation` field is not evidence that a signature was converted.** The literal
+> and the legacy `doc.doc` both land in the same place, so a report reading *95 of 95 documented* says
+> nothing about which form produced it. Counting coverage from the report is how a first pass at this
+> left 25 relation signatures — every overload in `groupBy.pure`, `pivot.pure`, `rows.pure` and
+> `range.pure` — on their original one-line tagged value while reporting the module complete.
+>
+> Count the literals instead, and confirm nothing is left behind:
+>
+> ```bash
+> grep -c "^'''$" <file>                                    # two lines per literal
+> grep -rn "doc\.doc" --include='*.pure' <module>/src/main/resources
+> ```
+>
+> The `doc.doc` grep should come back empty for a converted repository. Where it does not, check each
+> hit: `PCT.grammarDoc` is a different tag and stays, and a `doc.doc` on a declaration carrying no PCT
+> stereotype is out of scope.
+
+Two failure modes hide in files holding several overloads, and both were found by review of the
+equivalent legend-pure change:
+
+- **A whole overload left undocumented**, because the eye stops at the first signature. Documentation
+  is per signature; there is no inheritance between them.
+- **The full text on a secondary variant**, with the primary carrying a delta that points *forwards* to
+  text the reader has not reached. `Signature.documentation` is per signature and the REPL shows the
+  first one that has any, so a file whose first declaration is a delta reads back-to-front. Reorder the
+  file rather than duplicating the text.

--- a/docs/pct/pct-documentation.md
+++ b/docs/pct/pct-documentation.md
@@ -280,32 +280,31 @@ function by source id.
 
 ## Verifying
 
-Documentation is parse-time sugar, so **no PCT result should change**. Treat any diff as a real
-regression.
+Documentation is parse-time sugar over a tagged value, so **a documentation-only change cannot alter
+behaviour**. The module build is the whole verification; **do not run the relational PCT suites for
+it**, which costs minutes for a guaranteed-green result.
 
-A parse error — including the `doc.doc` conflict above — surfaces when the Pure repository compiles:
+Building the Pure repository is what catches everything that can actually break — a malformed literal,
+and the parse error raised when a declaration carries both a literal and an explicit `doc.doc`:
 
 ```bash
-mvn clean install -pl <the -pure module> -am
+mvn clean install -pl <the -pure module>
 ```
 
-That is not enough on its own. The PCT tests do not run in the `-pure` module; they run in the
-runtime-extension modules beside it, and **they load this code as bytecode from those jars**. Always
-reinstall both, or the whole suite runs against the previous build:
+**Do not verify with `-DskipTests`.** The `-pure` module's own tests include the compiled-state
+integrity check, and the runtime-extension modules beside it run the `<<PCT.test>>` functions against
+this code — worth building too when a change is large, since **they load it as bytecode from their
+jars** rather than from source:
 
 ```bash
 mvn clean install -pl <…-runtime-java-extension-compiled-functions-X>,<…-runtime-java-extension-interpreted-functions-X>
 ```
 
-Then confirm no behaviour changed, with the full suites rather than a filtered `-Dtest`:
-
-```bash
-mvn clean install -pl legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-h2/legend-engine-xt-relationalStore-h2-PCT
-mvn clean install -pl legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-duckdb/legend-engine-xt-relationalStore-duckdb-PCT
-```
-
-**Never verify with `-DskipTests`** — it proves the documentation parses and serializes, nothing more.
-Do not run two Maven `clean`s concurrently against a shared `~/.m2`.
+The exception that would justify a PCT run is a manifest whose `expectedError` embeds a source
+position from a file you are documenting — added lines shift it and break the match. The engine
+corpus carries none today; the greps in the section above are how you confirm that before a large
+pass. Note also that a shared `~/.m2` is contended, so a build there may pick up artifacts from
+another checkout; `-Dmaven.repo.local` pointed at a scratch copy avoids it.
 
 Finally check the emitted JSON, which is the thing actually published:
 

--- a/docs/pct/pct-documentation.md
+++ b/docs/pct/pct-documentation.md
@@ -1,0 +1,303 @@
+# Writing PCT function documentation
+
+This standard governs the `'''…'''` documentation on `<<PCT.function>>` declarations and
+`<<PCT.test>>` cases in the engine-side Pure function repositories:
+
+| Repository | Module |
+|---|---|
+| `core_functions_standard` | `legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure` |
+| `core_functions_relation` | `legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure` |
+| `core_functions_unclassified` | `legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-functions-unclassified-pure` |
+| `core_functions_variant` | `legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-variant/legend-engine-pure-functions-variant-pure` |
+| `core_scenario_quant` | `legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-scenario-quant-pure` |
+| `core` | `legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core` |
+| `core_dataquality` | `legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure` |
+
+These strings are **published to end users**. Write for someone using Pure to get work done, not for
+someone maintaining the compiler.
+
+For the language mechanics — where documentation attaches, how content is processed, the conflict
+with an explicit `doc.doc` — see
+[Type System § Documentation](../engineering/architecture/type-system.md#32-documentation--before-a-declaration).
+This document covers only *what to write*.
+
+The platform functions in legend-pure follow the same standard; see
+`docs/standards/pct-documentation.md` there.
+
+---
+
+## Why it is worth writing
+
+Documentation is sugar over the `meta::pure::profiles::doc` `doc` tagged value, and the pipeline that
+publishes it already exists end to end:
+
+```
+.pure  '''markdown'''
+  → doc.doc tagged value
+  → PCTTools.getDoc()
+  → Signature.documentation             (per signature)
+  → FunctionDefinition.tests[].documentation   (per test)
+  → FUNCTIONS_<repository>.json
+  → DocumentationGeneration.buildDocumentation()
+  → consumed downstream for published documentation
+```
+
+`FUNCTIONS_<repository>.json` is emitted by the `legend-pure-maven-generation-pct`
+`generate-pct-functions` execution declared in each `-pure` module's `pom.xml`, and lands in
+`target/classes/pct-reports/`.
+
+> **Test documentation requires `legend.pure.version` ≥ 5.94.0.** `TestDefinition` — the model
+> object that carries a test's documentation into the JSON — first exists at 5.94.0. Below that a
+> `'''…'''` literal on a `<<PCT.test>>` parses and attaches to the graph, and is then silently
+> dropped by the report generator. Signature documentation has no such constraint.
+
+---
+
+## The template
+
+````pure
+'''
+One-sentence summary, ending in a period.
+
+Optional paragraph on semantics, edge cases, and empty/`[0..1]` behaviour.
+
+**Parameters**
+- `variant` — what it is.
+
+**Returns** what comes back.
+
+**Examples**
+```pure
+fromJson('{ "Hello" : null }')->toJson()   // '{"Hello":null}'
+```
+
+**See also** `fromJson(String[1]):Variant[1]`,
+`toVariant(Any[*]):Variant[1]`
+'''
+native function
+    <<PCT.function>>
+meta::pure::functions::variant::convert::toJson(variant: Variant[1]): String[1];
+````
+
+The live reference implementation is
+[`core_functions_variant/functions/convert/toJson.pure`](../../legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-variant/legend-engine-pure-functions-variant-pure/src/main/resources/core_functions_variant/functions/convert/toJson.pure).
+
+Put the delimiters on their own lines, even for a one-liner — `'''One line.'''` does not canonicalize
+the way you would expect:
+
+```pure
+'''
+A key that is absent yields empty rather than failing.
+'''
+function <<PCT.test, PCTCoreQualifier.variant>> meta::pure::functions::variant::navigation::tests::get::testGetFromObjectWhenKeyDoesNotExists<Z|y>(…):Boolean[1]
+```
+
+Every function gets **at least one runnable example**. Prefer examples showing a normal case and at
+least one boundary — no match, empty collection, zero.
+
+---
+
+## Formatting rules
+
+1. **Keep the opening delimiter, the body and the closing delimiter at one indentation.** Content
+   indentation is measured relative to the closing delimiter, so a `'''` pulled left of the body leaves
+   that difference on every line — and 4+ spaces renders as a Markdown code block.
+
+2. **Use `-` for bullets.** Consistent with the corpus, and avoids any confusion with emphasis.
+
+3. **Never write `'''` inside the content** — it closes the literal. This is the only sequence that
+   needs avoiding; ordinary single quotes in Pure examples are fine.
+
+4. **Content is literal** — never unescaped, so `\n` is a backslash and an `n`. Write real line breaks.
+
+5. **Tag fenced blocks `pure`** so the published renderer can highlight them.
+
+6. **One documentation literal per declaration.** Two in a row is a parse error, and the message points
+   at the literal rather than at the duplication — easy to misread when it happens.
+
+7. **The literal precedes the whole declaration** — ahead of `native`/`function` and ahead of the
+   stereotype block, whatever qualifiers it carries (`<<PCT.function, PCT.platformOnly>>`,
+   `<<PCT.test, PCTRelationQualifier.relation>>`).
+
+---
+
+## Replacing an existing `doc.doc`
+
+Most engine signatures already carry a one-line `doc.doc` tagged value. **An element may not carry
+both** a documentation literal and an explicit `doc.doc` — it is a parse error:
+
+```
+Element has both documentation and an explicit doc.doc tagged value. Use one.
+```
+
+Delete the tagged value in the same edit that adds the literal. **Keep `PCT.grammarDoc` and
+`PCT.grammarCharacters`** — different tags, unaffected.
+
+```diff
++'''
++Renders a variant as its JSON text.
++…
++'''
+ native function
+     <<PCT.function>>
+-    {
+-        doc.doc='Returns the json representation of the given variant.'
+-    }
+ meta::pure::functions::variant::convert::toJson(variant: Variant[1]): String[1];
+```
+
+Where only a `doc.doc` was present, the whole brace block goes; where `PCT.grammarDoc` shares the
+block, only the `doc.doc` entry does.
+
+Two shapes are worth watching for, because both currently publish something wrong:
+
+- **Concatenated values.** `doc.doc='first line\n' + 'second line'` publishes as
+  `first line\n, second line` — the concatenation is not evaluated at the tagged-value level. A
+  documentation literal has real line breaks and no such artefact.
+- **Empty values.** `doc.doc=''` publishes an empty string, which is indistinguishable downstream
+  from a function nobody documented.
+
+---
+
+## Where the content comes from
+
+**Take examples and stated behaviour from the PCT tests in the same file, not from the signature.**
+The signature says what the types are; the assertions say what actually happens, and that is where
+the value is. Behaviour worth stating is almost always behaviour a test already pins:
+
+- `get(Variant[0..1], String[1])` returns empty for a missing key rather than failing —
+  `testGetFromObjectWhenKeyDoesNotExists` asserts it.
+- `to(Variant[0..1], T[0..1])` coerces across JSON types, so `'"1"'` reads as `1` for `@Integer`,
+  but `1.25` does not — `testToIntegerFromString` and `testToIntegerFromFloat` draw the line.
+- `toMany` fails rather than wrapping when the variant is not an array —
+  `testToManyFromNonArray`.
+
+Deriving prose from the signature is how documentation ends up factually wrong. Review of the
+equivalent legend-pure change found five such errors, every one of them contradicted by an assertion
+sitting in the same file.
+
+---
+
+## Overloads
+
+`Signature.documentation` is per-signature, and the REPL shows the **first** signature that has
+documentation.
+
+> Put the **full** documentation on the **primary** variant — the plain form a caller reaches for,
+> which is usually the shortest. Give each other overload a short comment stating only how it differs.
+
+Primary is not the same as most general. `to(Variant[0..1], T[0..1]):T[0..1]` delegates to the
+four-argument form that takes an explicit type key and lookup, yet it is the one every caller and
+every test uses, so it carries the text and the four-argument form gets the delta. **Reorder the file
+so the primary leads** when it does not already — legend-pure did exactly this for `greaterThanEqual`
+and `elementToPath`, whose documentation had landed on a secondary variant because that variant
+happened to come first.
+
+Make the delta self-contained: name the signature being contrasted rather than writing "as above", since
+a renderer may show each signature on its own.
+
+```pure
+'''
+As `to(Variant[0..1], T[0..1]):T[0..1]`, but resolves a subtype from `typeKeyName` in the payload
+against `typeLookup` rather than from the default `_type` key and an empty lookup.
+'''
+```
+
+Check which signature actually carries the stereotype block before assuming — it is not always the
+one you would guess.
+
+---
+
+## Cross-references (`See also`)
+
+Reference other functions by **full signature**, never bare name, so a renderer can resolve exactly one
+target:
+
+```
+**See also** `fromJson(String[1]):Variant[1]`
+```
+
+Two reasons from the current corpus: `to` and `toMany` each have two overloads, and `get` exists in
+both `meta::pure::functions::variant::navigation` and `meta::pure::functions::collection`.
+
+**Format** — match the `simple` field of `Signature` in `FUNCTIONS_*.json`: parameter types comma-space
+separated, return type after the colon. Strip the package when the target is in the same package as the
+function you are documenting; keep it otherwise.
+
+**Do not hand-write signatures.** Copy them from the generated JSON:
+
+```bash
+python3 -c "
+import json; d=json.load(open('legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-variant/legend-engine-pure-functions-variant-pure/target/classes/pct-reports/FUNCTIONS_variant.json'))
+print('\n'.join(s['simple'] for f in d['functionDefinitions'] for s in f['signatures']))"
+```
+
+Hand-written references are wrong surprisingly often.
+
+---
+
+## Before you document a file: check for position assertions
+
+Adding documentation **shifts every line below it**, and a test that asserts the line or column of an
+element in a documented file will fail naming a line number, not your documentation — so it reads as
+unrelated.
+
+**As of writing, the engine PCT corpus carries none of the three shapes.** Re-run these before a
+large pass rather than assuming it stayed that way:
+
+```bash
+# self-referential assertError — asserts the line it is written on
+grep -rn --include='*.pure' "assertError(.*',[[:space:]]*[0-9]" legend-engine-core/legend-engine-core-pure
+
+# error-message strings baking in a source position
+grep -rn --include='*.java' "\.pure line:" .
+
+# integer position assertions
+grep -rn --include='*.java' 'getSourceInformation()\.\(getLine\|getColumn\)' .
+```
+
+Note also that `FunctionsGeneration` permits only **one PCT function name per source file**. If a file
+holds several, split it — and move each function's tests with it, since tests are attributed to a
+function by source id.
+
+---
+
+## Verifying
+
+Documentation is parse-time sugar, so **no PCT result should change**. Treat any diff as a real
+regression.
+
+A parse error — including the `doc.doc` conflict above — surfaces when the Pure repository compiles:
+
+```bash
+mvn clean install -pl <the -pure module> -am
+```
+
+That is not enough on its own. The PCT tests do not run in the `-pure` module; they run in the
+runtime-extension modules beside it, and **they load this code as bytecode from those jars**. Always
+reinstall both, or the whole suite runs against the previous build:
+
+```bash
+mvn clean install -pl <…-runtime-java-extension-compiled-functions-X>,<…-runtime-java-extension-interpreted-functions-X>
+```
+
+Then confirm no behaviour changed, with the full suites rather than a filtered `-Dtest`:
+
+```bash
+mvn clean install -pl legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-h2/legend-engine-xt-relationalStore-h2-PCT
+mvn clean install -pl legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-duckdb/legend-engine-xt-relationalStore-duckdb-PCT
+```
+
+**Never verify with `-DskipTests`** — it proves the documentation parses and serializes, nothing more.
+Do not run two Maven `clean`s concurrently against a shared `~/.m2`.
+
+Finally check the emitted JSON, which is the thing actually published:
+
+```bash
+python3 -c "
+import json; d=json.load(open('<module>/target/classes/pct-reports/FUNCTIONS_<repository>.json'))
+print(json.dumps([f for f in d['functionDefinitions'] if f.get('name')=='toJson'], indent=2))"
+```
+
+Confirm `signatures[].documentation` holds the intended Markdown with newlines preserved, and — at
+`legend.pure.version` ≥ 5.94.0 — that tests appear under `tests` with their documentation attached.

--- a/docs/pct/purefunction-howto.md
+++ b/docs/pct/purefunction-howto.md
@@ -20,14 +20,31 @@ DuckDb - https://duckdb.org/docs/stable/sql/expressions/comparison_operators.htm
 ![howto-between.pure](assets/howto-between.pure.PNG)
 
 3. You can now use PureIDE to edit the file you created in step 2 to add the function signature determined in Step 1. E.g.
-```Java
+````Java
+'''
+Whether a value falls within an inclusive range.
+
+All three inputs are cast to the same type before comparing.
+
+**Parameters**
+- `value` — the value to test.
+- `lower` — the inclusive lower bound.
+- `upper` — the inclusive upper bound.
+
+**Returns** `true` when `value` lies between `lower` and `upper`.
+
+**Examples**
+```pure
+between(5, 0, 10)   // true
+between(5, 0, 2)    // false
+```
+'''
 function
     <<PCT.function>>
-    {
-        doc.doc='between returns true if the value is between inputs lower and upper; all inputs are cast to the same type'
-    }
     meta::pure::functions::boolean::between(value:Any[1], lower:Any[1], upper:Any[1]):Boolean[1];
-```
+````
+
+See [Writing PCT function documentation](pct-documentation.md) for the full template and rules.
 4. To help develop the logic for the function body, you can look at similar existing pure functions. Some of these may even be leveraged to implement your new function! E.g. looking at the "essential" functions in PureIDE, we see some similar foundational operators we can use to implement "**between**":
 
 ![between.pure](assets/howto-between-essentials.pure.PNG)

--- a/legend-engine-config/legend-engine-server/legend-engine-server-http-server/src/main/java/org/finos/legend/engine/server/core/pct/GeneratePCTFiles.java
+++ b/legend-engine-config/legend-engine-server/legend-engine-server-http-server/src/main/java/org/finos/legend/engine/server/core/pct/GeneratePCTFiles.java
@@ -38,6 +38,7 @@ public class GeneratePCTFiles
     public static void main(String[] args) throws Exception
     {
         Shared.writeStringToTarget("./target/pct", "PCT_Report_Compatibility.html", IOUtils.resourceToString("pct/PCT_Report_Compatibility.html", StandardCharsets.UTF_8, GeneratePCTFiles.class.getClassLoader()));
+        Shared.writeStringToTarget("./target/pct", "PCT_Report_Functions.html", IOUtils.resourceToString("pct/PCT_Report_Functions.html", StandardCharsets.UTF_8, GeneratePCTFiles.class.getClassLoader()));
         Shared.writeStringToTarget("./target/pct", "pct-docs.json", getDocumentationAsJson());
         Shared.writeStringToTarget("./target/pct", "git-info.json", DeploymentStateAndVersions.sdlcJSON);
     }

--- a/legend-engine-config/legend-engine-server/legend-engine-server-http-server/src/main/java/org/finos/legend/engine/server/core/pct/PCT.java
+++ b/legend-engine-config/legend-engine-server/legend-engine-server-http-server/src/main/java/org/finos/legend/engine/server/core/pct/PCT.java
@@ -58,6 +58,25 @@ public class PCT
     }
 
     @GET
+    @Path("functions")
+    @ApiOperation(value = "PCT function reference")
+    @Produces(MediaType.TEXT_HTML)
+    public Response functionsPCT()
+    {
+        return Response.status(200).type(MediaType.TEXT_HTML).entity(new StreamingOutput()
+        {
+            @Override
+            public void write(OutputStream outputStream) throws IOException
+            {
+                try (InputStream is = Objects.requireNonNull(ClassLoader.getSystemClassLoader().getResourceAsStream("pct/PCT_Report_Functions.html")))
+                {
+                    IOUtils.copy(is, outputStream);
+                }
+            }
+        }).build();
+    }
+
+    @GET
     @Path("git-info.json")
     @ApiOperation(value = "Git info for PCT report")
     @Produces(MediaType.APPLICATION_JSON)

--- a/legend-engine-config/legend-engine-server/legend-engine-server-http-server/src/main/resources/pct/PCT_Report_Compatibility.html
+++ b/legend-engine-config/legend-engine-server/legend-engine-server-http-server/src/main/resources/pct/PCT_Report_Compatibility.html
@@ -28,6 +28,7 @@
         .footer { font-size: 15px; }
         .form-section { margin-bottom: 20px; }
         .form-group { margin-right: 20px; display: inline-block; }
+        .nav-links { font-family: Arial; font-size: 14px; padding: 8px 0 0 8px; }
     </style>
     <script>
         function flip(stateId, ids) {
@@ -391,6 +392,7 @@
     </script>
 </head>
 <body>
+<div class="nav-links"><a href="./PCT_Report_Functions.html">Function reference</a></div>
 <br/><br/>
 <div id="pct-form-container"></div>
 <div id="pct-table"></div>

--- a/legend-engine-config/legend-engine-server/legend-engine-server-http-server/src/main/resources/pct/PCT_Report_Functions.html
+++ b/legend-engine-config/legend-engine-server/legend-engine-server-http-server/src/main/resources/pct/PCT_Report_Functions.html
@@ -205,7 +205,18 @@
             white-space: pre;
         }
 
-        .overload { margin-bottom: 26px; }
+        .overload { margin-bottom: 26px; scroll-margin-top: calc(var(--header-h) + 14px); }
+        .overload.target .sig { border-left-width: 6px; border-color: var(--accent); }
+        .sig-row { display: flex; align-items: flex-start; gap: 6px; }
+        .sig-row .sig { flex: 1; min-width: 0; }
+        .overload-link {
+            flex: none;
+            padding: 7px 2px;
+            color: var(--text-muted);
+            opacity: .35;
+            font-size: 13px;
+        }
+        .overload:hover .overload-link, .overload-link:focus { opacity: 1; }
         .doc { margin-left: 3px; }
         .doc p { margin: 8px 0; }
         .doc ul { margin: 8px 0; padding-left: 22px; }
@@ -379,10 +390,128 @@
         return fd.reportScope.module + '/' + (fd.functionDefinition.name || 'composition-tests') + '/' + fd.functionDefinition.sourceId;
     }
 
-    function shareRoute(fd)
+    // Signatures nest types in <>, {} and [], and the arrow in Function<{T[1]->Boolean[1]}> carries a '>'
+    // that closes nothing, so both scans below track depth and skip a '>' that follows a '-'.
+    function closesGroup(text, i)
+    {
+        const c = text.charAt(i);
+        return c === ')' || c === ']' || c === '}' || (c === '>' && text.charAt(i - 1) !== '-');
+    }
+
+    function opensGroup(c)
+    {
+        return c === '(' || c === '[' || c === '{' || c === '<';
+    }
+
+    function parameterList(simple)
+    {
+        const open = simple.indexOf('(');
+        if (open < 0)
+        {
+            return null;
+        }
+        let depth = 0;
+        for (let i = open; i < simple.length; i++)
+        {
+            if (opensGroup(simple.charAt(i)))
+            {
+                depth++;
+            }
+            else if (closesGroup(simple, i) && --depth === 0)
+            {
+                return simple.substring(open + 1, i);
+            }
+        }
+        return null;
+    }
+
+    function splitParameters(list)
+    {
+        const parts = [];
+        let depth = 0;
+        let current = '';
+        for (let i = 0; i < list.length; i++)
+        {
+            const c = list.charAt(i);
+            if (opensGroup(c))
+            {
+                depth++;
+            }
+            else if (closesGroup(list, i))
+            {
+                depth--;
+            }
+            if (c === ',' && depth === 0)
+            {
+                parts.push(current);
+                current = '';
+            }
+            else
+            {
+                current += c;
+            }
+        }
+        if (current.trim())
+        {
+            parts.push(current);
+        }
+        return parts.map(p => p.trim().replace(/\s+/g, ''));
+    }
+
+    function overloadKey(signature, withMultiplicity)
+    {
+        const list = parameterList(signature.simple);
+        if (list === null)
+        {
+            return null;
+        }
+        return '(' + splitParameters(list)
+            .map(p => withMultiplicity ? p : p.replace(/\[[^\[\]]*\]$/, ''))
+            .join(',') + ')';
+    }
+
+    // Multiplicity is dropped where the parameter types alone tell the overloads apart, so most links read
+    // as times(Float); max keeps it, since max(Number[*]) and max(Number[1..*]) return different multiplicities.
+    function overloadKeys(def)
+    {
+        const signatures = def.signatures || [];
+        const short = signatures.map(s => overloadKey(s, false));
+        return short.every((k, i) => k === null || short.indexOf(k) === i)
+            ? short
+            : signatures.map(s => overloadKey(s, true));
+    }
+
+    // A link may carry the key this page uses, or either form of it — a hand-written times(Float), or the
+    // times(Float[*]) read off a quoted signature — so all three are accepted.
+    function overloadIndex(def, wanted)
+    {
+        const signatures = def.signatures || [];
+        const forms = [overloadKeys(def), signatures.map(s => overloadKey(s, false)), signatures.map(s => overloadKey(s, true))];
+        for (let i = 0; i < forms.length; i++)
+        {
+            const found = forms[i].indexOf(wanted);
+            if (found >= 0)
+            {
+                return found;
+            }
+        }
+        return -1;
+    }
+
+    // The shortest route that still lands where it should: the bare name when nothing else uses it, or when
+    // the overload alone tells it apart from its namesakes, and the full route otherwise.
+    function shareRoute(fd, key)
     {
         const name = fd.functionDefinition.name;
-        return name && nameIndex[name].length === 1 ? name : functionRoute(fd);
+        const suffix = key || '';
+        if (!name)
+        {
+            return functionRoute(fd);
+        }
+        const namesakes = nameIndex[name];
+        const settled = namesakes.length === 1
+            || (key && namesakes.filter(c => overloadIndex(c.functionDefinition, key) >= 0).length === 1);
+        return (settled ? name : functionRoute(fd)) + suffix;
     }
 
     function packageOf(fd)
@@ -592,7 +721,11 @@
         {
             return code;
         }
-        return '<a href="#f/' + encodeURI(functionRoute(target)) + '">' + code + '</a>';
+        // "See also" and inline references quote a full signature, so they can land on the overload itself.
+        const keys = overloadKeys(target.functionDefinition);
+        const index = overloadIndex(target.functionDefinition, overloadKey({simple: code}, true));
+        const suffix = index >= 0 && keys[index] ? keys[index] : '';
+        return '<a href="#f/' + encodeURI(shareRoute(target, suffix)) + '">' + code + '</a>';
     }
 
     function sourceUrl(fd)
@@ -669,21 +802,31 @@
     function route()
     {
         const hash = location.hash;
-        activeRoute = decodeURI(hash.replace(/^#[fp]\//, ''));
+        const target = decodeURI(hash.replace(/^#[fp]\//, ''));
+        const parens = target.indexOf('(');
+        activeRoute = parens < 0 ? target : target.substring(0, parens);
         if (hash.startsWith('#f/'))
         {
-            renderFunction(decodeURI(hash.substring(3)));
+            renderFunction(activeRoute, parens < 0 ? null : target.substring(parens));
         }
         else if (hash.startsWith('#p/'))
         {
-            renderPackage(decodeURI(hash.substring(3)));
+            renderPackage(activeRoute);
         }
         else
         {
             renderOverview();
         }
         renderSidebar();
-        window.scrollTo(0, 0);
+        const targeted = document.querySelector('.overload.target');
+        if (targeted)
+        {
+            targeted.scrollIntoView();
+        }
+        else
+        {
+            window.scrollTo(0, 0);
+        }
     }
 
     function renderOverview()
@@ -733,7 +876,7 @@
             + functionTable(fns, false);
     }
 
-    function functionTable(fns, showLocation)
+    function functionTable(fns, showLocation, overload)
     {
         const rows = fns.map(fd =>
         {
@@ -742,7 +885,9 @@
             const tests = (fd.functionDefinition.tests || []).length;
             const summary = adapters.map(a => status(fd, a)).filter(s => s.total > 0);
             const passing = summary.filter(s => s.kind === 'pass').length;
-            return '<tr><td><a href="#f/' + encodeURI(functionRoute(fd)) + '"><code>' + escapeHtml(name) + '</code></a></td>'
+            const match = overload ? overloadIndex(fd.functionDefinition, overload) : -1;
+            const suffix = match >= 0 ? overloadKeys(fd.functionDefinition)[match] : '';
+            return '<tr><td><a href="#f/' + encodeURI(functionRoute(fd) + suffix) + '"><code>' + escapeHtml(name) + '</code></a></td>'
                 + (showLocation
                     ? '<td><span class="badge">' + escapeHtml(fd.reportScope.module) + '</span></td>'
                         + '<td><code>' + escapeHtml(packageOf(fd)) + '</code></td>'
@@ -758,28 +903,34 @@
             + rows + '</tbody></table>';
     }
 
-    function renderNameChoice(name, matches)
+    function renderNameChoice(name, matches, overload)
     {
         document.getElementById('content').innerHTML =
-            '<h1>' + escapeHtml(name) + ' <span class="kind">function</span></h1>'
+            '<h1>' + escapeHtml(name) + escapeHtml(overload || '') + ' <span class="kind">function</span></h1>'
             + '<div class="subtitle">' + matches.length + ' functions are named <code>' + escapeHtml(name) + '</code>. Pick the one you meant.</div>'
-            + functionTable(matches, true);
+            + functionTable(matches, true, overload);
     }
 
-    function renderFunction(route)
+    function renderFunction(route, overload)
     {
         // A route is either the full module/name/sourceId key or just a function name, so that a
         // shared link can stay short and survive the source file being moved.
         let fd = functionIndex[route];
         if (!fd)
         {
-            const named = nameIndex[route];
-            if (named && named.length > 1)
+            let named = nameIndex[route] || [];
+            if (named.length > 1 && overload)
             {
-                renderNameChoice(route, named);
+                // The overload can settle a shared name on its own: only date::max takes a Date.
+                const carrying = named.filter(c => overloadIndex(c.functionDefinition, overload) >= 0);
+                named = carrying.length ? carrying : named;
+            }
+            if (named.length > 1)
+            {
+                renderNameChoice(route, named, overload);
                 return;
             }
-            fd = named && named[0];
+            fd = named[0];
         }
         if (!fd)
         {
@@ -791,10 +942,16 @@
         const name = def.name || 'composition-tests';
         const url = sourceUrl(fd);
 
+        const keys = overloadKeys(def);
+        const wanted = overload ? overloadIndex(def, overload) : -1;
         const overloads = (def.signatures || []).map((s, i) =>
         {
             const simple = def.name && s.simple.indexOf(def.name + '(') >= 0 ? s.simple.substring(s.simple.indexOf(def.name + '(')) : s.simple;
-            return '<div class="overload"><div class="sig mono">' + escapeHtml(simple) + '</div>'
+            const anchor = keys[i]
+                ? '<a class="overload-link" href="#f/' + encodeURI(shareRoute(fd, keys[i])) + '" title="Link to this overload">#</a>'
+                : '';
+            return '<div class="overload' + (i === wanted ? ' target' : '') + '">'
+                + '<div class="sig-row"><div class="sig mono">' + escapeHtml(simple) + '</div>' + anchor + '</div>'
                 + (s.platformOnly ? '<div class="subtitle"><span class="badge">platform only</span> Tested outside PCT.</div>' : '')
                 + (s.documentation
                     ? '<div class="doc">' + markdown(s.documentation, fd) + '</div>'

--- a/legend-engine-config/legend-engine-server/legend-engine-server-http-server/src/main/resources/pct/PCT_Report_Functions.html
+++ b/legend-engine-config/legend-engine-server/legend-engine-server-http-server/src/main/resources/pct/PCT_Report_Functions.html
@@ -1,0 +1,887 @@
+<!--
+ Copyright 2026 Goldman Sachs
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>PCT Function Reference</title>
+    <style>
+        :root {
+            --bg: #ffffff;
+            --bg-alt: #f6f7f9;
+            --bg-sunken: #eef0f3;
+            --border: #d9dde3;
+            --border-soft: #e8ebef;
+            --text: #1b1f24;
+            --text-muted: #5c6773;
+            --link: #0b62c4;
+            --pass: #167c3c;
+            --pass-bg: #e6f4ea;
+            --fail: #c0243c;
+            --fail-bg: #fdeaed;
+            --partial: #a35b00;
+            --partial-bg: #fdf1e0;
+            --none: #8b95a1;
+            --code-bg: #f4f5f7;
+            --accent: #0b62c4;
+            --sidebar-w: 330px;
+            --header-h: 52px;
+        }
+
+        @media (prefers-color-scheme: dark) {
+            :root {
+                --bg: #14181d;
+                --bg-alt: #1a1f26;
+                --bg-sunken: #10141a;
+                --border: #2c333c;
+                --border-soft: #232930;
+                --text: #e4e8ed;
+                --text-muted: #99a3ae;
+                --link: #6cb0f5;
+                --pass: #5fd08a;
+                --pass-bg: #16301f;
+                --fail: #ff8095;
+                --fail-bg: #35171d;
+                --partial: #f0b45e;
+                --partial-bg: #33260f;
+                --none: #7a848f;
+                --code-bg: #1f252c;
+                --accent: #6cb0f5;
+            }
+        }
+
+        * { box-sizing: border-box; }
+
+        body {
+            margin: 0;
+            background: var(--bg);
+            color: var(--text);
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+            font-size: 14px;
+            line-height: 1.55;
+        }
+
+        a { color: var(--link); text-decoration: none; }
+        a:hover { text-decoration: underline; }
+        code, .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 12.5px; }
+
+        header.top {
+            position: fixed;
+            top: 0; left: 0; right: 0;
+            height: var(--header-h);
+            display: flex;
+            align-items: center;
+            gap: 16px;
+            padding: 0 18px;
+            background: var(--bg-alt);
+            border-bottom: 1px solid var(--border);
+            z-index: 10;
+        }
+        header.top .title { font-weight: 600; white-space: nowrap; }
+        header.top .title a { color: var(--text); }
+        header.top .spacer { flex: 1; }
+        header.top .links { font-size: 12.5px; color: var(--text-muted); white-space: nowrap; }
+
+        #search {
+            width: 260px;
+            padding: 5px 9px;
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            background: var(--bg);
+            color: var(--text);
+            font-size: 13px;
+        }
+
+        nav.sidebar {
+            position: fixed;
+            top: var(--header-h); bottom: 0; left: 0;
+            width: var(--sidebar-w);
+            overflow-y: auto;
+            border-right: 1px solid var(--border);
+            background: var(--bg-sunken);
+            padding: 12px 0 40px 0;
+        }
+
+        .nav-module {
+            padding: 7px 14px 3px 14px;
+            font-size: 11px;
+            font-weight: 700;
+            letter-spacing: .06em;
+            text-transform: uppercase;
+            color: var(--text-muted);
+        }
+        .nav-pkg {
+            display: block;
+            padding: 3px 14px 3px 22px;
+            color: var(--text);
+            font-size: 13px;
+            cursor: pointer;
+        }
+        .nav-pkg:hover { background: var(--border-soft); text-decoration: none; }
+        .nav-pkg.selected { background: var(--border-soft); font-weight: 600; }
+        .nav-pkg .count { color: var(--text-muted); font-size: 11.5px; margin-left: 6px; }
+        .nav-fn {
+            display: block;
+            padding: 2px 14px 2px 36px;
+            color: var(--text);
+            font-size: 13px;
+        }
+        .nav-fn:hover { background: var(--border-soft); text-decoration: none; }
+        .nav-fn.selected { background: var(--accent); color: #fff; border-radius: 3px; }
+        .nav-empty { padding: 12px 16px; color: var(--text-muted); font-size: 13px; }
+
+        main {
+            margin-left: var(--sidebar-w);
+            padding: calc(var(--header-h) + 22px) 32px 80px 32px;
+            max-width: 1180px;
+        }
+
+        h1 { font-size: 24px; margin: 0 0 4px 0; }
+        h1 .kind { color: var(--text-muted); font-weight: 400; font-size: 15px; }
+        h2 {
+            font-size: 16px;
+            margin: 34px 0 10px 0;
+            padding-bottom: 6px;
+            border-bottom: 1px solid var(--border);
+        }
+        h3 { font-size: 14px; margin: 22px 0 6px 0; }
+
+        .subtitle { color: var(--text-muted); font-size: 13px; margin-bottom: 18px; }
+        .subtitle .sep { margin: 0 8px; opacity: .5; }
+
+        .badge {
+            display: inline-block;
+            padding: 1px 7px;
+            border-radius: 10px;
+            background: var(--bg-sunken);
+            border: 1px solid var(--border);
+            font-size: 11px;
+            color: var(--text-muted);
+            vertical-align: 1px;
+        }
+
+        table { border-collapse: collapse; width: 100%; }
+        th, td { text-align: left; padding: 6px 10px; border-bottom: 1px solid var(--border-soft); vertical-align: top; }
+        th { font-size: 11.5px; text-transform: uppercase; letter-spacing: .04em; color: var(--text-muted); font-weight: 600; }
+        tbody tr:hover { background: var(--bg-alt); }
+
+        .scroll-x { overflow-x: auto; border: 1px solid var(--border); border-radius: 8px; }
+        .scroll-x table { min-width: 100%; }
+        .scroll-x th, .scroll-x td { white-space: nowrap; }
+        .scroll-x th.sticky-col, .scroll-x td.sticky-col {
+            position: sticky; left: 0;
+            background: var(--bg);
+            border-right: 1px solid var(--border-soft);
+            white-space: normal;
+            min-width: 260px;
+        }
+        .scroll-x tbody tr:hover td.sticky-col { background: var(--bg-alt); }
+        .scroll-x th.group-head { text-align: center; border-bottom: 1px solid var(--border); }
+        .scroll-x td.cell { text-align: center; }
+
+        .sig {
+            background: var(--code-bg);
+            border: 1px solid var(--border-soft);
+            border-left: 3px solid var(--accent);
+            border-radius: 5px;
+            padding: 7px 11px;
+            margin-bottom: 8px;
+            overflow-x: auto;
+            white-space: pre;
+        }
+
+        .overload { margin-bottom: 26px; }
+        .doc { margin-left: 3px; }
+        .doc p { margin: 8px 0; }
+        .doc ul { margin: 8px 0; padding-left: 22px; }
+        .doc li { margin: 2px 0; }
+        .doc code { background: var(--code-bg); padding: 1px 4px; border-radius: 3px; }
+        .doc pre {
+            background: var(--code-bg);
+            border: 1px solid var(--border-soft);
+            border-radius: 6px;
+            padding: 9px 12px;
+            overflow-x: auto;
+            margin: 10px 0;
+        }
+        .doc pre code { background: none; padding: 0; }
+        .no-doc { color: var(--text-muted); font-style: italic; }
+
+        .chips { display: flex; flex-wrap: wrap; gap: 7px; margin: 4px 0 6px 0; }
+        .chip {
+            display: inline-flex;
+            align-items: baseline;
+            gap: 6px;
+            padding: 3px 9px;
+            border-radius: 13px;
+            border: 1px solid var(--border);
+            font-size: 12px;
+            cursor: default;
+        }
+        .chip .n { font-weight: 600; }
+        .chip.pass { background: var(--pass-bg); border-color: transparent; color: var(--pass); }
+        .chip.partial { background: var(--partial-bg); border-color: transparent; color: var(--partial); }
+        .chip.fail { background: var(--fail-bg); border-color: transparent; color: var(--fail); }
+        .chip.none { color: var(--none); }
+
+        .mark { font-weight: 700; font-size: 16px; line-height: 1; }
+        .mark.pass { color: var(--pass); }
+        .mark.fail { color: var(--fail); cursor: pointer; text-decoration: underline dotted; }
+        .mark.partial { color: var(--partial); }
+        .mark.none { color: var(--none); }
+
+        .qualifier {
+            display: inline-block;
+            font-size: 10.5px;
+            padding: 0 6px;
+            border-radius: 8px;
+            background: var(--bg-sunken);
+            border: 1px solid var(--border);
+            color: var(--text-muted);
+            margin-right: 4px;
+        }
+
+        .failures { margin: 4px 0 18px 0; }
+        .failures h3 { margin: 12px 0 4px 0; }
+
+        .err {
+            margin: 6px 0 2px 0;
+            padding: 7px 10px;
+            background: var(--fail-bg);
+            border-radius: 5px;
+            font-size: 12px;
+            white-space: pre-wrap;
+            word-break: break-word;
+        }
+        .err .who { font-weight: 600; color: var(--fail); }
+
+        .toolbar {
+            display: flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 14px;
+            margin-bottom: 18px;
+            padding: 9px 12px;
+            background: var(--bg-alt);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            font-size: 12.5px;
+        }
+        .toolbar label { display: inline-flex; align-items: center; gap: 5px; cursor: pointer; }
+
+        footer.page {
+            margin-left: var(--sidebar-w);
+            padding: 18px 32px 40px 32px;
+            color: var(--text-muted);
+            font-size: 12px;
+            border-top: 1px solid var(--border-soft);
+        }
+
+        .cards { display: grid; grid-template-columns: repeat(auto-fill, minmax(250px, 1fr)); gap: 12px; }
+        .card {
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 12px 14px;
+            background: var(--bg-alt);
+        }
+        .card .name { font-weight: 600; margin-bottom: 2px; }
+        .card .meta { color: var(--text-muted); font-size: 12px; }
+
+        @media (max-width: 900px) {
+            nav.sidebar { position: static; width: auto; height: auto; max-height: 240px; border-right: none; border-bottom: 1px solid var(--border); }
+            main, footer.page { margin-left: 0; padding-left: 16px; padding-right: 16px; }
+            header.top { position: static; }
+            main { padding-top: 20px; }
+        }
+    </style>
+</head>
+<body>
+<header class="top">
+    <div class="title"><a href="#">Legend PCT Reference</a></div>
+    <input id="search" type="search" placeholder="Search functions…" autocomplete="off" spellcheck="false">
+    <div class="spacer"></div>
+    <div class="links"><a href="./PCT_Report_Compatibility.html">Compatibility matrix</a></div>
+</header>
+<nav class="sidebar" id="sidebar"></nav>
+<main id="content">Loading…</main>
+<footer class="page" id="footer"></footer>
+
+<script>
+    "use strict";
+
+    let doc = null;
+    let gitInfo = {};
+    let adapters = [];          // ordered AdapterKey list
+    // Keys are Pure identifiers — 'toString' and friends collide with Object.prototype, so these are all bare maps.
+    let byModulePackage = Object.create(null);   // module -> package -> [functionDocumentation]
+    let functionIndex = Object.create(null);     // route key -> functionDocumentation
+    let nameIndex = Object.create(null);         // function name -> [functionDocumentation]
+
+    /* ---------------------------------------------------------------- data */
+
+    async function load()
+    {
+        if (window.PCT_DATA)
+        {
+            doc = window.PCT_DATA;
+            gitInfo = window.PCT_GIT_INFO || {};
+        }
+        else
+        {
+            const [d, g] = await Promise.all([
+                fetch('./pct-docs.json').then(r => r.json()),
+                fetch('./git-info.json').then(r => r.json()).catch(() => ({}))
+            ]);
+            doc = d;
+            gitInfo = g || {};
+        }
+        index();
+        renderSidebar();
+        route();
+        window.addEventListener('hashchange', route);
+        document.getElementById('search').addEventListener('input', renderSidebar);
+        renderFooter();
+    }
+
+    function adapterKey(a)
+    {
+        return a.platform + ':' + a.adapter.group + ':' + a.adapter.name;
+    }
+
+    function adapterName(a)
+    {
+        return a.adapter.name === 'Native' ? 'Native (' + a.platform + ')' : a.adapter.name;
+    }
+
+    function adapterGroup(a)
+    {
+        return a.adapter.name === 'Native' ? 'Native' : a.adapter.group;
+    }
+
+    function functionRoute(fd)
+    {
+        return fd.reportScope.module + '/' + (fd.functionDefinition.name || 'composition-tests') + '/' + fd.functionDefinition.sourceId;
+    }
+
+    function packageOf(fd)
+    {
+        return fd.functionDefinition._package || fd.reportScope._package || '(default)';
+    }
+
+    function index()
+    {
+        const groups = Object.create(null);
+        doc.adapters.forEach(a => (groups[adapterGroup(a)] = groups[adapterGroup(a)] || []).push(a));
+        adapters = Object.keys(groups).sort().flatMap(g => groups[g].sort((x, y) => adapterName(x).localeCompare(adapterName(y))));
+
+        doc.functionsDocumentation.forEach(fd =>
+        {
+            const module = fd.reportScope.module;
+            const pkg = packageOf(fd);
+            byModulePackage[module] = byModulePackage[module] || Object.create(null);
+            (byModulePackage[module][pkg] = byModulePackage[module][pkg] || []).push(fd);
+            functionIndex[functionRoute(fd)] = fd;
+            const name = fd.functionDefinition.name;
+            if (name)
+            {
+                (nameIndex[name] = nameIndex[name] || []).push(fd);
+            }
+        });
+        Object.values(byModulePackage).forEach(pkgs =>
+            Object.values(pkgs).forEach(fns => fns.sort((a, b) =>
+                (a.functionDefinition.name || '').localeCompare(b.functionDefinition.name || ''))));
+    }
+
+    /* ------------------------------------------------------------- results */
+
+    function testsFor(fd, a)
+    {
+        const results = fd.functionTestResults ? fd.functionTestResults[adapterKey(a)] : null;
+        return results && results.tests ? results.tests : null;
+    }
+
+    function isPlatformOnly(fd)
+    {
+        return (fd.functionDefinition.signatures || []).some(s => s.platformOnly);
+    }
+
+    // Mirrors the compatibility matrix: a status for one function on one adapter.
+    function status(fd, a)
+    {
+        const tests = testsFor(fd, a);
+        if (tests === null)
+        {
+            if (isPlatformOnly(fd))
+            {
+                const count = (fd.functionDefinition.tests || []).filter(t => !t.pct).length;
+                return a.adapter.name === 'Native'
+                    ? {kind: 'pass', pass: count, total: count, note: 'Platform function — tests run outside PCT'}
+                    : {kind: 'none', pass: 0, total: 0, note: 'Platform function — tests run outside PCT'};
+            }
+            return {kind: 'none', pass: 0, total: 0, note: 'No tests (or reports) were found'};
+        }
+        if (tests.length === 0)
+        {
+            return {kind: 'none', pass: 0, total: 0, note: 'Unknown — to define'};
+        }
+        const pass = tests.filter(t => t.success).length;
+        return {
+            kind: pass === tests.length ? 'pass' : pass === 0 ? 'fail' : 'partial',
+            pass: pass,
+            total: tests.length,
+            note: null
+        };
+    }
+
+    function aggregate(fds, a)
+    {
+        let pass = 0, total = 0;
+        fds.forEach(fd =>
+        {
+            const tests = testsFor(fd, a);
+            if (tests)
+            {
+                pass += tests.filter(t => t.success).length;
+                total += tests.length;
+            }
+        });
+        return {
+            kind: total === 0 ? 'none' : pass === total ? 'pass' : pass === 0 ? 'fail' : 'partial',
+            pass: pass,
+            total: total
+        };
+    }
+
+    /* -------------------------------------------------------------- render */
+
+    function escapeHtml(s)
+    {
+        return String(s).replace(/[&<>"']/g, m => ({'&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'})[m]);
+    }
+
+    // Minimal Markdown: fenced code, bullet lists, paragraphs, bold, inline code, links.
+    // Input is escaped first, so everything below operates on HTML-safe text.
+    function markdown(src, currentFd)
+    {
+        if (!src)
+        {
+            return '';
+        }
+        const lines = escapeHtml(src).split('\n');
+        const out = [];
+        let para = [];
+        let list = [];
+        let fence = null;
+
+        const flushPara = () =>
+        {
+            if (para.length)
+            {
+                out.push('<p>' + inline(para.join(' '), currentFd) + '</p>');
+                para = [];
+            }
+        };
+        const flushList = () =>
+        {
+            if (list.length)
+            {
+                out.push('<ul>' + list.map(i => '<li>' + inline(i, currentFd) + '</li>').join('') + '</ul>');
+                list = [];
+            }
+        };
+
+        lines.forEach(line =>
+        {
+            const fenceMatch = line.match(/^\s*```(\w*)\s*$/);
+            if (fence !== null)
+            {
+                if (fenceMatch)
+                {
+                    out.push('<pre><code>' + fence.join('\n') + '</code></pre>');
+                    fence = null;
+                }
+                else
+                {
+                    fence.push(line);
+                }
+                return;
+            }
+            if (fenceMatch)
+            {
+                flushPara();
+                flushList();
+                fence = [];
+                return;
+            }
+            const bullet = line.match(/^\s*[-*]\s+(.*)$/);
+            if (bullet)
+            {
+                flushPara();
+                list.push(bullet[1]);
+                return;
+            }
+            if (!line.trim())
+            {
+                flushPara();
+                flushList();
+                return;
+            }
+            flushList();
+            para.push(line.trim());
+        });
+        if (fence !== null)
+        {
+            out.push('<pre><code>' + fence.join('\n') + '</code></pre>');
+        }
+        flushPara();
+        flushList();
+        return out.join('');
+    }
+
+    function inline(text, currentFd)
+    {
+        return text
+            .replace(/`([^`]+)`/g, (m, code) => '<code>' + linkSignature(code, currentFd) + '</code>')
+            .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
+            .replace(/\[([^\]]+)\]\(([^)\s]+)\)/g, '<a href="$2" target="_blank" rel="noopener">$1</a>');
+    }
+
+    // Turns `median(Number[*]):Float[1]` inside documentation into a link to that function's page.
+    function linkSignature(code, currentFd)
+    {
+        const match = code.match(/^([\w:]+)\(/);
+        if (!match)
+        {
+            return code;
+        }
+        const parts = match[1].split('::');
+        const name = parts[parts.length - 1];
+        const candidates = nameIndex[name];
+        if (!candidates || !candidates.length)
+        {
+            return code;
+        }
+        let target = candidates[0];
+        if (candidates.length > 1 && currentFd)
+        {
+            target = candidates.find(c => packageOf(c) === packageOf(currentFd)) || candidates[0];
+        }
+        if (currentFd && functionRoute(target) === functionRoute(currentFd))
+        {
+            return code;
+        }
+        return '<a href="#f/' + encodeURI(functionRoute(target)) + '">' + code + '</a>';
+    }
+
+    function sourceUrl(fd)
+    {
+        const commit = gitInfo['git.commit.id'] || 'master';
+        const moduleUrls = {
+            grammar: 'https://github.com/finos/legend-pure/tree/master/legend-pure-core/legend-pure-m3-core/src/main/resources',
+            essential: 'https://github.com/finos/legend-pure/tree/master/legend-pure-core/legend-pure-m3-core/src/main/resources',
+            standard: 'https://github.com/finos/legend-engine/tree/' + commit + '/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources',
+            relation: 'https://github.com/finos/legend-engine/tree/' + commit + '/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources',
+            unclassified: 'https://github.com/finos/legend-engine/tree/' + commit + '/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-functions-unclassified-pure/src/main/resources',
+            variant: 'https://github.com/finos/legend-engine/tree/' + commit + '/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-variant/legend-engine-pure-functions-variant-pure/src/main/resources',
+            scenario_quant: 'https://github.com/finos/legend-engine/tree/' + commit + '/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-scenario-quant-pure/src/main/resources'
+        };
+        const base = moduleUrls[fd.reportScope.module];
+        return base ? base + fd.functionDefinition.sourceId : null;
+    }
+
+    function renderSidebar()
+    {
+        const query = (document.getElementById('search').value || '').trim().toLowerCase();
+        const current = decodeURI(location.hash.replace(/^#[fp]\//, ''));
+        const html = [];
+
+        Object.keys(byModulePackage).sort().forEach(module =>
+        {
+            const packages = byModulePackage[module];
+            const rows = [];
+            Object.keys(packages).sort().forEach(pkg =>
+            {
+                const fns = packages[pkg].filter(fd => !query
+                    || (fd.functionDefinition.name || '').toLowerCase().includes(query)
+                    || pkg.toLowerCase().includes(query));
+                if (!fns.length)
+                {
+                    return;
+                }
+                const pkgRoute = module + '/' + pkg;
+                rows.push('<a class="nav-pkg' + (current === pkgRoute ? ' selected' : '') + '" href="#p/' + encodeURI(pkgRoute) + '">'
+                    + escapeHtml(pkg) + '<span class="count">' + packages[pkg].length + '</span></a>');
+                if (query || current === pkgRoute || fns.some(fd => current === functionRoute(fd)))
+                {
+                    fns.forEach(fd => rows.push('<a class="nav-fn' + (current === functionRoute(fd) ? ' selected' : '') + '" href="#f/'
+                        + encodeURI(functionRoute(fd)) + '">' + escapeHtml(fd.functionDefinition.name || 'composition-tests') + '</a>'));
+                }
+            });
+            if (rows.length)
+            {
+                html.push('<div class="nav-module">' + escapeHtml(module) + '</div>' + rows.join(''));
+            }
+        });
+        document.getElementById('sidebar').innerHTML = html.length ? html.join('') : '<div class="nav-empty">No match.</div>';
+    }
+
+    function renderFooter()
+    {
+        const commit = gitInfo['git.commit.id'] || 'master';
+        document.getElementById('footer').innerHTML = 'PCT results as of ' + escapeHtml(gitInfo['git.commit.time'] || 'unknown')
+            + ' using commit <a href="https://github.com/finos/legend-engine/tree/' + encodeURIComponent(commit) + '" target="_blank" rel="noopener">'
+            + escapeHtml(commit) + '</a>.';
+    }
+
+    function toolbar()
+    {
+        return '<div class="toolbar"><span style="color:var(--text-muted)">' + adapters.length + ' adapters reporting</span></div>';
+    }
+
+    function chip(label, st)
+    {
+        const value = st.total === 0 ? '—' : st.pass + '/' + st.total;
+        return '<span class="chip ' + st.kind + '" title="' + escapeHtml(st.note || '') + '">' + escapeHtml(label) + ' <span class="n">' + value + '</span></span>';
+    }
+
+    function route()
+    {
+        const hash = location.hash;
+        if (hash.startsWith('#f/'))
+        {
+            renderFunction(decodeURI(hash.substring(3)));
+        }
+        else if (hash.startsWith('#p/'))
+        {
+            renderPackage(decodeURI(hash.substring(3)));
+        }
+        else
+        {
+            renderOverview();
+        }
+        renderSidebar();
+        window.scrollTo(0, 0);
+    }
+
+    function renderOverview()
+    {
+        const all = doc.functionsDocumentation;
+        const groups = Object.create(null);
+        adapters.forEach(a => (groups[adapterGroup(a)] = groups[adapterGroup(a)] || []).push(a));
+
+        const modules = Object.keys(byModulePackage).sort().map(module =>
+        {
+            const packages = byModulePackage[module];
+            const count = Object.values(packages).reduce((n, fns) => n + fns.length, 0);
+            return '<div class="card"><div class="name">' + escapeHtml(module) + '</div><div class="meta">'
+                + count + ' functions in ' + Object.keys(packages).length + ' packages</div></div>';
+        }).join('');
+
+        document.getElementById('content').innerHTML =
+            '<h1>PCT Function Reference</h1>'
+            + '<div class="subtitle">Every function covered by the Pure Compatibility Test suite, its overloads, its test cases, '
+            + 'and how each store behaves on them. Pick a package on the left.</div>'
+            + toolbar()
+            + '<h2>Modules</h2><div class="cards">' + modules + '</div>'
+            + '<h2>Adapters</h2>'
+            + Object.keys(groups).sort().map(g =>
+                '<h3>' + escapeHtml(g) + '</h3><div class="chips">'
+                + groups[g].map(a => chip(adapterName(a), aggregate(all, a))).join('')
+                + '</div>').join('');
+    }
+
+    function renderPackage(route)
+    {
+        const slash = route.indexOf('/');
+        const module = route.substring(0, slash);
+        const pkg = route.substring(slash + 1);
+        const fns = (byModulePackage[module] || {})[pkg];
+        if (!fns)
+        {
+            document.getElementById('content').innerHTML = '<h1>Not found</h1><p>No package <code>' + escapeHtml(route) + '</code>.</p>';
+            return;
+        }
+
+        const rows = fns.map(fd =>
+        {
+            const name = fd.functionDefinition.name || 'composition-tests';
+            const signatures = (fd.functionDefinition.signatures || []).length;
+            const tests = (fd.functionDefinition.tests || []).length;
+            const summary = adapters.map(a => status(fd, a)).filter(s => s.total > 0);
+            const passing = summary.filter(s => s.kind === 'pass').length;
+            return '<tr><td><a href="#f/' + encodeURI(functionRoute(fd)) + '"><code>' + escapeHtml(name) + '</code></a></td>'
+                + '<td>' + signatures + '</td><td>' + tests + '</td>'
+                + '<td><span class="mark ' + (summary.length === 0 ? 'none' : passing === summary.length ? 'pass' : passing === 0 ? 'fail' : 'partial') + '">'
+                + (summary.length === 0 ? '—' : passing + '/' + summary.length) + '</span></td></tr>';
+        }).join('');
+
+        document.getElementById('content').innerHTML =
+            '<h1>' + escapeHtml(pkg) + ' <span class="kind">package</span></h1>'
+            + '<div class="subtitle"><span class="badge">' + escapeHtml(module) + '</span><span class="sep">·</span>' + fns.length + ' functions</div>'
+            + toolbar()
+            + '<h2>Functions</h2>'
+            + '<table><thead><tr><th>Function</th><th>Overloads</th><th>Tests</th><th>Adapters fully passing</th></tr></thead><tbody>'
+            + rows + '</tbody></table>';
+    }
+
+    function renderFunction(route)
+    {
+        const fd = functionIndex[route];
+        if (!fd)
+        {
+            document.getElementById('content').innerHTML = '<h1>Not found</h1><p>No function <code>' + escapeHtml(route) + '</code>.</p>';
+            return;
+        }
+        const def = fd.functionDefinition;
+        const name = def.name || 'composition-tests';
+        const url = sourceUrl(fd);
+
+        const overloads = (def.signatures || []).map((s, i) =>
+        {
+            const simple = def.name && s.simple.indexOf(def.name + '(') >= 0 ? s.simple.substring(s.simple.indexOf(def.name + '(')) : s.simple;
+            return '<div class="overload"><div class="sig mono">' + escapeHtml(simple) + '</div>'
+                + (s.platformOnly ? '<div class="subtitle"><span class="badge">platform only</span> Tested outside PCT.</div>' : '')
+                + (s.documentation
+                    ? '<div class="doc">' + markdown(s.documentation, fd) + '</div>'
+                    : '<div class="doc no-doc">No documentation yet.</div>')
+                + '</div>';
+        }).join('');
+
+        const testDocs = Object.create(null);
+        (def.tests || []).forEach(t => (testDocs[t.name] = t));
+
+        // Union of test names seen across adapters, so a test only some adapters run still shows.
+        const testNames = [];
+        (def.tests || []).forEach(t => testNames.push(t.name));
+        adapters.forEach(a =>
+        {
+            const tests = testsFor(fd, a) || [];
+            tests.forEach(t =>
+            {
+                if (!testNames.includes(t.testName))
+                {
+                    testNames.push(t.testName);
+                }
+            });
+        });
+        testNames.sort();
+
+        const results = Object.create(null);   // testName -> adapterKey -> TestInfo
+        adapters.forEach(a =>
+        {
+            (testsFor(fd, a) || []).forEach(t =>
+            {
+                (results[t.testName] = results[t.testName] || Object.create(null))[adapterKey(a)] = t;
+            });
+        });
+
+        const groups = Object.create(null);
+        adapters.forEach(a => (groups[adapterGroup(a)] = groups[adapterGroup(a)] || []).push(a));
+        const groupNames = Object.keys(groups).sort();
+
+        const header =
+            '<tr><th class="sticky-col" rowspan="2">Test case</th>'
+            + groupNames.map(g => '<th class="group-head" colspan="' + groups[g].length + '">' + escapeHtml(g) + '</th>').join('')
+            + '</tr><tr>'
+            + adapters.map(a => '<th style="text-align:center">' + escapeHtml(a.adapter.name === 'Native' ? a.platform : a.adapter.name) + '</th>').join('')
+            + '</tr>';
+
+        const body = testNames.map((testName, i) =>
+        {
+            const definition = testDocs[testName] || {};
+            const qualifiers = new Set();
+            adapters.forEach(a =>
+            {
+                const t = (results[testName] || {})[adapterKey(a)];
+                (t && t.qualifiers || []).forEach(q => qualifiers.add(q));
+            });
+
+            const cells = adapters.map(a =>
+            {
+                const t = (results[testName] || {})[adapterKey(a)];
+                if (!t)
+                {
+                    return '<td class="cell"><span class="mark none" title="Not reported">–</span></td>';
+                }
+                if (t.success)
+                {
+                    return '<td class="cell"><span class="mark pass" title="Passing">✓</span></td>';
+                }
+                return '<td class="cell"><span class="mark fail" title="' + escapeHtml(t.errorMessage || 'Failing')
+                    + '" onclick="toggleErrors(' + i + ')">×</span></td>';
+            }).join('');
+
+            return '<tr><td class="sticky-col"><code>' + escapeHtml(testName) + '</code>'
+                + (definition.pct === false ? ' <span class="badge">non-PCT</span>' : '')
+                + (qualifiers.size ? '<div>' + Array.from(qualifiers).sort().map(q => '<span class="qualifier">' + escapeHtml(q) + '</span>').join('') + '</div>' : '')
+                + (definition.documentation ? '<div class="doc">' + markdown(definition.documentation, fd) + '</div>' : '')
+                + '</td>' + cells + '</tr>';
+        }).join('');
+
+        // Failure detail lives outside the scrolling table so long SQL errors stay readable.
+        const failures = testNames.map((testName, i) =>
+        {
+            const rows = adapters.map(a =>
+            {
+                const t = (results[testName] || {})[adapterKey(a)];
+                return t && !t.success
+                    ? '<div class="err"><span class="who">' + escapeHtml(adapterName(a)) + '</span> — ' + escapeHtml(t.errorMessage || 'no message') + '</div>'
+                    : '';
+            }).join('');
+            return rows
+                ? '<div class="failures" id="errors-' + i + '" style="display:none"><h3><code>' + escapeHtml(testName) + '</code> failures</h3>' + rows + '</div>'
+                : '';
+        }).join('');
+
+        document.getElementById('content').innerHTML =
+            '<h1><code>' + escapeHtml(name) + '</code> <span class="kind">function</span></h1>'
+            + '<div class="subtitle"><span class="badge">' + escapeHtml(fd.reportScope.module) + '</span><span class="sep">·</span>'
+            + '<a href="#p/' + encodeURI(fd.reportScope.module + '/' + packageOf(fd)) + '">' + escapeHtml(packageOf(fd)) + '</a>'
+            + '<span class="sep">·</span>' + (url
+                ? '<a href="' + url + '" target="_blank" rel="noopener">' + escapeHtml(def.sourceId) + '</a>'
+                : '<code>' + escapeHtml(def.sourceId) + '</code>')
+            + '</div>'
+            + toolbar()
+            + '<h2>Compatibility</h2><div class="chips">' + adapters.map(a => chip(adapterName(a), status(fd, a))).join('') + '</div>'
+            + '<h2>Overloads</h2>' + (overloads || '<p class="no-doc">No signatures reported.</p>')
+            + '<h2>Test cases</h2>'
+            + (testNames.length
+                ? '<div class="scroll-x"><table><thead>' + header + '</thead><tbody>' + body + '</tbody></table></div>'
+                  + '<div class="subtitle" style="margin-top:8px">Click any <span class="mark fail">×</span> to read the failure.</div>'
+                  + failures
+                : '<p class="no-doc">No test cases reported.</p>');
+    }
+
+    function toggleErrors(i)
+    {
+        const panel = document.getElementById('errors-' + i);
+        if (panel)
+        {
+            const open = panel.style.display === 'none';
+            panel.style.display = open ? '' : 'none';
+            if (open)
+            {
+                panel.scrollIntoView({block: 'nearest'});
+            }
+        }
+    }
+
+    window.addEventListener('DOMContentLoaded', load);
+</script>
+</body>
+</html>

--- a/legend-engine-config/legend-engine-server/legend-engine-server-http-server/src/main/resources/pct/PCT_Report_Functions.html
+++ b/legend-engine-config/legend-engine-server/legend-engine-server-http-server/src/main/resources/pct/PCT_Report_Functions.html
@@ -331,6 +331,7 @@
     let byModulePackage = Object.create(null);   // module -> package -> [functionDocumentation]
     let functionIndex = Object.create(null);     // route key -> functionDocumentation
     let nameIndex = Object.create(null);         // function name -> [functionDocumentation]
+    let activeRoute = '';                        // full route of what is on screen, even when reached by a short link
 
     /* ---------------------------------------------------------------- data */
 
@@ -376,6 +377,12 @@
     function functionRoute(fd)
     {
         return fd.reportScope.module + '/' + (fd.functionDefinition.name || 'composition-tests') + '/' + fd.functionDefinition.sourceId;
+    }
+
+    function shareRoute(fd)
+    {
+        const name = fd.functionDefinition.name;
+        return name && nameIndex[name].length === 1 ? name : functionRoute(fd);
     }
 
     function packageOf(fd)
@@ -607,7 +614,7 @@
     function renderSidebar()
     {
         const query = (document.getElementById('search').value || '').trim().toLowerCase();
-        const current = decodeURI(location.hash.replace(/^#[fp]\//, ''));
+        const current = activeRoute;
         const html = [];
 
         Object.keys(byModulePackage).sort().forEach(module =>
@@ -662,6 +669,7 @@
     function route()
     {
         const hash = location.hash;
+        activeRoute = decodeURI(hash.replace(/^#[fp]\//, ''));
         if (hash.startsWith('#f/'))
         {
             renderFunction(decodeURI(hash.substring(3)));
@@ -717,6 +725,16 @@
             return;
         }
 
+        document.getElementById('content').innerHTML =
+            '<h1>' + escapeHtml(pkg) + ' <span class="kind">package</span></h1>'
+            + '<div class="subtitle"><span class="badge">' + escapeHtml(module) + '</span><span class="sep">·</span>' + fns.length + ' functions</div>'
+            + toolbar()
+            + '<h2>Functions</h2>'
+            + functionTable(fns, false);
+    }
+
+    function functionTable(fns, showLocation)
+    {
         const rows = fns.map(fd =>
         {
             const name = fd.functionDefinition.name || 'composition-tests';
@@ -725,28 +743,50 @@
             const summary = adapters.map(a => status(fd, a)).filter(s => s.total > 0);
             const passing = summary.filter(s => s.kind === 'pass').length;
             return '<tr><td><a href="#f/' + encodeURI(functionRoute(fd)) + '"><code>' + escapeHtml(name) + '</code></a></td>'
+                + (showLocation
+                    ? '<td><span class="badge">' + escapeHtml(fd.reportScope.module) + '</span></td>'
+                        + '<td><code>' + escapeHtml(packageOf(fd)) + '</code></td>'
+                    : '')
                 + '<td>' + signatures + '</td><td>' + tests + '</td>'
                 + '<td><span class="mark ' + (summary.length === 0 ? 'none' : passing === summary.length ? 'pass' : passing === 0 ? 'fail' : 'partial') + '">'
                 + (summary.length === 0 ? '—' : passing + '/' + summary.length) + '</span></td></tr>';
         }).join('');
 
-        document.getElementById('content').innerHTML =
-            '<h1>' + escapeHtml(pkg) + ' <span class="kind">package</span></h1>'
-            + '<div class="subtitle"><span class="badge">' + escapeHtml(module) + '</span><span class="sep">·</span>' + fns.length + ' functions</div>'
-            + toolbar()
-            + '<h2>Functions</h2>'
-            + '<table><thead><tr><th>Function</th><th>Overloads</th><th>Tests</th><th>Adapters fully passing</th></tr></thead><tbody>'
+        return '<table><thead><tr><th>Function</th>'
+            + (showLocation ? '<th>Module</th><th>Package</th>' : '')
+            + '<th>Overloads</th><th>Tests</th><th>Adapters fully passing</th></tr></thead><tbody>'
             + rows + '</tbody></table>';
+    }
+
+    function renderNameChoice(name, matches)
+    {
+        document.getElementById('content').innerHTML =
+            '<h1>' + escapeHtml(name) + ' <span class="kind">function</span></h1>'
+            + '<div class="subtitle">' + matches.length + ' functions are named <code>' + escapeHtml(name) + '</code>. Pick the one you meant.</div>'
+            + functionTable(matches, true);
     }
 
     function renderFunction(route)
     {
-        const fd = functionIndex[route];
+        // A route is either the full module/name/sourceId key or just a function name, so that a
+        // shared link can stay short and survive the source file being moved.
+        let fd = functionIndex[route];
+        if (!fd)
+        {
+            const named = nameIndex[route];
+            if (named && named.length > 1)
+            {
+                renderNameChoice(route, named);
+                return;
+            }
+            fd = named && named[0];
+        }
         if (!fd)
         {
             document.getElementById('content').innerHTML = '<h1>Not found</h1><p>No function <code>' + escapeHtml(route) + '</code>.</p>';
             return;
         }
+        activeRoute = functionRoute(fd);
         const def = fd.functionDefinition;
         const name = def.name || 'composition-tests';
         const url = sourceUrl(fd);
@@ -855,6 +895,7 @@
             + '<span class="sep">·</span>' + (url
                 ? '<a href="' + url + '" target="_blank" rel="noopener">' + escapeHtml(def.sourceId) + '</a>'
                 : '<code>' + escapeHtml(def.sourceId) + '</code>')
+            + '<span class="sep">·</span><a href="#f/' + encodeURI(shareRoute(fd)) + '" title="Shortest link that opens this page">link</a>'
             + '</div>'
             + toolbar()
             + '<h2>Compatibility</h2><div class="chips">' + adapters.map(a => chip(adapterName(a), status(fd, a))).join('') + '</div>'

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/constraints/constraintsExtensionEval.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/constraints/constraintsExtensionEval.pure
@@ -14,7 +14,37 @@
 
 import meta::pure::test::pct::*;
 
-function 
+'''
+Evaluates one named constraint on an object and returns its failure message, or empty if it holds.
+
+**Empty means the constraint passed**, so the result reads as a per-row explanation of what is wrong
+rather than as a boolean: project it alongside the data and every non-empty cell is a violation with
+the reason attached. The message is the constraint's own message function, which defaults to
+`Constraint failed: <name>`.
+
+`name` must be the name of a constraint declared on the object's class or inherited from anywhere in
+its hierarchy; the constraint is looked up by name at evaluation time.
+
+**Parameters**
+- `item` — the object to check.
+- `name` — the name of the constraint to evaluate.
+
+**Returns** the failure message, or empty when the constraint holds.
+
+**Examples**
+```pure
+// SimplePerson declares a constraint 'ageMustBePositive'
+$people->project(~[
+  name: x | $x.name,
+  ageValid: x | $x->createConstraintFailureMessage('ageMustBePositive')
+])
+
+// name      ageValid
+// Alex      null                                    age 12, the constraint holds
+// Bad Alex  Constraint failed: ageMustBePositive     age -20
+```
+'''
+function
   <<access.public, PCT.function,
 
   // TODO: this should not really be required, but is needed for routing issues
@@ -23,7 +53,6 @@ function
 
   functionType.NormalizeRequiredFunction
   >>
-  {doc.doc = 'Evaluate if the given object meets the specified constraint, if it fails return a message else empty'}
   meta::pure::constraints::functions::createConstraintFailureMessage<X>(item:X[1], name:String[1]):String[0..1]
 {
     if (meta::pure::constraints::functions::evaluateConstraint($item, $name), 

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/aggregation/joinStrings.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/aggregation/joinStrings.pure
@@ -17,45 +17,76 @@ import meta::pure::metamodel::relation::*;
 import meta::pure::functions::relation::*;
 
 // Nulls in the joined column are skipped rather than rendered, matching LISTAGG/STRING_AGG.
+'''
+Concatenates a column's values across the rows of a relation.
+
+The relational string aggregate — `LISTAGG` / `STRING_AGG` — reached through `groupBy` or
+`aggregate`, where the lambda receives the group as a relation:
+
+```pure
+$rel->groupBy(~grp, ~names : g | $g->joinStrings(~name, ','))
+```
+
+**The order of the values is not defined.** Rows arrive in whatever order the store produces them, so
+a test over this form has to sort the result before comparing. Use
+`joinStrings(Relation<T>[1], ColSpec<(?:String)⊆T>[1], String[1], SortInfo<X⊆T>[*]):String[1]` when
+the order matters; it emits `WITHIN GROUP (ORDER BY ...)`.
+
+**Absent values are skipped rather than rendered**, matching `LISTAGG` and `STRING_AGG` — a null row
+contributes neither text nor a separator.
+
+**Parameters**
+- `rel` — the group of rows, supplied by `groupBy` or `aggregate`.
+- `col` — the string column to concatenate.
+- `separator` — placed between consecutive values.
+
+**Returns** the joined string.
+
+**Examples**
+```pure
+$rel->groupBy(~grp, ~names : g | $g->joinStrings(~name, ','))
+```
+
+**See also** `joinStrings(Relation<T>[1], ColSpec<(?:String)⊆T>[1], String[1], SortInfo<X⊆T>[*]):String[1]`,
+`joinStrings(Relation<T>[1], Function<{T[1]->String[1]}>[1], String[1]):String[1]`
+'''
 function <<PCT.function>>
-{
-    doc.doc='Concatenates the values of the given column across the rows of the given relation, separated by ' +
-            'the given separator. The order of the values is not constrained -- use the overload taking a ' +
-            'sort spec when it matters.'
-}
 meta::pure::functions::relation::joinStrings<T>(rel:Relation<T>[1], col:ColSpec<(?:String)⊆T>[1], separator:String[1]):String[1]
 {
     $rel->meta::pure::functions::relation::reduce(x|eval($col, $x), y|$y->meta::pure::functions::string::joinStrings($separator));
 }
 
+'''
+As `joinStrings(Relation<T>[1], ColSpec<(?:String)⊆T>[1], String[1]):String[1]`, but the values are
+taken in the order the sort spec gives, which is emitted as `WITHIN GROUP (ORDER BY ...)`.
+
+This is the form to reach for whenever the output is compared or displayed:
+`$g->joinStrings(~name, ',', ~id->ascending())` over a group holding `C,A,B` at ids `3,1,2` gives
+`A,B,C`. **The sort column need not be the column being joined** — ordering by an id while
+concatenating names is the common case.
+'''
 function <<PCT.function>>
-{
-    doc.doc='Concatenates the values of the given column across the rows of the given relation, separated by ' +
-            'the given separator, taking the rows in the order given by the sort spec. Generates SQL ' +
-            'LISTAGG/STRING_AGG with a WITHIN GROUP (ORDER BY ...) clause.'
-}
 meta::pure::functions::relation::joinStrings<T,X>(rel:Relation<T>[1], col:ColSpec<(?:String)⊆T>[1], separator:String[1], sortInfo:SortInfo<X⊆T>[*]):String[1]
 {
     $rel->meta::pure::functions::relation::reduce(x|eval($col, $x), y|$y->meta::pure::functions::string::joinStrings($separator), $sortInfo);
 }
 
+'''
+As `joinStrings(Relation<T>[1], ColSpec<(?:String)⊆T>[1], String[1]):String[1]`, but each row is
+turned into a string by a function rather than read from a single column — so the joined text can
+combine columns or be computed, `{r| $r.first + ' ' + $r.last}`. The order is likewise undefined.
+'''
 function <<PCT.function>>
-{
-    doc.doc='Concatenates a value derived from each row of the given relation, separated by the given ' +
-            'separator. The order of the values is not constrained -- use the overload taking a sort spec ' +
-            'when it matters.'
-}
 meta::pure::functions::relation::joinStrings<T>(rel:Relation<T>[1], f:Function<{T[1]->String[1]}>[1], separator:String[1]):String[1]
 {
     $rel->meta::pure::functions::relation::reduce($f, y|$y->meta::pure::functions::string::joinStrings($separator));
 }
 
+'''
+As `joinStrings(Relation<T>[1], Function<{T[1]->String[1]}>[1], String[1]):String[1]`, taking the rows
+in the order the sort spec gives, emitted as `WITHIN GROUP (ORDER BY ...)`.
+'''
 function <<PCT.function>>
-{
-    doc.doc='Concatenates a value derived from each row of the given relation, separated by the given ' +
-            'separator, taking the rows in the order given by the sort spec. Generates SQL ' +
-            'LISTAGG/STRING_AGG with a WITHIN GROUP (ORDER BY ...) clause.'
-}
 meta::pure::functions::relation::joinStrings<T,X>(rel:Relation<T>[1], f:Function<{T[1]->String[1]}>[1], separator:String[1], sortInfo:SortInfo<X⊆T>[*]):String[1]
 {
     $rel->meta::pure::functions::relation::reduce($f, y|$y->meta::pure::functions::string::joinStrings($separator), $sortInfo);

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/columns.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/columns.pure
@@ -15,6 +15,26 @@
 import meta::pure::test::pct::*;
 import meta::pure::metamodel::relation::*;
 
+'''
+The columns of a relation, as metamodel objects.
+
+Reflection over the relation's shape rather than its data: each `Column` carries the name and, via
+its generic type, the declared type and multiplicity. Used by code that has to work with a relation
+whose shape is not known when it is written — `toString` builds its header this way.
+
+**Parameters**
+- `rel` — the relation to inspect.
+
+**Returns** its columns, in order.
+
+**Examples**
+```pure
+$rel->columns()->map(c | $c.name)   // the column names
+```
+
+**See also** `eval(ColSpec<(?:Z)⊆T>[1], T[1]):Z[0..1]`,
+`toString(Relation<T>[1]):String[1]`
+'''
 native function <<PCT.function, PCT.platformOnly>> meta::pure::functions::relation::columns<T>(rel:Relation<T>[1]):Column<Nil,Any|*>[*];
 
 function <<test.Test>> meta::pure::functions::relation::tests::columns::testSimpleColumns():Boolean[1]

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/eval.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/eval.pure
@@ -15,6 +15,30 @@
 import meta::pure::test::pct::*;
 import meta::pure::metamodel::relation::*;
 
+'''
+Reads a column out of a row, given the column as a value.
+
+Where `$row.name` names a column literally, this takes the column as a `ColSpec` argument — so a
+function can be written once against a column its caller chooses. That is what makes generic
+row-level helpers possible; the data quality functions use it to apply the same check to whichever
+column is passed in.
+
+Returns `[0..1]` regardless of the column's own multiplicity, since a column may hold no value for a
+given row.
+
+**Parameters**
+- `col` — the column to read.
+- `row` — the row to read it from.
+
+**Returns** the value in that column for that row, or empty.
+
+**Examples**
+```pure
+$rel->filter(row | eval(~code, $row)->isEmpty())     // rows with no code
+```
+
+**See also** `columns(Relation<T>[1]):Column<Nil, Any|*>[*]`
+'''
 function <<PCT.function>> meta::pure::functions::relation::eval<Z,T>(col:ColSpec<(?:Z)⊆T>[1], row:T[1]) : Z[0..1]
 {
   $col->genericType().typeArguments->at(0).rawType->toOne()->cast(@RelationType<Any>).columns->toOne()->cast(@Column<Nil,Z|0..1>)->eval($row);

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/graph/project.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/graph/project.pure
@@ -16,7 +16,52 @@ import meta::pure::test::pct::*;
 import meta::pure::metamodel::relation::*;
 import meta::pure::functions::relation::tests::project::*;
 
+'''
+Builds a relation out of a collection of objects, one row each.
+
+The bridge from Pure's object graph into the relational world: given class instances and a set of
+named functions, it produces a relation whose columns are those functions evaluated per object.
+Traversals are written inline, so a column may reach through associations —
+`~city : p | $p.address.city`.
+
+**Parameters**
+- `cl` — the objects, one row each.
+- `x` — the columns, as named functions over an object.
+
+**Returns** a relation of those columns.
+
+**Examples**
+```pure
+$people->project(~[name : p | $p.firstName, city : p | $p.address.city])
+```
+
+**See also** `project(Relation<T>[1], FuncColSpecArray<{T[1]->Any[*]}, Z>[1]):Relation<Z>[1]`,
+`extend(Relation<T>[1], FuncColSpec<{T[1]->Any[0..1]}, Z>[1]):Relation<T+Z>[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::relation::project<C,T>(cl:C[*], x:FuncColSpecArray<{C[1]->Any[*]},T>[1]):Relation<T>[1];
+
+'''
+Rebuilds a relation from named functions over its rows, keeping only the columns given.
+
+As `project(C[*], FuncColSpecArray<{C[1]->Any[*]}, T>[1]):Relation<T>[1]` but starting from a
+relation. **Columns not named are dropped**, which is the difference from
+`extend(Relation<T>[1], FuncColSpec<{T[1]->Any[0..1]}, Z>[1]):Relation<T+Z>[1]` — use this to select
+and compute in one step, as the quant functions do to round an aggregate before returning it.
+
+**Parameters**
+- `r` — the relation.
+- `fs` — the columns, as named functions over a row.
+
+**Returns** a relation of just those columns.
+
+**Examples**
+```pure
+$rel->project(~[symbol : x | $x.symbol, vwap : x | $x.vwap->round(2)])
+```
+
+**See also** `select(Relation<T>[1], ColSpecArray<Z⊆T>[1]):Relation<Z>[1]`,
+`extend(Relation<T>[1], FuncColSpec<{T[1]->Any[0..1]}, Z>[1]):Relation<T+Z>[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::relation::project<T,Z>(r:Relation<T>[1], fs:FuncColSpecArray<{T[1]->Any[*]},Z>[1]):Relation<Z>[1];
 
 Class meta::pure::functions::relation::tests::project::Address

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/iteration/filter.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/iteration/filter.pure
@@ -17,6 +17,28 @@ import meta::pure::functions::variant::navigation::*;
 import meta::pure::test::pct::*;
 import meta::pure::metamodel::relation::*;
 
+'''
+Keeps the rows for which a predicate holds.
+
+The predicate receives one row at a time and must return a `Boolean[1]` — an emptiness-producing
+expression will not compile, so guard with `isEmpty` or `isNotEmpty` when a column is optional. The
+result keeps the relation's type: filtering never changes the columns.
+
+**Parameters**
+- `rel` — the relation to filter.
+- `f` — the predicate, applied to each row.
+
+**Returns** the rows for which the predicate is `true`.
+
+**Examples**
+```pure
+$rel->filter(r | $r.val > 3)
+$rel->filter(r | $r.name->isNotEmpty() && $r.name->toOne()->startsWith('A'))
+```
+
+**See also** `select(Relation<T>[1], ColSpecArray<Z⊆T>[1]):Relation<Z>[1]`,
+`limit(Relation<T>[1], Integer[1]):Relation<T>[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::relation::filter<T>(rel:Relation<T>[1], f:Function<{T[1]->Boolean[1]}>[1]):Relation<T>[1];
 
 function <<PCT.test>> meta::pure::functions::relation::tests::filter::testSimpleFilterShared<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/iteration/map.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/iteration/map.pure
@@ -15,6 +15,30 @@
 import meta::pure::test::pct::*;
 import meta::pure::metamodel::relation::*;
 
+'''
+Applies a function to each row and returns the results as a collection.
+
+**This leaves the relational world**: the result is a plain `V[*]`, not a relation, so it is the way
+out of a relation into ordinary Pure values. To derive a new column and stay in a relation, use
+`extend(Relation<T>[1], FuncColSpec<{T[1]->Any[0..1]}, Z>[1]):Relation<T+Z>[1]` instead.
+
+Because the row function may return any multiplicity, the results are flattened into one collection
+rather than kept one-per-row.
+
+**Parameters**
+- `rel` — the relation to walk.
+- `f` — the function applied to each row.
+
+**Returns** the results, flattened into a single collection.
+
+**Examples**
+```pure
+$rel->map(r | $r.name)   // the names, as a String collection
+```
+
+**See also** `extend(Relation<T>[1], FuncColSpec<{T[1]->Any[0..1]}, Z>[1]):Relation<T+Z>[1]`,
+`filter(Relation<T>[1], Function<{T[1]->Boolean[1]}>[1]):Relation<T>[1]`
+'''
 native function <<PCT.function, PCT.platformOnly>> meta::pure::functions::relation::map<T,V>(rel:Relation<T>[1], f:Function<{T[1]->V[*]}>[1]):V[*];
 
 function <<test.Test>> meta::pure::functions::relation::tests::map::testSimpleMap():Boolean[1]

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/olap/frame/range.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/olap/frame/range.pure
@@ -22,79 +22,144 @@ Class meta::pure::functions::relation::_RangeInterval extends Frame
 {
 }
 
+'''
+Builds a window frame counted in **ordering values** rather than in rows.
+
+The bounds are offsets from the current row's ordering value `x`: the frame holds every row of the
+partition whose ordering value lies between `x + offsetFrom` and `x + offsetTo`. How many rows that
+is depends on the data, not on the position of the current row.
+
+Because membership is decided by value, **rows that tie on the ordering column always share a
+frame**. Over `0,1,10 / 0,1,10 / 0,3,30` ordered by the second column, `_range(unbounded(), 0)` gives
+`20` on *both* of the first two rows, where `rows(unbounded(), 0)` would give `10` then `20`.
+
+Direction follows the ordering. Under `ascending()` a positive offset reaches later values
+(`FOLLOWING`) and a negative one earlier values (`PRECEDING`); under `descending()` the two swap.
+`0` on either side is `CURRENT ROW`. `offsetFrom` may not exceed `offsetTo`; the function fails
+if it does.
+
+Write a bound as `meta::pure::functions::relation::unbounded()` to reach the edge of the partition,
+and use the `DurationUnit` overloads when the ordering column holds dates.
+
+**Parameters**
+- `offsetFrom` — lower bound, as an offset from the current row's ordering value.
+- `offsetTo` — upper bound, likewise.
+
+**Returns** the frame, to hand to `over`.
+
+**Examples**
+```pure
+// every row whose ordering value is within 1 of this row's
+$rel->extend(over(~p, ~o->ascending(), _range(-1, 1)), ~near:{p,w,r| $p->reduce($w, $r, {r|$r.i}, {y|$y->plus()})})
+```
+
+**See also** `_range(UnboundedFrameValue[1], Number[1]):_Range[1]`,
+`_range(Integer[1], DurationUnit[1], Integer[1], DurationUnit[1]):_RangeInterval[1]`,
+`rows(Integer[1], Integer[1]):Rows[1]`,
+`over(ColSpec<(?:NULL)⊆T>[1], SortInfo<(?:NULL)⊆T>[1], _Range[1]):_Window<T>[1]`
+'''
 function
     <<functionType.NormalizeRequiredFunction,
     PCT.function>>
-    {
-         doc.doc = 'Returns a window frame, which defines a logically computed set of rows specified by starting and ending points. When the ORDER BY expression is ascending (ASC), the syntax n FOLLOWING means rows with values greater than (or later than) x, and n PRECEDING means rows with values less than (or earlier than) x, where x is the ORDER BY value for the current row. When the ORDER BY expression is descending (DESC), the opposite is true. The offsets 0 PRECEDING and 0 FOLLOWING are equivalent to CURRENT ROW.'
-    }
     meta::pure::functions::relation::_range(offsetFrom:Number[1], offsetTo:Number[1]):_Range[1]
 {
   assert($offsetFrom <= $offsetTo, 'Invalid window frame boundary - lower bound of window frame cannot be greater than the upper bound!');
   ^_Range(offsetFrom = ^FrameNumericValue(value=$offsetFrom), offsetTo = ^FrameNumericValue(value=$offsetTo));
 }
 
+
+'''
+As `_range(Number[1], Number[1]):_Range[1]`, but the frame starts at the **edge of the partition** —
+every row from the partition boundary up to `x + offsetTo`. Write the lower bound as
+`meta::pure::functions::relation::unbounded()`.
+
+Under `ascending()` that boundary is the first row, so `_range(unbounded(), 0)` is a running frame
+over values. Under `descending()` it is the last, and the same call runs the other way.
+'''
 function
     <<functionType.NormalizeRequiredFunction,
     PCT.function>>
-    {
-         doc.doc = 'Returns a window frame, which defines a logically computed set of rows specified by starting and ending points. When the ORDER BY expression is ascending (ASC), the syntax n FOLLOWING means rows with values greater than (or later than) x, and n PRECEDING means rows with values less than (or earlier than) x, where x is the ORDER BY value for the current row. When the ORDER BY expression is descending (DESC), the opposite is true. The offsets 0 PRECEDING and 0 FOLLOWING are equivalent to CURRENT ROW.'
-    }
     meta::pure::functions::relation::_range(offsetFrom:meta::pure::functions::relation::UnboundedFrameValue[1], offsetTo:Number[1]):_Range[1]
 {
   ^_Range(offsetFrom = $offsetFrom, offsetTo = ^FrameNumericValue(value=$offsetTo));
 }
 
+'''
+As `_range(Number[1], Number[1]):_Range[1]`, but the frame runs from `x + offsetFrom` to the **far
+edge of the partition**. Write the upper bound as `meta::pure::functions::relation::unbounded()`.
+'''
 function
     <<functionType.NormalizeRequiredFunction,
     PCT.function>>
-    {
-         doc.doc = 'Returns a window frame, which defines a logically computed set of rows specified by starting and ending points. When the ORDER BY expression is ascending (ASC), the syntax n FOLLOWING means rows with values greater than (or later than) x, and n PRECEDING means rows with values less than (or earlier than) x, where x is the ORDER BY value for the current row. When the ORDER BY expression is descending (DESC), the opposite is true. The offsets 0 PRECEDING and 0 FOLLOWING are equivalent to CURRENT ROW.'
-    }
     meta::pure::functions::relation::_range(offsetFrom:Number[1], offsetTo:meta::pure::functions::relation::UnboundedFrameValue[1]):_Range[1]
 {
   ^_Range(offsetFrom = ^FrameNumericValue(value=$offsetFrom), offsetTo = $offsetTo);
 }
 
+'''
+As `_range(Number[1], Number[1]):_Range[1]`, but the frame is the **whole partition**, so the value
+computed over it is the same on every row whatever the ordering.
+'''
 function
     <<functionType.NormalizeRequiredFunction,
     PCT.function>>
-    {
-         doc.doc = 'Returns a window frame, which defines a logically computed set of rows specified by starting and ending points. When the ORDER BY expression is ascending (ASC), the syntax n FOLLOWING means rows with values greater than (or later than) x, and n PRECEDING means rows with values less than (or earlier than) x, where x is the ORDER BY value for the current row. When the ORDER BY expression is descending (DESC), the opposite is true. The offsets 0 PRECEDING and 0 FOLLOWING are equivalent to CURRENT ROW.'
-    }
     meta::pure::functions::relation::_range(offsetFrom:meta::pure::functions::relation::UnboundedFrameValue[1], offsetTo:meta::pure::functions::relation::UnboundedFrameValue[1]):_Range[1]
 {
   ^_Range(offsetFrom = $offsetFrom, offsetTo = $offsetTo);
 }
 
+'''
+As `_range(Number[1], Number[1]):_Range[1]`, but for an ordering column holding **dates**: each
+bound is a whole number of `DurationUnit`s away from the current row's date, and the two bounds carry
+their units independently.
+
+`_range(-1, DurationUnit.DAYS, 0, DurationUnit.DAYS)` over a datetime column frames yesterday and
+today. As with the numeric form, rows sharing a date share a frame.
+
+**Parameters**
+- `offsetFrom` — lower bound, in `offsetFromDurationUnit`s from the current row's date.
+- `offsetFromDurationUnit` — the unit that bound is measured in.
+- `offsetTo` — upper bound.
+- `offsetToDurationUnit` — the unit that bound is measured in.
+
+**Returns** the interval frame, to hand to `over`.
+
+**Examples**
+```pure
+$rel->extend(over(~p, ~o->ascending(), _range(meta::pure::functions::relation::unbounded(), 0, DurationUnit.DAYS)),
+             ~toDate:{p,w,r| $p->reduce($w, $r, {r|$r.i}, {y|$y->plus()})})
+```
+
+**See also** `_range(UnboundedFrameValue[1], Integer[1], DurationUnit[1]):_RangeInterval[1]`,
+`over(ColSpec<(?:NULL)⊆T>[1], SortInfo<(?:NULL)⊆T>[1], _RangeInterval[1]):_Window<T>[1]`
+'''
 function
     <<functionType.NormalizeRequiredFunction,
     PCT.function>>
-    {
-         doc.doc = 'Returns a window frame, which defines a logically computed set of rows specified by starting and ending points. When the ORDER BY expression is ascending (ASC), the syntax n FOLLOWING means rows with values greater than (or later than) x, and n PRECEDING means rows with values less than (or earlier than) x, where x is the ORDER BY value for the current row. When the ORDER BY expression is descending (DESC), the opposite is true. The offsets 0 PRECEDING and 0 FOLLOWING are equivalent to CURRENT ROW.'
-    }
     meta::pure::functions::relation::_range(offsetFrom:Integer[1], offsetFromDurationUnit:DurationUnit[1], offsetTo:Integer[1], offsetToDurationUnit:DurationUnit[1]):_RangeInterval[1]
 {
   ^_RangeInterval(offsetFrom = ^FrameIntervalValue(value=$offsetFrom, durationUnit=$offsetFromDurationUnit), offsetTo = ^FrameIntervalValue(value=$offsetTo, durationUnit=$offsetToDurationUnit));
 }
 
+'''
+As `_range(Integer[1], DurationUnit[1], Integer[1], DurationUnit[1]):_RangeInterval[1]`, but the
+frame starts at the edge of the partition. Only the upper bound carries a unit.
+'''
 function
     <<functionType.NormalizeRequiredFunction,
     PCT.function>>
-    {
-         doc.doc = 'Returns a window frame, which defines a logically computed set of rows specified by starting and ending points. When the ORDER BY expression is ascending (ASC), the syntax n FOLLOWING means rows with values greater than (or later than) x, and n PRECEDING means rows with values less than (or earlier than) x, where x is the ORDER BY value for the current row. When the ORDER BY expression is descending (DESC), the opposite is true. The offsets 0 PRECEDING and 0 FOLLOWING are equivalent to CURRENT ROW.'
-    }
     meta::pure::functions::relation::_range(offsetFrom:meta::pure::functions::relation::UnboundedFrameValue[1], offsetTo:Integer[1], offsetToDurationUnit:DurationUnit[1]):_RangeInterval[1]
 {
   ^_RangeInterval(offsetFrom = $offsetFrom, offsetTo = ^FrameIntervalValue(value=$offsetTo, durationUnit=$offsetToDurationUnit));
 }
 
+'''
+As `_range(Integer[1], DurationUnit[1], Integer[1], DurationUnit[1]):_RangeInterval[1]`, but the
+frame runs to the far edge of the partition. Only the lower bound carries a unit.
+'''
 function
     <<functionType.NormalizeRequiredFunction,
     PCT.function>>
-    {
-         doc.doc = 'Returns a window frame, which defines a logically computed set of rows specified by starting and ending points. When the ORDER BY expression is ascending (ASC), the syntax n FOLLOWING means rows with values greater than (or later than) x, and n PRECEDING means rows with values less than (or earlier than) x, where x is the ORDER BY value for the current row. When the ORDER BY expression is descending (DESC), the opposite is true. The offsets 0 PRECEDING and 0 FOLLOWING are equivalent to CURRENT ROW.'
-    }
     meta::pure::functions::relation::_range(offsetFrom:Integer[1], offsetFromDurationUnit:DurationUnit[1], offsetTo:meta::pure::functions::relation::UnboundedFrameValue[1]):_RangeInterval[1]
 {
   ^_RangeInterval(offsetFrom = ^FrameIntervalValue(value=$offsetFrom, durationUnit=$offsetFromDurationUnit), offsetTo = $offsetTo);

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/olap/frame/rows.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/olap/frame/rows.pure
@@ -18,46 +18,86 @@ Class meta::pure::functions::relation::Rows extends Frame
 {
 }
 
+'''
+Builds a window frame counted in **rows**: a fixed number of rows either side of the current one.
+
+Offsets are relative to the current row, which is `0`. A negative offset counts backwards
+(`PRECEDING`) and a positive one forwards (`FOLLOWING`), so `rows(-3, 0)` is
+`ROWS BETWEEN 3 PRECEDING AND CURRENT ROW`. `offsetFrom` may not exceed `offsetTo`; the function
+fails if it does.
+
+Pass the frame to `over`. **Without a frame the window runs from the start of the partition to the
+current row**, so pass one explicitly whenever you want something narrower or the whole partition.
+
+A row frame counts positions and ignores the ordering values, so rows that tie on the sort key are
+**not** kept together — the first of two equal rows sees only itself.
+`_range(Number[1], Number[1]):_Range[1]` frames by value and does keep them together.
+
+**Parameters**
+- `offsetFrom` — first row of the frame, relative to the current row.
+- `offsetTo` — last row of the frame, relative to the current row.
+
+**Returns** the frame, to hand to `over`.
+
+**Examples**
+```pure
+// the two rows before this one, this one excluded
+$rel->extend(over(~p, ~o->ascending(), rows(-2, -1)), ~sum:{p,w,r| $p->reduce($w, $r, {r|$r.i}, {y|$y->plus()})})
+
+// the current row alone
+$rel->extend(over(~p, ~o->ascending(), rows(0, 0)), ~self:{p,w,r| $p->reduce($w, $r, {r|$r.i}, {y|$y->plus()})})
+```
+
+**See also** `rows(UnboundedFrameValue[1], Integer[1]):Rows[1]`,
+`_range(Number[1], Number[1]):_Range[1]`,
+`over(ColSpec<(?:NULL)⊆T>[1], SortInfo<(?:NULL)⊆T>[*], Rows[1]):_Window<T>[1]`
+'''
 function
     <<functionType.NormalizeRequiredFunction,
     PCT.function>>
-    {
-         doc.doc = 'Returns a window frame, which defines a physical number of rows specified by starting and ending points. For example, rows(-3, 0) means start 3 rows before the current row and include all rows up to and including the current one, which is equivalent to ROWS BETWEEN 3 PRECEDING AND CURRENT ROW. Note that negative numbers represent N PRECEDING, positive numbers represent N FOLLOWING, and 0 represents CURRENT ROW.'
-    }
     meta::pure::functions::relation::rows(offsetFrom:Integer[1], offsetTo:Integer[1]):Rows[1]
 {
   assert($offsetFrom <= $offsetTo, 'Invalid window frame boundary - lower bound of window frame cannot be greater than the upper bound!');
   ^Rows(offsetFrom = ^FrameIntValue(value=$offsetFrom), offsetTo = ^FrameIntValue(value=$offsetTo));
 }
 
+'''
+As `rows(Integer[1], Integer[1]):Rows[1]`, but the frame starts at the **first row of the partition**
+— `ROWS BETWEEN UNBOUNDED PRECEDING AND n`. Write the lower bound as
+`meta::pure::functions::relation::unbounded()`.
+
+`rows(unbounded(), 0)` is the running frame: everything up to and including the current row.
+'''
 function
     <<functionType.NormalizeRequiredFunction,
     PCT.function>>
-    {
-         doc.doc = 'Returns a window frame, which defines a physical number of rows specified by starting and ending points. For example, rows(meta::pure::functions::relation::unbounded(), -2) means start from the very first row in the partition and include all rows up to 2 rows before current row, which is equivalent to ROWS BETWEEN UNBOUNDED PRECEDING AND 2 PRECEDING. Note that negative numbers represent N PRECEDING, positive numbers represent N FOLLOWING, and 0 represents CURRENT ROW.'
-    }
     meta::pure::functions::relation::rows(offsetFrom:meta::pure::functions::relation::UnboundedFrameValue[1], offsetTo:Integer[1]):Rows[1]
 {
   ^Rows(offsetFrom = $offsetFrom, offsetTo = ^FrameIntValue(value=$offsetTo));
 }
 
+'''
+As `rows(Integer[1], Integer[1]):Rows[1]`, but the frame ends at the **last row of the partition** —
+`ROWS BETWEEN n AND UNBOUNDED FOLLOWING`. Write the upper bound as
+`meta::pure::functions::relation::unbounded()`.
+'''
 function
     <<functionType.NormalizeRequiredFunction,
     PCT.function>>
-    {
-         doc.doc = 'Returns a window frame, which defines a physical number of rows specified by starting and ending points. For example, rows(3, meta::pure::functions::relation::unbounded()) means start counting 3 rows after the current row and include all rows after that, all the way to the end of the partition, which is equivalent to ROWS BETWEEN 3 FOLLOWING AND UNBOUNDED FOLLOWING. Note that negative numbers represent N PRECEDING, positive numbers represent N FOLLOWING, and 0 represents CURRENT ROW.'
-    }
     meta::pure::functions::relation::rows(offsetFrom:Integer[1], offsetTo:meta::pure::functions::relation::UnboundedFrameValue[1]):Rows[1]
 {
   ^Rows(offsetFrom = ^FrameIntValue(value=$offsetFrom), offsetTo = $offsetTo);
 }
 
+'''
+As `rows(Integer[1], Integer[1]):Rows[1]`, but the frame is the **whole partition** —
+`ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING` — so the value computed over it is the
+same on every row, whatever the ordering. This is the frame to pass when you want a partition total
+rather than a running one.
+'''
 function
     <<functionType.NormalizeRequiredFunction,
     PCT.function>>
-    {
-         doc.doc = 'Returns a window frame, which defines a physical number of rows specified by starting and ending points. For example, rows(meta::pure::functions::relation::unbounded(), meta::pure::functions::relation::unbounded()) means include every row in the partition - from the very first row to the very last row - no matter which row you are currently on, which is equivalent to ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING. Note that negative numbers represent N PRECEDING, positive numbers represent N FOLLOWING, and 0 represents CURRENT ROW.'
-    }
     meta::pure::functions::relation::rows(offsetFrom:meta::pure::functions::relation::UnboundedFrameValue[1], offsetTo:meta::pure::functions::relation::UnboundedFrameValue[1]):Rows[1]
 {
   ^Rows(offsetFrom = $offsetFrom, offsetTo = $offsetTo);

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/olap/over.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/olap/over.pure
@@ -15,6 +15,55 @@
 import meta::pure::test::pct::*;
 import meta::pure::metamodel::relation::*;
 
+'''
+Describes a window: how to partition a relation, how to order within a partition, and which rows
+around the current one to look at.
+
+`over` builds the window; it computes nothing on its own. Pass it to
+`extend(Relation<T>[1], _Window<T>[1], FuncColSpec<{Relation<T>[1], _Window<T>[1], T[1]->Any[0..1]}, R>[1]):Relation<T+R>[1]`,
+whose column function receives three arguments — the partition, the window and the current row:
+
+```pure
+$rel->extend(over(~grp, ~id->ascending()), ~n:{p,w,r| $p->rowNumber($r)})
+```
+
+A window has three independent parts, and each may be left out:
+
+- **Partition** — the rows are grouped by these columns and every computation stays inside one
+  group. Omit it and the whole relation is a single partition.
+- **Ordering** — sort keys built with `ascending(ColSpec<T>[1]):SortInfo<T>[1]` and
+  `descending(ColSpec<T>[1]):SortInfo<T>[1]`. Required for anything positional: `rank`, `lag`,
+  `first` and the rest are only meaningful once rows have an order.
+- **Frame** — which rows within the partition take part, built with
+  `rows(Integer[1], Integer[1]):Rows[1]` or the `_range` family. **Omit the frame and the window
+  runs from the start of the partition to the current row**, so a frameless aggregate is a running
+  total rather than a partition-wide one. Pass an explicit frame when you want either something
+  narrower or the whole partition.
+
+The overloads are the combinations of those three parts. This one takes partition columns as plain
+names and is the general form the others build on; in practice you write one of the `ColSpec`
+spellings below.
+
+**Parameters**
+- `cols` — the partition column names.
+- `sortInfo` — the sort keys, or empty for no ordering.
+- `frame` — the frame, or empty for start-of-partition to current row.
+
+**Returns** the window.
+
+**Examples**
+```pure
+over(~grp)                                    // partition only
+over(~id->ascending())                        // order only, one partition
+over(~grp, ~id->ascending())                  // partition and order
+over(~grp, ~id->ascending(), rows(-4, 0))     // and a five-row trailing frame
+over(~[grp, region], ~id->ascending())        // partition by two columns
+```
+
+**See also** `rows(Integer[1], Integer[1]):Rows[1]`,
+`ascending(ColSpec<T>[1]):SortInfo<T>[1]`,
+`reduce(Relation<T>[1], _Window<T>[1], T[1], Function<{T[1]->V[*]}>[1], Function<{V[*]->U[m]}>[1]):U[m]`
+'''
 function
     <<functionType.NormalizeRequiredFunction,
     PCT.function>>
@@ -28,6 +77,10 @@ function
   );
 }
 
+'''
+As `over(String[*], SortInfo<(?:NULL)⊆T>[*], Frame[0..1]):_Window<T>[1]`, partitioning by one column
+with no ordering and no frame: `over(~grp)`.
+'''
 function
     <<functionType.NormalizeRequiredFunction,
     PCT.function>>
@@ -39,6 +92,10 @@ function
   );
 }
 
+'''
+As `over(ColSpec<(?:NULL)⊆T>[1]):_Window<T>[1]`, with an explicit row frame and still no ordering:
+`over(~grp, rows(-4, 0))`.
+'''
 function
     <<functionType.NormalizeRequiredFunction,
     PCT.function>>
@@ -51,6 +108,10 @@ function
   );
 }
 
+'''
+As `over(ColSpec<(?:NULL)⊆T>[1]):_Window<T>[1]`, partitioning by several columns:
+`over(~[grp, region])`.
+'''
 function
     <<functionType.NormalizeRequiredFunction,
     PCT.function>>
@@ -62,6 +123,10 @@ function
   );
 }
 
+'''
+As `over(ColSpecArray<(?:NULL)⊆T>[1]):_Window<T>[1]`, with an explicit row frame and still no
+ordering: `over(~[grp, region], rows(-4, 0))`.
+'''
 function
     <<functionType.NormalizeRequiredFunction,
     PCT.function>>
@@ -74,6 +139,10 @@ function
   );
 }
 
+'''
+As `over(String[*], SortInfo<(?:NULL)⊆T>[*], Frame[0..1]):_Window<T>[1]`, ordering the whole relation
+as a single partition: `over(~id->ascending())`.
+'''
 function
     <<functionType.NormalizeRequiredFunction,
     PCT.function>>
@@ -82,6 +151,11 @@ function
   over([],$sortInfo,[])
 }
 
+'''
+As `over(SortInfo<(?:NULL)⊆T>[*]):_Window<T>[1]`, with a value range frame rather than a row frame.
+A range frame is measured in values of the ordering column, so peer rows sharing a value are always
+included or excluded together — unlike `rows`, which counts positions.
+'''
 function
     <<functionType.NormalizeRequiredFunction,
     PCT.function>>
@@ -90,6 +164,10 @@ function
   over([],$sortInfo,$range)
 }
 
+'''
+As `over(SortInfo<(?:NULL)⊆T>[1], _Range[1]):_Window<T>[1]`, with the range expressed as a time
+interval — for ordering by a date or timestamp, where the frame is a duration rather than a count.
+'''
 function
     <<functionType.NormalizeRequiredFunction,
     PCT.function>>
@@ -98,6 +176,12 @@ function
   over([],$sortInfo,$rangeInterval)
 }
 
+'''
+Partition by one column and order within it — the most common spelling:
+`over(~grp, ~id->ascending())`. As
+`over(String[*], SortInfo<(?:NULL)⊆T>[*], Frame[0..1]):_Window<T>[1]` with no explicit frame, so the
+window runs from the start of each partition to the current row.
+'''
 function
     <<functionType.NormalizeRequiredFunction,
     PCT.function>>
@@ -106,6 +190,10 @@ function
   over($cols.name,$sortInfo,[])
 }
 
+'''
+As `over(ColSpec<(?:NULL)⊆T>[1], SortInfo<(?:NULL)⊆T>[*]):_Window<T>[1]`, with an explicit row frame:
+`over(~grp, ~id->ascending(), rows(-4, 0))` for a five-row trailing window.
+'''
 function
     <<functionType.NormalizeRequiredFunction,
     PCT.function>>
@@ -114,6 +202,10 @@ function
   over($cols.name,$sortInfo,$rows)
 }
 
+'''
+As `over(ColSpec<(?:NULL)⊆T>[1], SortInfo<(?:NULL)⊆T>[*]):_Window<T>[1]`, with a value range frame
+rather than a row frame, so peer rows sharing an ordering value are included or excluded together.
+'''
 function
     <<functionType.NormalizeRequiredFunction,
     PCT.function>>
@@ -122,6 +214,10 @@ function
   over($cols.name,$sortInfo,$range)
 }
 
+'''
+As `over(ColSpec<(?:NULL)⊆T>[1], SortInfo<(?:NULL)⊆T>[1], _Range[1]):_Window<T>[1]`, with the range
+expressed as a time interval, for ordering by a date or timestamp.
+'''
 function
     <<functionType.NormalizeRequiredFunction,
     PCT.function>>
@@ -130,6 +226,10 @@ function
   over($cols.name,$sortInfo,$rangeInterval)
 }
 
+'''
+As `over(ColSpec<(?:NULL)⊆T>[1], SortInfo<(?:NULL)⊆T>[*]):_Window<T>[1]`, partitioning by several
+columns: `over(~[grp, region], ~id->ascending())`.
+'''
 function
     <<functionType.NormalizeRequiredFunction,
     PCT.function>>
@@ -138,6 +238,10 @@ function
   over($cols.names,$sortInfo,[])
 }
 
+'''
+As `over(ColSpecArray<(?:NULL)⊆T>[1], SortInfo<(?:NULL)⊆T>[*]):_Window<T>[1]`, with an explicit row
+frame.
+'''
 function
     <<functionType.NormalizeRequiredFunction,
     PCT.function>>
@@ -146,6 +250,10 @@ function
   over($cols.names,$sortInfo,$rows)
 }
 
+'''
+As `over(ColSpecArray<(?:NULL)⊆T>[1], SortInfo<(?:NULL)⊆T>[*]):_Window<T>[1]`, with a value range
+frame rather than a row frame.
+'''
 function
     <<functionType.NormalizeRequiredFunction,
     PCT.function>>
@@ -154,6 +262,10 @@ function
   over($cols.names,$sortInfo,$range)
 }
 
+'''
+As `over(ColSpecArray<(?:NULL)⊆T>[1], SortInfo<(?:NULL)⊆T>[1], _Range[1]):_Window<T>[1]`, with the
+range expressed as a time interval.
+'''
 function
     <<functionType.NormalizeRequiredFunction,
     PCT.function>>

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/olap/reduce.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/olap/reduce.pure
@@ -16,10 +16,46 @@ import meta::pure::test::pct::*;
 import meta::pure::metamodel::relation::*;
 import meta::pure::functions::relation::*;
 
+'''
+Aggregates the rows of a window in two steps: `map` pulls a value out of each row, then `agg`
+reduces the values it collected.
+
+This is the general window aggregate — `sum`, `average` and the rest are this function with a
+particular `agg`. It is called from inside a window column, where the three arguments `p`, `w` and
+`r` handed to the column function are passed straight through:
+
+```pure
+$rel->extend(over(~p, ~o->ascending()), ~running:{p,w,r| $p->reduce($w, $r, {r|$r.i}, {y|$y->plus()})})
+```
+
+**Which rows take part is decided by the window, not by this function.** With no frame the window
+runs from the start of the partition to the current row, making the result a running aggregate;
+`rows(UnboundedFrameValue[1], UnboundedFrameValue[1]):Rows[1]` makes it a partition total instead.
+
+`map` may return several values per row, or none — it is `V[*]`, and everything it yields across the
+frame is concatenated before `agg` sees it. **The result carries `agg`'s multiplicity**, `U[m]`, so a
+reducer returning a collection gives a collection.
+
+**Parameters**
+- `rel` — the partition, the first argument of the column function.
+- `w` — the window, its second argument.
+- `row` — the current row, its third.
+- `map` — pulls the value to aggregate out of one row.
+- `agg` — reduces the collected values.
+
+**Returns** whatever `agg` returns, with `agg`'s multiplicity.
+
+**Examples**
+```pure
+// sum of the two rows before this one
+$rel->extend(over(~p, ~o->ascending(), rows(-2, -1)), ~prev:{p,w,r| $p->reduce($w, $r, {r|$r.i}, {y|$y->plus()})})
+```
+
+**See also** `extend(Relation<T>[1], _Window<T>[1], FuncColSpec<{Relation<T>[1], _Window<T>[1], T[1]->Any[0..1]}, R>[1]):Relation<T+R>[1]`,
+`over(ColSpec<(?:NULL)⊆T>[1], SortInfo<(?:NULL)⊆T>[*], Rows[1]):_Window<T>[1]`,
+`rows(Integer[1], Integer[1]):Rows[1]`
+'''
 native function <<PCT.function>>
-{
-    doc.doc='Computes an aggregate value out of the partition rows by applying a map function to each row, and a reduce function that operates on the output to do the actual reduction operation (e.g. average)'
-}
 meta::pure::functions::relation::reduce<T, V, U|m>(
     rel:Relation<T>[1], 
     w:_Window<T>[1], 

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/order/ascending.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/order/ascending.pure
@@ -15,6 +15,27 @@
 import meta::pure::test::pct::*;
 import meta::pure::metamodel::relation::*;
 
+'''
+An ascending sort key on a column.
+
+Produces the `SortInfo` that `sort(Relation<T>[1], SortInfo<X⊆T>[*]):Relation<T>[1]` and the ordering
+part of `over` consume — it does not sort anything on its own. Written against a column reference:
+`~val->ascending()`.
+
+**Parameters**
+- `column` — the column to order by.
+
+**Returns** an ascending sort key for that column.
+
+**Examples**
+```pure
+$rel->sort(~val->ascending())
+$rel->extend(over(~grp, ~id->ascending()), ~n:{p,w,r| $p->rowNumber($r)})
+```
+
+**See also** `descending(ColSpec<T>[1]):SortInfo<T>[1]`,
+`sort(Relation<T>[1], SortInfo<X⊆T>[*]):Relation<T>[1]`
+'''
 function <<PCT.function,
            functionType.NormalizeRequiredFunction>> meta::pure::functions::relation::ascending<T> (column:ColSpec<T>[1]):SortInfo<T>[1]
 {

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/order/ascending.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/order/ascending.pure
@@ -42,6 +42,13 @@ function <<PCT.function,
    ^SortInfo<T>(column=$column, direction=SortType.ASC)
 }
 
+'''
+As `ascending(ColSpec<T>[1]):SortInfo<T>[1]`, with the placement of empty values given explicitly
+rather than left at the platform's canonical order.
+
+`emptyFirst(SortInfo<T>[1]):SortInfo<T>[1]` and `emptyLast(SortInfo<T>[1]):SortInfo<T>[1]` express
+the same thing as a modifier on the key, and read better in a sort list.
+'''
 function <<PCT.function,
            functionType.NormalizeRequiredFunction>> meta::pure::functions::relation::ascending<T> (column:ColSpec<T>[1], nullOrder:NullOrder[1]):SortInfo<T>[1]
 {

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/order/descending.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/order/descending.pure
@@ -15,6 +15,27 @@
 import meta::pure::test::pct::*;
 import meta::pure::metamodel::relation::*;
 
+'''
+A descending sort key on a column.
+
+As `ascending(ColSpec<T>[1]):SortInfo<T>[1]`, ordering from high to low. Produces the `SortInfo` that
+`sort(Relation<T>[1], SortInfo<X⊆T>[*]):Relation<T>[1]` and the ordering part of `over` consume — it
+does not sort anything on its own.
+
+**Parameters**
+- `column` — the column to order by.
+
+**Returns** a descending sort key for that column.
+
+**Examples**
+```pure
+$rel->sort(~val->descending())
+$rel->sort([~grp->ascending(), ~val->descending()])
+```
+
+**See also** `ascending(ColSpec<T>[1]):SortInfo<T>[1]`,
+`sort(Relation<T>[1], SortInfo<X⊆T>[*]):Relation<T>[1]`
+'''
 function <<PCT.function,
            functionType.NormalizeRequiredFunction>> meta::pure::functions::relation::descending<T>(column:ColSpec<T>[1]):SortInfo<T>[1]
 {

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/order/descending.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/order/descending.pure
@@ -42,6 +42,13 @@ function <<PCT.function,
    ^SortInfo<T>(column=$column, direction=SortType.DESC)
 }
 
+'''
+As `descending(ColSpec<T>[1]):SortInfo<T>[1]`, with the placement of empty values given explicitly
+rather than left at the platform's canonical order.
+
+`emptyFirst(SortInfo<T>[1]):SortInfo<T>[1]` and `emptyLast(SortInfo<T>[1]):SortInfo<T>[1]` express
+the same thing as a modifier on the key, and read better in a sort list.
+'''
 function <<PCT.function,
            functionType.NormalizeRequiredFunction>> meta::pure::functions::relation::descending<T>(column:ColSpec<T>[1], nullOrder:NullOrder[1]):SortInfo<T>[1]
 {

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/order/emptyFirst.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/order/emptyFirst.pure
@@ -15,12 +15,39 @@
 import meta::pure::test::pct::*;
 import meta::pure::metamodel::relation::*;
 
+'''
+Puts empty values at the start of an existing sort key — SQL's `NULLS FIRST`.
+
+Applied to a sort key rather than to a column, so it reads as a modifier on one:
+`~id->ascending()->emptyFirst()`. It changes only where empty values land; the direction the key
+already carries is untouched.
+
+Without an explicit empty order the platform's canonical order applies, in which an empty value sorts
+as the largest: `NULLS LAST` under `ascending`, `NULLS FIRST` under `descending`. `emptyFirst` on an
+ascending key is therefore the case that differs from the default, and `emptyLast` on a descending
+one.
+
+Each key in a multi-column sort carries its own empty order:
+`sort([~grp->ascending()->emptyLast(), ~id->descending()->emptyFirst()])`.
+
+**Parameters**
+- `sortInfo` — the sort key to modify.
+
+**Returns** the same key, ordering empty values first.
+
+**Examples**
+```pure
+// rows with no id come first, then 1, 2, 3
+$rel->sort([~id->ascending()->emptyFirst(), ~name->ascending()])
+```
+
+**See also** `emptyLast(SortInfo<T>[1]):SortInfo<T>[1]`,
+`ascending(ColSpec<T>[1]):SortInfo<T>[1]`,
+`sort(Relation<T>[1], SortInfo<X⊆T>[*]):Relation<T>[1]`
+'''
 function
    <<PCT.function,
      functionType.NormalizeRequiredFunction>>
-   {
-      doc.doc = 'Places empty values first in the sort defined by the given sort spec (SQL \'NULLS FIRST\'). Without an explicit empty order the platform\'s canonical order applies: empty values sort as the largest value, i.e. NULLS LAST on ascending, NULLS FIRST on descending.'
-   }
    meta::pure::functions::relation::emptyFirst<T>(sortInfo:SortInfo<T>[1]):SortInfo<T>[1]
 {
    // Explicit construction (not a ^$sortInfo(..) copy) so the router's NormalizeRequiredFunction

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/order/emptyLast.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/order/emptyLast.pure
@@ -15,12 +15,34 @@
 import meta::pure::test::pct::*;
 import meta::pure::metamodel::relation::*;
 
+'''
+Puts empty values at the end of an existing sort key — SQL's `NULLS LAST`.
+
+The mirror of `emptyFirst(SortInfo<T>[1]):SortInfo<T>[1]`, and read the same way, as a modifier on a
+key rather than on a column: `~id->ascending()->emptyLast()`.
+
+Without an explicit empty order the platform's canonical order applies, in which an empty value sorts
+as the largest: `NULLS LAST` under `ascending`, `NULLS FIRST` under `descending`. `emptyLast` on an
+ascending key therefore restates the default; on a descending key it changes the result.
+
+**Parameters**
+- `sortInfo` — the sort key to modify.
+
+**Returns** the same key, ordering empty values last.
+
+**Examples**
+```pure
+// 1, 2, 3, then the rows with no id
+$rel->sort([~id->ascending()->emptyLast(), ~name->ascending()])
+```
+
+**See also** `emptyFirst(SortInfo<T>[1]):SortInfo<T>[1]`,
+`descending(ColSpec<T>[1]):SortInfo<T>[1]`,
+`sort(Relation<T>[1], SortInfo<X⊆T>[*]):Relation<T>[1]`
+'''
 function
    <<PCT.function,
      functionType.NormalizeRequiredFunction>>
-   {
-      doc.doc = 'Places empty values last in the sort defined by the given sort spec (SQL \'NULLS LAST\'). Without an explicit empty order the platform\'s canonical order applies: empty values sort as the largest value, i.e. NULLS LAST on ascending, NULLS FIRST on descending.'
-   }
    meta::pure::functions::relation::emptyLast<T>(sortInfo:SortInfo<T>[1]):SortInfo<T>[1]
 {
    // Explicit construction (not a ^$sortInfo(..) copy) so the router's NormalizeRequiredFunction

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/order/sort.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/order/sort.pure
@@ -15,6 +15,33 @@
 import meta::pure::test::pct::*;
 import meta::pure::metamodel::relation::*;
 
+'''
+Orders a relation's rows by one or more columns.
+
+A relation has no inherent row order, so this is what makes row position meaningful — and what the
+positional functions `limit`, `drop` and `slice` need in front of them to be deterministic. Build the
+sort keys with `ascending(ColSpec<T>[1]):SortInfo<T>[1]` and
+`descending(ColSpec<T>[1]):SortInfo<T>[1]`; several may be given, and they apply in the order
+written, each breaking ties left by the one before.
+
+Rows that tie on every key keep no guaranteed order relative to each other.
+
+**Parameters**
+- `rel` — the relation to order.
+- `sortInfo` — the sort keys, applied left to right.
+
+**Returns** the relation, ordered.
+
+**Examples**
+```pure
+$rel->sort(~val->ascending())
+$rel->sort([~grp->ascending(), ~val->descending()])   // by group, then by value within it
+```
+
+**See also** `ascending(ColSpec<T>[1]):SortInfo<T>[1]`,
+`descending(ColSpec<T>[1]):SortInfo<T>[1]`,
+`limit(Relation<T>[1], Integer[1]):Relation<T>[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::relation::sort<X,T>(rel:Relation<T>[1], sortInfo:SortInfo<X⊆T>[*]):Relation<T>[1];
 
 

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/quantification/exists.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/quantification/exists.pure
@@ -15,10 +15,44 @@
 import meta::pure::test::pct::*;
 import meta::pure::metamodel::relation::*;
 
+'''
+Whether any row of a relation satisfies a predicate.
+
+The predicate may close over a row of an **enclosing** relation, which is what makes this the way to
+ask a question of one relation while iterating another:
+
+```pure
+$departments->filter(d | $employees->exists(e | $e.department == $d.departmentId))
+```
+
+On relational stores that compiles to an `EXISTS` subquery, correlated when the predicate reaches
+outward as above and uncorrelated when it does not. It stops at the first matching row rather than
+counting them, so it is the cheaper question to ask when you only want to know whether a match
+exists.
+
+**An empty relation gives `false`**, so `!$rel->exists(...)` over one keeps every row of the outer
+relation. Unlike `in(U[0..1], Relation<Z=(?:U)>[1]):Boolean[1]`, negating it is supported everywhere.
+
+**Parameters**
+- `rel` — the relation to search.
+- `f` — the predicate, applied to each of its rows.
+
+**Returns** `true` if at least one row satisfies `f`.
+
+**Examples**
+```pure
+#TDS val 1 3 4 #->exists(x | $x.val > 3)     // true
+#TDS val 1 3 4 #->exists(x | $x.val > 100)   // false
+
+// correlated: departments that have at least one employee
+$departments->filter(d | $employees->exists(e | $e.department == $d.departmentId))
+```
+
+**See also** `in(U[0..1], Relation<Z=(?:U)>[1]):Boolean[1]`,
+`filter(Relation<T>[1], Function<{T[1]->Boolean[1]}>[1]):Relation<T>[1]`,
+`size(Relation<T>[1]):Integer[1]`
+'''
 function <<PCT.function>>
-{
-    doc.doc='Returns true if at least one row of the given relation satisfies the given predicate. On relational stores this generates an EXISTS subquery, correlated when the predicate closes over a row of an enclosing relation.'
-}
 meta::pure::functions::relation::exists<T>(rel:Relation<T>[1], f:Function<{T[1]->Boolean[1]}>[1]):Boolean[1]
 {
    $rel->meta::pure::functions::relation::filter($f)->meta::pure::functions::relation::size() > 0

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/quantification/in.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/quantification/in.pure
@@ -16,15 +16,48 @@ import meta::pure::test::pct::*;
 import meta::pure::metamodel::relation::*;
 import meta::pure::functions::relation::*;
 
-// An empty value is never in the relation, matching meta::pure::functions::collection::in(Any[0..1], Any[*]).
-//
-// Boolean[1] is two-valued, so a null on either side answers false here where SQL's `in` would answer
-// UNKNOWN. The relational stores drop nulls from the searched column inside the subquery, which makes SQL
-// two-valued at the source rather than compensating for it afterwards.
+'''
+Whether a value appears in a relation's column.
+
+**The relation must have exactly one column**, of the value's type — narrow it with `select` first:
+`$d.departmentId->in($employees->select(~department))`. On relational stores this compiles to an
+`IN (subquery)` predicate.
+
+**Do not negate it against a relation.** `!$value->in($rel)` is rejected on every relational store
+rather than being answered differently from the in-memory engines, because SQL's `NOT IN` returns
+`UNKNOWN` — and so drops rows — as soon as the searched column holds a null. Write the question with
+`exists` instead, which makes the treatment of an absent value explicit:
+
+```pure
+// instead of  !$d.departmentId->in($employees->select(~department))
+$d.departmentId->isEmpty() || !$employees->exists(e | $e.department == $d.departmentId)
+```
+
+The result is `Boolean[1]` and therefore **two-valued**: a null on either side answers `false`, never
+`UNKNOWN`. An absent `value` is never in the relation, matching
+`meta::pure::functions::collection::in(Any[0..1], Any[*]):Boolean[1]`; a null *in the column* simply
+fails to match, and the relational stores drop those nulls inside the subquery so SQL agrees at the
+source rather than being corrected afterwards. An empty relation matches nothing.
+
+**Parameters**
+- `value` — the value to look for; empty is never found.
+- `rel` — a single-column relation to look in.
+
+**Returns** `true` if `value` appears in the column.
+
+**Examples**
+```pure
+$departments->filter(d | $d.departmentId->in($employees->select(~department)))
+
+// a null in the searched column costs nothing: rows that do match still match
+// a null value matches nothing, so that row is filtered out
+```
+
+**See also** `exists(Relation<T>[1], Function<{T[1]->Boolean[1]}>[1]):Boolean[1]`,
+`select(Relation<T>[1], ColSpec<Z⊆T>[1]):Relation<Z>[1]`,
+`meta::pure::functions::collection::in(Any[0..1], Any[*]):Boolean[1]`
+'''
 function <<PCT.function, functionType.NormalizeRequiredFunction>>
-{
-    doc.doc='Returns true if the given value appears in the single column of the given relation. On relational stores this generates an IN (subquery) predicate.'
-}
 meta::pure::functions::relation::in<U,Z>(value:U[0..1], rel:Relation<Z=(?:U)>[1]):Boolean[1]
 {
    let col = $rel->genericType().typeArguments->at(0).rawType->toOne()->cast(@RelationType<Any>).columns->toOne()->cast(@Column<Nil,U|0..1>);

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/ranking/cumulativeDistribution.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/ranking/cumulativeDistribution.pure
@@ -15,6 +15,35 @@
 import meta::pure::test::pct::*;
 import meta::pure::metamodel::relation::*;
 
+'''
+The proportion of a partition's rows that sort at or before the current row.
+
+Rows counted at or before the current one, divided by the partition size. **The last row is always
+1.0 and no row is ever 0.0**, since a row always counts itself — which is what distinguishes this
+from `percentRank(Relation<T>[1], _Window<T>[1], T[1]):Float[1]`, whose first row is 0.0. Tied rows
+all take the proportion reached by the last of them.
+
+**Parameters**
+- `rel` — the partition, supplied by `extend`.
+- `w` — the window, supplied by `extend`.
+- `row` — the current row, supplied by `extend`.
+
+**Returns** the cumulative proportion, greater than 0.0 and at most 1.0.
+
+**Examples**
+```pure
+$rel->extend(over(~grp, ~id->descending()), ~cd:{p,w,r| round($p->cumulativeDistribution($w, $r), 2)})
+
+// a three-row partition, ids 8, 6, 2
+// id  cd
+//  8  0.33
+//  6  0.67
+//  2  1.0
+```
+
+**See also** `percentRank(Relation<T>[1], _Window<T>[1], T[1]):Float[1]`,
+`ntile(Relation<T>[1], T[1], Integer[1]):Integer[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::relation::cumulativeDistribution<T>(rel:Relation<T>[1], w:_Window<T>[1], row:T[1]):Float[1];
 
 function <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.olap>> meta::pure::functions::relation::tests::cumulativeDistribution::testOLAPWithPartitionAndOrderCummulativeDistribution<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/ranking/denseRank.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/ranking/denseRank.pure
@@ -15,6 +15,35 @@
 import meta::pure::test::pct::*;
 import meta::pure::metamodel::relation::*;
 
+'''
+The position of a row within its partition, counting from 1, without gaps after ties.
+
+As `rank(Relation<T>[1], _Window<T>[1], T[1]):Integer[1]`, rows that tie on the ordering columns
+share a rank — but **the next rank continues from the next integer rather than skipping**, so three
+rows tied at 1 are followed by 2. The result counts distinct ordering values rather than rows.
+
+Called from inside an `extend` with a window; the window must specify an ordering.
+
+**Parameters**
+- `rel` — the partition, supplied by `extend`.
+- `w` — the window, supplied by `extend`.
+- `row` — the current row, supplied by `extend`.
+
+**Returns** the dense rank, counting from 1 within each partition.
+
+**Examples**
+```pure
+$rel->extend(over(~grp, ~id->descending()), ~rnk:{p,w,r| $p->denseRank($w, $r)})
+
+// id  grp  rnk
+//  8    1    1
+//  8    1    1     tied, so the same rank
+//  2    1    2     and the next rank does not skip, where rank would give 3
+```
+
+**See also** `rank(Relation<T>[1], _Window<T>[1], T[1]):Integer[1]`,
+`rowNumber(Relation<T>[1], T[1]):Integer[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::relation::denseRank<T>(rel:Relation<T>[1], w:_Window<T>[1], row:T[1]):Integer[1];
 
 function <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.olap>> meta::pure::functions::relation::tests::denseRank::testOLAPWithPartitionAndOrderDenseRank<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/ranking/ntile.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/ranking/ntile.pure
@@ -15,6 +15,34 @@
 import meta::pure::test::pct::*;
 import meta::pure::metamodel::relation::*;
 
+'''
+Distributes a partition's rows into buckets of near-equal size, numbering them from 1.
+
+The way to compute quartiles, deciles and the like: pass 4 or 10 as `tileCount`. Buckets are filled
+in the window's order, so bucket 1 holds the rows that sort first.
+
+**Bucketing is by position, not by value**, so tied rows may land in different buckets — this splits
+a partition into equal counts, not into equal value ranges.
+
+Note the signature takes no window: it is called as `$p->ntile($r, 4)`.
+
+**Parameters**
+- `rel` — the partition, supplied by `extend`.
+- `row` — the current row, supplied by `extend`.
+- `tileCount` — how many buckets to distribute into.
+
+**Returns** the bucket number, counting from 1.
+
+**Examples**
+```pure
+$rel->extend(over(~grp, ~name->descending()), ~half:{p,w,r| $p->ntile($r, 2)})
+
+// a seven-row partition split in two: four rows in bucket 1, three in bucket 2
+```
+
+**See also** `cumulativeDistribution(Relation<T>[1], _Window<T>[1], T[1]):Float[1]`,
+`rowNumber(Relation<T>[1], T[1]):Integer[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::relation::ntile<T>(rel:Relation<T>[1], row:T[1], tileCount:Integer[1]):Integer[1];
 
 function <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.olap>> meta::pure::functions::relation::tests::ntile::testOLAPWithPartitionAndOrderNTile<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/ranking/percentRank.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/ranking/percentRank.pure
@@ -15,6 +15,38 @@
 import meta::pure::test::pct::*;
 import meta::pure::metamodel::relation::*;
 
+'''
+A row's rank within its partition, rescaled to run from 0.0 to 1.0.
+
+`(rank - 1) / (rowCount - 1)`, so **the first row is always 0.0 and the last is always 1.0**, and
+tied rows share a value just as they share a rank. A partition of one row gives 0.0.
+
+Because it anchors at both ends, it answers "how far through the ordering is this row" rather than
+"what proportion is at or below it" — that second question is
+`cumulativeDistribution(Relation<T>[1], _Window<T>[1], T[1]):Float[1]`, which never returns 0.0.
+
+**Parameters**
+- `rel` — the partition, supplied by `extend`.
+- `w` — the window, supplied by `extend`.
+- `row` — the current row, supplied by `extend`.
+
+**Returns** the rank rescaled to between 0.0 and 1.0.
+
+**Examples**
+```pure
+$rel->extend(over(~grp, ~id->descending()), ~pr:{p,w,r| $p->percentRank($w, $r)})
+
+// a six-row partition, ids 8, 6, 3, 3, 3, 1
+// id  pr
+//  8  0.0     first
+//  6  0.2
+//  3  0.4     three-way tie, all rank 3
+//  1  1.0     last
+```
+
+**See also** `cumulativeDistribution(Relation<T>[1], _Window<T>[1], T[1]):Float[1]`,
+`rank(Relation<T>[1], _Window<T>[1], T[1]):Integer[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::relation::percentRank<T>(rel:Relation<T>[1], w:_Window<T>[1], row:T[1]):Float[1];
 
 function <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.olap>> meta::pure::functions::relation::tests::percentRank::testOLAPWithPartitionAndOrderPercentRank<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/ranking/rank.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/ranking/rank.pure
@@ -15,6 +15,39 @@
 import meta::pure::test::pct::*;
 import meta::pure::metamodel::relation::*;
 
+'''
+The position of a row within its partition, counting from 1, with gaps after ties.
+
+**Rows that tie on the ordering columns share a rank, and the next rank skips ahead** by the number
+of tied rows — three rows tied at rank 1 are followed by rank 4, not rank 2. Use
+`denseRank(Relation<T>[1], _Window<T>[1], T[1]):Integer[1]` when you want consecutive ranks with no
+gaps, and `rowNumber(Relation<T>[1], T[1]):Integer[1]` when every row should get a distinct number
+regardless of ties.
+
+Called from inside an `extend` with a window; the window must specify an ordering for the rank to
+mean anything.
+
+**Parameters**
+- `rel` — the partition, supplied by `extend`.
+- `w` — the window, supplied by `extend`.
+- `row` — the current row, supplied by `extend`.
+
+**Returns** the rank, counting from 1 within each partition.
+
+**Examples**
+```pure
+$rel->extend(over(~grp, ~id->descending()), ~rnk:{p,w,r| $p->rank($w, $r)})
+
+// id  grp  rnk
+//  8    1    1
+//  8    1    1     tied, so the same rank
+//  2    1    3     and the next rank skips 2
+```
+
+**See also** `denseRank(Relation<T>[1], _Window<T>[1], T[1]):Integer[1]`,
+`rowNumber(Relation<T>[1], T[1]):Integer[1]`,
+`percentRank(Relation<T>[1], _Window<T>[1], T[1]):Float[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::relation::rank<T>(rel:Relation<T>[1], w:_Window<T>[1], row:T[1]):Integer[1];
 
 function <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.olap>> meta::pure::functions::relation::tests::rank::testOLAPWithPartitionAndOrderRank<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/ranking/rowNumber.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/ranking/rowNumber.pure
@@ -15,6 +15,36 @@
 import meta::pure::test::pct::*;
 import meta::pure::metamodel::relation::*;
 
+'''
+A sequential number for each row within its partition, counting from 1.
+
+**Every row gets a distinct number even when rows tie** on the ordering columns, which is what
+separates this from `rank` and `denseRank`. That also means the number assigned among tied rows is
+not determined by the ordering alone — add a tie-breaking sort key when it needs to be stable.
+
+Note the signature takes no window: it is called as `$p->rowNumber($r)`, with the partition and the
+current row.
+
+**Parameters**
+- `rel` — the partition, supplied by `extend`.
+- `row` — the current row, supplied by `extend`.
+
+**Returns** the row's sequential position, counting from 1 within each partition.
+
+**Examples**
+```pure
+$rel->extend(over(~grp, ~id->descending()), ~n:{p,w,r| $p->rowNumber($r)})
+
+// id  grp  n
+//  8    1  1
+//  8    1  2     tied on id, but numbered distinctly
+//  2    1  3
+```
+
+**See also** `rank(Relation<T>[1], _Window<T>[1], T[1]):Integer[1]`,
+`denseRank(Relation<T>[1], _Window<T>[1], T[1]):Integer[1]`,
+`ntile(Relation<T>[1], T[1], Integer[1]):Integer[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::relation::rowNumber<T>(rel:Relation<T>[1],row:T[1]):Integer[1];
 
 function <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.olap>> meta::pure::functions::relation::tests::rowNumber::testOLAPWithPartitionAndRowNumber<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/s.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/s.pure
@@ -27,6 +27,16 @@ one. **An absent value renders as the text `null`**, not as an empty string.
 
 **Returns** the value as `#TDS` text.
 
+**Examples**
+```pure
+s('abc')   // 'abc', a plain string is passed through unquoted
+s(1)       // '1'
+s([])      // 'null', the four characters, not an empty string
+```
+
+A string containing `{` or `[` is the exception: it is wrapped in single quotes and its backslashes
+and quotes escaped, so that JSON-looking text survives being read back out of `#TDS`.
+
 **See also** `s(Any[0..1], Type[0..1]):String[1]`,
 `toString(Relation<T>[1]):String[1]`
 '''

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/s.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/s.pure
@@ -15,11 +15,31 @@
 import meta::pure::metamodel::variant::*;
 import meta::pure::test::pct::*;
 
+'''
+Renders a single value the way `toString` renders it inside a relation.
+
+The per-cell half of relation printing: `toString(Relation<T>[1]):String[1]` calls this for each
+value, so dates, numbers and strings come out in the `#TDS` spelling rather than their ordinary Pure
+one. **An absent value renders as the text `null`**, not as an empty string.
+
+**Parameters**
+- `a` — the value to render.
+
+**Returns** the value as `#TDS` text.
+
+**See also** `s(Any[0..1], Type[0..1]):String[1]`,
+`toString(Relation<T>[1]):String[1]`
+'''
 function <<PCT.function, PCT.platformOnly>> meta::pure::functions::relation::s(a:Any[0..1]):String[1]
-{  
+{
   s($a,[]);
 }
 
+'''
+As `s(Any[0..1]):String[1]`, with the column's declared type supplied so an absent value can be
+rendered as that type requires. It matters for `Variant`, where absence prints as the quoted JSON
+`'null'` rather than the bare `null` used elsewhere.
+'''
 function <<PCT.function, PCT.platformOnly>> meta::pure::functions::relation::s(a:Any[0..1], type:Type[0..1]):String[1]
 {  
   if ($a->isEmpty(),

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/size/size.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/size/size.pure
@@ -15,6 +15,26 @@
 import meta::pure::test::pct::*;
 import meta::pure::metamodel::relation::*;
 
+'''
+The number of rows in a relation.
+
+Counts rows, not distinct values, and takes no account of the columns — an empty relation gives 0
+rather than empty. Combine with `distinct(Relation<T>[1]):Relation<T>[1]` to count distinct rows.
+
+**Parameters**
+- `rel` — the relation to count.
+
+**Returns** the row count.
+
+**Examples**
+```pure
+// val: 1, 3, 4
+$rel->size()   // 3
+```
+
+**See also** `distinct(Relation<T>[1]):Relation<T>[1]`,
+`filter(Relation<T>[1], Function<{T[1]->Boolean[1]}>[1]):Relation<T>[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::relation::size<T>(rel:Relation<T>[1]):Integer[1];
 
 function <<PCT.test>> meta::pure::functions::relation::tests::size::testSimpleSize<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/slice/drop.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/slice/drop.pure
@@ -15,6 +15,29 @@
 import meta::pure::test::pct::*;
 import meta::pure::metamodel::relation::*;
 
+'''
+A relation with its first `size` rows removed.
+
+The complement of `limit(Relation<T>[1], Integer[1]):Relation<T>[1]`, and the way to page past rows
+already seen. **Sort first** — a relation has no inherent row order, so which rows are dropped is
+only defined once an order is imposed. Dropping more rows than the relation holds gives an empty
+relation rather than failing.
+
+**Parameters**
+- `rel` — the relation to drop from.
+- `size` — how many leading rows to remove.
+
+**Returns** the relation without its first `size` rows.
+
+**Examples**
+```pure
+// val: 1, 3, 4, 5, 6
+$rel->sort(~val->ascending())->drop(3)   // val: 5, 6
+```
+
+**See also** `limit(Relation<T>[1], Integer[1]):Relation<T>[1]`,
+`slice(Relation<T>[1], Integer[1], Integer[1]):Relation<T>[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::relation::drop<T>(rel:Relation<T>[1], size:Integer[1]):Relation<T>[1];
 
 function <<PCT.test>> meta::pure::functions::relation::tests::drop::testSimpleDropShared<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/slice/first.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/slice/first.pure
@@ -15,6 +15,40 @@
 import meta::pure::test::pct::*;
 import meta::pure::metamodel::relation::*;
 
+'''
+The first row of the current window.
+
+Returns a whole row, so read a column off it: `$p->first($w, $r).name`. Every row in a partition sees
+the same first row, which makes this the way to compare each row against the leader of its group —
+the earliest date, the highest score — without a self join.
+
+**The window's frame decides what "first" means.** With no frame the window runs from the start of
+the partition to the current row, so the first row is the partition's; with a trailing frame such as
+`rows(-4, 0)` it is the first row of that five-row window and therefore moves with the current row.
+
+Returns empty when the window has no rows.
+
+**Parameters**
+- `w` — the partition, supplied by `extend`.
+- `f` — the window, supplied by `extend`.
+- `r` — the current row, supplied by `extend`.
+
+**Returns** the first row of the window, or empty when it has none.
+
+**Examples**
+```pure
+$rel->extend(over(~grp, ~id->descending()), ~top:{p,w,r| $p->first($w, $r).name})
+
+// id  grp  name  top
+//  8    1    H    H     first by id descending within grp 1
+//  6    1    F    H
+//  2    1    B    H
+```
+
+**See also** `last(Relation<T>[1], _Window<T>[1], T[1]):T[0..1]`,
+`nth(Relation<T>[1], _Window<T>[1], T[1], Integer[1]):T[0..1]`,
+`lag(Relation<T>[1], T[1]):T[0..1]`
+'''
 native function <<PCT.function>> meta::pure::functions::relation::first<T>(w:Relation<T>[1], f:_Window<T>[1], r:T[1]):T[0..1];
 
 function <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.olap>> meta::pure::functions::relation::tests::first::testOLAPWithPartitionAndOrderFirstWindow<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/slice/lag.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/slice/lag.pure
@@ -16,12 +16,50 @@ import meta::pure::test::pct::*;
 import meta::pure::metamodel::relation::*;
 import meta::pure::functions::relation::*;
 
+'''
+The previous row within the partition.
+
+Returns a whole row, so read a column off it: `$p->lag($r).name`. The standard way to compare a row
+against the one before it — a change since the last reading, a gap between consecutive events —
+without a self join.
+
+**The first row of each partition returns empty**, since it has no predecessor. Combine with
+`meta::pure::functions::flow::coalesce(T[0..1], T[1]):T[1]` to supply a default, which is what the
+quant functions do to make a first-row return zero.
+
+Unlike `first` and `last`, this takes no window argument: it is positional relative to the current
+row and does not depend on the frame.
+
+**Parameters**
+- `w` — the partition, supplied by `extend`.
+- `r` — the current row, supplied by `extend`.
+
+**Returns** the preceding row, or empty at the start of a partition.
+
+**Examples**
+```pure
+$rel->extend(over(~grp, ~id->descending()), ~newCol:{p,w,r| $p->lag($r).name})
+
+// id  grp  name  newCol
+//  8    1    H    null     no predecessor within grp 1
+//  6    1    F    H
+//  2    1    B    F
+```
+
+**See also** `lag(Relation<T>[1], T[1], Integer[1]):T[0..1]`,
+`lead(Relation<T>[1], T[1]):T[0..1]`,
+`offset(Relation<T>[1], T[1], Integer[1]):T[0..1]`
+'''
 function <<functionType.NormalizeRequiredFunction,
            PCT.function>> meta::pure::functions::relation::lag<T>(w:Relation<T>[1],r:T[1]):T[0..1]
 {
   lag($w, $r, 1);
 }
 
+'''
+As `lag(Relation<T>[1], T[1]):T[0..1]`, going back `offset` rows rather than one. `lag($r, 1)` is the
+one-argument form.
+'''
 function <<functionType.NormalizeRequiredFunction,
            PCT.function>> meta::pure::functions::relation::lag<T>(w:Relation<T>[1],r:T[1], offset:Integer[1]):T[0..1]
 {

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/slice/last.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/slice/last.pure
@@ -15,6 +15,40 @@
 import meta::pure::test::pct::*;
 import meta::pure::metamodel::relation::*;
 
+'''
+The last row of the current window.
+
+Returns a whole row, so read a column off it: `$p->last($w, $r).id`.
+
+**With no explicit frame this is the current row, not the last row of the partition.** An unframed
+window runs from the start of the partition to the current row, so its last row is the one being
+evaluated — every row sees itself. That is rarely what someone reaching for "last" wants: to get the
+partition's final row, give the window a frame that reaches the end, or order the window the other
+way and use `first(Relation<T>[1], _Window<T>[1], T[1]):T[0..1]`.
+
+Returns empty when the window has no rows.
+
+**Parameters**
+- `w` — the partition, supplied by `extend`.
+- `f` — the window, supplied by `extend`.
+- `row` — the current row, supplied by `extend`.
+
+**Returns** the last row of the window, or empty when it has none.
+
+**Examples**
+```pure
+$rel->extend(over(~grp, ~id->descending()), ~newCol:{p,w,r| $p->last($w, $r).id})
+
+// id  grp  newCol
+//  8    1     8      the window ends at the current row,
+//  6    1     6      so each row gets its own id back
+//  2    1     2
+```
+
+**See also** `first(Relation<T>[1], _Window<T>[1], T[1]):T[0..1]`,
+`nth(Relation<T>[1], _Window<T>[1], T[1], Integer[1]):T[0..1]`,
+`over(String[*], SortInfo<(?:NULL)⊆T>[*], Frame[0..1]):_Window<T>[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::relation::last<T>(w:Relation<T>[1], f:_Window<T>[1], row:T[1]):T[0..1];
 
 function <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.olap>> meta::pure::functions::relation::tests::last::testOLAPWithPartitionAndOrderLastWindow<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/slice/lead.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/slice/lead.pure
@@ -16,12 +16,43 @@ import meta::pure::test::pct::*;
 import meta::pure::metamodel::relation::*;
 import meta::pure::functions::relation::*;
 
+'''
+The next row within the partition.
+
+The mirror of `lag(Relation<T>[1], T[1]):T[0..1]`, looking forwards instead of back. Returns a whole
+row, so read a column off it: `$p->lead($r).name`. Useful for looking ahead — the next event's
+timestamp, the following period's value.
+
+**The last row of each partition returns empty**, since it has no successor.
+
+Like `lag`, this takes no window argument: it is positional relative to the current row and does not
+depend on the frame.
+
+**Parameters**
+- `w` — the partition, supplied by `extend`.
+- `r` — the current row, supplied by `extend`.
+
+**Returns** the following row, or empty at the end of a partition.
+
+**Examples**
+```pure
+$rel->extend(over(~grp, ~id->ascending()), ~next:{p,w,r| $p->lead($r).name})
+```
+
+**See also** `lead(Relation<T>[1], T[1], Integer[1]):T[0..1]`,
+`lag(Relation<T>[1], T[1]):T[0..1]`,
+`offset(Relation<T>[1], T[1], Integer[1]):T[0..1]`
+'''
 function <<functionType.NormalizeRequiredFunction,
            PCT.function>> meta::pure::functions::relation::lead<T>(w:Relation<T>[1],r:T[1]):T[0..1]
 {
   lead($w, $r, 1)
 }
 
+'''
+As `lead(Relation<T>[1], T[1]):T[0..1]`, going forward `offset` rows rather than one. `lead($r, 1)`
+is the one-argument form.
+'''
 function <<functionType.NormalizeRequiredFunction,
            PCT.function>> meta::pure::functions::relation::lead<T>(w:Relation<T>[1],r:T[1], offset:Integer[1]):T[0..1]
 {

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/slice/limit.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/slice/limit.pure
@@ -15,6 +15,29 @@
 import meta::pure::test::pct::*;
 import meta::pure::metamodel::relation::*;
 
+'''
+The first `size` rows of a relation.
+
+**Sort first.** A relation has no inherent row order, so which rows come back is only defined once an
+order is imposed — every test in this file calls `sort` before `limit` for that reason. Asking for
+more rows than the relation holds returns all of them rather than failing.
+
+**Parameters**
+- `rel` — the relation to take from.
+- `size` — how many rows to keep.
+
+**Returns** a relation of at most `size` rows.
+
+**Examples**
+```pure
+// val: 1, 3, 4, 5, 6
+$rel->sort(~val->ascending())->limit(3)   // val: 1, 3, 4
+```
+
+**See also** `drop(Relation<T>[1], Integer[1]):Relation<T>[1]`,
+`slice(Relation<T>[1], Integer[1], Integer[1]):Relation<T>[1]`,
+`sort(Relation<T>[1], SortInfo<X⊆T>[*]):Relation<T>[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::relation::limit<T>(rel:Relation<T>[1], size:Integer[1]):Relation<T>[1];
 
 function <<PCT.test>> meta::pure::functions::relation::tests::limit::testSimpleLimitShared<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/slice/nth.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/slice/nth.pure
@@ -15,6 +15,41 @@
 import meta::pure::test::pct::*;
 import meta::pure::metamodel::relation::*;
 
+'''
+The row at a given position within the current window.
+
+Returns a whole row, so read a column off it: `$p->nth($w, $r, 1).id`. **Positions count from 1**, so
+`nth($w, $r, 1)` is the same row as `first(Relation<T>[1], _Window<T>[1], T[1]):T[0..1]`.
+
+The position is measured from the start of the window, not from the current row — for a row relative
+to the current one, use `lag(Relation<T>[1], T[1]):T[0..1]` or
+`lead(Relation<T>[1], T[1]):T[0..1]`. As with the rest of the family, the window's frame decides what
+the window contains; with no frame it runs from the start of the partition to the current row.
+
+Returns empty when the window holds fewer rows than the position asked for.
+
+**Parameters**
+- `w` — the partition, supplied by `extend`.
+- `f` — the window, supplied by `extend`.
+- `r` — the current row, supplied by `extend`.
+- `offset` — the position within the window, counting from 1.
+
+**Returns** the row at that position, or empty when the window is shorter.
+
+**Examples**
+```pure
+$rel->extend(over(~grp, ~id->descending()), ~newCol:{p,w,r| $p->nth($w, $r, 1).id})
+
+// id  grp  newCol
+//  8    1     8      position 1 within grp 1
+//  6    1     8
+//  2    1     8
+```
+
+**See also** `first(Relation<T>[1], _Window<T>[1], T[1]):T[0..1]`,
+`last(Relation<T>[1], _Window<T>[1], T[1]):T[0..1]`,
+`offset(Relation<T>[1], T[1], Integer[1]):T[0..1]`
+'''
 native function <<PCT.function>> meta::pure::functions::relation::nth<T>(w:Relation<T>[1], f:_Window<T>[1], r:T[1], offset:Integer[1]):T[0..1];
 
 function <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.olap>> meta::pure::functions::relation::tests::nth::testOLAPWithPartitionAndOrderNthWindow<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/slice/offset.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/slice/offset.pure
@@ -33,6 +33,11 @@ backwards.
 
 **Returns** the row at that offset, or empty when it falls outside the partition.
 
+**Examples**
+```pure
+$rel->extend(over(~grp, ~id->ascending()), ~twoBack : {p, w, r| $p->offset($r, -2).name})
+```
+
 **See also** `lag(Relation<T>[1], T[1]):T[0..1]`,
 `lead(Relation<T>[1], T[1]):T[0..1]`,
 `nth(Relation<T>[1], _Window<T>[1], T[1], Integer[1]):T[0..1]`

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/slice/offset.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/slice/offset.pure
@@ -15,4 +15,26 @@
 import meta::pure::test::pct::*;
 import meta::pure::metamodel::relation::*;
 
+'''
+The row a given number of positions away from the current one.
+
+The primitive behind `lag(Relation<T>[1], T[1]):T[0..1]` and `lead(Relation<T>[1], T[1]):T[0..1]`,
+which are defined as negative and positive offsets respectively. A negative `offset` looks backwards
+and a positive one forwards; 0 is the current row.
+
+Returns empty when the offset falls outside the partition, so the first rows have no predecessor and
+the last no successor. Prefer `lag` and `lead` in ordinary code — the sign convention is easy to get
+backwards.
+
+**Parameters**
+- `w` — the partition, supplied by `extend`.
+- `r` — the current row, supplied by `extend`.
+- `offset` — how many rows to move, negative backwards and positive forwards.
+
+**Returns** the row at that offset, or empty when it falls outside the partition.
+
+**See also** `lag(Relation<T>[1], T[1]):T[0..1]`,
+`lead(Relation<T>[1], T[1]):T[0..1]`,
+`nth(Relation<T>[1], _Window<T>[1], T[1], Integer[1]):T[0..1]`
+'''
 native function <<PCT.function, PCT.platformOnly>> meta::pure::functions::relation::offset<T>(w:Relation<T>[1], r:T[1], offset:Integer[1]):T[0..1];

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/slice/slice.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/slice/slice.pure
@@ -15,6 +15,31 @@
 import meta::pure::test::pct::*;
 import meta::pure::metamodel::relation::*;
 
+'''
+The rows of a relation between two positions.
+
+Positions are zero-based, `start` is included and `stop` is excluded, so the result holds
+`stop - start` rows and `slice(1, 3)` returns the second and third. **Sort first** — a relation has
+no inherent row order, so which rows fall in the range is only defined once an order is imposed.
+
+Equivalent to a `drop` followed by a `limit`, in one call.
+
+**Parameters**
+- `rel` — the relation to take from.
+- `start` — the zero-based position to start at, included.
+- `stop` — the zero-based position to stop at, excluded.
+
+**Returns** the rows in the half-open range.
+
+**Examples**
+```pure
+// val: 1, 3, 4, 5, 6
+$rel->sort(~val->ascending())->slice(1, 3)   // val: 3, 4
+```
+
+**See also** `limit(Relation<T>[1], Integer[1]):Relation<T>[1]`,
+`drop(Relation<T>[1], Integer[1]):Relation<T>[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::relation::slice<T>(rel:Relation<T>[1], start:Integer[1], stop: Integer[1]):Relation<T>[1];
 
 function <<PCT.test>> meta::pure::functions::relation::tests::slice::testSimpleSliceShared<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/tdsEquivalent.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/tdsEquivalent.pure
@@ -17,11 +17,41 @@ import meta::pure::metamodel::variant::*;
 import meta::pure::metamodel::relation::*;
 import meta::pure::test::pct::*;
 
+'''
+Asserts two relations match, comparing numbers within a tolerance.
+
+For tests whose expected values are computed rather than exact — anything involving division, roots
+or accumulated floating point, where a bit-for-bit comparison would fail differently on each target
+database. Column count, column names and row count must all agree exactly; only numeric values are
+allowed to differ, and only by at most `delta`.
+
+Prefer this to comparing `toString` output whenever the result contains a computed number.
+
+**Parameters**
+- `one` — the expected relation.
+- `two` — the actual relation.
+- `delta` — the tolerance allowed on numeric values.
+
+**Returns** `true` when the relations match; fails otherwise.
+
+**Examples**
+```pure
+assertTdsEquivalent(#TDS symbol,vwap AAPL,192.71 #, $res, 0.00001)
+```
+
+**See also** `assertTdsEquivalent(Relation<Any>[1], Relation<Any>[1], Number[1], Number[1]):Boolean[1]`,
+`toString(Relation<T>[1]):String[1]`
+'''
 function <<PCT.function, PCT.platformOnly>> meta::pure::functions::relation::assertTdsEquivalent(one:Relation<Any>[1], two:Relation<Any>[1], delta:Number[1]):Boolean[1]
 {
    meta::pure::functions::relation::assertTdsEquivalent($one, $two, $delta, 0);
 }
 
+'''
+As `assertTdsEquivalent(Relation<Any>[1], Relation<Any>[1], Number[1]):Boolean[1]`, with a separate
+tolerance for date and time values, in seconds. The three-argument form passes 0, requiring
+timestamps to match exactly.
+'''
 function <<PCT.function, PCT.platformOnly>> meta::pure::functions::relation::assertTdsEquivalent(one:Relation<Any>[1], two:Relation<Any>[1], delta:Number[1], timeDeltaInSeconds:Number[1]):Boolean[1]
 {
    let oneCol = $one->meta::pure::functions::relation::columns();

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/toCSVString.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/toCSVString.pure
@@ -15,6 +15,30 @@
 import meta::pure::test::pct::*;
 import meta::pure::functions::string::*;
 
+'''
+Quotes a string for the `#TDS` CSV format, if it needs it.
+
+**Quoting is conditional**: a string containing a comma, a single quote, a newline or a carriage
+return is wrapped in single quotes with any embedded quote backslash-escaped; anything else is
+returned untouched. That keeps rendered relations readable, at the cost of the output not being
+uniformly quoted.
+
+Note the escape is `\\'`, not the doubled `''` some CSV dialects use — a reader written for RFC 4180
+will not parse this.
+
+**Parameters**
+- `string` — the value to render.
+
+**Returns** the value, quoted and escaped only if it needs to be.
+
+**Examples**
+```pure
+'plain'->toCSVString()      // 'plain', unquoted
+'a,b'->toCSVString()        // wrapped in single quotes, because of the comma
+```
+
+**See also** `toString(Relation<T>[1]):String[1]`
+'''
 function <<PCT.function, PCT.platformOnly>> meta::pure::functions::relation::toCSVString(string: String[1]):String[1]
 {
    if($string->contains(',') || $string->contains('\'') || $string->contains('\n') || $string->contains('\r'),

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/toString.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/toString.pure
@@ -16,11 +16,46 @@ import meta::pure::test::pct::*;
 import meta::pure::metamodel::relation::*;
 import meta::pure::functions::relation::*;
 
+'''
+Renders a relation in the `#TDS` literal format.
+
+The format `#TDS ... #` accepts as input, so the output can be pasted back into Pure — which is why
+almost every PCT test in this repository asserts against a `toString` result rather than inspecting
+rows. Values are escaped as `toCSVString(String[1]):String[1]` describes, and an absent value prints
+as `null`.
+
+**Row order is whatever the relation happens to have**, so sort before rendering when comparing
+against a fixed expectation.
+
+**Parameters**
+- `rel` — the relation to render.
+
+**Returns** the relation as `#TDS` text.
+
+**Examples**
+```pure
+$rel->sort(~val->ascending())->toString()
+
+// #TDS
+//    val,str
+//    1,a
+//    3,ewe
+// #
+```
+
+**See also** `toString(Relation<T>[1], Boolean[1]):String[1]`,
+`toCSVString(String[1]):String[1]`
+'''
 function <<PCT.function, PCT.platformOnly>> meta::pure::functions::relation::toString<T>(rel:Relation<T>[1]):String[1]
 {
   $rel->toString(false);
 }
 
+'''
+As `toString(Relation<T>[1]):String[1]`, optionally annotating each column in the header with its
+type and multiplicity — `val:Integer[1]` rather than `val`. Pass `true` when the point of printing is
+to check the relation's shape rather than its contents.
+'''
 function <<PCT.function, PCT.platformOnly>> meta::pure::functions::relation::toString<T>(rel:Relation<T>[1], typesAndMuls : Boolean[1]):String[1]
 {
     let cols = $rel->columns();

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/transformation/aggregate.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/transformation/aggregate.pure
@@ -15,16 +15,48 @@
 import meta::pure::test::pct::*;
 import meta::pure::metamodel::relation::*;
 
-native function <<PCT.function>> 
-{
-    doc.doc='Aggregates the entire given relation and adds new column where its value is aggregated using the reduce (second) function using the values collected from the map (first) function'
-}
+'''
+Collapses a whole relation to **one row** holding an aggregate over every input row.
+
+The aggregate spec has two parts, written `~name : row | expr : values | reduction` — a map from
+each row to a value, and a function reducing everything collected. `~idSum : x | $x.id : y |
+$y->plus()` over ten rows gives a single `idSum`.
+
+**Only the aggregated columns survive**, since there is nothing to group by: the result type is `R`,
+not `T+R`. That is what separates this from
+`extend(Relation<T>[1], AggColSpec<{T[1]->K[0..1]}, {K[*]->V[0..1]}, R>[1]):Relation<T+R>[1]`, which
+computes the same value and repeats it across every original row, and from
+`groupBy(Relation<T>[1], ColSpec<Z⊆T>[1], AggColSpec<{T[1]->K[0..1]}, {K[*]->V[0..1]}, R>[1]):Relation<Z+R>[1]`,
+which is this function per group.
+
+**Parameters**
+- `r` — the relation to aggregate.
+- `agg` — the aggregate column, as a map and a reduction.
+
+**Returns** a relation of one row and one column.
+
+**Examples**
+```pure
+$rel->aggregate(~idSum : x | $x.id : y | $y->plus())
+```
+
+**See also** `aggregate(Relation<T>[1], AggColSpecArray<{T[1]->K[0..1]}, {K[*]->V[0..1]}, R>[1]):Relation<R>[1]`,
+`groupBy(Relation<T>[1], ColSpec<Z⊆T>[1], AggColSpec<{T[1]->K[0..1]}, {K[*]->V[0..1]}, R>[1]):Relation<Z+R>[1]`,
+`extend(Relation<T>[1], AggColSpec<{T[1]->K[0..1]}, {K[*]->V[0..1]}, R>[1]):Relation<T+R>[1]`
+'''
+native function <<PCT.function>>
 meta::pure::functions::relation::aggregate<T,K,V,R>(r:Relation<T>[1], agg:meta::pure::metamodel::relation::AggColSpec<{T[1]->K[0..1]},{K[*]->V[0..1]}, R>[1]):Relation<R>[1];
 
+'''
+As `aggregate(Relation<T>[1], AggColSpec<{T[1]->K[0..1]}, {K[*]->V[0..1]}, R>[1]):Relation<R>[1]`,
+computing several aggregates over the same relation in one pass — still a single result row, now
+with one column per spec:
+
+```pure
+$rel->aggregate(~[idSum : x | $x.id : y | $y->plus(), codes : x | $x.code : y | $y->joinStrings(':')])
+```
+'''
 native function <<PCT.function>>
-{
-    doc.doc='Aggregates the entire given relation and adds new column(s) where their values are aggregated using the reduce (second) function using the values collected from the map (first) function'
-}
 meta::pure::functions::relation::aggregate<T,K,V,R>(r:Relation<T>[1], agg:meta::pure::metamodel::relation::AggColSpecArray<{T[1]->K[0..1]},{K[*]->V[0..1]}, R>[1]):Relation<R>[1];
 
 // See the note on the equivalent groupBy overloads.

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/transformation/aggregate.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/transformation/aggregate.pure
@@ -60,16 +60,21 @@ native function <<PCT.function>>
 meta::pure::functions::relation::aggregate<T,K,V,R>(r:Relation<T>[1], agg:meta::pure::metamodel::relation::AggColSpecArray<{T[1]->K[0..1]},{K[*]->V[0..1]}, R>[1]):Relation<R>[1];
 
 // See the note on the equivalent groupBy overloads.
+'''
+As `aggregate(Relation<T>[1], AggColSpec<{T[1]->K[0..1]}, {K[*]->V[0..1]}, R>[1]):Relation<R>[1]`,
+but the aggregate is a single lambda over the whole relation rather than a map/reduce pair — the same
+distinction as on
+`groupBy(Relation<T>[1], ColSpecArray<Z⊆T>[1], FuncColSpec<{Relation<T>[1]->Any[0..1]}, R>[1]):Relation<Z+R>[1]`,
+and for the same reason: the lambda can still see every column.
+'''
 native function <<PCT.function>>
-{
-    doc.doc='Aggregates the entire given relation and adds a new column whose value is computed by applying the given function to the relation'
-}
 meta::pure::functions::relation::aggregate<T,R>(r:Relation<T>[1], agg:meta::pure::metamodel::relation::FuncColSpec<{Relation<T>[1]->Any[0..1]}, R>[1]):Relation<R>[1];
 
+'''
+As `aggregate(Relation<T>[1], FuncColSpec<{Relation<T>[1]->Any[0..1]}, R>[1]):Relation<R>[1]`,
+computing several such aggregates in one pass.
+'''
 native function <<PCT.function>>
-{
-    doc.doc='Aggregates the entire given relation and adds new columns whose values are computed by applying the given functions to the relation'
-}
 meta::pure::functions::relation::aggregate<T,R>(r:Relation<T>[1], agg:meta::pure::metamodel::relation::FuncColSpecArray<{Relation<T>[1]->Any[*]}, R>[1]):Relation<R>[1];
 
 

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/transformation/asofjoin.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/transformation/asofjoin.pure
@@ -15,8 +15,66 @@
 import meta::pure::test::pct::*;
 import meta::pure::metamodel::relation::*;
 
+'''
+Joins each left row to the **closest** right row satisfying a condition, rather than to all of them.
+
+The point-in-time join: pairing a trade with the quote in force when it happened, a reading with the
+most recent calibration. An ordinary `join` on `>` would match every earlier right row; this matches
+only the nearest one, so the result has exactly one row per left row.
+
+Which row is "closest" follows the direction of the `match` condition — write `>` to take the latest
+right row before the left one, `<` to take the earliest one after.
+
+**Unmatched left rows are kept, with the right columns empty**, so this behaves like a left join: a
+left row with nothing before it survives with nulls rather than disappearing. As with `join`, the two
+sides' column names must be distinct.
+
+**Parameters**
+- `rel1` — the left relation, one result row per row of it.
+- `rel2` — the right relation, searched for the closest match.
+- `match` — the condition selecting candidate rows and fixing the direction.
+
+**Returns** the joined relation, with the columns of both sides.
+
+**Examples**
+```pure
+// the latest quote strictly before each trade
+$trades->asOfJoin($quotes, {t, q | $t.time->toOne() > $q.time2->toOne()})
+
+// time      value  time2       value2
+// 06:30:00   5000  null        null      nothing precedes it
+// 06:31:00   4000  06:30:10    2000      the closest earlier row, not all of them
+// 06:32:00   3000  06:31:20    3000
+```
+
+**See also** `asOfJoin(Relation<T>[1], Relation<V>[1], Function<{T[1], V[1]->Boolean[1]}>[1], Function<{T[1], V[1]->Boolean[1]}>[1]):Relation<T+V>[1]`,
+`join(Relation<T>[1], Relation<V>[1], JoinKind[1], Function<{T[1], V[1]->Boolean[1]}>[1]):Relation<T+V>[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::relation::asOfJoin<T,V>(rel1:Relation<T>[1], rel2:Relation<V>[1], match:Function<{T[1],V[1]->Boolean[1]}>[1]):Relation<T+V>[1];
 
+'''
+As `asOfJoin(Relation<T>[1], Relation<V>[1], Function<{T[1], V[1]->Boolean[1]}>[1]):Relation<T+V>[1]`,
+with a second condition that must also hold.
+
+The closest match is then sought only among right rows satisfying `join` — normally an equality that
+keeps the search within one instrument, account or key, so that a trade is matched against quotes for
+its own symbol rather than the market as a whole.
+
+**Parameters**
+- `rel1` — the left relation.
+- `rel2` — the right relation.
+- `match` — the condition selecting candidate rows and fixing the direction.
+- `join` — an additional condition every candidate must satisfy.
+
+**Returns** the joined relation, with the columns of both sides.
+
+**Examples**
+```pure
+$tds1->asOfJoin($tds2,
+                {x, y | $x.time->toOne() > $y.time2->toOne()},
+                {x, y | $x.key->toOne() == $y.key2->toOne()})
+```
+'''
 native function <<PCT.function>> meta::pure::functions::relation::asOfJoin<T,V>(rel1:Relation<T>[1], rel2:Relation<V>[1], match:Function<{T[1],V[1]->Boolean[1]}>[1], join:Function<{T[1],V[1]->Boolean[1]}>[1]):Relation<T+V>[1];
 
 function <<PCT.test>> meta::pure::functions::relation::tests::asOfJoin::testSimpleAsOfJoin<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/transformation/concatenate.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/transformation/concatenate.pure
@@ -15,6 +15,30 @@
 import meta::pure::test::pct::*;
 import meta::pure::metamodel::relation::*;
 
+'''
+Stacks one relation on another, row-wise.
+
+Both relations must have the same type, which the signature enforces — this joins nothing and
+matches nothing, it simply puts the rows together. **Duplicates are kept**: this is a union-all, so
+follow with `distinct(Relation<T>[1]):Relation<T>[1]` if you want set semantics.
+
+The result carries no guaranteed row order, so sort afterwards if the order matters.
+
+**Parameters**
+- `rel1` — the first relation.
+- `rel2` — the second, of the same type.
+
+**Returns** the rows of both.
+
+**Examples**
+```pure
+$thisYear->concatenate($lastYear)
+$thisYear->concatenate($lastYear)->distinct()   // set semantics
+```
+
+**See also** `distinct(Relation<T>[1]):Relation<T>[1]`,
+`join(Relation<T>[1], Relation<V>[1], JoinKind[1], Function<{T[1], V[1]->Boolean[1]}>[1]):Relation<T+V>[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::relation::concatenate<T>(rel1:Relation<T>[1], rel2:Relation<T>[1]):Relation<T>[1];
 
 function <<PCT.test>> meta::pure::functions::relation::tests::concatenate::testSimpleConcatenateShared<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/transformation/distinct.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/transformation/distinct.pure
@@ -15,7 +15,37 @@
 import meta::pure::metamodel::relation::*;
 import meta::pure::test::pct::*;
 
+'''
+Narrows a relation to the given columns and removes duplicate rows.
+
+**It projects as well as deduplicates** — the result holds only `columns`, so this is a `select` and
+a dedup in one step, not a dedup that preserves the other columns. Rows count as duplicates when
+they agree on every one of the chosen columns; a column left out cannot keep two rows apart.
+
+Where several rows collapse into one, which of them survived is not observable, since only the
+chosen columns remain.
+
+**Parameters**
+- `rel` — the relation.
+- `columns` — the columns to keep and to compare on.
+
+**Returns** the distinct rows, holding only those columns.
+
+**Examples**
+```pure
+$rel->distinct(~[grp, region])   // the distinct group-and-region pairs
+```
+
+**See also** `distinct(Relation<T>[1]):Relation<T>[1]`,
+`select(Relation<T>[1], ColSpecArray<Z⊆T>[1]):Relation<Z>[1]`,
+`groupBy(Relation<T>[1], ColSpecArray<Z⊆T>[1], AggColSpec<{T[1]->K[0..1]}, {K[*]->V[0..1]}, R>[1]):Relation<Z+R>[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::relation::distinct<X,T>(rel:Relation<T>[1], columns:ColSpecArray<X⊆T>[1]):Relation<X>[1];
+
+'''
+As `distinct(Relation<T>[1], ColSpecArray<X⊆T>[1]):Relation<X>[1]`, comparing on every column and
+keeping them all — whole-row deduplication.
+'''
 native function <<PCT.function>> meta::pure::functions::relation::distinct<T>(rel:Relation<T>[1]):Relation<T>[1];
 
 function <<PCT.test>> meta::pure::functions::relation::tests::distinct::testDistinctSingle<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/transformation/extend.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/transformation/extend.pure
@@ -17,34 +17,111 @@ import meta::pure::functions::variant::navigation::*;
 import meta::pure::test::pct::*;
 import meta::pure::metamodel::relation::*;
 
+'''
+Adds a column to a relation, computed from each row.
+
+The workhorse for derived columns. **Every input column is kept** — the result type is the input
+plus the new column, which is what separates this from
+`project(Relation<T>[1], FuncColSpecArray<{T[1]->Any[*]}, Z>[1]):Relation<Z>[1]`, which keeps only
+what it is given. Row count is unchanged.
+
+The column is written as a named function over the row: `~newCol : x | $x.a + $x.b`.
+
+There are eight overloads, in three families. This one and the next compute **per row**. Those taking
+an `AggColSpec` compute an **aggregate** over the whole relation and repeat it on every row. Those
+taking a `_Window` compute over a window, and their column function receives three arguments —
+partition, window and current row — rather than one.
+
+**Parameters**
+- `r` — the relation to extend.
+- `f` — the new column, as a named function over a row.
+
+**Returns** the relation with the new column added.
+
+**Examples**
+```pure
+$rel->extend(~total : x | $x.price * $x.quantity)
+```
+
+**See also** `extend(Relation<T>[1], FuncColSpecArray<{T[1]->Any[*]}, Z>[1]):Relation<T+Z>[1]`,
+`extend(Relation<T>[1], _Window<T>[1], FuncColSpec<{Relation<T>[1], _Window<T>[1], T[1]->Any[0..1]}, R>[1]):Relation<T+R>[1]`,
+`project(Relation<T>[1], FuncColSpecArray<{T[1]->Any[*]}, Z>[1]):Relation<Z>[1]`
+'''
 native function <<PCT.function>>
-{
-    doc.doc='Extend the given relation with a new column, and its value is computed with the given function'
-}
 meta::pure::functions::relation::extend<T,Z>(r:Relation<T>[1], f:FuncColSpec<{T[1]->Any[0..1]},Z>[1]):Relation<T+Z>[1];
 
+'''
+As `extend(Relation<T>[1], FuncColSpec<{T[1]->Any[0..1]}, Z>[1]):Relation<T+Z>[1]`, adding several
+columns in one call: `$rel->extend(~[total : x | $x.a * $x.b, flag : x | $x.a > 0])`.
+'''
 native function <<PCT.function>>
-{
-    doc.doc='Extend the given relation with a set of new columns, and their values is computed with their associated function'
-}
 meta::pure::functions::relation::extend<T,Z>(r:Relation<T>[1], fs:FuncColSpecArray<{T[1]->Any[*]},Z>[1]):Relation<T+Z>[1];
 
+'''
+As `extend(Relation<T>[1], FuncColSpec<{T[1]->Any[0..1]}, Z>[1]):Relation<T+Z>[1]`, but the new
+column is an **aggregate over the whole relation**, repeated identically on every row — a grand
+total to compare each row against, without a join. The spec has two parts: a map from each row to a
+value, and a function reducing the collected values.
+'''
 native function <<PCT.function>> meta::pure::functions::relation::extend<T,K,V,R>(r:Relation<T>[1], agg:AggColSpec<{T[1]->K[0..1]},{K[*]->V[0..1]}, R>[1]):Relation<T+R>[1];
+
+'''
+As `extend(Relation<T>[1], AggColSpec<{T[1]->K[0..1]}, {K[*]->V[0..1]}, R>[1]):Relation<T+R>[1]`,
+adding several aggregate columns in one call.
+'''
 native function <<PCT.function>> meta::pure::functions::relation::extend<T,K,V,R>(r:Relation<T>[1], agg:AggColSpecArray<{T[1]->K[0..1]},{K[*]->V[0..1]}, R>[1]):Relation<T+R>[1];
 
+'''
+Adds a column computed over a window — the form every window function is called through.
+
+**The column function takes three arguments, not one**: the partition, the window and the current
+row, conventionally written `{p, w, r| ...}`. Pass those on to `rank`, `lag`, `first` and the rest,
+which all expect them.
+
+Build the window with `over`. Remember that a window with no explicit frame runs from the start of
+the partition to the current row, which is what makes an unframed aggregate a running one.
+
+**Parameters**
+- `r` — the relation to extend.
+- `window` — the window, from `over`.
+- `f` — the new column, as a function of partition, window and row.
+
+**Returns** the relation with the new column added.
+
+**Examples**
+```pure
+$rel->extend(over(~grp, ~id->descending()), ~rnk : {p, w, r| $p->rank($w, $r)})
+$rel->extend(over(~grp, ~id->ascending()),  ~prev : {p, w, r| $p->lag($r).name})
+```
+
+**See also** `over(String[*], SortInfo<(?:NULL)⊆T>[*], Frame[0..1]):_Window<T>[1]`,
+`rank(Relation<T>[1], _Window<T>[1], T[1]):Integer[1]`,
+`reduce(Relation<T>[1], _Window<T>[1], T[1], Function<{T[1]->V[*]}>[1], Function<{V[*]->U[m]}>[1]):U[m]`
+'''
 native function <<PCT.function>> meta::pure::functions::relation::extend<T,Z,W,R>(r:Relation<T>[1], window:_Window<T>[1], f:FuncColSpec<{Relation<T>[1],_Window<T>[1],T[1]->Any[0..1]},R>[1]):Relation<T+R>[1];
+
+'''
+As `extend(Relation<T>[1], _Window<T>[1], FuncColSpec<{Relation<T>[1], _Window<T>[1], T[1]->Any[0..1]}, R>[1]):Relation<T+R>[1]`,
+adding several window columns in one call.
+'''
 native function <<PCT.function>> meta::pure::functions::relation::extend<T,Z,W,R>(r:Relation<T>[1], window:_Window<T>[1], f:FuncColSpecArray<{Relation<T>[1],_Window<T>[1],T[1]->Any[*]},R>[1]):Relation<T+R>[1];
 
+'''
+As `extend(Relation<T>[1], _Window<T>[1], FuncColSpec<{Relation<T>[1], _Window<T>[1], T[1]->Any[0..1]}, R>[1]):Relation<T+R>[1]`,
+but the column **aggregates the values within the window** rather than picking a row out of it. The
+spec has two parts: a map from each row of the window to a value, and a function reducing the
+collected values — `~total : {p, w, r| $r.value} : y | $y->sum()`.
+
+With no frame on the window this gives a running aggregate, since the window ends at the current row.
+'''
 native function <<PCT.function>>
-{
-    doc.doc='OLAP - Extend the given relation with a new column, and its value is aggregated using the given function using the values collected from the given window'
-}
 meta::pure::functions::relation::extend<T,K,V,R>(r:Relation<T>[1], window:_Window<T>[1], agg:AggColSpec<{Relation<T>[1],_Window<T>[1],T[1]->K[0..1]},{K[*]->V[0..1]}, R>[1]):Relation<T+R>[1];
 
+'''
+As `extend(Relation<T>[1], _Window<T>[1], AggColSpec<{Relation<T>[1], _Window<T>[1], T[1]->K[0..1]}, {K[*]->V[0..1]}, R>[1]):Relation<T+R>[1]`,
+adding several aggregated window columns in one call.
+'''
 native function <<PCT.function>>
-{
-    doc.doc='OLAP - Extend the given relation with a set of new columns, and their values are aggregated using their associated function using the values collected from the given window'
-}
 meta::pure::functions::relation::extend<T,K,V,R>(r:Relation<T>[1], window:_Window<T>[1], agg:AggColSpecArray<{Relation<T>[1],_Window<T>[1],T[1]->K[0..1]},{K[*]->V[0..1]}, R>[1]):Relation<T+R>[1];
 
 

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/transformation/extend.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/transformation/extend.pure
@@ -1421,10 +1421,12 @@ function <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.olap>> 
                   '#', $res->sort([~grp->ascending(), ~id->descending()])->toString());
 }
 
-function <<PCT.test, PCTRelationQualifier.relation, PCTCoreQualifier.variant>> 
-{
-  doc.doc='Extends a given TDS where the new column value is pass thru of a variant column'
-}
+'''
+A variant column carried through `extend` unchanged. The copy prints as the same JSON text as the
+original, so a variant survives the round trip through a relational store rather than degrading to a
+string.
+'''
+function <<PCT.test, PCTRelationQualifier.relation, PCTCoreQualifier.variant>>
 meta::pure::functions::relation::tests::extend::testVariantColumn<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
    let tds = #TDS
@@ -1452,10 +1454,12 @@ meta::pure::functions::relation::tests::extend::testVariantColumn<T|m>(f:Functio
                 '#', $res->toString());
 }
 
+'''
+Indexing into a variant array column with `get`, one `extend` per position. The extracted values are
+themselves variants — the result prints `'1'`, not `1` — so unpack with `to(@Integer)` before doing
+arithmetic on them.
+'''
 function <<PCT.test, PCTRelationQualifier.relation, PCTCoreQualifier.variant>>
-{
-  doc.doc='Extends a given TDS where the new column value is extracted from a variant array using the value\'s index number'
-}
 meta::pure::functions::relation::tests::extend::testVariantColumn_indexExtraction<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
    let tds = #TDS
@@ -1484,10 +1488,12 @@ meta::pure::functions::relation::tests::extend::testVariantColumn_indexExtractio
                 '#', $res->toString());
 }
 
-function <<PCT.test, PCTRelationQualifier.relation, PCTCoreQualifier.variant>> 
-{
-  doc.doc='Extends a given TDS where the new column value is extracted from a variant map using the value\'s key name'
-}
+'''
+Reading named keys out of a variant object column, three in one `extend`. Each result stays a
+variant, which is why the string key prints with its JSON quotes intact — `'"hello"'` rather than
+`hello`.
+'''
+function <<PCT.test, PCTRelationQualifier.relation, PCTCoreQualifier.variant>>
 meta::pure::functions::relation::tests::extend::testVariantColumn_keyExtraction<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
    let tds = #TDS
@@ -1515,10 +1521,12 @@ meta::pure::functions::relation::tests::extend::testVariantColumn_keyExtraction<
                 '#', $res->toString());
 }
 
-function <<PCT.test, PCTRelationQualifier.relation, PCTCoreQualifier.variant>> 
-{
-  doc.doc='Extends a given TDS where the new column is computed transforming a variant array by filtering its content using a given expression'
-}
+'''
+Filtering inside a variant array column: `toMany(@Integer)` opens the array into a collection,
+`filter` narrows it, and `toVariant` packs the survivors back into a variant. The column stays one
+variant per row throughout — the collection exists only within the expression.
+'''
+function <<PCT.test, PCTRelationQualifier.relation, PCTCoreQualifier.variant>>
 meta::pure::functions::relation::tests::extend::testVariantColumn_filter<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
    let tds = #TDS
@@ -1546,10 +1554,11 @@ meta::pure::functions::relation::tests::extend::testVariantColumn_filter<T|m>(f:
                 '#', $res->toString());
 }
 
-function <<PCT.test, PCTRelationQualifier.relation, PCTCoreQualifier.variant>> 
-{
-  doc.doc='Extends a given TDS where the new column is computed transforming a variant array by mapping its values to new values using a given expression'
-}
+'''
+Mapping over a variant array column. Unlike the filter case the result keeps one entry per input
+entry, so `[1,2,3]` becomes `[1,0,1]` — same length, transformed values.
+'''
+function <<PCT.test, PCTRelationQualifier.relation, PCTCoreQualifier.variant>>
 meta::pure::functions::relation::tests::extend::testVariantColumn_map<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
    let tds = #TDS
@@ -1577,10 +1586,12 @@ meta::pure::functions::relation::tests::extend::testVariantColumn_map<T|m>(f:Fun
                 '#', $res->toString());
 }
 
-function <<PCT.test, PCTRelationQualifier.relation, PCTCoreQualifier.variant>> 
-{
-  doc.doc='Extends a given TDS where the new column is computed transforming a variant array by folding its values to a new value using a given expression'
-}
+'''
+Folding a variant array column down to a scalar — here the product of the entries, seeded at `1`.
+The result column is an `Integer`, not a variant, because `fold` returns the accumulator's type and
+the seed is a plain integer; no `toVariant` is needed to close the expression.
+'''
+function <<PCT.test, PCTRelationQualifier.relation, PCTCoreQualifier.variant>>
 meta::pure::functions::relation::tests::extend::testVariantColumn_fold<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
    let tds = #TDS

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/transformation/groupBy.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/transformation/groupBy.pure
@@ -15,28 +15,62 @@
 import meta::pure::test::pct::*;
 import meta::pure::metamodel::relation::*;
 
+'''
+Groups a relation by one or more columns and computes an aggregate per group — one output row per
+distinct combination of the grouping values.
+
+The aggregate spec has two parts, written `~name : row | expr : values | reduction`: a map pulling a
+value out of each row of the group, and a function reducing everything collected.
+
+**The result holds only the grouping columns and the aggregates** — its type is `Z+R`, so every
+column not named in `cols` and not produced by `agg` is gone. Reach for
+`extend(Relation<T>[1], AggColSpec<{T[1]->K[0..1]}, {K[*]->V[0..1]}, R>[1]):Relation<T+R>[1]` when
+you want the original rows kept alongside the aggregate.
+
+**Group order is not defined.** Sort the result if you need one. The values collected within a group
+have no defined order either, which is why an order-sensitive reduction such as `joinStrings` gives a
+stable set of characters but not a stable arrangement of them.
+
+**Parameters**
+- `r` — the relation to group.
+- `cols` — the grouping columns.
+- `agg` — the aggregate column, as a map and a reduction.
+
+**Returns** a relation of the grouping columns plus the aggregate, one row per group.
+
+**Examples**
+```pure
+$rel->groupBy(~[grp], ~total : x | $x.value : y | $y->plus())
+```
+
+**See also** `groupBy(Relation<T>[1], ColSpec<Z⊆T>[1], AggColSpec<{T[1]->K[0..1]}, {K[*]->V[0..1]}, R>[1]):Relation<Z+R>[1]`,
+`aggregate(Relation<T>[1], AggColSpec<{T[1]->K[0..1]}, {K[*]->V[0..1]}, R>[1]):Relation<R>[1]`,
+`pivot(Relation<T>[1], ColSpecArray<Z⊆T>[1], AggColSpec<{T[1]->K[0..1]}, {K[*]->V[0..1]}, R>[1]):Relation<Any>[1]`
+'''
 native function <<PCT.function>>
-{
-    doc.doc='Groups the given relation with the given columns and adds new column where its value is aggregated using the reduce (second) function using the values collected from the map (first) function'
-}
 meta::pure::functions::relation::groupBy<T,Z,K,V,R>(r:Relation<T>[1], cols:ColSpecArray<Z⊆T>[1], agg:meta::pure::metamodel::relation::AggColSpec<{T[1]->K[0..1]},{K[*]->V[0..1]}, R>[1]):Relation<Z+R>[1];
 
+'''
+As `groupBy(Relation<T>[1], ColSpecArray<Z⊆T>[1], AggColSpec<{T[1]->K[0..1]}, {K[*]->V[0..1]}, R>[1]):Relation<Z+R>[1]`,
+grouping by a single column written without the brackets: `$rel->groupBy(~grp, ~total : x | $x.value
+: y | $y->plus())`.
+'''
 native function <<PCT.function>>
-{
-    doc.doc='Groups the given relation with the given column and adds new column where its value is aggregated using the reduce (second) function using the values collected from the map (first) function'
-}
 meta::pure::functions::relation::groupBy<T,Z,K,V,R>(r:Relation<T>[1], cols:ColSpec<Z⊆T>[1], agg:meta::pure::metamodel::relation::AggColSpec<{T[1]->K[0..1]},{K[*]->V[0..1]}, R>[1]):Relation<Z+R>[1];
 
+'''
+As `groupBy(Relation<T>[1], ColSpecArray<Z⊆T>[1], AggColSpec<{T[1]->K[0..1]}, {K[*]->V[0..1]}, R>[1]):Relation<Z+R>[1]`,
+computing several aggregates over the same grouping in one pass — one column per spec, still one row
+per group.
+'''
 native function <<PCT.function>>
-{
-    doc.doc='Groups the given relation with the given columns and adds new column(s) where their values are aggregated using the reduce (second) function using the values collected from the map (first) function'
-}
 meta::pure::functions::relation::groupBy<T,Z,K,V,R>(r:Relation<T>[1], cols:ColSpecArray<Z⊆T>[1], agg:meta::pure::metamodel::relation::AggColSpecArray<{T[1]->K[0..1]},{K[*]->V[0..1]}, R>[1]):Relation<Z+R>[1];
 
+'''
+As `groupBy(Relation<T>[1], ColSpecArray<Z⊆T>[1], AggColSpecArray<{T[1]->K[0..1]}, {K[*]->V[0..1]}, R>[1]):Relation<Z+R>[1]`,
+grouping by a single column written without the brackets.
+'''
 native function <<PCT.function>>
-{
-    doc.doc='Groups the given relation with the given column and adds new column(s) where their values are aggregated using the reduce (second) function using the values collected from the map (first) function'
-}
 meta::pure::functions::relation::groupBy<T,Z,K,V,R>(r:Relation<T>[1], cols:ColSpec<Z⊆T>[1], agg:meta::pure::metamodel::relation::AggColSpecArray<{T[1]->K[0..1]},{K[*]->V[0..1]}, R>[1]):Relation<Z+R>[1];
 
 // A single lambda over the whole group, so an aggregate can name columns beyond the one it aggregates -- an

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/transformation/groupBy.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/transformation/groupBy.pure
@@ -75,28 +75,40 @@ meta::pure::functions::relation::groupBy<T,Z,K,V,R>(r:Relation<T>[1], cols:ColSp
 
 // A single lambda over the whole group, so an aggregate can name columns beyond the one it aggregates -- an
 // ordering, a tie-break -- which the map/reduce pair cannot once the map has narrowed each row to a value.
+'''
+As `groupBy(Relation<T>[1], ColSpecArray<Z⊆T>[1], AggColSpec<{T[1]->K[0..1]}, {K[*]->V[0..1]}, R>[1]):Relation<Z+R>[1]`,
+but the aggregate is **a single lambda over the whole group**, which arrives as a `Relation`:
+
+```pure
+$rel->groupBy(~[grp], ~names : g | $g->joinStrings(~name, ',', ~id->ascending()))
+```
+
+The map/reduce pair narrows each row to one value before the reduction sees it, so it cannot express
+an aggregate that needs another column — an ordering, a tie-break. This form can, because the lambda
+still has the whole group to look at. `joinStrings` with a sort spec is the motivating case.
+'''
 native function <<PCT.function>>
-{
-    doc.doc='Groups the given relation with the given columns and adds a new column whose value is computed by applying the given function to the relation of rows in each group'
-}
 meta::pure::functions::relation::groupBy<T,Z,R>(r:Relation<T>[1], cols:ColSpecArray<Z⊆T>[1], agg:meta::pure::metamodel::relation::FuncColSpec<{Relation<T>[1]->Any[0..1]}, R>[1]):Relation<Z+R>[1];
 
+'''
+As `groupBy(Relation<T>[1], ColSpecArray<Z⊆T>[1], FuncColSpec<{Relation<T>[1]->Any[0..1]}, R>[1]):Relation<Z+R>[1]`,
+grouping by a single column written without the brackets.
+'''
 native function <<PCT.function>>
-{
-    doc.doc='Groups the given relation with the given column and adds a new column whose value is computed by applying the given function to the relation of rows in each group'
-}
 meta::pure::functions::relation::groupBy<T,Z,R>(r:Relation<T>[1], cols:ColSpec<Z⊆T>[1], agg:meta::pure::metamodel::relation::FuncColSpec<{Relation<T>[1]->Any[0..1]}, R>[1]):Relation<Z+R>[1];
 
+'''
+As `groupBy(Relation<T>[1], ColSpecArray<Z⊆T>[1], FuncColSpec<{Relation<T>[1]->Any[0..1]}, R>[1]):Relation<Z+R>[1]`,
+computing several such aggregates over the same grouping in one pass.
+'''
 native function <<PCT.function>>
-{
-    doc.doc='Groups the given relation with the given columns and adds new columns whose values are computed by applying the given functions to the relation of rows in each group'
-}
 meta::pure::functions::relation::groupBy<T,Z,R>(r:Relation<T>[1], cols:ColSpecArray<Z⊆T>[1], agg:meta::pure::metamodel::relation::FuncColSpecArray<{Relation<T>[1]->Any[*]}, R>[1]):Relation<Z+R>[1];
 
+'''
+As `groupBy(Relation<T>[1], ColSpecArray<Z⊆T>[1], FuncColSpec<{Relation<T>[1]->Any[0..1]}, R>[1]):Relation<Z+R>[1]`,
+grouping by a single column and computing several such aggregates.
+'''
 native function <<PCT.function>>
-{
-    doc.doc='Groups the given relation with the given column and adds new columns whose values are computed by applying the given functions to the relation of rows in each group'
-}
 meta::pure::functions::relation::groupBy<T,Z,R>(r:Relation<T>[1], cols:ColSpec<Z⊆T>[1], agg:meta::pure::metamodel::relation::FuncColSpecArray<{Relation<T>[1]->Any[*]}, R>[1]):Relation<Z+R>[1];
 
 function <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.aggregation>> meta::pure::functions::relation::tests::groupBy::testSimpleGroupBy_SingleSingle<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/transformation/join.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/transformation/join.pure
@@ -23,6 +23,40 @@ Enum meta::pure::functions::relation::JoinKind
   INNER
 }
 
+'''
+Joins two relations on an arbitrary condition.
+
+The condition receives one row from each side and returns a `Boolean[1]`, so it is not restricted to
+equality — any comparison between the two rows will do. The result type is the two column sets
+concatenated, so **both sides' columns must have distinct names**; rename one first if they clash.
+
+`joinKind` chooses which unmatched rows survive:
+
+- `JoinKind.INNER` — only rows that matched.
+- `JoinKind.LEFT` — every left row, with the right columns empty where nothing matched.
+- `JoinKind.RIGHT` — the mirror of `LEFT`.
+- `JoinKind.FULL` — every row from both sides.
+
+A left row matching several right rows produces one result row per match, so a join can grow the
+relation.
+
+**Parameters**
+- `rel1` — the left relation.
+- `rel2` — the right relation.
+- `joinKind` — which unmatched rows to keep.
+- `f` — the join condition, applied to a pair of rows.
+
+**Returns** the joined relation, with the columns of both sides.
+
+**Examples**
+```pure
+$orders->join($customers, JoinKind.INNER, {o, c | $o.customerId == $c.id})
+$orders->join($customers, JoinKind.LEFT,  {o, c | $o.customerId == $c.id})
+```
+
+**See also** `asOfJoin(Relation<T>[1], Relation<V>[1], Function<{T[1], V[1]->Boolean[1]}>[1]):Relation<T+V>[1]`,
+`concatenate(Relation<T>[1], Relation<T>[1]):Relation<T>[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::relation::join<T,V>(rel1:Relation<T>[1], rel2:Relation<V>[1], joinKind:JoinKind[1], f:Function<{T[1],V[1]->Boolean[1]}>[1]):Relation<T+V>[1];
 
 function <<PCT.test>> meta::pure::functions::relation::tests::join::testSimpleJoinShared<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/transformation/lateral.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/transformation/lateral.pure
@@ -16,10 +16,32 @@ import meta::pure::test::pct::*;
 import meta::pure::metamodel::relation::*;
 import meta::pure::functions::relation::*;
 
+'''
+Joins each row to a relation computed **from that row**.
+
+`f` is called once per input row and may use the row's values, which is what an ordinary join cannot
+do — the right-hand side is not fixed. Each input row is then paired with every row `f` returned for
+it, and the result carries both column sets, `T+V`.
+
+**A row whose `f` returns nothing disappears from the result**, as in an inner join: over a
+department relation joined to its employees, a department with no employees is not in the output.
+
+**Parameters**
+- `rel` — the driving relation.
+- `f` — given one row, the relation to join it to.
+
+**Returns** the input columns and the computed ones, one output row per (input row, computed row)
+pair.
+
+**Examples**
+```pure
+$departments->lateral(x | $employees->filter(y | $y.department == $x.departmentId))
+```
+
+**See also** `join(Relation<T>[1], Relation<V>[1], JoinKind[1], Function<{T[1], V[1]->Boolean[1]}>[1]):Relation<T+V>[1]`,
+`meta::pure::functions::relation::variant::flatten(T[*], ColSpec<Z=(?:T)>[1]):Relation<Z>[1]`
+'''
 native function <<PCT.function>>
-{
-    doc.doc='Perform a lateral join, where the given function is applied to each row of the first relation, and the result is a relation that is joined with the second relation based on the function\'s output.'
-}
 meta::pure::functions::relation::lateral<T,V>(rel:Relation<T>[1], f:Function<{T[1]->Relation<V>[1]}>[1]):Relation<T+V>[1];
 
 function <<PCT.test>> meta::pure::functions::relation::tests::lateral::testLateralJoin<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/transformation/pivot.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/transformation/pivot.pure
@@ -15,19 +15,90 @@
 import meta::pure::test::pct::*;
 import meta::pure::metamodel::relation::*;
 
-native function <<PCT.function>> {doc.doc = 'Pivots a relation by rotating data from rows into columns. Takes multiple pivot columns and a single aggregate specification. All unique combinations of values from the pivot columns become new columns in the result. Each combination is aggregated according to the aggregate specification. All remaining columns (not pivoted or aggregated) become grouping columns.'}
+'''
+Rotates values out of rows and into columns: each distinct combination of the pivot columns becomes a
+column of its own, holding the aggregate for that combination.
+
+**Grouping is implicit.** Every column that is neither pivoted nor consumed by the aggregate becomes
+a grouping column, so removing an unrelated column from the input changes the shape of the output.
+Pivoting `city, country, year, treePlanted` on `~[year]` aggregating `treePlanted` leaves `city` and
+`country` as the grouping columns.
+
+Generated columns are named `<value>__|__<aggName>` — `2011__|__newCol` — and combinations absent
+from a group are `null` there.
+
+**The result type is `Relation<Any>` and almost always needs a cast**, because which columns exist
+depends on the data rather than on the query:
+
+```pure
+$res->cast(@Relation<(city:String, country:String, '\'2011__|__newCol\'':Integer)>)
+```
+
+The quotes in a generated name are part of it, hence the doubling inside the cast. Use
+`pivot(Relation<T>[1], ColSpec<Z⊆T>[1], Any[1..*], AggColSpec<{T[1]->K[0..1]}, {K[*]->V[0..1]}, R>[1]):Relation<Any>[1]`
+to fix the column set in advance and avoid guessing it.
+
+**Parameters**
+- `r` — the relation to pivot.
+- `cols` — the columns whose values become new columns.
+- `agg` — the aggregate computed for each combination.
+
+**Returns** the grouping columns plus one column per combination, typed `Relation<Any>`.
+
+**Examples**
+```pure
+$rel->pivot(~[year], ~newCol : x | $x.treePlanted : y | $y->plus())
+```
+
+**See also** `pivot(Relation<T>[1], ColSpec<Z⊆T>[1], Any[1..*], AggColSpec<{T[1]->K[0..1]}, {K[*]->V[0..1]}, R>[1]):Relation<Any>[1]`,
+`groupBy(Relation<T>[1], ColSpecArray<Z⊆T>[1], AggColSpec<{T[1]->K[0..1]}, {K[*]->V[0..1]}, R>[1]):Relation<Z+R>[1]`
+'''
+native function <<PCT.function>>
   meta::pure::functions::relation::pivot<T,Z,K,V,R>(r:Relation<T>[1], cols:ColSpecArray<Z⊆T>[1], agg:AggColSpec<{T[1]->K[0..1]},{K[*]->V[0..1]}, R>[1]):Relation<Any>[1];
 
-native function <<PCT.function>> {doc.doc = 'Pivots a relation by rotating data from rows into columns. Takes a single pivot column and a single aggregate specification. All unique values from the pivot column become new columns in the result. Each value is aggregated according to the aggregate specification. All remaining columns (not pivoted or aggregated) become grouping columns.'}
+'''
+As `pivot(Relation<T>[1], ColSpecArray<Z⊆T>[1], AggColSpec<{T[1]->K[0..1]}, {K[*]->V[0..1]}, R>[1]):Relation<Any>[1]`,
+pivoting on a single column written without the brackets: `$rel->pivot(~year, ~newCol : x |
+$x.treePlanted : y | $y->plus())`.
+'''
+native function <<PCT.function>>
   meta::pure::functions::relation::pivot<T,Z,K,V,R>(r:Relation<T>[1], cols:ColSpec<Z⊆T>[1], agg:AggColSpec<{T[1]->K[0..1]},{K[*]->V[0..1]}, R>[1]):Relation<Any>[1];
 
-native function <<PCT.function>> {doc.doc = 'Pivots a relation by rotating data from rows into columns. Takes a single pivot column with explicitly specified values and a single aggregate specification. Only the specified pivot values become new columns in the result. Each value is aggregated according to the aggregate specification. This static pivot allows control over which columns appear in the output and their order. All remaining columns (not pivoted or aggregated) become grouping columns.'}
+'''
+As `pivot(Relation<T>[1], ColSpec<Z⊆T>[1], AggColSpec<{T[1]->K[0..1]}, {K[*]->V[0..1]}, R>[1]):Relation<Any>[1]`,
+but the output columns are **named up front** rather than discovered from the data — the static
+pivot.
+
+`values` fixes both which columns appear and their order. **Values present in the data but not
+listed are dropped**: over rows for 2000, 2011 and 2012, `pivot(~year, [2000, 2011], ...)` produces
+two columns and the 2012 rows contribute to neither.
+
+Prefer this form wherever the interesting values are known, since it makes the result type
+predictable and the cast that follows the pivot no longer a guess. The implicit grouping still
+applies, so a column left in the relation by accident — a per-row count, a timestamp — splits what
+you expected to be one row into several.
+
+**Examples**
+```pure
+$rel->pivot(~year, [2000, 2011], ~newCol : x | $x.treePlanted : y | $y->plus())
+```
+'''
+native function <<PCT.function>>
   meta::pure::functions::relation::pivot<T,Z,K,V,R>(r:Relation<T>[1], cols:ColSpec<Z⊆T>[1], values:Any[1..*], agg:AggColSpec<{T[1]->K[0..1]},{K[*]->V[0..1]}, R>[1]):Relation<Any>[1];
 
-native function <<PCT.function>> {doc.doc = 'Pivots a relation by rotating data from rows into columns. Takes multiple pivot columns and multiple aggregate specifications. All unique combinations of values from the pivot columns become new column groups in the result. For each combination, multiple aggregated columns are created (one per aggregate specification). All remaining columns (not pivoted or aggregated) become grouping columns.'}
+'''
+As `pivot(Relation<T>[1], ColSpecArray<Z⊆T>[1], AggColSpec<{T[1]->K[0..1]}, {K[*]->V[0..1]}, R>[1]):Relation<Any>[1]`,
+with several aggregates: each combination of pivot values yields one column **per aggregate spec**,
+named `<value>__|__<aggName>` as before.
+'''
+native function <<PCT.function>>
   meta::pure::functions::relation::pivot<T,Z,K,V,R>(r:Relation<T>[1], cols:ColSpecArray<Z⊆T>[1], agg:AggColSpecArray<{T[1]->K[0..1]},{K[*]->V[0..1]}, R>[1]):Relation<Any>[1];
 
-native function <<PCT.function>> {doc.doc = 'Pivots a relation by rotating data from rows into columns. Takes a single pivot column and multiple aggregate specifications. All unique values from the pivot column become new column groups in the result. For each value, multiple aggregated columns are created (one per aggregate specification). All remaining columns (not pivoted or aggregated) become grouping columns.'}
+'''
+As `pivot(Relation<T>[1], ColSpecArray<Z⊆T>[1], AggColSpecArray<{T[1]->K[0..1]}, {K[*]->V[0..1]}, R>[1]):Relation<Any>[1]`,
+pivoting on a single column written without the brackets.
+'''
+native function <<PCT.function>>
   meta::pure::functions::relation::pivot<T,Z,K,V,R>(r:Relation<T>[1], cols:ColSpec<Z⊆T>[1], agg:AggColSpecArray<{T[1]->K[0..1]},{K[*]->V[0..1]}, R>[1]):Relation<Any>[1];
 
 function <<PCT.test>> meta::pure::functions::relation::tests::pivot::testPivot_SingleSingle<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/transformation/rename.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/transformation/rename.pure
@@ -15,6 +15,31 @@
 import meta::pure::test::pct::*;
 import meta::pure::metamodel::relation::*;
 
+'''
+Renames one column, leaving its values and position alone.
+
+Only the name changes — the column keeps its type, which the signature enforces by requiring the old
+and new specs to agree on it. The result type is the input with the old name removed and the new one
+added, so later steps must use the new name.
+
+Renames one column per call; chain calls to rename several.
+
+**Parameters**
+- `r` — the relation.
+- `old` — the column to rename.
+- `new` — the name to give it.
+
+**Returns** the relation with that column renamed.
+
+**Examples**
+```pure
+$rel->rename(~val, ~value)
+$rel->rename(~val, ~value)->rename(~str, ~text)   // chain for several
+```
+
+**See also** `select(Relation<T>[1], ColSpecArray<Z⊆T>[1]):Relation<Z>[1]`,
+`extend(Relation<T>[1], FuncColSpec<{T[1]->Any[0..1]}, Z>[1]):Relation<T+Z>[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::relation::rename<T,Z,K,V>(r:Relation<T>[1], old:ColSpec<Z=(?:K)⊆T>[1], new:ColSpec<V=(?:K)>[1]):Relation<T-Z+V>[1];
 
 function <<PCT.test>> meta::pure::functions::relation::tests::rename::testSimpleRenameShared<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/transformation/select.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/transformation/select.pure
@@ -15,10 +15,45 @@
 import meta::pure::test::pct::*;
 import meta::pure::metamodel::relation::*;
 
+'''
+Narrows a relation to a chosen set of columns.
+
+Projection, and only projection: rows are neither filtered nor deduplicated, so the result has the
+same number of rows as the input. The result's type is the chosen columns, which is what lets the
+compiler reject a later reference to a column that was dropped.
+
+Columns come back in the order given, so this reorders as well as narrows. To drop duplicate rows at
+the same time, use `distinct(Relation<T>[1], ColSpecArray<X⊆T>[1]):Relation<X>[1]`.
+
+**Parameters**
+- `r` — the relation to narrow.
+- `cols` — the columns to keep.
+
+**Returns** a relation of just those columns.
+
+**Examples**
+```pure
+$rel->select(~[id, name])
+```
+
+**See also** `select(Relation<T>[1], ColSpec<Z⊆T>[1]):Relation<Z>[1]`,
+`distinct(Relation<T>[1], ColSpecArray<X⊆T>[1]):Relation<X>[1]`,
+`extend(Relation<T>[1], FuncColSpec<{T[1]->Any[0..1]}, Z>[1]):Relation<T+Z>[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::relation::select<T,Z>(r:Relation<T>[1], cols:ColSpecArray<Z⊆T>[1]):Relation<Z>[1];
 
+'''
+As `select(Relation<T>[1], ColSpecArray<Z⊆T>[1]):Relation<Z>[1]`, for a single column:
+`$rel->select(~name)`.
+'''
 native function <<PCT.function>> meta::pure::functions::relation::select<T,Z>(r:Relation<T>[1], cols:ColSpec<Z⊆T>[1]):Relation<Z>[1];
 
+'''
+As `select(Relation<T>[1], ColSpecArray<Z⊆T>[1]):Relation<Z>[1]`, keeping every column — a genuine
+no-op, useful as an explicit step in a generated or composed pipeline. Note it does **not**
+deduplicate despite sharing a signature shape with
+`distinct(Relation<T>[1]):Relation<T>[1]`: duplicate rows survive.
+'''
 native function <<PCT.function>> meta::pure::functions::relation::select<T>(r:Relation<T>[1]):Relation<T>[1];
 
 function <<PCT.test>> meta::pure::functions::relation::tests::select::testMultiColsSelectShared<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/variant/flatten.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/variant/flatten.pure
@@ -20,10 +20,33 @@ import meta::pure::functions::variant::convert::*;
 import meta::pure::functions::variant::navigation::*;
 import meta::pure::functions::relation::variant::*;
 
+'''
+Turns a collection of values into a one-column relation, one row per value.
+
+The way into relational processing from a plain collection: `[1, 2, 3, 4]->flatten(~integer)` is a
+relation of four rows. The column takes the name given and the type of the values flattened, so the
+result can be filtered, joined and aggregated like any other relation.
+
+**One row per element of the input, not per element of a nested array.** Flattening
+`fromJson('[[1, 2], [3, 4], [5, 6]]')->toMany(@Variant)` gives three rows, each holding the array
+`[1,2]`, `[3,4]`, `[5,6]` as a variant — the inner arrays are untouched. Flatten again to open them.
+
+**Parameters**
+- `valueToFlatten` — the values, one row each.
+- `columnWithFlattenedValue` — the name for the single output column.
+
+**Returns** a relation with that one column and one row per input value.
+
+**Examples**
+```pure
+[1, 2, 3, 4]->flatten(~integer)                                       // 4 rows
+fromJson('[[1, 2], [3, 4]]')->toMany(@Variant)->flatten(~variant)     // 2 rows, each an array
+```
+
+**See also** `meta::pure::functions::relation::lateral(Relation<T>[1], Function<{T[1]->Relation<V>[1]}>[1]):Relation<T+V>[1]`,
+`meta::pure::functions::variant::convert::toMany(Variant[0..1], T[0..1]):T[*]`
+'''
 native function <<PCT.function>>
-{
-    doc.doc='Flatten the given variant values into a relation with a single column containing the flattened values.  The output relation will have a column of the given name (2nd parameter), the column type will be of the values flattened, and will have onw row per value on the input.'
-}
 meta::pure::functions::relation::variant::flatten<T,Z>(valueToFlatten: T[*], columnWithFlattenedValue: ColSpec<Z=(?:T)>[1]):Relation<Z>[1];
 
 function <<PCT.test, PCTRelationQualifier.relation, PCTCoreQualifier.variant>> meta::pure::functions::relation::variant::tests::flatten::testFlatten_Scalar<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/wrapPrimitiveInTDS.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/wrapPrimitiveInTDS.pure
@@ -16,6 +16,31 @@ import meta::pure::metamodel::variant::*;
 import meta::pure::test::pct::*;
 
 //Issue: we require type as a parameter so that the function can be called from 'dynamic compiled mode'
+'''
+Lifts a collection of primitives into a one-column relation named `value`.
+
+The way into the relational world from plain values, where
+`project(C[*], FuncColSpecArray<{C[1]->Any[*]}, T>[1]):Relation<T>[1]` needs objects with properties
+to project. One row per element.
+
+The `type` argument is redundant with `value`'s own type and is there only so the function can be
+called from dynamic compiled mode; pass a type literal such as `@String`.
+
+**Parameters**
+- `value` — the primitives, one row each.
+- `type` — the element type, as a type literal.
+
+**Returns** a relation with a single column, `value`.
+
+**Examples**
+```pure
+wrapPrimitiveInTDS('o', @String)->map(x | $x.value->toOne() + 'k')   // 'ok'
+wrapPrimitiveInTDS(1, @Integer)->map(x | $x.value->toOne() + 2)      // 3
+```
+
+**See also** `project(C[*], FuncColSpecArray<{C[1]->Any[*]}, T>[1]):Relation<T>[1]`,
+`map(Relation<T>[1], Function<{T[1]->V[*]}>[1]):V[*]`
+'''
 native function <<PCT.function, PCT.platformOnly>> meta::pure::functions::relation::wrapPrimitiveInTDS<T>(value:T[*], type:T[1]):meta::pure::metamodel::relation::TDS<(value:T[0..1])>[1];
 
 function <<test.Test>> meta::pure::functions::relation::tests::wrapPrimitiveInTDS::testWrap():Boolean[1]

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/write/write.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/write/write.pure
@@ -32,6 +32,11 @@ The return is the row count, not the relation, so a write ends a pipeline rather
 
 **Returns** the number of rows written.
 
+**Examples**
+```pure
+$rel->select()->write($target->newTDSRelationAccessor())   // 5, for a five-row relation
+```
+
 **See also** `concatenate(Relation<T>[1], Relation<T>[1]):Relation<T>[1]`
 '''
 native function <<PCT.function, functionType.SideEffectFunction>> meta::pure::functions::relation::write<T>(rel:Relation<T>[1], relationElementAccessor:RelationElementAccessor<T>[1]):Integer[1];

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/write/write.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/write/write.pure
@@ -17,6 +17,23 @@ import meta::pure::functions::relation::*;
 import meta::pure::store::*;
 import meta::pure::test::pct::*;
 
+'''
+Writes a relation's rows into a target table, returning how many were written.
+
+**This has a side effect** — it is stereotyped `SideEffectFunction` and mutates the store, unlike
+every other function in this repository. The target is named by a `RelationElementAccessor`, whose
+type must match the relation's, so the columns are checked before anything is written.
+
+The return is the row count, not the relation, so a write ends a pipeline rather than continuing it.
+
+**Parameters**
+- `rel` — the rows to write.
+- `relationElementAccessor` — the target table.
+
+**Returns** the number of rows written.
+
+**See also** `concatenate(Relation<T>[1], Relation<T>[1]):Relation<T>[1]`
+'''
 native function <<PCT.function, functionType.SideEffectFunction>> meta::pure::functions::relation::write<T>(rel:Relation<T>[1], relationElementAccessor:RelationElementAccessor<T>[1]):Integer[1];
 
 function meta::pure::functions::relation::write::writeFunctions():Function<Any>[*]

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/tests/composition.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/tests/composition.pure
@@ -49,6 +49,9 @@ Class meta::pure::functions::relation::tests::composition::SimpleNumbersTypeForC
   val3 : Number[1];
 }
 
+'''
+A filter may reference a column that `extend` created earlier in the same pipeline.
+'''
 function <<PCT.test>> meta::pure::functions::relation::tests::composition::testExtendFilter<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
     let expr = {
@@ -71,6 +74,10 @@ function <<PCT.test>> meta::pure::functions::relation::tests::composition::testE
                   '#', $res->toString());
 }
 
+'''
+Projecting a `[*]` property multiplies rows, and a later filter applies to the projected relation
+rather than to the source instances.
+'''
 function <<PCT.test>> meta::pure::functions::relation::tests::composition::testFilterPostProject<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
     let expr = {|
@@ -112,6 +119,10 @@ function <<PCT.test>> meta::pure::functions::relation::tests::composition::testF
 }
 
 
+'''
+`distinct` over a subset of columns narrows the relation to those columns before the `groupBy`
+sees it, so `str2` is gone by the time the aggregate runs.
+'''
 function <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.aggregation>> meta::pure::functions::relation::tests::composition::test_Distinct_GroupBy<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
     let expr = {
@@ -135,6 +146,9 @@ function <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.aggrega
                   '#', $res->sort(~str->ascending())->toString());
 }
 
+'''
+The filter runs against the narrowed relation, so it may only name columns that `distinct` kept.
+'''
 function <<PCT.test>> meta::pure::functions::relation::tests::composition::test_Distinct_Filter<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
     let expr = {
@@ -158,6 +172,9 @@ function <<PCT.test>> meta::pure::functions::relation::tests::composition::test_
                   '#', $res->sort(~val->ascending())->toString());
 }
 
+'''
+An aggregate column may itself be aggregated: the second `groupBy` sums the first one's output.
+'''
 function <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.aggregation>> meta::pure::functions::relation::tests::composition::test_GroupBy_GroupBy<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
     let expr = {
@@ -181,6 +198,10 @@ function <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.aggrega
                   '#', $res->sort(~str->ascending())->toString());
 }
 
+'''
+`distinct` over a subset of the grouping keys discards the aggregate column entirely, leaving
+only those keys.
+'''
 function <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.aggregation>> meta::pure::functions::relation::tests::composition::test_GroupBy_Distinct<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
     let expr = {
@@ -204,6 +225,10 @@ function <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.aggrega
                   '#', $res->sort(~str->ascending())->toString());
 }
 
+'''
+A filter after a dynamic `pivot` operates on the relation as re-typed by the `cast` that the
+pivot requires.
+'''
 function <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.aggregation>> meta::pure::functions::relation::tests::composition::test_Pivot_Filter<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
     let expr = {
@@ -231,6 +256,11 @@ function <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.aggrega
                   '#', $res->toString());
 }
 
+'''
+The `groupBy` sums the `year` column, so the sums themselves become the pivoted column names:
+SAN's two 2011 rows give `4022` and NYC's `2011 + 2012 + 2012` gives `6035`. The odd-looking names
+are the point — the pivot column is computed, not read.
+'''
 function <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.aggregation>> meta::pure::functions::relation::tests::composition::test_Extend_Filter_Select_ComplexGroupBy_Pivot<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
     let expr = {
@@ -265,6 +295,10 @@ function <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.aggrega
                   '#', $res->toString());
 }
 
+'''
+A seven-step pipeline in which `extend`, `sort` and `limit` all follow the `cast` that a dynamic
+`pivot` requires.
+'''
 function <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.aggregation>> meta::pure::functions::relation::tests::composition::test_Extend_Filter_Select_GroupBy_Pivot_Extend_Sort_Limit<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
     let expr = {
@@ -301,6 +335,9 @@ function <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.aggrega
                   '#', $res->toString());
 }
 
+'''
+Pivoting before grouping: the `groupBy` then has to name the quoted columns the pivot generated.
+'''
 function <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.aggregation>> meta::pure::functions::relation::tests::composition::test_Extend_Filter_Select_Pivot_GroupBy_Extend_Sort<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
     let expr = {
@@ -337,6 +374,9 @@ function <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.aggrega
 
 // ------------------------------------- TO FIX -------------------------------------
 
+'''
+The minimal aggregate-then-filter case — the filter names the aggregate column, not a source column.
+'''
 function <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.aggregation>> meta::pure::functions::relation::tests::composition::test_GroupBy_Filter<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
     let expr = {
@@ -360,6 +400,10 @@ function <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.aggrega
                   '#', $res->sort(~str->ascending())->toString());
 }
 
+'''
+`distinct` between the aggregation and the filter keeps rows that share a grouping key but differ
+in the aggregate, so both `qw` rows survive.
+'''
 function <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.aggregation>> meta::pure::functions::relation::tests::composition::test_GroupBy_Distinct_Filter<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
     let expr = {
@@ -383,6 +427,10 @@ function <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.aggrega
                   '#', $res->sort([~str->ascending(), ~newCol->ascending()])->toString());
 }
 
+'''
+Deduplicating whole rows before aggregating drops one of the two identical `2, a, b` rows, so
+group `a` sums to 2 rather than 4 and the filter then removes it.
+'''
 function <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.aggregation>> meta::pure::functions::relation::tests::composition::test_Distinct_GroupBy_Filter<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
     let expr = {
@@ -404,6 +452,10 @@ function <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.aggrega
                   '#', $res->sort(~str->ascending())->toString());
 }
 
+'''
+`lead` and `lag` over a projection of class instances. The last row of each partition has no lead
+and the first has no lag, so both come back empty.
+'''
 function <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.olap>> meta::pure::functions::relation::tests::composition::testWindowFunctionsAfterProject<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
     let expr = {|
@@ -433,12 +485,11 @@ function <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.olap>> 
                   '#', $res->toString());
 }
 
-function
-  <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.aggregation>>
-  {
-    doc.doc='Tests map and casting the values of the column before applying the aggregate function. Cast is treated as a noop in this case.'
-  }
-meta::pure::functions::relation::tests::composition::testGroupByCastBeforeAgg<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]{
+'''
+Casting the column values before the aggregate is applied is a no-op — the sums match the uncast
+form.
+'''
+function <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.aggregation>> meta::pure::functions::relation::tests::composition::testGroupByCastBeforeAgg<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]{
   let expr = {
               | #TDS
                 id, grp
@@ -468,12 +519,10 @@ meta::pure::functions::relation::tests::composition::testGroupByCastBeforeAgg<T|
                 '#', $res->sort(~grp->ascending())->toString());
 }
 
-function
-  <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.aggregation>>
-  {
-    doc.doc='Tests map and casting result of the aggregate function. Cast is treated as a noop in this case.'
-  }
-meta::pure::functions::relation::tests::composition::testGroupByCastAfterAgg<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]{
+'''
+Casting the aggregate's result is a no-op — the sums match the uncast form.
+'''
+function <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.aggregation>> meta::pure::functions::relation::tests::composition::testGroupByCastAfterAgg<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]{
   let expr = {
               | #TDS
                 id, grp
@@ -503,12 +552,11 @@ meta::pure::functions::relation::tests::composition::testGroupByCastAfterAgg<T|m
                 '#', $res->sort(~grp->ascending())->toString());
 }
 
-function
-  <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.olap>>
-  {
-    doc.doc='Tests olap with a partition window and casting result of the aggregate function. Cast is treated as a noop in this case.'
-  }
-meta::pure::functions::relation::tests::composition::testOLAPCastAggWithPartitionWindow<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+'''
+Casting the aggregate's result inside a partitioned window is a no-op. With no ordering on the
+`over`, the frame is the whole partition, so every row of a group carries that group's total.
+'''
+function <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.olap>> meta::pure::functions::relation::tests::composition::testOLAPCastAggWithPartitionWindow<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
     let expr = {
                 | #TDS
@@ -544,12 +592,10 @@ meta::pure::functions::relation::tests::composition::testOLAPCastAggWithPartitio
                   '#', $res->sort([~grp->ascending(), ~id->ascending()])->toString());
 }
 
-function
-  <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.olap>>
-  {
-    doc.doc='Tests olap with a partition window and casting the values of the column before applying the aggregate function. Cast is treated as a noop in this case.'
-  }
-meta::pure::functions::relation::tests::composition::testOLAPAggCastWithPartitionWindow<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+'''
+Casting the extracted values before the windowed aggregate is a no-op.
+'''
+function <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.olap>> meta::pure::functions::relation::tests::composition::testOLAPAggCastWithPartitionWindow<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
     let expr = {
                 | #TDS
@@ -585,12 +631,10 @@ meta::pure::functions::relation::tests::composition::testOLAPAggCastWithPartitio
                   '#', $res->sort([~grp->ascending(), ~id->ascending()])->toString());
 }
 
-function
-  <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.olap>>
-  {
-    doc.doc='Tests olap with a partition window and casting the values of the extract function before applying the aggregate function. Cast is treated as a noop in this case.'
-  }
-meta::pure::functions::relation::tests::composition::testOLAPCastExtractAggWithPartitionWindow<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+'''
+Casting inside the window's extraction lambda is a no-op.
+'''
+function <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.olap>> meta::pure::functions::relation::tests::composition::testOLAPCastExtractAggWithPartitionWindow<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
     let expr = {
                 | #TDS
@@ -626,12 +670,10 @@ meta::pure::functions::relation::tests::composition::testOLAPCastExtractAggWithP
                   '#', $res->sort([~grp->ascending(), ~id->ascending()])->toString());
 }
 
-function
-  <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.olap>>
-  {
-    doc.doc='Tests olap with a partition window, casting the values of the extract function before applying the aggregate function, and casting result of the aggregate function. Cast is treated as a noop in this case.'
-  }
-meta::pure::functions::relation::tests::composition::testOLAPCastExtractCastAggWithPartitionWindow<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+'''
+Casting in both window positions at once is still a no-op.
+'''
+function <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.olap>> meta::pure::functions::relation::tests::composition::testOLAPCastExtractCastAggWithPartitionWindow<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
     let expr = {
                 | #TDS
@@ -667,6 +709,10 @@ meta::pure::functions::relation::tests::composition::testOLAPCastExtractCastAggW
                   '#', $res->sort([~grp->ascending(), ~id->ascending()])->toString());
 }
 
+'''
+`distinct` compares the projected values, not the source rows, so `george` and `George` collapse
+to one row once `toLower` has been applied.
+'''
 function <<PCT.test>> meta::pure::functions::relation::tests::composition::testProjectDistinct<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
   let tds = #TDS
@@ -694,6 +740,10 @@ function <<PCT.test>> meta::pure::functions::relation::tests::composition::testP
                   '#', $res->sort([~id->ascending(), ~name->ascending()])->toString());
 }
 
+'''
+Projections on both sides of a join, re-projected afterwards; the final projection may rename
+columns drawn from either side.
+'''
 function <<PCT.test>> meta::pure::functions::relation::tests::composition::testProjectJoinWithProjectProject<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
   let tds = #TDS
@@ -722,6 +772,11 @@ function <<PCT.test>> meta::pure::functions::relation::tests::composition::testP
                 '#', $res->sort([~id->ascending(),~name->ascending()])->toString());
 }
 
+'''
+Equality is null-safe, so an INNER join on a nullable key matches empty to empty: two null-keyed
+left rows and two null-keyed right rows produce all four combinations. Under SQL's three-valued
+logic those rows would not match at all.
+'''
 function <<PCT.test, PCTRelationQualifier.relation>> meta::pure::functions::relation::tests::composition::testJoinOnNullKey<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
   let tds = #TDS
@@ -758,6 +813,9 @@ function <<PCT.test, PCTRelationQualifier.relation>> meta::pure::functions::rela
                 '#', $res->sort([~name->ascending(), ~col->ascending()])->toString());
 }
 
+'''
+`null == null` is true, so the row with both columns empty survives the filter.
+'''
 function <<PCT.test, PCTRelationQualifier.relation>> meta::pure::functions::relation::tests::composition::testFilterEqualOnNullableColumns<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
   let tds = #TDS
@@ -782,6 +840,9 @@ function <<PCT.test, PCTRelationQualifier.relation>> meta::pure::functions::rela
                 '#', $res->sort(~name->ascending())->toString());
 }
 
+'''
+`null != 5` is true and `null != null` is false — the exact complement of the equality case.
+'''
 function <<PCT.test, PCTRelationQualifier.relation>> meta::pure::functions::relation::tests::composition::testFilterNotEqualOnNullableColumns<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
   let tds = #TDS
@@ -807,6 +868,9 @@ function <<PCT.test, PCTRelationQualifier.relation>> meta::pure::functions::rela
                 '#', $res->sort(~name->ascending())->toString());
 }
 
+'''
+Projecting `==` into a column yields `true` or `false` on every row, never an empty value.
+'''
 function <<PCT.test, PCTRelationQualifier.relation>> meta::pure::functions::relation::tests::composition::testProjectEqualityOnNullableColumns<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
   let tds = #TDS
@@ -834,6 +898,9 @@ function <<PCT.test, PCTRelationQualifier.relation>> meta::pure::functions::rela
                 '#', $res->sort(~name->ascending())->toString());
 }
 
+'''
+Projecting `!=` likewise yields a total boolean, the negation of the equality column.
+'''
 function <<PCT.test, PCTRelationQualifier.relation>> meta::pure::functions::relation::tests::composition::testProjectNotEqualityOnNullableColumns<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
   let tds = #TDS
@@ -861,6 +928,10 @@ function <<PCT.test, PCTRelationQualifier.relation>> meta::pure::functions::rela
                 '#', $res->sort(~name->ascending())->toString());
 }
 
+'''
+A variant array can be unpacked with `toMany`, sorted, and packed back with `toVariant`, all
+inside an `extend`.
+'''
 function <<PCT.test, PCTRelationQualifier.relation, PCTCoreQualifier.variant>> meta::pure::functions::relation::tests::composition::testVariantArrayColumn_sort<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
    let tds = #TDS
@@ -888,6 +959,9 @@ function <<PCT.test, PCTRelationQualifier.relation, PCTCoreQualifier.variant>> m
                 '#', $res->toString());
 }
 
+'''
+The same round trip through `reverse`.
+'''
 function <<PCT.test, PCTRelationQualifier.relation, PCTCoreQualifier.variant>> meta::pure::functions::relation::tests::composition::testVariantArrayColumn_reverse<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
    let tds = #TDS
@@ -915,11 +989,10 @@ function <<PCT.test, PCTRelationQualifier.relation, PCTCoreQualifier.variant>> m
                 '#', $res->toString());
 }
 
-function <<PCT.test, PCTRelationQualifier.relation, PCTCoreQualifier.variant>>
-{
-  doc.doc='Extends a given TDS where the new column value is extracted from a variant array using the value\'s index number and then reference the new column in a filter expression.'
-}
-meta::pure::functions::relation::tests::composition::testVariantColumn_extend_indexExtraction_filter<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+'''
+A column extracted from a variant array by index can be filtered on later in the pipeline.
+'''
+function <<PCT.test, PCTRelationQualifier.relation, PCTCoreQualifier.variant>> meta::pure::functions::relation::tests::composition::testVariantColumn_extend_indexExtraction_filter<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
    let tds = #TDS
      id, payload:meta::pure::metamodel::variant::Variant
@@ -944,11 +1017,11 @@ meta::pure::functions::relation::tests::composition::testVariantColumn_extend_in
                 '#', $res->toString());
 }
 
-function <<PCT.test, PCTRelationQualifier.relation, PCTCoreQualifier.variant>>
-{
-  doc.doc='Filter the given TDS by inspecting the values of a variant array.  The values are inspected calling another function, demonstrating function composition when operating on variants.'
-}
-meta::pure::functions::relation::tests::composition::testVariantColumn_functionComposition<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+'''
+A filter predicate over a variant array may call a user-defined function on the unpacked
+collection.
+'''
+function <<PCT.test, PCTRelationQualifier.relation, PCTCoreQualifier.variant>> meta::pure::functions::relation::tests::composition::testVariantColumn_functionComposition<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
    let tds = #TDS
      id, payload:meta::pure::metamodel::variant::Variant
@@ -977,12 +1050,10 @@ function meta::pure::functions::relation::tests::composition::testVariantColumn_
   $val->filter(y | $y->mod(2) == 0)->size() == 2;
 }
 
-function
-  <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.olap>>
-  {
-    doc.doc='Qualify grammar should be produced instead of subselect.'
-  }
-meta::pure::functions::relation::tests::composition::testExtendWindowFilter<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+'''
+Filtering on a window column produces qualify grammar rather than a sub-select.
+'''
+function <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.olap>> meta::pure::functions::relation::tests::composition::testExtendWindowFilter<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
   let expr = {
                 | #TDS
@@ -1010,12 +1081,11 @@ meta::pure::functions::relation::tests::composition::testExtendWindowFilter<T|m>
                   '#', $res->sort([~grp->ascending(), ~id->ascending()])->toString());
 }
 
-function
-  <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.aggregation, PCTRelationQualifier.olap>>
-  {
-    doc.doc='Produces qualify and having grammar together.'
-  }
-meta::pure::functions::relation::tests::composition::testGroupByFilterExtendFilter<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+'''
+A pipeline that filters an aggregate and then filters a window column produces having and qualify
+grammar together.
+'''
+function <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.aggregation, PCTRelationQualifier.olap>> meta::pure::functions::relation::tests::composition::testGroupByFilterExtendFilter<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
     let expr = {
                 | #TDS
@@ -1045,6 +1115,10 @@ meta::pure::functions::relation::tests::composition::testGroupByFilterExtendFilt
                   '#', $res->sort([~rank->ascending(), ~grp->ascending()])->toString());
 }
 
+'''
+Chained `rename`s over names differing only in case and leading underscores, including renaming a
+column twice; the filter has to resolve the final names.
+'''
 function <<PCT.test>> meta::pure::functions::relation::tests::composition::testMixColumnNamesRenameFilter<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
   let expr = {
@@ -1076,6 +1150,10 @@ function <<PCT.test>> meta::pure::functions::relation::tests::composition::testM
                   '#', $res->toString());
 }
 
+'''
+The same renaming with `extend` and `select` interleaved, including renaming a column that
+`extend` had just created.
+'''
 function <<PCT.test, PCTRelationQualifier.relation>> meta::pure::functions::relation::tests::composition::testMixColumnNamesRenameExtend<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
   let expr = {
@@ -1112,6 +1190,12 @@ function <<PCT.test, PCTRelationQualifier.relation>> meta::pure::functions::rela
                   '#', $res->sort(~col_one_num->ascending())->toString());
 }
 
+'''
+A filter on a source column is applied **before** the window aggregate, so rows the filter removes
+do not contribute to the sum — partition 100 totals 60, not the 110 its five rows would give.
+Contrast `testExtendWindowFilter`, where the filter names the window output and therefore cannot
+move below it. The in-memory Pure engines read the pipeline literally and are excluded here.
+'''
 function <<PCT.test, PCTRelationQualifier.relation>> meta::pure::functions::relation::tests::composition::testExtendFilterOutNull<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
   let expr = {
@@ -1155,6 +1239,10 @@ function <<PCT.test, PCTRelationQualifier.relation>> meta::pure::functions::rela
                   '#', $res->sort([~p->descending(), ~o->descending(), ~i->descending()])->toString());
 }
 
+'''
+`joinStrings` over a window containing empty values. The assertion re-splits and re-sorts the
+result, so what it pins down is which values survive, not the order they arrive in.
+'''
 function <<PCT.test, PCTRelationQualifier.relation>> meta::pure::functions::relation::tests::composition::testExtendJoinStringOnNull<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
     let expr = {
@@ -1191,6 +1279,9 @@ function <<PCT.test, PCTRelationQualifier.relation>> meta::pure::functions::rela
                   '#', $res->sort([~grp->ascending(), ~id->ascending()])->toString());
 }
 
+'''
+A windowed sum over a partition whose values are all empty returns an empty value, not zero.
+'''
 function <<PCT.test, PCTRelationQualifier.relation>> meta::pure::functions::relation::tests::composition::testExtendAddOnNull<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
     let expr = {
@@ -1226,6 +1317,10 @@ function <<PCT.test, PCTRelationQualifier.relation>> meta::pure::functions::rela
                   '#', $res->sort([~grp->ascending(), ~id->ascending()])->toString());
 }
 
+'''
+`groupBy` treats the empty value as a grouping key in its own right rather than discarding those
+rows.
+'''
 function <<PCT.test>> meta::pure::functions::relation::tests::composition::testGroupByOnNull<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
     let expr = {
@@ -1253,6 +1348,9 @@ function <<PCT.test>> meta::pure::functions::relation::tests::composition::testG
                   '#', $res->sort([~grp->ascending()])->toString());
 }
 
+'''
+Either branch of an `if` may be a variant column.
+'''
 function <<PCT.test, PCTRelationQualifier.relation, PCTCoreQualifier.variant>> meta::pure::functions::relation::tests::composition::testVariant_if<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
    let tds = #TDS
@@ -1280,6 +1378,10 @@ function <<PCT.test, PCTRelationQualifier.relation, PCTCoreQualifier.variant>> m
                 '#', $res->toString());
 }
 
+'''
+A variant holding JSON `null` unpacks to an empty collection, so it reports empty exactly as `[]`
+does.
+'''
 function <<PCT.test, PCTRelationQualifier.relation, PCTCoreQualifier.variant>> meta::pure::functions::relation::tests::composition::testVariantColumn_isEmpty<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
     let expr = {
@@ -1303,6 +1405,9 @@ function <<PCT.test, PCTRelationQualifier.relation, PCTCoreQualifier.variant>> m
                 '#', $res->toString());
 }
 
+'''
+The complement of the `isEmpty` case.
+'''
 function <<PCT.test, PCTRelationQualifier.relation, PCTCoreQualifier.variant>> meta::pure::functions::relation::tests::composition::testVariantColumn_isNotEmpty<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
     let expr = {
@@ -1326,6 +1431,9 @@ function <<PCT.test, PCTRelationQualifier.relation, PCTCoreQualifier.variant>> m
                 '#', $res->toString());
 }
 
+'''
+`indexOf` returns `-1` both for a value that is absent and for a variant holding JSON `null`.
+'''
 function <<PCT.test, PCTRelationQualifier.relation, PCTCoreQualifier.variant>> meta::pure::functions::relation::tests::composition::testVariantColumn_indexOf<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
     let expr = {
@@ -1349,6 +1457,9 @@ function <<PCT.test, PCTRelationQualifier.relation, PCTCoreQualifier.variant>> m
                 '#', $res->toString());
 }
 
+'''
+`slice` with negative bounds yields an empty array — it does not index from the end.
+'''
 function <<PCT.test, PCTRelationQualifier.relation, PCTCoreQualifier.variant>> meta::pure::functions::relation::tests::composition::testVariantColumn_slice<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
     let expr = {
@@ -1372,6 +1483,9 @@ function <<PCT.test, PCTRelationQualifier.relation, PCTCoreQualifier.variant>> m
                 '#', $res->toString());
 }
 
+'''
+A computed projection column can be narrowed to `Integer[1]` with a `cast`.
+'''
 function <<PCTRelationQualifier.relation, PCT.test>> meta::pure::functions::relation::tests::composition::testProjectOfComputedColumn_withCast<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
     let expr = {
@@ -1399,6 +1513,9 @@ function <<PCTRelationQualifier.relation, PCT.test>> meta::pure::functions::rela
                   '#', $res->sort([~val3->ascending()])->toString());
 }
 
+'''
+`contains` is false for a variant holding JSON `null`.
+'''
 function <<PCT.test, PCTRelationQualifier.relation, PCTCoreQualifier.variant>> meta::pure::functions::relation::tests::composition::testVariantColumn_contains<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
     let expr = {
@@ -1420,6 +1537,9 @@ function <<PCT.test, PCTRelationQualifier.relation, PCTCoreQualifier.variant>> m
                 '#', $res->toString());
 }
 
+'''
+`distinct` and `removeDuplicates` agree on a variant array, including one holding JSON `null`.
+'''
 function <<PCT.test, PCTRelationQualifier.relation, PCTCoreQualifier.variant>> meta::pure::functions::relation::tests::composition::testVariantColumn_distinct_removeDuplicates<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
     let expr = {
@@ -1442,6 +1562,11 @@ function <<PCT.test, PCTRelationQualifier.relation, PCTCoreQualifier.variant>> m
                 '#', $res->toString());
 }
 
+'''
+Projecting a variant to a whole model instance is not supported, and fails with an error naming
+the class. Contrast `testVariantColumn_projectModelProperty`, where a property of that same
+conversion does work.
+'''
 function <<PCT.test, PCTRelationQualifier.relation, PCTCoreQualifier.variant>> meta::pure::functions::relation::tests::composition::testVariantColumn_modelOutputNotSupported<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
     let expr = {
@@ -1457,6 +1582,9 @@ function <<PCT.test, PCTRelationQualifier.relation, PCTCoreQualifier.variant>> m
 }
 
 
+'''
+Projecting a *property* of the converted model works, unlike projecting the model itself.
+'''
 function <<PCT.test, PCTRelationQualifier.relation, PCTCoreQualifier.variant>> meta::pure::functions::relation::tests::composition::testVariantColumn_projectModelProperty<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
     let expr = {
@@ -1522,6 +1650,9 @@ function <<PCT.test, PCTRelationQualifier.relation, PCTCoreQualifier.variant>> m
                 '#', $res->toString());
 }
 
+'''
+The multi-branch `if([pair(...), pair(...)], |default)` form inside an `extend`.
+'''
 function <<PCT.test, PCTRelationQualifier.relation>> meta::pure::functions::relation::tests::composition::testMultiIfTDS<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
   let expr = {
@@ -1543,6 +1674,10 @@ function <<PCT.test, PCTRelationQualifier.relation>> meta::pure::functions::rela
                 '#', $res->sort([~id->ascending()])->toString());
 }
 
+'''
+A static `pivot` fixes the value list up front, but still generates quoted column names and still
+needs a `cast` before anything downstream can name them.
+'''
 function <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.aggregation>> meta::pure::functions::relation::tests::composition::test_Static_Pivot_Filter<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
 
@@ -1571,6 +1706,10 @@ function <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.aggrega
                   '#', $res->toString());
 }
 
+'''
+A projection and a filter ahead of a static pivot; the generated names derive from the renamed
+columns, not the originals.
+'''
 function <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.aggregation>> meta::pure::functions::relation::tests::composition::test_Project_Filter_Before_Static_Pivot<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
   let expr = {
@@ -1600,12 +1739,11 @@ function <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.aggrega
                 '#', $res->toString());
 }
 
-function 
-  <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.aggregation>> 
-  {
-    doc.doc='Test when alias name is same as column name across two or more joined tables'
-  }
-meta::pure::functions::relation::tests::composition::testGroupBy_Conflicting_Alias_With_Table_Columns<T|m> (f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+'''
+A projection alias that collides with a real column on the other side of a join still resolves to
+the projected value.
+'''
+function <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.aggregation>> meta::pure::functions::relation::tests::composition::testGroupBy_Conflicting_Alias_With_Table_Columns<T|m> (f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
   let tds1 = #TDS
                 id, grp, name
@@ -1641,12 +1779,11 @@ meta::pure::functions::relation::tests::composition::testGroupBy_Conflicting_Ali
                 '#', $res->sort(~name2->ascending())->select(~[name2, newCol])->toString());
 }
 
-function
-  <<PCT.test, PCTRelationQualifier.relation>>
-  {
-    doc.doc='Verify processing with joins including currentUserId'
-  }
-meta::pure::functions::relation::tests::composition::TestJoin_CurrentUserId<T|m> (f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+'''
+`currentUserId()` may appear in a join condition. Here it matches nothing, so the LEFT join fills
+the right-hand columns with empty values.
+'''
+function <<PCT.test, PCTRelationQualifier.relation>> meta::pure::functions::relation::tests::composition::TestJoin_CurrentUserId<T|m> (f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
   let expr = {|
     let t1 = #TDS
@@ -1670,6 +1807,10 @@ meta::pure::functions::relation::tests::composition::TestJoin_CurrentUserId<T|m>
                 '#', $res->sort(~id->ascending())->toString());
 }
 
+'''
+Multi-argument `coalesce` in a projection, including a row where every argument is empty and the
+literal default is taken.
+'''
 function <<PCT.test>> meta::pure::functions::relation::tests::composition::testMultiCoalesceInProject<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
     let expr = {|
@@ -1693,6 +1834,9 @@ function <<PCT.test>> meta::pure::functions::relation::tests::composition::testM
                   '#', $res->sort([~name->descending()])->toString());
 }
 
+'''
+`coalesce` on the right of a comparison inside `filter`, ahead of any projection.
+'''
 function <<PCT.test, PCTRelationQualifier.relation>> meta::pure::functions::relation::tests::composition::testCoalesceInPreFilter<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
     let expr = {|
@@ -1711,6 +1855,9 @@ function <<PCT.test, PCTRelationQualifier.relation>> meta::pure::functions::rela
     assertEquals(2, $res);
 }
 
+'''
+Binary `+`, `*` and `-` on relation columns inside a `project`.
+'''
 function <<PCTRelationQualifier.relation, PCT.test>> meta::pure::functions::relation::tests::composition::testTDSPlusTimesMinus<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
     let expr = {
@@ -1740,6 +1887,10 @@ function <<PCTRelationQualifier.relation, PCT.test>> meta::pure::functions::rela
                   '#', $res->sort([~plus->ascending()])->toString());
 }
 
+'''
+The variadic `plus`/`times`/`minus` forms over a mix of Integer and Float properties, compared
+with a tolerance.
+'''
 function <<PCT.test, PCTRelationQualifier.relation>> meta::pure::functions::relation::tests::composition::testProjectNumbersPlusTimesMinus<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
     let expr = {|
@@ -1772,6 +1923,9 @@ function <<PCT.test, PCTRelationQualifier.relation>> meta::pure::functions::rela
     );
 }
 
+'''
+Renaming a `groupBy` result with `project`.
+'''
 function <<PCT.test>> meta::pure::functions::relation::tests::composition::test_Extend_GroupBy_Project<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
     let expr = {
@@ -1812,6 +1966,9 @@ function <<PCT.test>> meta::pure::functions::relation::tests::composition::test_
                   '#', $res->sort(~finalId->ascending())->toString());
 }
 
+'''
+Renaming the same `groupBy` result with `extend` and `select` instead.
+'''
 function <<PCT.test>> meta::pure::functions::relation::tests::composition::test_Extend_GroupBy_Extend_Select<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
     let expr = {
@@ -1858,6 +2015,9 @@ function <<PCT.test>> meta::pure::functions::relation::tests::composition::test_
                   '#', $res->sort(~finalId->ascending())->toString());
 }
 
+'''
+Renaming a sorted relation with `project`.
+'''
 function <<PCT.test>> meta::pure::functions::relation::tests::composition::test_Extend_Sort_Project<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
     let expr = {
@@ -1891,6 +2051,9 @@ function <<PCT.test>> meta::pure::functions::relation::tests::composition::test_
                   '#', $res->sort(~finalId->ascending())->toString());
 }
 
+'''
+Renaming the same sorted relation with `extend` and `select` instead.
+'''
 function <<PCT.test>> meta::pure::functions::relation::tests::composition::test_Extend_Sort_Extend_Select<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
     let expr = {
@@ -1930,6 +2093,10 @@ function <<PCT.test>> meta::pure::functions::relation::tests::composition::test_
                   '#', $res->sort(~finalId->ascending())->toString());
 }
 
+'''
+A LEFT join whose condition combines an equality with an arithmetic inequality; the row matching
+nothing keeps empty values on the right.
+'''
 function <<PCT.test, PCTRelationQualifier.relation>> meta::pure::functions::relation::tests::composition::testNestedJoinArithmeticComparisonExpression<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
   let tds = #TDS
@@ -1983,6 +2150,9 @@ function <<PCT.test, PCTRelationQualifier.relation>> meta::pure::functions::rela
                 '#', $res->sort([~id->ascending(), ~order->ascending(), ~val1->ascending(), ~val2->ascending()])->toString());
 }
 
+'''
+Arithmetic on both sides of a comparison inside `filter`.
+'''
 function <<PCT.test, PCTRelationQualifier.relation>> meta::pure::functions::relation::tests::composition::testFilterArithmeticComparisonExpression<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
   let expr = {
@@ -2006,12 +2176,10 @@ function <<PCT.test, PCTRelationQualifier.relation>> meta::pure::functions::rela
                   '#', $res->sort([~val->ascending()])->toString());
 }
 
-function
-  <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.olap>>
-  {
-    doc.doc='Tests project followed by extend with an OLAP lead inside a nested if with adjust.'
-  }
-meta::pure::functions::relation::tests::composition::testProjectExtendNestedIfLeadAdjust<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+'''
+A `lead` inside nested `if` branches, with `adjust` supplying the fallback date.
+'''
+function <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.olap>> meta::pure::functions::relation::tests::composition::testProjectExtendNestedIfLeadAdjust<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
     let expr = {
                 | #TDS
@@ -2068,12 +2236,10 @@ meta::pure::functions::relation::tests::composition::testProjectExtendNestedIfLe
     );
 }
 
-function
-  <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.olap>>
-  {
-    doc.doc='Tests extend with an OLAP lead inside an if with adjust using a derived offset.'
-  }
-meta::pure::functions::relation::tests::composition::testExtendLeadAdjustDerivedOffset<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+'''
+An `adjust` whose offset is itself read from the row that `lead` returns.
+'''
+function <<PCT.test, PCTRelationQualifier.relation, PCTRelationQualifier.olap>> meta::pure::functions::relation::tests::composition::testExtendLeadAdjustDerivedOffset<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
     let expr = {
                 | #TDS
@@ -2118,6 +2284,10 @@ meta::pure::functions::relation::tests::composition::testExtendLeadAdjustDerived
     );
 }
 
+'''
+A static pivot over a `concatenate`. With no grouping key collapsed, each source row stays its own
+row and the column it did not match is empty.
+'''
 function <<PCT.test>> meta::pure::functions::relation::tests::composition::testStaticPivot_AfterConcatenate<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
    let expr = {|
@@ -2149,6 +2319,10 @@ function <<PCT.test>> meta::pure::functions::relation::tests::composition::testS
    );
 }
 
+'''
+A static pivot where the left arm of the `concatenate` computes a window column that the right arm
+supplies as a literal.
+'''
 function <<PCT.test>> meta::pure::functions::relation::tests::composition::testStaticPivot_AfterExtendConcatenate<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
    let expr = {|
@@ -2186,6 +2360,9 @@ function <<PCT.test>> meta::pure::functions::relation::tests::composition::testS
    );
 }
 
+'''
+`joinStrings` over a variant array, including one holding JSON `null`, which contributes nothing.
+'''
 function <<PCT.test, PCTRelationQualifier.relation, PCTCoreQualifier.variant>> meta::pure::functions::relation::tests::composition::testVariantArrayColumn_joinStrings<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
    let tds = #TDS
@@ -2210,6 +2387,10 @@ function <<PCT.test, PCTRelationQualifier.relation, PCTCoreQualifier.variant>> m
                 '   4,\'null\',\n'+
                 '#', $res->toString());
 }
+'''
+A `concatenate` whose left arm is a join and whose right arm is not, so the two arms reach the
+common table expression with different column representations.
+'''
 function <<PCT.test>> meta::pure::functions::relation::tests::composition::testConcatenateWithJoinOnOneSide<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
    let expr = {|
@@ -2277,6 +2458,10 @@ function <<PCT.test>> meta::pure::functions::relation::tests::composition::testC
                  '#', $res->sort(~accountId->ascending())->toString());
 }
 
+'''
+`lateral` with `flatten` over the keys of a `Map<String, Variant>`, multiplying each source row by
+its key count.
+'''
 function <<PCT.test, PCTRelationQualifier.relation, PCTCoreQualifier.variant>> meta::pure::functions::relation::tests::composition::testVariantMapColumn_keys_LateralFlatten<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
    let tds = #TDS
@@ -2300,6 +2485,9 @@ function <<PCT.test, PCTRelationQualifier.relation, PCTCoreQualifier.variant>> m
                 '#', $res->toString());
 }
 
+'''
+The same over map values, with a `get` applied to each value before flattening.
+'''
 function <<PCT.test, PCTRelationQualifier.relation, PCTCoreQualifier.variant>> meta::pure::functions::relation::tests::composition::testVariantMapColumn_values_LateralFlatten<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
    let tds = #TDS

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/boolean/inequality/between.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/boolean/inequality/between.pure
@@ -15,31 +15,57 @@
 import meta::pure::test::pct::*;
 import meta::pure::functions::boolean::*;
 
+'''
+Whether a value falls within an inclusive range.
+
+**Both bounds are inclusive**, so a value equal to `lower` or to `upper` is between them. Written out
+it is `($value >= $lower) && ($value <= $upper)`; the point of the function is that it names the
+intent and evaluates the value once.
+
+There are three overloads, one per comparable type — `Number`, `String` and `Date`.
+All three arguments are `[0..1]`, and an absent operand makes the comparison false rather than
+propagating emptiness, so a missing value is never reported as being in range.
+
+**Parameters**
+- `value` — the value to test.
+- `lower` — the inclusive lower bound.
+- `upper` — the inclusive upper bound.
+
+**Returns** `true` when the value lies within the bounds.
+
+**Examples**
+```pure
+between(5, 0, 10)   // true
+between(0, 0, 10)   // true, the bounds are inclusive
+between(5, 0, 2)    // false
+```
+
+**See also** `between(String[0..1], String[0..1], String[0..1]):Boolean[1]`,
+`between(Date[0..1], Date[0..1], Date[0..1]):Boolean[1]`
+'''
 function
     <<PCT.function>>
-    {
-        doc.doc='between returns true if the value is >= lower and <= upper; supports numeric values and bounds'
-    }
 meta::pure::functions::boolean::between(value:Number[0..1], lower:Number[0..1], upper:Number[0..1]):Boolean[1]
 {
   ($value >= $lower) && ($value <= $upper);
 }
 
+'''
+As `between(Number[0..1], Number[0..1], Number[0..1]):Boolean[1]`, for `String` values, ordering strings lexicographically.
+'''
 function
     <<PCT.function>>
-    {
-        doc.doc='between returns true if the value is >= lower and <= upper; supports string values and bounds'
-    }
 meta::pure::functions::boolean::between(value:String[0..1], lower:String[0..1], upper:String[0..1]):Boolean[1]
 {
   ($value >= $lower) && ($value <= $upper);
 }
 
+'''
+As `between(Number[0..1], Number[0..1], Number[0..1]):Boolean[1]`, for `Date` values. Accepts any
+date — `StrictDate`, `DateTime` or a partial date — and orders them chronologically.
+'''
 function
     <<PCT.function>>
-    {
-        doc.doc='between returns true if the value is >= lower and <= upper; supports any Date values and bounds (StrictDate, DateTime, or partial dates)'
-    }
 meta::pure::functions::boolean::between(value:Date[0..1], lower:Date[0..1], upper:Date[0..1]):Boolean[1]
 {
   ($value >= $lower) && ($value <= $upper);

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/boolean/operation/xor.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/boolean/operation/xor.pure
@@ -14,6 +14,27 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Exclusive or: true when exactly one of the two operands is true.
+
+Differs from `||` in rejecting the case where both are true, which makes it the test for "one or the
+other, but not both".
+
+**Parameters**
+- `first` — the first operand.
+- `second` — the second operand.
+
+**Returns** `true` when exactly one operand is `true`.
+
+**Examples**
+```pure
+xor(true, false)   // true
+xor(true, true)    // false, unlike ||
+xor(false, false)  // false
+```
+
+**See also** `meta::pure::functions::collection::or(Boolean[*]):Boolean[1]`
+'''
 function <<PCT.function>> meta::pure::functions::boolean::xor(first:Boolean[1], second:Boolean[1]):Boolean[1]
 {
    and(or($first, $second), or(!$first, !$second));

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/boolean/operation/xor.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/boolean/operation/xor.pure
@@ -29,6 +29,7 @@ other, but not both".
 **Examples**
 ```pure
 xor(true, false)   // true
+xor(false, true)   // true
 xor(true, true)    // false, unlike ||
 xor(false, false)  // false
 ```

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/collection/and.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/collection/and.pure
@@ -14,6 +14,31 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Whether every value in a collection is true.
+
+The collection form of `&&`. **An empty collection gives `true`**, which is the identity for
+conjunction and the usual convention, but it does mean "all of nothing" passes — test for emptiness
+separately when that matters.
+
+This is an aggregate: it is what a relational `groupBy` or a window aggregation calls to fold a
+boolean column.
+
+**Parameters**
+- `vals` — the values.
+
+**Returns** `true` when every value is `true`, and for an empty collection.
+
+**Examples**
+```pure
+and([true, true])          // true
+and([true, false])         // false
+and([true, true, false])   // false
+```
+
+**See also** `or(Boolean[*]):Boolean[1]`,
+`meta::pure::functions::boolean::xor(Boolean[1], Boolean[1]):Boolean[1]`
+'''
 function <<PCT.function>> meta::pure::functions::collection::and(vals:Boolean[*]):Boolean[1]
 {
    $vals->fold({i,a|$i && $a}, true)

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/collection/count.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/collection/count.pure
@@ -14,6 +14,25 @@
 
 import meta::pure::test::pct::*;
 
+'''
+How many values a collection holds.
+
+Counts values of any type, and gives 0 rather than empty for an empty collection. As an aggregate in
+a `groupBy` this is the row count per group.
+
+**Parameters**
+- `s` — the collection to count.
+
+**Returns** the number of values.
+
+**Examples**
+```pure
+count([1, 2, 3])   // 3
+count([])          // 0
+```
+
+**See also** `meta::pure::functions::relation::size(Relation<T>[1]):Integer[1]`
+'''
 function <<PCT.function>> meta::pure::functions::collection::count(s:Any[*]):Integer[1]
 {
    $s->size();

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/collection/greatest.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/collection/greatest.pure
@@ -14,21 +14,38 @@
 
 import meta::pure::test::pct::*;
 
+'''
+The largest value in a collection, by the type's natural order.
+
+A synonym for `max(X[1..*]):X[1]`, named after the SQL function of the same name so that a query
+translated from SQL reads the same. Supports every primitive type, not only numbers.
+
+**Parameters**
+- `values` — the values, at least one.
+
+**Returns** the largest value.
+
+**Examples**
+```pure
+greatest([1, 5, 3])   // 5
+```
+
+**See also** `greatest(X[*]):X[0..1]`,
+`max(X[1..*]):X[1]`,
+`least(X[1..*]):X[1]`
+'''
 function
   <<PCT.function>>
-  {
-      doc.doc='greatest returns largest value from the list by type order; supports all primitive data types'
-  }
 meta::pure::functions::collection::greatest<X>(values : X[1..*]):X[1]
 {
     max($values);
 }
 
+'''
+As `greatest(X[1..*]):X[1]`, for a collection that may be empty — an empty collection gives empty.
+'''
 function
   <<PCT.function>>
-  {
-      doc.doc='greatest returns largest value from the list by type order; supports all primitive data types'
-  }
 meta::pure::functions::collection::greatest<X>(values : X[*]):X[0..1]
 {
     max($values);

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/collection/in.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/collection/in.pure
@@ -15,11 +15,38 @@
 import meta::pure::functions::collection::tests::in::*;
 import meta::pure::test::pct::*;
 
+'''
+Whether a value appears in a collection.
+
+Membership by equality. **An absent `value` gives `false` rather than empty or an error**, so a
+missing value is never considered a member even if the collection is empty too — the emptiness is
+tested explicitly before the search.
+
+**Parameters**
+- `value` — the value to look for, possibly absent.
+- `collection` — the values to search.
+
+**Returns** `true` when the value appears in the collection.
+
+**Examples**
+```pure
+1->in([1, 2, 3])    // true
+4->in([1, 2, 3])    // false
+[]->in([1, 2, 3])   // false, an absent value is never a member
+```
+
+**See also** `in(Any[1], Any[*]):Boolean[1]`,
+`count(Any[*]):Integer[1]`
+'''
 function <<PCT.function>> meta::pure::functions::collection::in(value:Any[0..1], collection:Any[*]):Boolean[1]
 {
     $value->isNotEmpty() && $collection->exists(x | $value == $x)
 }
 
+'''
+As `in(Any[0..1], Any[*]):Boolean[1]`, for a value known to be present, so the absent case cannot
+arise.
+'''
 function <<PCT.function>> meta::pure::functions::collection::in(value:Any[1], collection:Any[*]):Boolean[1]
 {
     $collection->exists(x | $value == $x)

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/collection/least.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/collection/least.pure
@@ -14,21 +14,38 @@
 
 import meta::pure::test::pct::*;
 
+'''
+As `least(X[1..*]):X[1]`, for a collection that may be empty — an empty collection gives empty.
+'''
 function
   <<PCT.function>>
-  {
-      doc.doc='least returns smallest value from the list by type order; supports all primitive data types'
-  }
 meta::pure::functions::collection::least<X>(values : X[*]):X[0..1]
 {
     min($values);
 }
 
+'''
+The smallest value in a collection, by the type's natural order.
+
+A synonym for `min(X[1..*]):X[1]`, named after the SQL function of the same name. Supports every
+primitive type, not only numbers.
+
+**Parameters**
+- `values` — the values, at least one.
+
+**Returns** the smallest value.
+
+**Examples**
+```pure
+least([1, 5, 3])   // 1
+```
+
+**See also** `least(X[*]):X[0..1]`,
+`min(X[1..*]):X[1]`,
+`greatest(X[1..*]):X[1]`
+'''
 function
   <<PCT.function>>
-  {
-      doc.doc='least returns smallest value from the list by type order; supports all primitive data types'
-  }
 meta::pure::functions::collection::least<X>(values : X[1..*]):X[1]
 {
     min($values);

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/collection/least.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/collection/least.pure
@@ -15,16 +15,6 @@
 import meta::pure::test::pct::*;
 
 '''
-As `least(X[1..*]):X[1]`, for a collection that may be empty — an empty collection gives empty.
-'''
-function
-  <<PCT.function>>
-meta::pure::functions::collection::least<X>(values : X[*]):X[0..1]
-{
-    min($values);
-}
-
-'''
 The smallest value in a collection, by the type's natural order.
 
 A synonym for `min(X[1..*]):X[1]`, named after the SQL function of the same name. Supports every
@@ -47,6 +37,16 @@ least([1, 5, 3])   // 1
 function
   <<PCT.function>>
 meta::pure::functions::collection::least<X>(values : X[1..*]):X[1]
+{
+    min($values);
+}
+
+'''
+As `least(X[1..*]):X[1]`, for a collection that may be empty — an empty collection gives empty.
+'''
+function
+  <<PCT.function>>
+meta::pure::functions::collection::least<X>(values : X[*]):X[0..1]
 {
     min($values);
 }

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/collection/max.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/collection/max.pure
@@ -14,31 +14,58 @@
 
 import meta::pure::test::pct::*;
 
+'''
+The largest value in a collection, by the type's natural order.
+
+Unlike `meta::pure::functions::math::max(Integer[1..*]):Integer[1]`, this is **not restricted to
+numbers** — it orders any primitive type, so it finds the latest date or the last string
+alphabetically as readily as the largest number.
+
+Takes `[1..*]`, so the result is `[1]` and needs no `toOne`; use `max(X[*]):X[0..1]` where the
+collection may be empty.
+
+**Parameters**
+- `values` — the values, at least one.
+
+**Returns** the largest value.
+
+**Examples**
+```pure
+max([1, 5, 3])           // 5
+max(['a', 'c', 'b'])     // 'c'
+```
+
+**See also** `max(X[*]):X[0..1]`,
+`max(T[1..*], Function<{T[1], T[1]->Integer[1]}>[1]):T[1]`,
+`min(X[1..*]):X[1]`
+'''
 function
   <<PCT.function, functionType.ReducerFunction>>
-  {
-      doc.doc='max returns largest value from the list by type order'
-  }
 meta::pure::functions::collection::max<X>(values : X[1..*]):X[1]
 {
     $values->sort()->last()->toOne();
 }
 
+'''
+As `max(X[1..*]):X[1]`, for a collection that may be empty — **an empty collection gives empty**,
+which is why the result is `[0..1]`.
+'''
 function
   <<PCT.function, functionType.ReducerFunction>>
-  {
-      doc.doc='max returns largest value from the list by type order'
-  }
 meta::pure::functions::collection::max<X>(values : X[*]):X[0..1]
 {
     $values->sort()->last();
 }
 
+'''
+As `max(X[1..*]):X[1]`, ordering by a supplied comparator rather than the type's natural order.
+
+`comp` returns a positive number when its first argument sorts after its second, as
+`meta::pure::functions::lang::compare(T[1], T[1]):Integer[1]` does. Use it to find the largest
+by a derived key — the longest string, the record with the latest of two dates.
+'''
 function
   <<PCT.function, functionType.ReducerFunction>>
-  {
-      doc.doc='max returns largest value from the list by type order based on the supplied comp function'
-  }
 meta::pure::functions::collection::max<T>(col:T[1..*], comp:Function<{T[1],T[1]->Integer[1]}>[1]):T[1]
 {
     $col->tail()->fold({v, m | if($comp->eval($v, $m) > 0, | $v, | $m)}, $col->at(0))

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/collection/min.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/collection/min.pure
@@ -14,31 +14,50 @@
 
 import meta::pure::test::pct::*;
 
+'''
+The smallest value in a collection, by the type's natural order.
+
+The mirror of `max(X[1..*]):X[1]`, and like it **not restricted to numbers** — it orders any
+primitive type. Takes `[1..*]`, so the result is `[1]`.
+
+**Parameters**
+- `values` — the values, at least one.
+
+**Returns** the smallest value.
+
+**Examples**
+```pure
+min([1, 5, 3])         // 1
+min(['a', 'c', 'b'])   // 'a'
+```
+
+**See also** `min(X[*]):X[0..1]`,
+`min(T[1..*], Function<{T[1], T[1]->Integer[1]}>[1]):T[1]`,
+`max(X[1..*]):X[1]`
+'''
 function
   <<PCT.function, functionType.ReducerFunction>>
-  {
-      doc.doc='min returns smallest value from the list by type order'
-  }
 meta::pure::functions::collection::min<X>(values : X[1..*]):X[1]
 {
   $values->sort()->first()->toOne();
 }
 
+'''
+As `min(X[1..*]):X[1]`, for a collection that may be empty — an empty collection gives empty.
+'''
 function
   <<PCT.function, functionType.ReducerFunction>>
-  {
-      doc.doc='min returns smallest value from the list by type order'
-  }
 meta::pure::functions::collection::min<X>(values : X[*]):X[0..1]
 {
     $values->sort()->first();
 }
 
+'''
+As `min(X[1..*]):X[1]`, ordering by a supplied comparator rather than the type's natural order.
+`comp` returns a negative number when its first argument sorts before its second.
+'''
 function
   <<PCT.function, functionType.ReducerFunction>>
-  {
-      doc.doc='min returns smallest value from the list by type order based on the supplied comp function'
-  }
 meta::pure::functions::collection::min<T>(col:T[1..*], comp:Function<{T[1],T[1]->Integer[1]}>[1]):T[1]
 {
     $col->tail()->fold({v, m | if($comp->eval($v, $m) < 0, | $v, | $m)}, $col->at(0))

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/collection/or.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/collection/or.pure
@@ -14,11 +14,38 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Whether any value in a collection is true.
+
+The collection form of `||`. **An empty collection gives `false`**, the identity for disjunction and
+the mirror of `and(Boolean[*]):Boolean[1]` returning `true`.
+
+This is an aggregate: it is what a relational `groupBy` or a window aggregation calls to fold a
+boolean column.
+
+**Parameters**
+- `vals` — the values.
+
+**Returns** `true` when any value is `true`; `false` for an empty collection.
+
+**Examples**
+```pure
+or([false, true])    // true
+or([false, false])   // false
+```
+
+**See also** `and(Boolean[*]):Boolean[1]`,
+`meta::pure::functions::boolean::xor(Boolean[1], Boolean[1]):Boolean[1]`
+'''
 function <<PCT.function>> meta::pure::functions::collection::or(vals:Boolean[*]):Boolean[1]
 {
    $vals->fold({i,a|$i || $a}, false)
 }
 
+'''
+As `or(Boolean[*]):Boolean[1]`, for a collection known to hold at least one value, so the
+empty-collection case cannot arise.
+'''
 function <<PCT.function>> meta::pure::functions::collection::or(vals:Boolean[1..*]):Boolean[1]
 {
    $vals->fold({i,a|$i || $a}, false)

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/collection/or.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/collection/or.pure
@@ -32,6 +32,7 @@ boolean column.
 ```pure
 or([false, true])    // true
 or([false, false])   // false
+or([])               // false
 ```
 
 **See also** `and(Boolean[*]):Boolean[1]`,

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/date/aggregator/max.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/date/aggregator/max.pure
@@ -73,6 +73,12 @@ the `[1..*]` variant below returns `[1]` and needs no `toOne`.
 
 **Returns** the largest date, or empty when there are none.
 
+**Examples**
+```pure
+max([%2025-02-10, %2025-02-10T20:10:20])   // %2025-02-10T20:10:20
+max([]->cast(@Date))                       // empty
+```
+
 **See also** `max(Date[1..*]):Date[1]`,
 `max(Date[1], Date[1]):Date[1]`,
 `min(Date[*]):Date[0..1]`

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/date/aggregator/max.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/date/aggregator/max.pure
@@ -14,76 +14,122 @@
 
 import meta::pure::test::pct::*;
 
+'''
+The later of two dates.
+
+The date counterpart of `meta::pure::functions::math::max(Integer[1], Integer[1]):Integer[1]`, with
+the same two shapes: this and the two below compare **two arguments**, the six after them reduce a
+**collection**. `Date`, `StrictDate` and `DateTime` variants keep the argument type.
+
+Dates of differing precision compare by the start of the interval each covers, so a `StrictDate`
+sorts before any `DateTime` on the same day.
+
+**Parameters**
+- `left` — the first date.
+- `right` — the second date.
+
+**Returns** whichever is later.
+
+**Examples**
+```pure
+max(%2025-01-01, %2025-06-30)   // %2025-06-30
+```
+
+**See also** `max(Date[*]):Date[0..1]`,
+`min(Date[1], Date[1]):Date[1]`
+'''
 function <<PCT.function, functionType.ReducerFunction>> meta::pure::functions::date::max(left:Date[1], right:Date[1]):Date[1]
 {
     if($left < $right, | $right, | $left)
 }
 
+'''
+As `max(Date[1], Date[1]):Date[1]`, for `StrictDate` arguments, returning a `StrictDate`.
+'''
 function <<PCT.function, functionType.ReducerFunction>> meta::pure::functions::date::max(left:StrictDate[1], right:StrictDate[1]):StrictDate[1]
 {
     if($left < $right, | $right, | $left)
 }
 
+'''
+As `max(Date[1], Date[1]):Date[1]`, for `DateTime` arguments, returning a `DateTime`.
+'''
 function <<PCT.function, functionType.ReducerFunction>> meta::pure::functions::date::max(left:DateTime[1], right:DateTime[1]):DateTime[1]
 {
     if($left < $right, | $right, | $left)
 }
 
+'''
+The largest date in a collection.
+
+The collection form of `max(Date[1], Date[1]):Date[1]`, and the aggregate a relational `groupBy`
+or window aggregation calls. **An empty collection gives empty**, which is why this returns `[0..1]`;
+the `[1..*]` variant below returns `[1]` and needs no `toOne`.
+
+`Date`, `StrictDate` and `DateTime` variants keep the element type.
+
+**Parameters**
+- `dates` — the dates to reduce.
+
+**Returns** the largest date, or empty when there are none.
+
+**See also** `max(Date[1..*]):Date[1]`,
+`max(Date[1], Date[1]):Date[1]`,
+`min(Date[*]):Date[0..1]`
+'''
 function
   <<PCT.function, functionType.ReducerFunction>>
-  {
-      doc.doc='max returns smallest Date value from the list'
-  }
 meta::pure::functions::date::max(dates:Date[*]):Date[0..1]
 {
     $dates->fold({n, m | max($n, $m->toOne())}, $dates->first())
 }
 
+'''
+As `max(Date[*]):Date[0..1]`, for a collection known to hold at least one date, so the result is
+`[1]`.
+'''
 function
   <<PCT.function, functionType.ReducerFunction>>
-  {
-      doc.doc='max returns smallest Date value from the list'
-  }
 meta::pure::functions::date::max(dates:Date[1..*]):Date[1]
 {
     $dates->fold({n, m | max($n, $m)}, $dates->at(0))
 }
 
+'''
+As `max(Date[*]):Date[0..1]`, for `StrictDate` values.
+'''
 function
   <<PCT.function, functionType.ReducerFunction>>
-  {
-      doc.doc='max returns smallest StrictDate value from the list'
-  }
 meta::pure::functions::date::max(dates:StrictDate[*]):StrictDate[0..1]
 {
     $dates->fold({n, m | max($n, $m->toOne())}, $dates->first())
 }
 
+'''
+As `max(Date[1..*]):Date[1]`, for `StrictDate` values.
+'''
 function
   <<PCT.function, functionType.ReducerFunction>>
-  {
-      doc.doc='max returns smallest Date value from the list'
-  }
 meta::pure::functions::date::max(dates:StrictDate[1..*]):StrictDate[1]
 {
     $dates->fold({n, m | max($n, $m)}, $dates->at(0))
 }
 
+'''
+As `max(Date[*]):Date[0..1]`, for `DateTime` values.
+'''
 function
   <<PCT.function, functionType.ReducerFunction>>
-  {
-      doc.doc='max returns smallest DateTime value from the list'
-  }
 meta::pure::functions::date::max(dates:DateTime[*]):DateTime[0..1]
 {
     $dates->fold({n, m | max($n, $m->toOne())}, $dates->first())
 }
 
+'''
+As `max(Date[1..*]):Date[1]`, for `DateTime` values.
+'''
 function
   <<PCT.function, functionType.ReducerFunction>>
-  {
-      doc.doc='max returns smallest Date value from the list'
-  }
 meta::pure::functions::date::max(dates:DateTime[1..*]):DateTime[1]
 {
     $dates->fold({n, m | max($n, $m)}, $dates->at(0))

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/date/aggregator/min.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/date/aggregator/min.pure
@@ -14,76 +14,118 @@
 
 import meta::pure::test::pct::*;
 
+'''
+The earlier of two dates.
+
+The mirror of `max(Date[1], Date[1]):Date[1]`, with the same shapes and the same comparison rule:
+dates of differing precision compare by the start of the interval each covers.
+
+**Parameters**
+- `left` — the first date.
+- `right` — the second date.
+
+**Returns** whichever is earlier.
+
+**Examples**
+```pure
+min(%2025-01-01, %2025-06-30)   // %2025-01-01
+```
+
+**See also** `min(Date[*]):Date[0..1]`,
+`max(Date[1], Date[1]):Date[1]`
+'''
 function <<PCT.function, functionType.ReducerFunction>> meta::pure::functions::date::min(left:Date[1], right:Date[1]):Date[1]
 {
     if($right < $left, | $right, | $left)
 }
 
+'''
+As `min(Date[1], Date[1]):Date[1]`, for `StrictDate` arguments, returning a `StrictDate`.
+'''
 function <<PCT.function, functionType.ReducerFunction>> meta::pure::functions::date::min(left:StrictDate[1], right:StrictDate[1]):StrictDate[1]
 {
     if($right < $left, | $right, | $left)
 }
 
+'''
+As `min(Date[1], Date[1]):Date[1]`, for `DateTime` arguments, returning a `DateTime`.
+'''
 function <<PCT.function, functionType.ReducerFunction>> meta::pure::functions::date::min(left:DateTime[1], right:DateTime[1]):DateTime[1]
 {
     if($right < $left, | $right, | $left)
 }
 
+'''
+The smallest date in a collection.
+
+The collection form of `min(Date[1], Date[1]):Date[1]`, and the aggregate a relational `groupBy`
+or window aggregation calls. **An empty collection gives empty**, which is why this returns `[0..1]`;
+the `[1..*]` variant below returns `[1]` and needs no `toOne`.
+
+`Date`, `StrictDate` and `DateTime` variants keep the element type.
+
+**Parameters**
+- `dates` — the dates to reduce.
+
+**Returns** the smallest date, or empty when there are none.
+
+**See also** `min(Date[1..*]):Date[1]`,
+`min(Date[1], Date[1]):Date[1]`,
+`max(Date[*]):Date[0..1]`
+'''
 function
   <<PCT.function, functionType.ReducerFunction>>
-  {
-      doc.doc='min returns smallest Date value from the list'
-  }
 meta::pure::functions::date::min(dates:Date[*]):Date[0..1]
 {
     $dates->fold({n, m | min($n, $m->toOne())}, $dates->first())
 }
 
+'''
+As `min(Date[*]):Date[0..1]`, for a collection known to hold at least one date, so the result is
+`[1]`.
+'''
 function
   <<PCT.function, functionType.ReducerFunction>>
-  {
-      doc.doc='min returns smallest Date value from the list'
-  }
 meta::pure::functions::date::min(dates:Date[1..*]):Date[1]
 {
     $dates->fold({n, m | min($n, $m)}, $dates->at(0))
 }
 
+'''
+As `min(Date[*]):Date[0..1]`, for `StrictDate` values.
+'''
 function
   <<PCT.function, functionType.ReducerFunction>>
-  {
-      doc.doc='min returns smallest StrictDate value from the list'
-  }
 meta::pure::functions::date::min(dates:StrictDate[*]):StrictDate[0..1]
 {
     $dates->fold({n, m | min($n, $m->toOne())}, $dates->first())
 }
 
+'''
+As `min(Date[1..*]):Date[1]`, for `StrictDate` values.
+'''
 function
   <<PCT.function, functionType.ReducerFunction>>
-  {
-      doc.doc='min returns smallest Date value from the list'
-  }
 meta::pure::functions::date::min(dates:StrictDate[1..*]):StrictDate[1]
 {
     $dates->fold({n, m | min($n, $m)}, $dates->at(0))
 }
 
+'''
+As `min(Date[*]):Date[0..1]`, for `DateTime` values.
+'''
 function
   <<PCT.function, functionType.ReducerFunction>>
-  {
-      doc.doc='min returns smallest DateTime value from the list'
-  }
 meta::pure::functions::date::min(dates:DateTime[*]):DateTime[0..1]
 {
     $dates->fold({n, m | min($n, $m->toOne())}, $dates->first())
 }
 
+'''
+As `min(Date[1..*]):Date[1]`, for `DateTime` values.
+'''
 function
   <<PCT.function, functionType.ReducerFunction>>
-  {
-      doc.doc='min returns smallest Date value from the list'
-  }
 meta::pure::functions::date::min(dates:DateTime[1..*]):DateTime[1]
 {
     $dates->fold({n, m | min($n, $m)}, $dates->at(0))

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/date/aggregator/min.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/date/aggregator/min.pure
@@ -69,6 +69,12 @@ the `[1..*]` variant below returns `[1]` and needs no `toOne`.
 
 **Returns** the smallest date, or empty when there are none.
 
+**Examples**
+```pure
+min([%2025-02-10T20:10:20, %2025-02-10])   // %2025-02-10
+min([]->cast(@Date))                       // empty
+```
+
 **See also** `min(Date[1..*]):Date[1]`,
 `min(Date[1], Date[1]):Date[1]`,
 `max(Date[*]):Date[0..1]`

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/date/extract/dayOfWeek.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/date/extract/dayOfWeek.pure
@@ -15,6 +15,26 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Which day of the week a date falls on.
+
+Returns a `DayOfWeek` enumeration value rather than a number, so comparisons read as
+`== DayOfWeek.Saturday` and cannot be confused by the differing conventions databases use for
+numbering days.
+
+**Parameters**
+- `d` — the date.
+
+**Returns** the day of the week.
+
+**Examples**
+```pure
+%1985-01-12->dayOfWeek()   // DayOfWeek.Saturday
+%2025-09-22->dayOfWeek()   // DayOfWeek.Monday
+```
+
+**See also** `meta::pure::functions::date::timeBucket(StrictDate[1], Integer[1], DurationUnit[1]):StrictDate[1]`
+'''
 function <<PCT.function>> meta::pure::functions::date::dayOfWeek(d:Date[1]):DayOfWeek[1]
 {
     $d->dayOfWeekNumber()->dayOfWeek()

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/date/operation/formatDate.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/date/operation/formatDate.pure
@@ -25,11 +25,28 @@ Enum meta::pure::functions::date::DateTimeFormat
    ISO8601_NanoSecondPrecision
 }
 
+'''
+Renders a date as text in a named format.
+
+The format is an enumeration rather than a pattern string, so the set of shapes is fixed and checked
+at compile time instead of being a string that might be malformed. **Only
+`StrictDateFormat.ISO8601` is supported today**, and any other value fails at runtime.
+
+**Parameters**
+- `date` — the date to render.
+- `dateFormat` — the format to use.
+
+**Returns** the formatted date.
+
+**Examples**
+```pure
+%2025-04-09->formatDate(StrictDateFormat.ISO8601)   // '2025-04-09'
+```
+
+**See also** `formatDate(DateTime[1], DateTimeFormat[1]):String[1]`
+'''
 function
-   <<PCT.function>>
-   {
-      doc.doc = 'Formats a StrictDate to a string using the specified StrictDateFormat'
-   }
+    <<PCT.function>>
 meta::pure::functions::date::formatDate(date:StrictDate[1], dateFormat:StrictDateFormat[1]):String[1]
 {
    if($dateFormat == StrictDateFormat.ISO8601,
@@ -37,11 +54,14 @@ meta::pure::functions::date::formatDate(date:StrictDate[1], dateFormat:StrictDat
       | assert(false, |'Unsupported StrictDateFormat: ' + $dateFormat->toString()); '';);
 }
 
+'''
+As `formatDate(StrictDate[1], StrictDateFormat[1]):String[1]`, for a timestamp.
+
+**Only `DateTimeFormat.ISO8601_NanoSecondPrecision` is supported today**, which renders the full
+sub-second precision; any other value fails at runtime.
+'''
 function
-   <<PCT.function>>
-   {
-      doc.doc = 'Formats a DateTime to a string using the specified DateTimeFormat'
-   }
+    <<PCT.function>>
 meta::pure::functions::date::formatDate(dateTime:DateTime[1], dateTimeFormat:DateTimeFormat[1]):String[1]
 {
    if($dateTimeFormat == DateTimeFormat.ISO8601_NanoSecondPrecision,

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/date/operation/timeBucket.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/date/operation/timeBucket.pure
@@ -14,35 +14,65 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Rounds a timestamp down to the start of the bucket it falls in.
+
+The way to group events into fixed intervals — five-minute bars, hourly counts, monthly totals —
+without computing boundaries by hand. The result is the **start** of the containing bucket, so all
+timestamps in the same interval collapse to the same value and can be grouped on directly.
+
+**Buckets are measured from the Unix epoch**, not from the earliest value in the data, so the same
+timestamp always lands in the same bucket regardless of what else is in the relation. That is what
+makes buckets comparable across queries, but it also means a bucket boundary need not align with a
+natural calendar start when `quantity` is greater than 1.
+
+**Parameters**
+- `date` — the timestamp to bucket.
+- `quantity` — how many units wide the bucket is.
+- `unit` — the unit, as a `DurationUnit`.
+
+**Returns** the start of the containing bucket.
+
+**Examples**
+```pure
+$t->timeBucket(5, DurationUnit.MINUTES)
+$t->timeBucket(1, DurationUnit.MONTHS)    // the first instant of the month
+```
+
+**See also** `timeBucket(StrictDate[1], Integer[1], DurationUnit[1]):StrictDate[1]`,
+`meta::pure::functions::date::dayOfWeek(Date[1]):DayOfWeek[1]`
+'''
 native function
     <<PCT.function>>
-    {
-         doc.doc='calculates a time bucket for DateTime, where the bucket is of size quantity unit (e.g. 5 Hours). Uses unix Epoch as the origin for the calculation.'
-    }
 meta::pure::functions::date::timeBucket(date:DateTime[1], quantity:Integer[1], unit:DurationUnit[1]):DateTime[1];
 
+'''
+As `timeBucket(DateTime[1], Integer[1], DurationUnit[1]):DateTime[1]`, for a timestamp that may be
+absent — empty in, empty out.
+'''
 function
     <<PCT.function>>
-    {
-         doc.doc='calculates a time bucket for DateTime, where the bucket is of size quantity unit (e.g. 5 Hours). Uses unix Epoch as the origin for the calculation. Multiplicity 0..1 is allowed.'
-    }
 meta::pure::functions::date::timeBucket(date:DateTime[0..1], quantity:Integer[1], unit:DurationUnit[1]):DateTime[0..1]
 {
   if($date->isEmpty(),|[],|$date->toOne()->timeBucket($quantity, $unit));
 }
 
+'''
+As `timeBucket(DateTime[1], Integer[1], DurationUnit[1]):DateTime[1]`, for a calendar day.
+
+**Only `YEARS`, `MONTHS`, `WEEKS` and `DAYS` are accepted** — a `StrictDate` has no time of day, so a
+sub-day unit has nothing to round.
+'''
 native function
     <<PCT.function>>
-    {
-         doc.doc='calculates a time bucket for StrictDate, where the bucket is of size quantity unit (e.g. 5 Months). Only units in the set (YEARS, DAYS, MONTHS, WEEKS) are allowed.'
-    }
 meta::pure::functions::date::timeBucket(date:StrictDate[1], quantity:Integer[1], unit:DurationUnit[1]):StrictDate[1];
 
+'''
+As `timeBucket(StrictDate[1], Integer[1], DurationUnit[1]):StrictDate[1]`, for a date that may be
+absent — empty in, empty out.
+'''
 function
     <<PCT.function>>
-    {
-         doc.doc='calculates a time bucket for StrictDate, where the bucket is of size quantity unit (e.g. 5 months). Only units in the set (YEARS, DAYS, MONTHS, WEEKS) are allowed. Multiplicity 0..1 is allowed.'
-    }
 meta::pure::functions::date::timeBucket(date:StrictDate[0..1], quantity:Integer[1], unit:DurationUnit[1]):StrictDate[0..1]
 {
   if($date->isEmpty(),|[],|$date->toOne()->timeBucket($quantity, $unit));

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/date/operation/timeBucket.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/date/operation/timeBucket.pure
@@ -21,7 +21,8 @@ The way to group events into fixed intervals — five-minute bars, hourly counts
 without computing boundaries by hand. The result is the **start** of the containing bucket, so all
 timestamps in the same interval collapse to the same value and can be grouped on directly.
 
-**Buckets are measured from the Unix epoch**, not from the earliest value in the data, so the same
+**Buckets are measured from `1970-01-01T00:00:00` UTC** (the Unix epoch), not from the earliest value
+in the data, so the same
 timestamp always lands in the same bucket regardless of what else is in the relation. That is what
 makes buckets comparable across queries, but it also means a bucket boundary need not align with a
 natural calendar start when `quantity` is greater than 1.
@@ -37,6 +38,9 @@ natural calendar start when `quantity` is greater than 1.
 ```pure
 $t->timeBucket(5, DurationUnit.MINUTES)
 $t->timeBucket(1, DurationUnit.MONTHS)    // the first instant of the month
+
+// counting from the epoch, an 18-second bucket need not start on a round part of the minute
+%2024-01-31T00:32:34.999+0000->timeBucket(18, DurationUnit.SECONDS)   // %2024-01-31T00:32:24+0000
 ```
 
 **See also** `timeBucket(StrictDate[1], Integer[1], DurationUnit[1]):StrictDate[1]`,

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/average.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/average.pure
@@ -79,6 +79,11 @@ row, making this a running average rather than a partition-wide one.
 
 **Returns** the mean of the column within the window.
 
+**Examples**
+```pure
+$rel->extend(over(~grp, ~id->ascending()), ~runningAvg : {p, w, r| $p->average($w, $r, ~value)})
+```
+
 **See also** `average(Number[*]):Float[1]`,
 `meta::pure::functions::relation::over(String[*], SortInfo<(?:NULL)⊆T>[*], Frame[0..1]):_Window<T>[1]`
 '''

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/average.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/average.pure
@@ -14,22 +14,77 @@
 
 import meta::pure::test::pct::*;
 
+'''
+The arithmetic mean of a collection of numbers.
+
+**The result is always `Float`**, even for `Integer` input, so an exact average is not silently
+truncated. `mean(Number[*]):Float[1]` is a synonym.
+
+An empty collection has no average, and the division by zero fails rather than returning empty —
+guard with `isEmpty` where the collection may have no rows.
+
+This is an aggregate: it is what a relational `groupBy` or a window aggregation calls.
+
+**Parameters**
+- `numbers` — the values to average.
+
+**Returns** the mean, as a `Float`.
+
+**Examples**
+```pure
+average([1, 2, 3, 4])   // 2.5
+```
+
+**See also** `mean(Number[*]):Float[1]`,
+`median(Number[*]):Float[1]`,
+`sum(Number[*]):Number[1]`
+'''
 function <<PCT.function, functionType.ReducerFunction>> meta::pure::functions::math::average(numbers:Number[*]):Float[1]
 {
     if($numbers->isEmpty(),|fail('Error: Mean of an empty set.');0.0;,|$numbers->sum() / $numbers->size())
 }
 
+'''
+As `average(Number[*]):Float[1]`, for `Integer` values. The result is still a `Float`.
+'''
 function <<PCT.function, functionType.ReducerFunction>> meta::pure::functions::math::average(numbers:Integer[*]):Float[1]
 {
     if($numbers->isEmpty(),|fail('Error: Mean of an empty set.');0.0;,|$numbers->sum() / $numbers->size())
 }
 
+'''
+As `average(Number[*]):Float[1]`, for `Float` values.
+'''
 function <<PCT.function, functionType.ReducerFunction>> meta::pure::functions::math::average(numbers:Float[*]):Float[1]
 {
     if($numbers->isEmpty(),|fail('Error: Mean of an empty set.');0.0;,|$numbers->sum() / $numbers->size())
 }
 
-function <<PCT.function>> {doc.doc='Returns the average of the non-NULL values on the given column of the current window, and frame for the current row'} meta::pure::functions::math::average<T>(partition: meta::pure::metamodel::relation::Relation<T>[1], window: meta::pure::functions::relation::_Window<T>[1], row: T[1], colToAgg:meta::pure::metamodel::relation::ColSpec<(?:Number)⊆T>[1]):Float[1]
+'''
+The mean of a column's values within the current window.
+
+This is the window form: it is called from inside an `extend` with a window, receiving the partition,
+the window and the current row, and reads its values from `colToAgg` rather than from a collection
+argument.
+
+Absent values are skipped rather than counted as zero, so the divisor is the number of values present.
+Remember that a window with no explicit frame runs from the start of the partition to the current
+row, making this a running average rather than a partition-wide one.
+
+**Parameters**
+- `partition` — the partition, supplied by `extend`.
+- `window` — the window, supplied by `extend`.
+- `row` — the current row, supplied by `extend`.
+- `colToAgg` — the column to average.
+
+**Returns** the mean of the column within the window.
+
+**See also** `average(Number[*]):Float[1]`,
+`meta::pure::functions::relation::over(String[*], SortInfo<(?:NULL)⊆T>[*], Frame[0..1]):_Window<T>[1]`
+'''
+function
+  <<PCT.function>>
+meta::pure::functions::math::average<T>(partition: meta::pure::metamodel::relation::Relation<T>[1], window: meta::pure::functions::relation::_Window<T>[1], row: T[1], colToAgg:meta::pure::metamodel::relation::ColSpec<(?:Number)⊆T>[1]):Float[1]
 {
     reduce($partition, $window, $row, x|eval($colToAgg, $x), y|$y->average());
 }

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/corr.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/corr.pure
@@ -14,11 +14,30 @@
 
 import meta::pure::test::pct::*;
 
+'''
+The Pearson correlation coefficient of two series.
+
+**Bounded between -1 and 1**: 1 is a perfect positive linear relationship, -1 a perfect negative one,
+and 0 no linear relationship. Being normalised, it is comparable across pairs of series in a way that
+`covarSample(Number[*], Number[*]):Number[0..1]` is not.
+
+It measures only *linear* association — a strong non-linear relationship can still give a
+correlation near zero.
+
+The two collections are positional and are paired by index. **Returns empty rather than failing when
+the coefficient is undefined**, which includes the case where either series has no variance.
+
+**Parameters**
+- `numbersA` — the first series.
+- `numbersB` — the second series, paired by position.
+
+**Returns** the correlation, between -1 and 1, or empty when undefined.
+
+**See also** `covarSample(Number[*], Number[*]):Number[0..1]`,
+`covarPopulation(Number[*], Number[*]):Number[0..1]`
+'''
 function
-<<PCT.function, functionType.ReducerFunction>>
-    {
-        doc.doc='Returns the correlation coefficient for non-null pairs in a group.'
-    }
+  <<PCT.function, functionType.ReducerFunction>>
 meta::pure::functions::math::corr(numbersA:Number[*], numbersB:Number[*]):Number[0..1]
 {
   if( covarPopulation($numbersA, $numbersB)->equal([]),

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/corr.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/corr.pure
@@ -33,6 +33,13 @@ the coefficient is undefined**, which includes the case where either series has 
 
 **Returns** the correlation, between -1 and 1, or empty when undefined.
 
+**Examples**
+```pure
+corr([1, 2], [10, 20])   // 1.0, they rise together
+corr([1, 2], [30, 10])   // -1.0, one rises as the other falls
+corr([1], [])            // empty, nothing to pair
+```
+
 **See also** `covarSample(Number[*], Number[*]):Number[0..1]`,
 `covarPopulation(Number[*], Number[*]):Number[0..1]`
 '''

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/covarPopulation.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/covarPopulation.pure
@@ -14,11 +14,27 @@
 
 import meta::pure::test::pct::*;
 
+'''
+The population covariance of two series.
+
+`covariance(Number[*], Number[*], Integer[1], Boolean[1]):Number[0..1]` with the bias correction off,
+dividing by the number of pairs. Use it when the pairs are the whole population rather than a sample.
+
+Unnormalised, so its magnitude depends on the units of both series; use
+`corr(Number[*], Number[*]):Number[0..1]` to compare relationships across different pairs. Returns
+empty when there are no pairs.
+
+**Parameters**
+- `numbersA` — the first series.
+- `numbersB` — the second series, paired by position.
+
+**Returns** the population covariance, or empty.
+
+**See also** `covarSample(Number[*], Number[*]):Number[0..1]`,
+`corr(Number[*], Number[*]):Number[0..1]`
+'''
 function
-<<PCT.function, functionType.ReducerFunction>>
-    {
-        doc.doc='Returns the population covariance for non-null pairs in a group.'
-    }
+  <<PCT.function, functionType.ReducerFunction>>
 meta::pure::functions::math::covarPopulation(numbersA:Number[*], numbersB:Number[*]):Number[0..1]
 {
   covariance($numbersA, $numbersB, min($numbersA->size(),$numbersB->size()), false);

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/covarPopulation.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/covarPopulation.pure
@@ -30,6 +30,13 @@ empty when there are no pairs.
 
 **Returns** the population covariance, or empty.
 
+**Examples**
+```pure
+covarPopulation([1, 2], [10, 20])   // 2.5
+covarPopulation([1, 2], [30, 10])   // -5.0
+covarPopulation([1], [])            // empty, no pairs
+```
+
 **See also** `covarSample(Number[*], Number[*]):Number[0..1]`,
 `corr(Number[*], Number[*]):Number[0..1]`
 '''

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/covarSample.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/covarSample.pure
@@ -14,11 +14,26 @@
 
 import meta::pure::test::pct::*;
 
+'''
+The sample covariance of two series.
+
+`covariance(Number[*], Number[*], Integer[1], Boolean[1]):Number[0..1]` with the bias correction on,
+dividing by one fewer than the number of pairs. Use it when the pairs are a sample and you are
+estimating the covariance of the population they came from.
+
+Returns empty when there are fewer than two pairs, since the divisor would be zero.
+
+**Parameters**
+- `numbersA` — the first series.
+- `numbersB` — the second series, paired by position.
+
+**Returns** the sample covariance, or empty.
+
+**See also** `covarPopulation(Number[*], Number[*]):Number[0..1]`,
+`corr(Number[*], Number[*]):Number[0..1]`
+'''
 function
-<<PCT.function, functionType.ReducerFunction>>
-    {
-        doc.doc='Returns the sample covariance for non-null pairs in a group.'
-    }
+  <<PCT.function, functionType.ReducerFunction>>
 meta::pure::functions::math::covarSample(numbersA:Number[*], numbersB:Number[*]):Number[0..1]
 {
   covariance($numbersA, $numbersB, min($numbersA->size(),$numbersB->size()), true);

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/covarSample.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/covarSample.pure
@@ -29,6 +29,13 @@ Returns empty when there are fewer than two pairs, since the divisor would be ze
 
 **Returns** the sample covariance, or empty.
 
+**Examples**
+```pure
+covarSample([1, 2], [10, 20])   // 5.0, twice the population figure over two pairs
+covarSample([1, 2], [30, 10])   // -10.0
+covarSample([1], [10])          // empty, one pair is not enough
+```
+
 **See also** `covarPopulation(Number[*], Number[*]):Number[0..1]`,
 `corr(Number[*], Number[*]):Number[0..1]`
 '''

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/covariance.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/covariance.pure
@@ -37,6 +37,13 @@ there is nothing to divide by** — a `count` of 0, or of 1 with the bias correc
 
 **Returns** the covariance, or empty when it is undefined.
 
+**Examples**
+```pure
+covariance([1, 2], [10, 20], 2, true)    // 5.0,  the sample form
+covariance([1, 2], [10, 20], 2, false)   // 2.5,  the population form
+covariance([1], [10], 1, true)           // empty, count 1 with the correction on
+```
+
 **See also** `covarSample(Number[*], Number[*]):Number[0..1]`,
 `covarPopulation(Number[*], Number[*]):Number[0..1]`,
 `corr(Number[*], Number[*]):Number[0..1]`

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/covariance.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/covariance.pure
@@ -14,6 +14,33 @@
 
 import meta::pure::test::pct::*;
 
+'''
+The covariance of two collections, sample or population depending on the flag.
+
+How two series move together: positive when they rise and fall in step, negative when one rises as
+the other falls, near zero when unrelated. Unlike `corr`, it is not normalised, so its magnitude
+depends on the units of both inputs and is not comparable across pairs.
+
+`isBiasCorrected` selects the divisor — `true` divides by `count - 1` for a **sample** covariance,
+`false` by `count` for a **population** one. Prefer the named
+`covarSample(Number[*], Number[*]):Number[0..1]` and
+`covarPopulation(Number[*], Number[*]):Number[0..1]` in ordinary code.
+
+The two collections are positional and are paired by index. **Returns empty rather than failing when
+there is nothing to divide by** — a `count` of 0, or of 1 with the bias correction on.
+
+**Parameters**
+- `numbersA` — the first series.
+- `numbersB` — the second series, paired by position.
+- `count` — the number of pairs.
+- `isBiasCorrected` — `true` for the sample covariance, `false` for the population one.
+
+**Returns** the covariance, or empty when it is undefined.
+
+**See also** `covarSample(Number[*], Number[*]):Number[0..1]`,
+`covarPopulation(Number[*], Number[*]):Number[0..1]`,
+`corr(Number[*], Number[*]):Number[0..1]`
+'''
 function <<PCT.function>> meta::pure::functions::math::covariance(numbersA:Number[*], numbersB:Number[*], count:Integer[1], isBiasCorrected: Boolean[1]):Number[0..1]
 {
   if($count == 0 || ($isBiasCorrected && ($count <= 1)), |[], | ($numbersA->zip($numbersB)->map(p | $p.first * $p.second)->sum() - sum($numbersA)*sum($numbersB)/$count)/($count- if ($isBiasCorrected, |1, |0)))

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/max.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/max.pure
@@ -14,46 +14,118 @@
 
 import meta::pure::test::pct::*;
 
+'''
+The larger of two values.
+
+The family has two shapes. This one and the two below compare **two arguments**; the six after them
+reduce a **collection**. Both come in `Integer`, `Float` and `Number` variants so the result keeps
+the argument type rather than widening to `Number`.
+
+Ordering is numeric, and equal arguments give that value back.
+
+**Parameters**
+- `left` — the first value.
+- `right` — the second value.
+
+**Returns** whichever is larger.
+
+**Examples**
+```pure
+max(1, 2)   // 2
+max(2, 1)   // 2
+```
+
+**See also** `max(Integer[*]):Integer[0..1]`,
+`min(Integer[1], Integer[1]):Integer[1]`,
+`meta::pure::functions::collection::max(T[1..*], Function<{T[1], T[1]->Integer[1]}>[1]):T[1]`
+'''
 function <<PCT.function, functionType.ReducerFunction>> meta::pure::functions::math::max(left:Integer[1], right:Integer[1]):Integer[1]
 {
     if($left < $right, | $right, | $left)
 }
 
+'''
+As `max(Integer[1], Integer[1]):Integer[1]`, for `Float` arguments.
+'''
 function <<PCT.function, functionType.ReducerFunction>> meta::pure::functions::math::max(left:Float[1], right:Float[1]):Float[1]
 {
     if($left < $right, | $right, | $left)
 }
 
+'''
+As `max(Integer[1], Integer[1]):Integer[1]`, for `Number` arguments — use this when the two sides may
+be a mix of `Integer` and `Float`.
+'''
 function <<PCT.function, functionType.ReducerFunction>> meta::pure::functions::math::max(left:Number[1], right:Number[1]):Number[1]
 {
     if($left < $right, | $right, | $left)
 }
 
+'''
+The largest value in a collection.
+
+**Returns empty for an empty collection**, which is why the result is `[0..1]`. Where the collection
+is known to be non-empty, `max(Integer[1..*]):Integer[1]` returns `[1]` and saves a `toOne`.
+
+This is the aggregate form: it is what a relational `groupBy` or a window aggregation calls.
+
+**Parameters**
+- `ints` — the values to reduce.
+
+**Returns** the largest value, or empty when there are none.
+
+**Examples**
+```pure
+max([1, 5, 3])            // 5
+max([]->cast(@Integer))   // empty
+```
+
+**See also** `max(Integer[1..*]):Integer[1]`,
+`max(Integer[1], Integer[1]):Integer[1]`,
+`min(Integer[*]):Integer[0..1]`
+'''
 function <<PCT.function, functionType.ReducerFunction>> meta::pure::functions::math::max(ints:Integer[*]):Integer[0..1]
 {
     $ints->fold({i, m | max($i, $m->toOne())}, $ints->first())
 }
 
+'''
+As `max(Integer[*]):Integer[0..1]`, for a collection known to hold at least one value, so the result
+is `[1]` rather than `[0..1]`.
+'''
 function <<PCT.function, functionType.ReducerFunction>> meta::pure::functions::math::max(ints:Integer[1..*]):Integer[1]
 {
     $ints->fold({i, m | max($i, $m)}, $ints->at(0))
 }
 
+'''
+As `max(Integer[*]):Integer[0..1]`, for `Float` values.
+'''
 function <<PCT.function, functionType.ReducerFunction>> meta::pure::functions::math::max(floats:Float[*]):Float[0..1]
 {
     $floats->fold({f, m | max($f, $m->toOne())}, $floats->first())
 }
 
+'''
+As `max(Integer[1..*]):Integer[1]`, for `Float` values.
+'''
 function <<PCT.function, functionType.ReducerFunction>> meta::pure::functions::math::max(floats:Float[1..*]):Float[1]
 {
     $floats->fold({f, m | max($f, $m)}, $floats->at(0))
 }
 
+'''
+As `max(Integer[*]):Integer[0..1]`, for `Number` values — the form to use when the collection mixes
+`Integer` and `Float`.
+'''
 function <<PCT.function, functionType.ReducerFunction>> meta::pure::functions::math::max(numbers:Number[*]):Number[0..1]
 {
     $numbers->fold({n, m | max($n, $m->toOne())}, $numbers->first())
 }
 
+'''
+As `max(Number[*]):Number[0..1]`, for a collection known to hold at least one value.
+'''
 function <<PCT.function, functionType.ReducerFunction>> meta::pure::functions::math::max(numbers:Number[1..*]):Number[1]
 {
     $numbers->fold({n, m | max($n, $m)}, $numbers->at(0))

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/maxBy.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/maxBy.pure
@@ -16,6 +16,31 @@ import meta::pure::functions::variant::convert::*;
 import meta::pure::functions::math::mathUtility::*;
 import meta::pure::test::pct::*;
 
+'''
+The value from one collection that sits where another collection is largest.
+
+An argmax: `col_containing_maximum` decides *which* position wins, and the value at that position of
+`col_to_return` is what comes back. The typical use is picking the row-derived value associated with
+a peak — the name of the top earner, the date of the highest reading — without sorting.
+
+The two collections are positional and must line up. **Returns empty when they are empty**, which is
+why the result is `[0..1]`.
+
+**Parameters**
+- `col_to_return` — the values to choose from.
+- `col_containing_maximum` — the values to compare.
+
+**Returns** the value at the position of the maximum, or empty.
+
+**Examples**
+```pure
+$rel->groupBy(~grp, ~top : x | $x.name : y | $y->maxBy($x.salary))
+```
+
+**See also** `maxBy(T[*], Number[*], Integer[1]):T[*]`,
+`minBy(T[*], Number[*], Integer[1]):T[*]`,
+`max(Number[*]):Number[0..1]`
+'''
 function <<PCT.function, functionType.ReducerFunction>> meta::pure::functions::math::maxBy<T>(col_to_return:T[*], col_containing_maximum:Number[*]):T[0..1]
 {
   maxBy($col_to_return, $col_containing_maximum, 1)->head();
@@ -27,6 +52,10 @@ function <<functionType.ReducerFunction>> meta::pure::functions::math::maxBy<T>(
   maxBy($colRows.rowA, $colRows.rowB);
 }
 
+'''
+As `maxBy(T[*], Number[*]):T[0..1]`, returning the values at the `n` largest positions rather than
+just the largest — a top-`n` rather than a top-one.
+'''
 function <<PCT.function, functionType.ReducerFunction>> meta::pure::functions::math::maxBy<T>(col_to_return:T[*], col_containing_maximum:Number[*], n:Integer[1]): T[*]
 {
   $col_to_return->zip($col_containing_maximum)->sort({x, y | $y.second->compare($x.second)})->slice(0, $n).first;

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/mean.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/mean.pure
@@ -14,16 +14,44 @@
 
 import meta::pure::test::pct::*;
 
+'''
+The arithmetic mean of a collection of numbers.
+
+A synonym for `average(Number[*]):Float[1]` — same computation, same result type. **The result is
+always `Float`**, even for `Integer` input, so an exact average is not rounded to an integer.
+
+An empty collection has no mean, and the division by zero fails rather than returning empty.
+
+**Parameters**
+- `numbers` — the values to average.
+
+**Returns** the mean, as a `Float`.
+
+**Examples**
+```pure
+mean([1, 2, 3, 4])   // 2.5
+```
+
+**See also** `average(Number[*]):Float[1]`,
+`median(Number[*]):Float[1]`,
+`sum(Number[*]):Number[1]`
+'''
 function <<PCT.function, functionType.ReducerFunction>> meta::pure::functions::math::mean(numbers:Number[*]):Float[1]
 {
     $numbers->average();
 }
 
+'''
+As `mean(Number[*]):Float[1]`, for `Integer` values. The result is still a `Float`.
+'''
 function <<PCT.function, functionType.ReducerFunction>> meta::pure::functions::math::mean(numbers:Integer[*]):Float[1]
 {
     $numbers->average();
 }
 
+'''
+As `mean(Number[*]):Float[1]`, for `Float` values.
+'''
 function <<PCT.function, functionType.ReducerFunction>> meta::pure::functions::math::mean(numbers:Float[*]):Float[1]
 {
     $numbers->average();

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/median.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/median.pure
@@ -14,6 +14,30 @@
 
 import meta::pure::test::pct::*;
 
+'''
+The middle value of a collection, once sorted.
+
+**With an even number of values the two middle ones are averaged**, so the median need not be a value
+that appears in the collection — the median of `[1, 2, 3, 4]` is 2.5. The result is always `Float`
+for that reason, even for `Integer` input.
+
+Less sensitive to outliers than `mean(Number[*]):Float[1]`, which is usually why it is chosen.
+
+**Parameters**
+- `numbers` — the values.
+
+**Returns** the median, as a `Float`.
+
+**Examples**
+```pure
+median([1, 2, 3])      // 2.0, the middle value
+median([1, 2, 3, 4])   // 2.5, the average of the two middle values
+```
+
+**See also** `mean(Number[*]):Float[1]`,
+`percentile(Number[*], Float[1]):Number[0..1]`,
+`mode(Float[*]):Float[1]`
+'''
 function <<PCT.function, functionType.ReducerFunction>> meta::pure::functions::math::median(numbers:Number[*]):Float[1]
 {
     let sortedNumbers = $numbers->toOneMany()->sort();
@@ -23,6 +47,9 @@ function <<PCT.function, functionType.ReducerFunction>> meta::pure::functions::m
     );
 }
 
+'''
+As `median(Number[*]):Float[1]`, for `Integer` values. The result is still a `Float`.
+'''
 function <<PCT.function, functionType.ReducerFunction>> meta::pure::functions::math::median(numbers:Integer[*]):Float[1]
 {
     let sortedNumbers = $numbers->toOneMany()->sort();
@@ -32,6 +59,9 @@ function <<PCT.function, functionType.ReducerFunction>> meta::pure::functions::m
     );
 }
 
+'''
+As `median(Number[*]):Float[1]`, for `Float` values.
+'''
 function <<PCT.function, functionType.ReducerFunction>> meta::pure::functions::math::median(numbers:Float[*]):Float[1]
 {
     let sortedNumbers = $numbers->toOneMany()->sort();

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/min.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/min.pure
@@ -14,46 +14,113 @@
 
 import meta::pure::test::pct::*;
 
+'''
+The smaller of two values.
+
+The mirror of `max(Integer[1], Integer[1]):Integer[1]`, with the same two shapes: this and the two
+below compare **two arguments**, the six after them reduce a **collection**. Each comes in `Integer`,
+`Float` and `Number` variants so the result keeps the argument type.
+
+Ordering is numeric, and equal arguments give that value back.
+
+**Parameters**
+- `left` — the first value.
+- `right` — the second value.
+
+**Returns** whichever is smaller.
+
+**Examples**
+```pure
+min(1, 2)   // 1
+min(2, 1)   // 1
+```
+
+**See also** `min(Integer[*]):Integer[0..1]`,
+`max(Integer[1], Integer[1]):Integer[1]`
+'''
 function <<PCT.function, functionType.ReducerFunction>> meta::pure::functions::math::min(left:Integer[1], right:Integer[1]):Integer[1]
 {
     if($right < $left, | $right, | $left)
 }
 
+'''
+As `min(Integer[1], Integer[1]):Integer[1]`, for `Float` arguments.
+'''
 function <<PCT.function, functionType.ReducerFunction>> meta::pure::functions::math::min(left:Float[1], right:Float[1]):Float[1]
 {
     if($right < $left, | $right, | $left)
 }
 
+'''
+As `min(Integer[1], Integer[1]):Integer[1]`, for `Number` arguments — use this when the two sides may
+be a mix of `Integer` and `Float`.
+'''
 function <<PCT.function, functionType.ReducerFunction>> meta::pure::functions::math::min(left:Number[1], right:Number[1]):Number[1]
 {
     if($right < $left, | $right, | $left)
 }
 
+'''
+The smallest value in a collection known to hold at least one, so the result is `[1]` and needs no
+`toOne`. Use `min(Integer[*]):Integer[0..1]` where the collection may be empty.
+
+This is the aggregate form: it is what a relational `groupBy` or a window aggregation calls.
+
+**Parameters**
+- `ints` — the values to reduce.
+
+**Returns** the smallest value.
+
+**Examples**
+```pure
+min([1, 5, 3])   // 1
+```
+
+**See also** `min(Integer[*]):Integer[0..1]`,
+`max(Integer[1..*]):Integer[1]`
+'''
 function <<PCT.function, functionType.ReducerFunction>> meta::pure::functions::math::min(ints:Integer[1..*]):Integer[1]
 {
     $ints->fold({i, m | min($i, $m)}, $ints->at(0))
 }
 
+'''
+As `min(Integer[1..*]):Integer[1]`, for a collection that may be empty — **an empty collection gives
+empty**, which is why the result is `[0..1]`.
+'''
 function <<PCT.function, functionType.ReducerFunction>> meta::pure::functions::math::min(ints:Integer[*]):Integer[0..1]
 {
     $ints->fold({i, m | min($i, $m->toOne())}, $ints->first())
 }
 
+'''
+As `min(Integer[1..*]):Integer[1]`, for `Float` values.
+'''
 function <<PCT.function, functionType.ReducerFunction>> meta::pure::functions::math::min(floats:Float[1..*]):Float[1]
 {
     $floats->fold({f, m | min($f, $m)}, $floats->at(0))
 }
 
+'''
+As `min(Integer[*]):Integer[0..1]`, for `Float` values.
+'''
 function <<PCT.function, functionType.ReducerFunction>> meta::pure::functions::math::min(floats:Float[*]):Float[0..1]
 {
     $floats->fold({f, m | min($f, $m->toOne())}, $floats->first())
 }
 
+'''
+As `min(Integer[1..*]):Integer[1]`, for `Number` values — the form to use when the collection mixes
+`Integer` and `Float`.
+'''
 function <<PCT.function, functionType.ReducerFunction>> meta::pure::functions::math::min(numbers:Number[1..*]):Number[1]
 {
     $numbers->fold({n, m | min($n, $m)}, $numbers->at(0))
 }
 
+'''
+As `min(Number[1..*]):Number[1]`, for a collection that may be empty.
+'''
 function <<PCT.function, functionType.ReducerFunction>> meta::pure::functions::math::min(numbers:Number[*]):Number[0..1]
 {
     $numbers->fold({n, m | min($n, $m->toOne())}, $numbers->first())

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/minBy.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/minBy.pure
@@ -16,16 +16,41 @@ import meta::pure::functions::variant::convert::*;
 import meta::pure::functions::math::mathUtility::*;
 import meta::pure::test::pct::*;
 
-function 
-<<PCT.function, functionType.ReducerFunction>>
-    {
-        doc.doc='Finds the row(s) containing the minimum value for a column and returns the value of another column in that row.'
-    } 
+'''
+The value from one collection that sits where another collection is smallest.
+
+An argmin, and the mirror of `maxBy(T[*], Number[*]):T[0..1]`: `col_containing_minimum` decides which
+position wins, and the value at that position of `col_to_return` is what comes back.
+
+The two collections are positional and must line up. **Returns empty when they are empty**, which is
+why the result is `[0..1]`.
+
+**Parameters**
+- `col_to_return` — the values to choose from.
+- `col_containing_minimum` — the values to compare.
+
+**Returns** the value at the position of the minimum, or empty.
+
+**Examples**
+```pure
+$rel->groupBy(~grp, ~cheapest : x | $x.name : y | $y->minBy($x.price))
+```
+
+**See also** `minBy(T[*], Number[*], Integer[1]):T[*]`,
+`maxBy(T[*], Number[*]):T[0..1]`,
+`min(Number[*]):Number[0..1]`
+'''
+function
+  <<PCT.function, functionType.ReducerFunction>>
 meta::pure::functions::math::minBy<T>(col_to_return:T[*], col_containing_minimum:Number[*]):T[0..1]
 {
   minBy($col_to_return, $col_containing_minimum, 1)->head();
 }
 
+'''
+As `minBy(T[*], Number[*]):T[0..1]`, returning the values at the `n` smallest positions rather than
+just the smallest — a bottom-`n` rather than a bottom-one.
+'''
 function <<PCT.function, functionType.ReducerFunction>> meta::pure::functions::math::minBy<T>(col_to_return:T[*], col_containing_minimum:Number[*], n:Integer[1]): T[*]
 {
   $col_to_return->zip($col_containing_minimum)->sort({x, y | $x.second->compare($y.second)})->slice(0, $n).first;

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/mode.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/mode.pure
@@ -22,11 +22,30 @@ Class <<access.private>> meta::pure::functions::math::Accumulator
    prevCount: Integer[1];   
 }
 
+'''
+The most frequently occurring value in a collection.
+
+Unlike the mean and the median, the mode is always a value that actually appears. **Where several
+values tie for most frequent, one of them is returned rather than all** — which one is decided by the
+sort the implementation performs first, so treat it as unspecified.
+
+Absent values are ignored rather than counted as a value in their own right.
+
+**Parameters**
+- `numbers` — the values.
+
+**Returns** the most frequent value.
+
+**Examples**
+```pure
+mode([1, 2, 2, 3])   // 2
+```
+
+**See also** `median(Number[*]):Float[1]`,
+`mean(Number[*]):Float[1]`
+'''
 function
-<<PCT.function, functionType.ReducerFunction>>
-    {
-        doc.doc='Returns the most frequent value for the values within expr1. NULL values are ignored.'
-    }
+  <<PCT.function, functionType.ReducerFunction>>
 meta::pure::functions::math::mode(numbers:Number[*]):Number[1]
 {
      let sortedNumbers = $numbers->toOneMany()->sort();
@@ -40,6 +59,9 @@ meta::pure::functions::math::mode(numbers:Number[*]):Number[1]
     $res.numMax->cast(@Number);
 }
 
+'''
+As `mode(Number[*]):Number[1]`, for `Float` values.
+'''
 function <<PCT.function, functionType.ReducerFunction>> meta::pure::functions::math::mode(numbers:Float[*]):Float[1]
 {
      let sortedNumbers = $numbers->toOneMany()->sort();
@@ -53,6 +75,9 @@ function <<PCT.function, functionType.ReducerFunction>> meta::pure::functions::m
 }
 
 
+'''
+As `mode(Number[*]):Number[1]`, for `Integer` values.
+'''
 function <<PCT.function, functionType.ReducerFunction>> meta::pure::functions::math::mode(numbers:Integer[*]):Integer[1]
 {
      let sortedNumbers = $numbers->toOneMany()->sort();

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/mode.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/mode.pure
@@ -26,8 +26,8 @@ Class <<access.private>> meta::pure::functions::math::Accumulator
 The most frequently occurring value in a collection.
 
 Unlike the mean and the median, the mode is always a value that actually appears. **Where several
-values tie for most frequent, one of them is returned rather than all** — which one is decided by the
-sort the implementation performs first, so treat it as unspecified.
+values tie for most frequent, one of them is returned rather than all.** Which one is returned is
+unspecified.
 
 Absent values are ignored rather than counted as a value in their own right.
 

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/percentile.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/percentile.pure
@@ -14,6 +14,33 @@
 
 import meta::pure::test::pct::*;
 
+'''
+The value below which a given proportion of a collection falls.
+
+`percentile` is a **fraction between 0 and 1**, not a number out of 100 — pass 0.5 for the median,
+0.95 for the 95th percentile. Values outside that range fail the declared constraint rather than
+being clamped.
+
+Interpolates between the two neighbouring values when the requested position falls between them, and
+reads the collection in ascending order. Pass
+`percentile(Number[*], Float[1], Boolean[1], Boolean[1]):Number[0..1]` to change either.
+
+**Returns empty for an empty collection**, which is why the result is `[0..1]`.
+
+**Parameters**
+- `numbers` — the values.
+- `percentile` — the proportion, between 0 and 1.
+
+**Returns** the value at that percentile, or empty.
+
+**Examples**
+```pure
+percentile([1, 2, 3, 4], 0.5)   // the median
+```
+
+**See also** `percentile(Number[*], Float[1], Boolean[1], Boolean[1]):Number[0..1]`,
+`median(Number[*]):Float[1]`
+'''
 function <<PCT.function, functionType.ReducerFunction>> meta::pure::functions::math::percentile(numbers: Number[*], percentile: Float[1]): Number[0..1]
 [
   ($percentile >= 0) && ($percentile <= 1)
@@ -22,6 +49,23 @@ function <<PCT.function, functionType.ReducerFunction>> meta::pure::functions::m
   percentile($numbers, $percentile, true, true)
 }
 
+'''
+As `percentile(Number[*], Float[1]):Number[0..1]`, with the ordering and the interpolation given
+explicitly rather than left at their defaults of ascending and interpolating.
+
+Set `ascending` to `false` to read the collection from the top, so 0.95 asks for the 95th percentile
+from the largest end. Set `continuous` to `false` to take the nearest actual value rather than
+interpolating between the two neighbours — a discrete percentile always returns a value that appears
+in the collection.
+
+**Parameters**
+- `numbers` — the values.
+- `percentile` — the proportion, between 0 and 1.
+- `ascending` — `true` to read from the smallest end.
+- `continuous` — `true` to interpolate, `false` to take the nearest value.
+
+**Returns** the value at that percentile, or empty.
+'''
 function <<PCT.function, functionType.ReducerFunction>> meta::pure::functions::math::percentile(numbers: Number[*], percentile: Float[1], ascending: Boolean[1], continuous: Boolean[1]): Number[0..1]
 [
   ($percentile >= 0) && ($percentile <= 1)

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/stdDev.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/stdDev.pure
@@ -30,6 +30,12 @@ Takes `[1..*]`, so an empty collection will not compile rather than failing at r
 
 **Returns** the standard deviation.
 
+**Examples**
+```pure
+stdDev([1, 2, 3], true)    // 1.0, the sample form
+stdDev([1, 2], false)      // 0.5, the population form
+```
+
 **See also** `stdDevSample(Number[1..*]):Number[1]`,
 `stdDevPopulation(Number[1..*]):Number[1]`,
 `variance(Number[*], Boolean[1]):Number[1]`

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/stdDev.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/stdDev.pure
@@ -14,6 +14,26 @@
 
 import meta::pure::test::pct::*;
 
+'''
+The standard deviation of a collection, sample or population depending on the flag.
+
+The square root of `variance(Number[*], Boolean[1]):Number[1]`, and `isBiasCorrected` means the same
+thing: `true` divides by `n - 1` for a **sample** standard deviation, `false` by `n` for a
+**population** one. Prefer the named `stdDevSample(Number[1..*]):Number[1]` and
+`stdDevPopulation(Number[1..*]):Number[1]`, which say which they mean.
+
+Takes `[1..*]`, so an empty collection will not compile rather than failing at runtime.
+
+**Parameters**
+- `numbers` — the values, at least one.
+- `isBiasCorrected` — `true` for the sample standard deviation, `false` for the population one.
+
+**Returns** the standard deviation.
+
+**See also** `stdDevSample(Number[1..*]):Number[1]`,
+`stdDevPopulation(Number[1..*]):Number[1]`,
+`variance(Number[*], Boolean[1]):Number[1]`
+'''
 function <<PCT.function, functionType.ReducerFunction>> meta::pure::functions::math::stdDev(numbers:Number[1..*], isBiasCorrected: Boolean[1]):Number[1]
 {
     sqrt(variance($numbers, $isBiasCorrected));

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/stdDevPopulation.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/stdDevPopulation.pure
@@ -28,6 +28,12 @@ Takes `[1..*]`, so an empty collection will not compile.
 
 **Returns** the population standard deviation.
 
+**Examples**
+```pure
+stdDevPopulation([1, 2])   // 0.5
+stdDevPopulation([2, 4])   // 1.0
+```
+
 **See also** `stdDevSample(Number[1..*]):Number[1]`,
 `variancePopulation(Number[*]):Number[1]`
 '''
@@ -63,6 +69,11 @@ the current row, making this a running figure.
 - `colToAgg` — the column to measure.
 
 **Returns** the population standard deviation within the window.
+
+**Examples**
+```pure
+$rel->extend(over(~grp), ~spread : {p, w, r| $p->stdDevPopulation($w, $r, ~value)})
+```
 
 **See also** `stdDevPopulation(Number[1..*]):Number[1]`,
 `zScore(Relation<T>[1], _Window<T>[1], T[1], ColSpec<(?:Number)⊆T>[1]):Float[1]`

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/stdDevPopulation.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/stdDevPopulation.pure
@@ -15,16 +15,6 @@
 import meta::pure::test::pct::*;
 
 '''
-As `stdDevPopulation(Number[1..*]):Number[1]`, accepting a collection that may be empty.
-'''
-function
-  <<PCT.function, functionType.ReducerFunction>>
-meta::pure::functions::math::stdDevPopulation(numbers:Number[*]):Number[1]
-{
-    meta::pure::functions::math::stdDev($numbers->toOneMany(), false);
-}
-
-'''
 The population standard deviation of a collection.
 
 `stdDev(Number[1..*], Boolean[1]):Number[1]` with the bias correction off — the square root of the
@@ -44,6 +34,16 @@ Takes `[1..*]`, so an empty collection will not compile.
 function <<PCT.function, functionType.ReducerFunction>> meta::pure::functions::math::stdDevPopulation(numbers:Number[1..*]):Number[1]
 {
     meta::pure::functions::math::stdDev($numbers, false);
+}
+
+'''
+As `stdDevPopulation(Number[1..*]):Number[1]`, accepting a collection that may be empty.
+'''
+function
+  <<PCT.function, functionType.ReducerFunction>>
+meta::pure::functions::math::stdDevPopulation(numbers:Number[*]):Number[1]
+{
+    meta::pure::functions::math::stdDev($numbers->toOneMany(), false);
 }
 
 '''

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/stdDevPopulation.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/stdDevPopulation.pure
@@ -14,22 +14,62 @@
 
 import meta::pure::test::pct::*;
 
+'''
+As `stdDevPopulation(Number[1..*]):Number[1]`, accepting a collection that may be empty.
+'''
 function
-<<PCT.function, functionType.ReducerFunction>>
-    {
-        doc.doc='Returns the population standard deviation (square root of variance) of non-NULL values.'
-    }
+  <<PCT.function, functionType.ReducerFunction>>
 meta::pure::functions::math::stdDevPopulation(numbers:Number[*]):Number[1]
 {
     meta::pure::functions::math::stdDev($numbers->toOneMany(), false);
 }
 
+'''
+The population standard deviation of a collection.
+
+`stdDev(Number[1..*], Boolean[1]):Number[1]` with the bias correction off — the square root of the
+population variance, dividing by `n`. Use it when the values are the whole population rather than a
+sample.
+
+Takes `[1..*]`, so an empty collection will not compile.
+
+**Parameters**
+- `numbers` — the values, at least one.
+
+**Returns** the population standard deviation.
+
+**See also** `stdDevSample(Number[1..*]):Number[1]`,
+`variancePopulation(Number[*]):Number[1]`
+'''
 function <<PCT.function, functionType.ReducerFunction>> meta::pure::functions::math::stdDevPopulation(numbers:Number[1..*]):Number[1]
 {
     meta::pure::functions::math::stdDev($numbers, false);
 }
 
-function <<PCT.function>> {doc.doc='Returns the population standard deviation (square root of variance) of non-NULL values on the given column of the current window, and frame for the current row'} meta::pure::functions::math::stdDevPopulation<T>(partition: meta::pure::metamodel::relation::Relation<T>[1], window: meta::pure::functions::relation::_Window<T>[1], row: T[1], colToAgg:meta::pure::metamodel::relation::ColSpec<(?:Number)⊆T>[1]):Number[1]
+'''
+The population standard deviation of a column's values within the current window.
+
+This is the window form: it is called from inside an `extend` with a window, receiving the partition,
+the window and the current row, and reads its values from `colToAgg` rather than from a collection
+argument.
+
+Absent values are skipped. As elsewhere, an unframed window runs from the start of the partition to
+the current row, making this a running figure.
+
+**Parameters**
+- `partition` — the partition, supplied by `extend`.
+- `window` — the window, supplied by `extend`.
+- `row` — the current row, supplied by `extend`.
+- `colToAgg` — the column to measure.
+
+**Returns** the population standard deviation within the window.
+
+**See also** `stdDevPopulation(Number[1..*]):Number[1]`,
+`zScore(Relation<T>[1], _Window<T>[1], T[1], ColSpec<(?:Number)⊆T>[1]):Float[1]`
+'''
+function
+  <<PCT.function>>
+meta::pure::functions::math::stdDevPopulation<T>(partition: meta::pure::metamodel::relation::Relation<T>[1], window: meta::pure::functions::relation::_Window<T>[1], row: T[1], colToAgg:meta::pure::metamodel::relation::ColSpec<(?:Number)⊆T>[1]):Number[1]
 {
     reduce($partition, $window, $row, x|eval($colToAgg, $x), y|$y->stdDevPopulation());
 }

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/stdDevSample.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/stdDevSample.pure
@@ -14,16 +14,31 @@
 
 import meta::pure::test::pct::*;
 
+'''
+As `stdDevSample(Number[1..*]):Number[1]`, accepting a collection that may be empty.
+'''
 function
-<<PCT.function, functionType.ReducerFunction>>
-    {
-        doc.doc='Returns the sample standard deviation (square root of sample variance) of non-NULL values.'
-    }
+  <<PCT.function, functionType.ReducerFunction>>
 meta::pure::functions::math::stdDevSample(numbers:Number[*]):Number[1]
 {
     meta::pure::functions::math::stdDev($numbers->toOneMany(), true);
 }
 
+'''
+The sample standard deviation of a collection.
+
+`stdDev(Number[1..*], Boolean[1]):Number[1]` with the bias correction on — the square root of the
+sample variance, dividing by `n - 1`. Use it when the values are a sample and you are estimating the
+spread of the population they came from.
+
+**Parameters**
+- `numbers` — the values, at least one.
+
+**Returns** the sample standard deviation.
+
+**See also** `stdDevPopulation(Number[1..*]):Number[1]`,
+`varianceSample(Number[*]):Number[1]`
+'''
 function <<PCT.function, functionType.ReducerFunction>> meta::pure::functions::math::stdDevSample(numbers:Number[1..*]):Number[1]
 {
     meta::pure::functions::math::stdDev($numbers, true);

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/stdDevSample.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/stdDevSample.pure
@@ -15,16 +15,6 @@
 import meta::pure::test::pct::*;
 
 '''
-As `stdDevSample(Number[1..*]):Number[1]`, accepting a collection that may be empty.
-'''
-function
-  <<PCT.function, functionType.ReducerFunction>>
-meta::pure::functions::math::stdDevSample(numbers:Number[*]):Number[1]
-{
-    meta::pure::functions::math::stdDev($numbers->toOneMany(), true);
-}
-
-'''
 The sample standard deviation of a collection.
 
 `stdDev(Number[1..*], Boolean[1]):Number[1]` with the bias correction on — the square root of the
@@ -42,6 +32,16 @@ spread of the population they came from.
 function <<PCT.function, functionType.ReducerFunction>> meta::pure::functions::math::stdDevSample(numbers:Number[1..*]):Number[1]
 {
     meta::pure::functions::math::stdDev($numbers, true);
+}
+
+'''
+As `stdDevSample(Number[1..*]):Number[1]`, accepting a collection that may be empty.
+'''
+function
+  <<PCT.function, functionType.ReducerFunction>>
+meta::pure::functions::math::stdDevSample(numbers:Number[*]):Number[1]
+{
+    meta::pure::functions::math::stdDev($numbers->toOneMany(), true);
 }
 
 function <<PCT.test>> meta::pure::functions::math::tests::stdDev::testIntStdDev<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/stdDevSample.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/stdDevSample.pure
@@ -26,6 +26,13 @@ spread of the population they came from.
 
 **Returns** the sample standard deviation.
 
+**Examples**
+```pure
+stdDevSample([1, 2, 3])          // 1.0
+stdDevSample([2, 4, 6])          // 2.0
+stdDevSample([3.14, 6.28, 9.42]) // 3.14
+```
+
 **See also** `stdDevPopulation(Number[1..*]):Number[1]`,
 `varianceSample(Number[*]):Number[1]`
 '''

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/sum.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/sum.pure
@@ -14,16 +14,47 @@
 
 import meta::pure::test::pct::*;
 
+'''
+The total of a collection of numbers.
+
+**An empty collection gives 0, not empty**, which is why the result is `[1]` — `sum` is defined in
+terms of `plus`, whose identity is zero. That means a sum of no rows is indistinguishable from a sum
+of rows that happen to cancel; test the collection separately if the difference matters.
+
+The `Integer` and `Float` variants keep their type; this one accepts a mix and returns `Number`.
+
+This is an aggregate: it is what a relational `groupBy` or a window aggregation calls.
+
+**Parameters**
+- `numbers` — the values to total.
+
+**Returns** the total, or 0 when there are none.
+
+**Examples**
+```pure
+sum([15, 13, 2.0, 1, 1.0])   // 32.0
+```
+
+**See also** `sum(Integer[*]):Integer[1]`,
+`average(Number[*]):Float[1]`,
+`max(Number[*]):Number[0..1]`
+'''
 function <<PCT.function, functionType.ReducerFunction>> meta::pure::functions::math::sum(numbers:Number[*]):Number[1]
 {
     $numbers->plus();
 }
 
+'''
+As `sum(Number[*]):Number[1]`, for `Integer` values, returning an `Integer`.
+'''
 function <<PCT.function, functionType.ReducerFunction>> meta::pure::functions::math::sum(numbers:Integer[*]):Integer[1]
 {
     $numbers->plus();
 }
 
+'''
+As `sum(Number[*]):Number[1]`, for `Float` values, returning a `Float`.
+'''
 function <<PCT.function, functionType.ReducerFunction>> meta::pure::functions::math::sum(numbers:Float[*]):Float[1]
 {
     $numbers->plus();

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/sum.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/sum.pure
@@ -15,11 +15,11 @@
 import meta::pure::test::pct::*;
 
 '''
-The total of a collection of numbers.
+The sum of a collection of numbers.
 
 **An empty collection gives 0, not empty**, which is why the result is `[1]` — `sum` is defined in
-terms of `plus`, whose identity is zero. That means a sum of no rows is indistinguishable from a sum
-of rows that happen to cancel; test the collection separately if the difference matters.
+terms of `plus`, whose identity is zero. That means a sum of no values is indistinguishable from a sum
+of values that happen to cancel; test the collection separately if the difference matters.
 
 The `Integer` and `Float` variants keep their type; this one accepts a mix and returns `Number`.
 

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/variance.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/variance.pure
@@ -14,6 +14,33 @@
 
 import meta::pure::test::pct::*;
 
+'''
+The variance of a collection, sample or population depending on the flag.
+
+`isBiasCorrected` selects the divisor: `true` divides by `n - 1` for a **sample** variance, `false`
+by `n` for a **population** variance. Prefer the named
+`varianceSample(Number[*]):Number[1]` and `variancePopulation(Number[*]):Number[1]` in ordinary code,
+which say which one they mean.
+
+**A single value gives 0 either way**, short-circuiting the division by `n - 1` that would otherwise
+fail for a sample variance.
+
+**Parameters**
+- `numbers` — the values.
+- `isBiasCorrected` — `true` for the sample variance, `false` for the population variance.
+
+**Returns** the variance.
+
+**Examples**
+```pure
+variance([1, 2], false)   // 0.25, dividing by n
+variance([1, 2], true)    // 0.5,  dividing by n - 1
+```
+
+**See also** `varianceSample(Number[*]):Number[1]`,
+`variancePopulation(Number[*]):Number[1]`,
+`stdDev(Number[1..*], Boolean[1]):Number[1]`
+'''
 function <<PCT.function, functionType.ReducerFunction>> meta::pure::functions::math::variance(numbers:Number[*], isBiasCorrected: Boolean[1]):Number[1]
 {
     if ($numbers->size() == 1,

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/variancePopulation.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/variancePopulation.pure
@@ -14,6 +14,27 @@
 
 import meta::pure::test::pct::*;
 
+'''
+The population variance of a collection.
+
+`variance(Number[*], Boolean[1]):Number[1]` with the bias correction off — the sum of squared
+deviations divided by `n`. Use this when the values are the whole population rather than a sample
+drawn from one.
+
+**Parameters**
+- `numbers` — the values.
+
+**Returns** the population variance.
+
+**Examples**
+```pure
+variancePopulation([1, 2])   // 0.25
+```
+
+**See also** `varianceSample(Number[*]):Number[1]`,
+`stdDevPopulation(Number[1..*]):Number[1]`,
+`variance(Number[*], Boolean[1]):Number[1]`
+'''
 function <<PCT.function, functionType.ReducerFunction>> meta::pure::functions::math::variancePopulation(numbers:Number[*]):Number[1]
 {
    variance($numbers, false);

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/varianceSample.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/varianceSample.pure
@@ -14,6 +14,27 @@
 
 import meta::pure::test::pct::*;
 
+'''
+The sample variance of a collection.
+
+`variance(Number[*], Boolean[1]):Number[1]` with the bias correction on — the sum of squared
+deviations divided by `n - 1`. Use this when the values are a sample and you are estimating the
+variance of the population they came from.
+
+**Parameters**
+- `numbers` — the values.
+
+**Returns** the sample variance.
+
+**Examples**
+```pure
+varianceSample([1, 2])   // 0.5
+```
+
+**See also** `variancePopulation(Number[*]):Number[1]`,
+`stdDevSample(Number[1..*]):Number[1]`,
+`variance(Number[*], Boolean[1]):Number[1]`
+'''
 function <<PCT.function, functionType.ReducerFunction>>  meta::pure::functions::math::varianceSample(numbers:Number[*]):Number[1]
 {
    variance($numbers, true);

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/wavg.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/wavg.pure
@@ -15,10 +15,32 @@
 import meta::pure::test::pct::*;
 import meta::pure::tds::extensions::*;
 
-function 
-<<PCT.function, functionType.ReducerFunction>>
+'''
+The weighted average of a series, each value counting in proportion to its weight.
+
+The sum of value times weight, divided by the sum of the weights. Use it where the values are not
+equally representative — averaging prices by traded volume, or rates by notional.
+
+The two collections are positional and are paired by index. **It fails rather than returning empty**
+in three cases: either collection empty, the two differing in length, or the weights summing to zero.
+
+**Parameters**
+- `numbers` — the values to average.
+- `weights` — the weight of each value, paired by position.
+
+**Returns** the weighted average.
+
+**Examples**
+```pure
+wavg([10, 20], [1, 3])   // 17.5, the second value counting three times
+```
+
+**See also** `average(Number[*]):Float[1]`,
+`sum(Number[*]):Number[1]`
+'''
+function
+    <<PCT.function, functionType.ReducerFunction>>
     {
-        doc.doc='Performs weighted average on a given data field with its respective weight field',
         PCT.grammarDoc='wavg is used by wavg(Number[*], Number[*])'
     }
 meta::pure::functions::math::wavg(numbers:Number[*], weights:Number[*]):Float[1]

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/zScore.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/aggregator/zScore.pure
@@ -17,9 +17,35 @@ import meta::pure::metamodel::relation::*;
 import meta::pure::functions::relation::*;
 import meta::pure::functions::math::*;
 
+'''
+How many standard deviations a value sits from the mean of its window.
+
+0 means the value equals the mean; positive is above it and negative below. Normalising this way
+makes values from differently-scaled columns comparable, which is why it is the usual basis for
+outlier detection — a threshold such as 3 means the same thing whatever the units.
+
+This is the window form: it is called from inside an `extend` with a window, receiving the partition,
+the window and the current row, and reads its values from `colToAgg` rather than from a collection
+argument.
+
+**Parameters**
+- `partition` — the partition, supplied by `extend`.
+- `window` — the window, supplied by `extend`.
+- `row` — the current row, supplied by `extend`.
+- `colToZScore` — the column to score.
+
+**Returns** the z-score of this row's value.
+
+**Examples**
+```pure
+$rel->extend(over(~grp), ~z : {p, w, r| $p->zScore($w, $r, ~value)})
+```
+
+**See also** `stdDevPopulation(Number[*]):Number[1]`,
+`average(Number[*]):Float[1]`
+'''
 function
-<<PCT.function>>
-{doc.doc='Returns how many standard deviations a value is from the mean within its window partition. A z-score of 0 indicates the value equals the mean; positive values are above average, negative below. Commonly used for outlier detection and normalizing data.'}
+  <<PCT.function>>
 meta::pure::functions::math::zScore<T>(partition: Relation<T>[1], window: _Window<T>[1], row: T[1], colToZScore:ColSpec<(?:Number)⊆T>[1]):Float[1]
 {
     (eval($colToZScore, $row)->toOne() - average($partition, $window, $row, $colToZScore)) / max(stdDevPopulation($partition, $window, $row, $colToZScore), 0.0000000001)

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/numeric/pi.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/numeric/pi.pure
@@ -14,6 +14,20 @@
 
 import meta::pure::test::pct::*;
 
+'''
+The constant π.
+
+**Returns** π as a `Float`.
+
+**Examples**
+```pure
+pi()                    // 3.141592653589793
+180->toRadians()        // pi()
+```
+
+**See also** `toRadians(Number[1]):Float[1]`,
+`toDegrees(Number[1]):Float[1]`
+'''
 function <<PCT.function>> meta::pure::functions::math::pi():Float[1]
 {
     3.141592653589793;

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/numeric/toDegrees.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/numeric/toDegrees.pure
@@ -14,6 +14,25 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Converts an angle from radians to degrees.
+
+The inverse of `toRadians(Number[1]):Float[1]`, for presenting an angle that the trigonometric
+functions produced in radians.
+
+**Parameters**
+- `radians` — the angle in radians.
+
+**Returns** the angle in degrees.
+
+**Examples**
+```pure
+pi()->toDegrees()   // 180.0
+```
+
+**See also** `toRadians(Number[1]):Float[1]`,
+`pi():Float[1]`
+'''
 function <<PCT.function>> meta::pure::functions::math::toDegrees(radians:Number[1]):Float[1]
 {
     $radians * 180 / pi();

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/numeric/toRadians.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/numeric/toRadians.pure
@@ -14,6 +14,26 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Converts an angle from degrees to radians.
+
+The trigonometric functions all take radians, so this is the usual first step when an angle arrives
+in degrees.
+
+**Parameters**
+- `degrees` — the angle in degrees.
+
+**Returns** the angle in radians.
+
+**Examples**
+```pure
+180->toRadians()   // pi()
+90->toRadians()    // pi() / 2
+```
+
+**See also** `toDegrees(Number[1]):Float[1]`,
+`pi():Float[1]`
+'''
 function <<PCT.function>> meta::pure::functions::math::toRadians(degrees:Number[1]):Float[1]
 {
     $degrees * pi() / 180;

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/trigonometry/cosh.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/trigonometry/cosh.pure
@@ -14,11 +14,28 @@
 
 import meta::pure::test::pct::*;
 
+'''
+The hyperbolic cosine of a number.
+
+`(e^x + e^-x) / 2`. Unlike the circular cosine it is unbounded, and **never returns less than 1** —
+`cosh(0)` is its minimum.
+
+**Parameters**
+- `number` — the argument, in radians.
+
+**Returns** the hyperbolic cosine.
+
+**Examples**
+```pure
+cosh(0)   // 1.0
+```
+
+**See also** `sinh(Number[1]):Float[1]`,
+`cosh(Number[1]):Float[1]`,
+`tanh(Number[1]):Float[1]`
+'''
 native function
     <<PCT.function>>
-    {
-        doc.doc='cosh returns the hyperbolic cosine of a number'
-    }
 meta::pure::functions::math::cosh(number:Number[1]):Float[1];
 
 function <<PCT.test>> meta::pure::functions::math::tests::trigonometry::cosh::testCosH_Identities<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/trigonometry/sinh.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/trigonometry/sinh.pure
@@ -14,11 +14,27 @@
 
 import meta::pure::test::pct::*;
 
+'''
+The hyperbolic sine of a number.
+
+`(e^x - e^-x) / 2`. Odd and unbounded: negating the argument negates the result, and `sinh(0)` is 0.
+
+**Parameters**
+- `number` — the argument, in radians.
+
+**Returns** the hyperbolic sine.
+
+**Examples**
+```pure
+sinh(0)   // 0.0
+```
+
+**See also** `sinh(Number[1]):Float[1]`,
+`cosh(Number[1]):Float[1]`,
+`tanh(Number[1]):Float[1]`
+'''
 native function
     <<PCT.function>>
-    {
-        doc.doc='sinh returns the hyperbolic sine of a number'
-    }
 meta::pure::functions::math::sinh(number:Number[1]):Float[1];
 
 function <<PCT.test>> meta::pure::functions::math::tests::trigonometry::sinh::testSinH_Identities<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/trigonometry/tanh.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/math/trigonometry/tanh.pure
@@ -14,11 +14,28 @@
 
 import meta::pure::test::pct::*;
 
+'''
+The hyperbolic tangent of a number.
+
+`sinh(x) / cosh(x)`. **Bounded strictly between -1 and 1**, approaching them as the argument grows in
+either direction, which is what makes it a common squashing function.
+
+**Parameters**
+- `number` — the argument, in radians.
+
+**Returns** the hyperbolic tangent.
+
+**Examples**
+```pure
+tanh(0)   // 0.0
+```
+
+**See also** `sinh(Number[1]):Float[1]`,
+`cosh(Number[1]):Float[1]`,
+`tanh(Number[1]):Float[1]`
+'''
 native function
     <<PCT.function>>
-    {
-        doc.doc='tanh returns the hyperbolic tangent of a number'
-    }
 meta::pure::functions::math::tanh(number:Number[1]):Float[1];
 
 function <<PCT.test>> meta::pure::functions::math::tests::trigonometry::tanh::testTanH_Identities<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/tbd/bitAnd.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/tbd/bitAnd.pure
@@ -14,11 +14,30 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Bitwise AND of two integers.
+
+Each bit of the result is 1 only where that bit is 1 in both arguments. The usual use is masking —
+keeping the bits a flag word sets and clearing the rest.
+
+**Parameters**
+- `arg1` — the first operand.
+- `arg2` — the second operand.
+
+**Returns** the bitwise AND.
+
+**Examples**
+```pure
+bitAnd(5, 6)     // 4, binary 101 AND 110
+bitAnd(1, 0)     // 0
+```
+
+**See also** `bitAnd(Integer[1], Integer[1]):Integer[1]`,
+`bitOr(Integer[1], Integer[1]):Integer[1]`,
+`bitXor(Integer[1], Integer[1]):Integer[1]`
+'''
 native function
     <<PCT.function>>
-    {
-        doc.doc='bitwise AND operator returns a Number representing the bitwise AND of the Number input params'
-    }
 meta::pure::functions::math::bitAnd(arg1:Integer[1], arg2:Integer[1]):Integer[1];
 
 function <<PCT.test>> meta::pure::functions::math::tests::bitAnd::testBitAnd_SmallNumbers<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/tbd/bitNot.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/tbd/bitNot.pure
@@ -14,11 +14,30 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Bitwise NOT of an integer.
+
+Inverts every bit. Integers are signed and two's complement, so **the result of inverting a
+non-negative number is negative**: `bitNot(n)` is `-n - 1`, not a positive number with the low bits
+flipped.
+
+**Parameters**
+- `arg` — the operand.
+
+**Returns** the bitwise complement.
+
+**Examples**
+```pure
+bitNot(0)    // -1
+bitNot(5)    // -6
+bitNot(25)   // -26
+```
+
+**See also** `bitAnd(Integer[1], Integer[1]):Integer[1]`,
+`bitXor(Integer[1], Integer[1]):Integer[1]`
+'''
 native function
     <<PCT.function>>
-    {
-        doc.doc='bitwise NOT operator returns a Number representing the bitwise NOT of the Number input param'
-    }
 meta::pure::functions::math::bitNot(arg:Integer[1]):Integer[1];
 
 function <<PCT.test>> meta::pure::functions::math::tests::bitNot::testBitNot_SmallNumbers<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/tbd/bitOr.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/tbd/bitOr.pure
@@ -14,11 +14,30 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Bitwise OR of two integers.
+
+Each bit of the result is 1 where that bit is 1 in either argument — the way to set flags in a bit
+field without disturbing the others.
+
+**Parameters**
+- `arg1` — the first operand.
+- `arg2` — the second operand.
+
+**Returns** the bitwise OR.
+
+**Examples**
+```pure
+bitOr(5, 6)     // 7, binary 101 OR 110
+bitOr(25, 11)   // 27
+```
+
+**See also** `bitAnd(Integer[1], Integer[1]):Integer[1]`,
+`bitOr(Integer[1], Integer[1]):Integer[1]`,
+`bitXor(Integer[1], Integer[1]):Integer[1]`
+'''
 native function
     <<PCT.function>>
-    {
-        doc.doc='bitwise OR operator returns an Number representing the bitwise OR of the Number input params'
-    }
 meta::pure::functions::math::bitOr(arg1:Integer[1], arg2:Integer[1]):Integer[1];
 
 function <<PCT.test>> meta::pure::functions::math::tests::bitOr::testBitOr_SmallNumbers<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/tbd/bitShiftLeft.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/tbd/bitShiftLeft.pure
@@ -14,11 +14,28 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Shifts an integer's bits left by a given number of places.
+
+Each place doubles the value, so shifting left by `n` multiplies by 2 to the power `n` — until bits
+run off the top of a signed 64-bit integer, where the result wraps rather than saturating.
+
+**Parameters**
+- `arg` — the value to shift.
+- `n` — how many places to shift.
+
+**Returns** the shifted value.
+
+**Examples**
+```pure
+bitShiftLeft(1, 0)   // 1
+bitShiftLeft(1, 3)   // 8
+```
+
+**See also** `bitShiftRight(Integer[1], Integer[1]):Integer[1]`
+'''
 native function
     <<PCT.function>>
-    {
-        doc.doc='bitwise LEFT SHIFT operator returns a Number representing the arg Number input shifted by n bits to the LEFT'
-    }
 meta::pure::functions::math::bitShiftLeft(arg:Integer[1], n:Integer[1]):Integer[1];
 
 function <<PCT.test>> meta::pure::functions::math::tests::bitShiftLeft::testBitShiftLeft_UpTo62Bits<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/tbd/bitShiftRight.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/tbd/bitShiftRight.pure
@@ -14,11 +14,30 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Shifts an integer's bits right by a given number of places.
+
+Each place halves the value, discarding the bits shifted off the bottom, so it is a division by 2 to
+the power `n` that rounds towards negative infinity rather than towards zero. Shifting by 0 returns
+the value unchanged.
+
+**Parameters**
+- `arg` — the value to shift.
+- `n` — how many places to shift.
+
+**Returns** the shifted value.
+
+**Examples**
+```pure
+bitShiftRight(1, 0)   // 1
+bitShiftRight(1, 1)   // 0, the low bit is discarded
+bitShiftRight(9223372036854775807, 62)   // 1
+```
+
+**See also** `bitShiftLeft(Integer[1], Integer[1]):Integer[1]`
+'''
 native function
     <<PCT.function>>
-    {
-        doc.doc='bitwise RIGHT SHIFT operator returns a Number representing the arg Number input shifted by n bits to the RIGHT'
-    }
 meta::pure::functions::math::bitShiftRight(arg:Integer[1], n:Integer[1]):Integer[1];
 
 function <<PCT.test>> meta::pure::functions::math::tests::bitShiftRight::testBitShiftRight_UpTo62Bits<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/tbd/bitXor.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/tbd/bitXor.pure
@@ -14,11 +14,30 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Bitwise exclusive OR of two integers.
+
+Each bit of the result is 1 where that bit differs between the arguments. Applying the same operand
+twice restores the original value, which is what makes it useful for toggling flags.
+
+**Parameters**
+- `arg1` — the first operand.
+- `arg2` — the second operand.
+
+**Returns** the bitwise XOR.
+
+**Examples**
+```pure
+bitXor(5, 6)     // 3, binary 101 XOR 110
+bitXor(25, 11)   // 18
+```
+
+**See also** `bitAnd(Integer[1], Integer[1]):Integer[1]`,
+`bitOr(Integer[1], Integer[1]):Integer[1]`,
+`bitXor(Integer[1], Integer[1]):Integer[1]`
+'''
 native function
     <<PCT.function>>
-    {
-        doc.doc='bitwise XOR operator returns an Number representing the bitwise XOR of the Number input params'
-    }
 meta::pure::functions::math::bitXor(arg1:Integer[1], arg2:Integer[1]):Integer[1];
 
 function <<PCT.test>> meta::pure::functions::math::tests::bitXor::testBitXor_SmallNumbers<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/tbd/generateGuid.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/tbd/generateGuid.pure
@@ -24,6 +24,12 @@ the same result.
 
 **Returns** a new GUID, as a string.
 
+**Examples**
+```pure
+// no example can pin an output — every call gives a different one
+$rel->extend(~uid : x | generateGuid())   // a distinct identifier on each row
+```
+
 **See also** `meta::pure::functions::hash::hashCode(Any[*]):Integer[1]`
 '''
 native function <<PCT.function, functionType.SideEffectFunction>> meta::pure::functions::string::generation::generateGuid():String[1];

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/tbd/generateGuid.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/tbd/generateGuid.pure
@@ -15,6 +15,17 @@
 
 import meta::pure::test::pct::*;
 
+'''
+A freshly generated globally unique identifier.
+
+**This is not a pure function** — it is stereotyped `SideEffectFunction` and returns a different
+value on every call, so two calls never agree and a query using it cannot be cached or replayed to
+the same result.
+
+**Returns** a new GUID, as a string.
+
+**See also** `meta::pure::functions::hash::hashCode(Any[*]):Integer[1]`
+'''
 native function <<PCT.function, functionType.SideEffectFunction>> meta::pure::functions::string::generation::generateGuid():String[1];
 
 

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/tbd/hashCode.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/tbd/hashCode.pure
@@ -15,7 +15,26 @@
 import meta::pure::test::pct::*;
 import meta::pure::functions::hash::*;
 
-native function <<PCT.function>> {doc.doc = ''}
+'''
+A hash code for a collection of values.
+
+For bucketing, partitioning and cheap equality pre-checks — not for cryptographic use, where
+`meta::pure::functions::hash::hash(String[1], HashType[1]):String[1]` is the right tool.
+
+**Nesting does not affect the result**: a collection is flattened before hashing, so `[10]` and
+`[[10]]` hash alike.
+
+Equal values hash alike, but the converse does not hold — a collision means only that two inputs may
+be equal.
+
+**Parameters**
+- `vals` — the values to hash.
+
+**Returns** the hash code.
+
+**See also** `hash(String[1], HashType[1]):String[1]`
+'''
+native function <<PCT.function>>
   meta::pure::functions::hash::hashCode(vals:Any[*]):Integer[1];
 
 function <<PCT.test>> meta::pure::functions::hashCode::tests::testHashCode<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/tbd/hashCode.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/tbd/hashCode.pure
@@ -32,6 +32,12 @@ be equal.
 
 **Returns** the hash code.
 
+**Examples**
+```pure
+hashCode([10]) == hashCode([[10]])   // true, nesting is flattened away
+hashCode([])                         // a value, not empty
+```
+
 **See also** `hash(String[1], HashType[1]):String[1]`
 '''
 native function <<PCT.function>>

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-functions-unclassified-pure/src/main/resources/core_functions_unclassified/flow/coalesce.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-functions-unclassified-pure/src/main/resources/core_functions_unclassified/flow/coalesce.pure
@@ -15,31 +15,79 @@
 import meta::pure::functions::flow::*;
 import meta::pure::test::pct::*;
 
+'''
+The first argument that is not empty.
+
+The way to supply a fallback for a value that may be absent, without writing an `if` on `isEmpty`.
+Arguments are tried left to right and the first present one wins; only emptiness is considered, so a
+value that is present but zero, `false` or `''` is still returned.
+
+**The last argument decides the result's multiplicity.** Where it is `[1]`, as here, a result is
+guaranteed and the call satisfies a `[1]` use site with no `toOne` — which is the reason to prefer
+this overload. Where it is `[0..1]`, as in `coalesce(T[0..1], T[0..1]):T[0..1]`, everything may be
+absent and the result may be empty.
+
+Overloads take up to four arguments. All share these semantics; they differ only in how many values
+they try and in the multiplicity of the last.
+
+**Parameters**
+- `value` — the value to use when present.
+- `ifEmpty` — the fallback, which must be present.
+
+**Returns** `value` when present, otherwise `ifEmpty`.
+
+**Examples**
+```pure
+coalesce('hello', 'world')   // 'hello'
+coalesce([], 'world')        // 'world'
+```
+
+**See also** `coalesce(T[0..1], T[0..1]):T[0..1]`,
+`coalesce(T[0..1], T[0..1], T[1]):T[1]`
+'''
 function <<PCT.function>> meta::pure::functions::flow::coalesce<T>(value: T[0..1], ifEmpty: T[1]): T[1]
 {
     if($value->isEmpty(), |$ifEmpty, |$value->toOne());
 }
 
+'''
+As `coalesce(T[0..1], T[1]):T[1]`, trying two values before the fallback.
+'''
 function <<PCT.function>> meta::pure::functions::flow::coalesce<T>(value1: T[0..1], value2: T[0..1], ifEmpty: T[1]): T[1]
 {
     coalesce($value1, coalesce($value2, $ifEmpty));
 }
 
+'''
+As `coalesce(T[0..1], T[1]):T[1]`, trying three values before the fallback.
+'''
 function <<PCT.function>> meta::pure::functions::flow::coalesce<T>(value1: T[0..1], value2: T[0..1], value3: T[0..1], ifEmpty: T[1]): T[1]
 {
     coalesce($value1, coalesce($value2, $value3, $ifEmpty));
 }
 
+'''
+As `coalesce(T[0..1], T[1]):T[1]`, but the fallback may itself be absent, so **the result may be
+empty** — `coalesce([], [])` gives empty rather than failing.
+'''
 function <<PCT.function>> meta::pure::functions::flow::coalesce<T>(value: T[0..1], ifEmpty: T[0..1]): T[0..1]
 {
     if($value->isEmpty(), |$ifEmpty, |$value);
 }
 
+'''
+As `coalesce(T[0..1], T[0..1]):T[0..1]`, trying two values before the fallback. The result may be
+empty.
+'''
 function <<PCT.function>> meta::pure::functions::flow::coalesce<T>(value1: T[0..1], value2: T[0..1], ifEmpty: T[0..1]): T[0..1]
 {
     coalesce($value1, coalesce($value2, $ifEmpty));
 }
 
+'''
+As `coalesce(T[0..1], T[0..1]):T[0..1]`, trying three values before the fallback. The result may be
+empty.
+'''
 function <<PCT.function>> meta::pure::functions::flow::coalesce<T>(value1: T[0..1], value2: T[0..1], value3: T[0..1], ifEmpty: T[0..1]): T[0..1]
 {
     coalesce($value1, coalesce($value2, $value3, $ifEmpty));

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-functions-unclassified-pure/src/main/resources/core_functions_unclassified/hash/hash.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-functions-unclassified-pure/src/main/resources/core_functions_unclassified/hash/hash.pure
@@ -22,7 +22,33 @@ Enum meta::pure::functions::hash::HashType
     SHA256
 }
 
-native function <<PCT.function>> {doc.doc = 'Computes the hash of the given text using the specified hash algorithm (MD5, SHA1, or SHA256) and returns the resulting hash as a string.'}
+'''
+Hashes text with MD5, SHA1 or SHA256.
+
+The digest comes back as **lower case** hexadecimal, so compare against a lower cased expectation or
+case-fold both sides. Its length is fixed by the algorithm: 32 characters for MD5, 40 for SHA1, 64
+for SHA256.
+
+MD5 and SHA1 are here for interoperating with systems that already use them — checksums, cache keys,
+partitioning. Neither is collision resistant, so do not use them where an adversary chooses the
+input.
+
+**Parameters**
+- `text` — the text to hash.
+- `hashType` — the algorithm: `HashType.MD5`, `HashType.SHA1` or `HashType.SHA256`.
+
+**Returns** the digest as lower case hexadecimal.
+
+**Examples**
+```pure
+'Hello, World!'->hash(HashType.MD5)      // '65a8e27d8879283831b664bd8b7f0ad4'
+'Hello, World!'->hash(HashType.SHA1)     // '0a0a9f2a6772942557ab5355d76af442f8f65e01'
+'Hello, World!'->hash(HashType.SHA256)   // 'dffd6021bb2bd5b0af676290809ec3a53191dd81c7f70a4b28688a362182986f'
+```
+
+**See also** `meta::pure::functions::string::encodeBase64(String[1]):String[1]`
+'''
+native function <<PCT.function>>
   meta::pure::functions::hash::hash(text: String[1], hashType: meta::pure::functions::hash::HashType[1]):String[1];
 
 function <<PCT.test>> meta::pure::functions::hash::tests::testMD5Hash<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-functions-unclassified-pure/src/main/resources/core_functions_unclassified/runtime/currentUserId.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-functions-unclassified-pure/src/main/resources/core_functions_unclassified/runtime/currentUserId.pure
@@ -16,6 +16,22 @@ import meta::pure::test::pct::*;
 
 native function <<functionType.SideEffectFunction>> meta::core::runtime::currentUserId():String[1];
 
+'''
+The identity the query is executing as.
+
+Resolved from the execution context rather than from the data, so **it is not a constant**: the same
+query returns different values for different users, and two calls are only guaranteed to agree
+within one execution. That makes it the building block for row-level entitlement — filtering a
+relation down to the rows belonging to the caller — but it also means a query using it cannot be
+cached or compared across users as though it were pure.
+
+**Returns** the current user's identifier.
+
+**Examples**
+```pure
+$orders->filter(o | $o.owner == currentUserId())
+```
+'''
 function <<PCT.function>> meta::pure::functions::runtime::currentUserId():String[1]
 {
   meta::core::runtime::currentUserId();

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-functions-unclassified-pure/src/main/resources/core_functions_unclassified/string/ascii/ascii.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-functions-unclassified-pure/src/main/resources/core_functions_unclassified/string/ascii/ascii.pure
@@ -14,7 +14,31 @@
 
 import meta::pure::test::pct::*;
 
-native function <<PCT.function>> {doc.doc = 'Returns the ASCII integer value of the first character in the given string.'} 
+'''
+The ASCII code of a string's first character.
+
+**Only the first character is read** — the rest of the string is ignored rather than being an error,
+so `'abc'` and `'a'` both give 97. An empty string gives 0, which is also the code of the NUL
+character, so 0 does not distinguish "empty" from "a string starting with NUL".
+
+**Parameters**
+- `source` — the string whose first character to encode.
+
+**Returns** the ASCII code of the first character.
+
+**Examples**
+```pure
+'A'->ascii()     // 65
+'z'->ascii()     // 122
+'0'->ascii()     // 48
+' '->ascii()     // 32
+'abc'->ascii()   // 97, the trailing characters are ignored
+''->ascii()      // 0
+```
+
+**See also** `char(Integer[1]):String[1]`
+'''
+native function <<PCT.function>>
   meta::pure::functions::string::ascii(source:String[1]):Integer[1];
 
 function <<PCT.test>> meta::pure::functions::string::tests::ascii::testAsciiUpper<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-functions-unclassified-pure/src/main/resources/core_functions_unclassified/string/ascii/char.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-functions-unclassified-pure/src/main/resources/core_functions_unclassified/string/ascii/char.pure
@@ -14,7 +14,30 @@
 
 import meta::pure::test::pct::*;
 
-native function <<PCT.function>> {doc.doc = 'Returns the character corresponding to the specified ASCII integer value.'}
+'''
+The one-character string for an ASCII code.
+
+The inverse of `ascii(String[1]):Integer[1]`. Control codes come back as themselves rather than as an
+escape or a placeholder: 10 is a real newline and 0 is a real NUL character, not an empty string.
+
+**Parameters**
+- `source` — the ASCII code to decode.
+
+**Returns** the corresponding one-character string.
+
+**Examples**
+```pure
+65->char()    // 'A'
+122->char()   // 'z'
+48->char()    // '0'
+32->char()    // ' '
+10->char()    // a newline
+0->char()     // a NUL character, not ''
+```
+
+**See also** `ascii(String[1]):Integer[1]`
+'''
+native function <<PCT.function>>
   meta::pure::functions::string::char(source:Integer[1]):String[1];
 
 function <<PCT.test>> meta::pure::functions::string::tests::char::testCharUpper<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-functions-unclassified-pure/src/main/resources/core_functions_unclassified/string/codec/decodeBase64.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-functions-unclassified-pure/src/main/resources/core_functions_unclassified/string/codec/decodeBase64.pure
@@ -14,7 +14,27 @@
 
 import meta::pure::test::pct::*;
 
-native function <<PCT.function>> {doc.doc = 'Decodes a Base64-encoded string and returns the original string.'}
+'''
+Decodes a Base64 string.
+
+**Padding is optional on input**: `'SGVsbG8sIFdvcmxkIQ'` decodes the same as
+`'SGVsbG8sIFdvcmxkIQ=='`, even though `encodeBase64(String[1]):String[1]` always emits the padded
+form. Round-tripping is therefore only guaranteed in the direction that ends in an encode.
+
+**Parameters**
+- `string` — the Base64 text to decode.
+
+**Returns** the decoded string.
+
+**Examples**
+```pure
+'SGVsbG8sIFdvcmxkIQ=='->decodeBase64()   // 'Hello, World!'
+'SGVsbG8sIFdvcmxkIQ'->decodeBase64()     // 'Hello, World!', unpadded input is accepted
+```
+
+**See also** `encodeBase64(String[1]):String[1]`
+'''
+native function <<PCT.function>>
   meta::pure::functions::string::decodeBase64(string:String[1]):String[1];
 
 function <<PCT.test>> meta::pure::functions::string::tests::base64::testDecodeBase64<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-functions-unclassified-pure/src/main/resources/core_functions_unclassified/string/codec/encodeBase64.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-functions-unclassified-pure/src/main/resources/core_functions_unclassified/string/codec/encodeBase64.pure
@@ -14,7 +14,26 @@
 
 import meta::pure::test::pct::*;
 
-native function <<PCT.function>> {doc.doc = 'Encodes a string into its Base64 representation.'} 
+'''
+Encodes a string as Base64.
+
+Emits padded Base64, so the output length is always a multiple of four and may end in `=`. There is
+nothing Base64-specific about the input: encoding an already-encoded string encodes it a second time
+rather than returning it unchanged.
+
+**Parameters**
+- `string` — the string to encode.
+
+**Returns** the Base64 representation.
+
+**Examples**
+```pure
+'Hello, World!'->encodeBase64()   // 'SGVsbG8sIFdvcmxkIQ=='
+```
+
+**See also** `decodeBase64(String[1]):String[1]`
+'''
+native function <<PCT.function>>
   meta::pure::functions::string::encodeBase64(string:String[1]):String[1];
 
 function <<PCT.test>> meta::pure::functions::string::tests::base64::testEncodeBase64<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-functions-unclassified-pure/src/main/resources/core_functions_unclassified/string/padding/lpad.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-functions-unclassified-pure/src/main/resources/core_functions_unclassified/string/padding/lpad.pure
@@ -14,13 +14,47 @@
 
 import meta::pure::test::pct::*;
 
-function <<PCT.function>> {doc.doc = 'Pads the beginning of a string with the specified character until it reaches the desired length.'}
+'''
+Pads the beginning of a string with a fill character until it reaches a given length.
+
+**It truncates as well as pads**, so the result is always exactly `length` characters when `char` is
+a single character: a string longer than `length` is cut down to its first `length` characters — from
+the right, so `'abcd'->lpad(3, '_')` gives `'abc'`, not `'bcd'`. An empty `char` has nothing to pad
+with and returns `str` untouched.
+
+**Pass a single character.** A multi-character fill discards the string being padded rather than
+prefixing it: `'pp'->lpad(5, 'xo')` gives `'xoxox'`, with the `'pp'` gone. This is a defect in the
+underlying `pad`, not intended behaviour;
+`rpad(String[1], Integer[1], String[1]):String[1]` cycles the fill correctly.
+
+**Parameters**
+- `str` — the string to pad.
+- `length` — the length to pad or truncate to.
+- `char` — the single-character fill to prepend.
+
+**Returns** the padded or truncated string.
+
+**Examples**
+```pure
+'abcd'->lpad(10, '_')   // '______abcd'
+'abcd'->lpad(3, '_')    // 'abc', longer input is truncated from the right
+''->lpad(3, '?')        // '???'
+'abcd'->lpad(10, '')    // 'abcd', nothing to pad with
+```
+
+**See also** `lpad(String[1], Integer[1]):String[1]`,
+`rpad(String[1], Integer[1], String[1]):String[1]`
+'''
+function <<PCT.function>>
   meta::pure::functions::string::lpad(str:String[1], length:Integer[1], char:String[1]):String[1]
 {
   pad($str, $length, $char, true)
 }
 
-function <<PCT.function>> 
+'''
+As `lpad(String[1], Integer[1], String[1]):String[1]`, padding with a space.
+'''
+function <<PCT.function>>
   meta::pure::functions::string::lpad(str:String[1], length:Integer[1]):String[1]
 {
   lpad($str, $length, ' ')

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-functions-unclassified-pure/src/main/resources/core_functions_unclassified/string/padding/repeatString.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-functions-unclassified-pure/src/main/resources/core_functions_unclassified/string/padding/repeatString.pure
@@ -14,7 +14,28 @@
 
 import meta::pure::test::pct::*;
 
-function <<PCT.function>> {doc.doc = 'Repeats the given string a specified number of times and returns the resulting concatenated string.'}
+'''
+Concatenates a string with itself a given number of times.
+
+**Empty in, empty out**: an absent `str` gives an absent result rather than `''`, which is what makes
+the return `[0..1]`. An empty string is present, so it repeats to `''`.
+
+**Parameters**
+- `str` — the string to repeat.
+- `times` — how many copies to concatenate.
+
+**Returns** the concatenation, or empty when `str` is empty.
+
+**Examples**
+```pure
+'ab'->repeatString(2)   // 'abab'
+''->repeatString(2)     // ''
+[]->repeatString(2)     // empty
+```
+
+**See also** `rpad(String[1], Integer[1], String[1]):String[1]`
+'''
+function <<PCT.function>>
   meta::pure::functions::string::repeatString(str:String[0..1], times:Integer[1]):String[0..1]
 {
   if ($str->isNotEmpty(),

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-functions-unclassified-pure/src/main/resources/core_functions_unclassified/string/padding/rpad.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-functions-unclassified-pure/src/main/resources/core_functions_unclassified/string/padding/rpad.pure
@@ -14,12 +14,43 @@
 
 import meta::pure::test::pct::*;
 
-function <<PCT.function>> {doc.doc = 'Pads the end of a string with the specified character until it reaches the desired length.'}
+'''
+Pads the end of a string with a fill character until it reaches a given length.
+
+**It truncates as well as pads**, so the result is always exactly `length` characters when `char` is
+non-empty: a string longer than `length` is cut down to its first `length` characters rather than
+returned unchanged. Two cases break that rule — an empty `char` has nothing to pad with and returns
+`str` untouched, and a multi-character `char` is cycled and clipped, so `'pp'->rpad(5, 'xo')` gives
+`'ppxox'`.
+
+**Parameters**
+- `str` — the string to pad.
+- `length` — the length to pad or truncate to.
+- `char` — the fill to append.
+
+**Returns** the padded or truncated string.
+
+**Examples**
+```pure
+'abcd'->rpad(10, '_')   // 'abcd______'
+'abcd'->rpad(3, '_')    // 'abc', longer input is truncated
+''->rpad(3, '?')        // '???'
+'abcd'->rpad(10, '')    // 'abcd', nothing to pad with
+'pp'->rpad(5, 'xo')     // 'ppxox', a multi-character fill is cycled
+```
+
+**See also** `rpad(String[1], Integer[1]):String[1]`,
+`lpad(String[1], Integer[1], String[1]):String[1]`
+'''
+function <<PCT.function>>
   meta::pure::functions::string::rpad(str:String[1], length:Integer[1], char:String[1]):String[1]
 {
   pad($str, $length, $char, false)
 }
 
+'''
+As `rpad(String[1], Integer[1], String[1]):String[1]`, padding with a space.
+'''
 function <<PCT.function>>
   meta::pure::functions::string::rpad(str:String[1], length:Integer[1]):String[1]
 {

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-functions-unclassified-pure/src/main/resources/core_functions_unclassified/string/similarity/jaroWinklerSimilarity.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-functions-unclassified-pure/src/main/resources/core_functions_unclassified/string/similarity/jaroWinklerSimilarity.pure
@@ -14,7 +14,30 @@
 
 import meta::pure::test::pct::*;
 
-native function <<PCT.function>> {doc.doc = 'Calculates the Jaro-Winkler similarity between two strings, returning a value between 0 and 1.'}
+'''
+How similar two strings are, on the Jaro-Winkler scale from 0 to 1.
+
+1.0 means identical and 0.0 means nothing in common. The Winkler part weights a shared prefix, so
+strings that begin alike score higher than their raw Jaro similarity — which suits names and
+identifiers, where the discriminating characters usually come first. Unlike
+`levenshteinDistance(String[1], String[1]):Integer[1]`, **higher is more alike**, and the score is
+scale-free rather than a count, so it is comparable across strings of different lengths.
+
+**Parameters**
+- `str1` — the first string.
+- `str2` — the second string.
+
+**Returns** the similarity, between 0.0 and 1.0.
+
+**Examples**
+```pure
+'John Smith'->jaroWinklerSimilarity('John Smith')   // 1.0
+'John Smith'->jaroWinklerSimilarity('Jane Smith')   // 0.88
+```
+
+**See also** `levenshteinDistance(String[1], String[1]):Integer[1]`
+'''
+native function <<PCT.function>>
   meta::pure::functions::string::jaroWinklerSimilarity(str1:String[1], str2:String[1]):Float[1];
 
 function <<PCT.test>> meta::pure::functions::string::tests::jaroWinklerSimilarity::testJaroWinklerSimilarityEqual<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-functions-unclassified-pure/src/main/resources/core_functions_unclassified/string/similarity/levenshteinDistance.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-functions-unclassified-pure/src/main/resources/core_functions_unclassified/string/similarity/levenshteinDistance.pure
@@ -14,7 +14,30 @@
 
 import meta::pure::test::pct::*;
 
-native function <<PCT.function>> {doc.doc = 'Calculates the Levenshtein distance between two strings, returning the number of single character edits required to transform one string into the other.'}
+'''
+The number of single-character edits needed to turn one string into the other.
+
+Insertions, deletions and substitutions each count as one. **Lower is more alike** — 0 means the
+strings are identical — which is the opposite direction to
+`jaroWinklerSimilarity(String[1], String[1]):Float[1]`. It is an absolute count and not normalised
+by length, so a distance of 3 means something different between short strings than between long
+ones; divide by the longer length if you need a comparable ratio.
+
+**Parameters**
+- `str1` — the first string.
+- `str2` — the second string.
+
+**Returns** the edit distance.
+
+**Examples**
+```pure
+'John Smith'->levenshteinDistance('John Smith')   // 0
+'John Smith'->levenshteinDistance('Jane Smith')   // 3, substituting o-h-n for a-n-e
+```
+
+**See also** `jaroWinklerSimilarity(String[1], String[1]):Float[1]`
+'''
+native function <<PCT.function>>
 meta::pure::functions::string::levenshteinDistance(str1:String[1], str2:String[1]):Integer[1];
 
 function <<PCT.test>> meta::pure::functions::string::tests::levenshteinDistance::testLevenshteinDistanceEqual<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-functions-unclassified-pure/src/main/resources/core_functions_unclassified/string/split/splitPart.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-functions-unclassified-pure/src/main/resources/core_functions_unclassified/string/split/splitPart.pure
@@ -14,7 +14,39 @@
 
 import meta::pure::test::pct::*;
 
-function <<PCT.function>>{doc.doc = 'Split the string and select the part.'}
+'''
+Splits a string on a separator and returns one part by position.
+
+`part` is zero-based, so 0 is the text before the first separator. A separator that never occurs
+means there is one part, the whole string, so part 0 gives back the input; an empty `token` splits
+nothing and does the same. **Empty in, empty out** — an absent `str` gives an absent result rather
+than an error, which is what makes the return `[0..1]`.
+
+**Pass a single-character separator.** A multi-character `token` is treated as a set of characters to
+split on rather than as a sequence, so `'Hello World'->splitPart('or', 0)` splits at `o` and at `r`
+independently and gives `'Hell'`. This is a defect in the underlying `split`, not intended behaviour.
+
+**Parameters**
+- `str` — the string to split.
+- `token` — the separator.
+- `part` — the zero-based position of the part to return.
+
+**Returns** the requested part, or empty when `str` is empty.
+
+**Examples**
+```pure
+'Hello World'->splitPart(' ', 0)          // 'Hello'
+'Hello World'->splitPart(' ', 1)          // 'World'
+'a;b;c;d;e'->splitPart(';', 4)            // 'e'
+'super-duper-looper'->splitPart('-', 0)   // 'super'
+'Hello World'->splitPart(';', 0)          // 'Hello World', the separator never occurs
+'Hello World'->splitPart('', 0)           // 'Hello World'
+[]->splitPart(' ', 0)                     // empty
+```
+
+**See also** `repeatString(String[0..1], Integer[1]):String[0..1]`
+'''
+function <<PCT.function>>
    meta::pure::functions::string::splitPart(str:String[0..1], token:String[1], part:Integer[1]):String[0..1]
 {
   if ($str->isEmpty(),

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-functions-unclassified-pure/src/main/resources/core_functions_unclassified/string/transformation/toLowerFirstCharacter.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-functions-unclassified-pure/src/main/resources/core_functions_unclassified/string/transformation/toLowerFirstCharacter.pure
@@ -14,8 +14,31 @@
 
 import meta::pure::test::pct::*;
 
-function <<PCT.function>> {doc.doc = 'Lower cases the first charater of the provided string'}
-  meta::pure::functions::string::toLowerFirstCharacter(str : String[1]) : String[1] 
+'''
+Lower cases a string's first character, leaving the rest alone.
+
+**Only the first character is touched**, so the remainder keeps whatever case it already had — the
+usual reason to reach for this is turning a class name into a property name. A first character with
+no lower case form, such as a digit, is left as it is, and an empty string returns empty rather than
+failing.
+
+**Parameters**
+- `str` — the string to transform.
+
+**Returns** the string with its first character lower cased.
+
+**Examples**
+```pure
+'XoXoXoX'->toLowerFirstCharacter()   // 'xoXoXoX', the rest is untouched
+'xOxOxOx'->toLowerFirstCharacter()   // 'xOxOxOx', already lower
+'1isOne'->toLowerFirstCharacter()    // '1isOne', a digit has no lower case
+''->toLowerFirstCharacter()          // ''
+```
+
+**See also** `toUpperFirstCharacter(String[1]):String[1]`
+'''
+function <<PCT.function>>
+  meta::pure::functions::string::toLowerFirstCharacter(str : String[1]) : String[1]
 {
   if($str->length() == 0,
     |$str,

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-functions-unclassified-pure/src/main/resources/core_functions_unclassified/string/transformation/toUpperFirstCharacter.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-functions-unclassified-pure/src/main/resources/core_functions_unclassified/string/transformation/toUpperFirstCharacter.pure
@@ -14,8 +14,30 @@
 
 import meta::pure::test::pct::*;
 
-function <<PCT.function>> {doc.doc = 'Upper cases the first character of the provided string'}
-  meta::pure::functions::string::toUpperFirstCharacter(str : String[1]) : String[1] 
+'''
+Upper cases a string's first character, leaving the rest alone.
+
+**Only the first character is touched** — this is not title casing, so the remainder keeps whatever
+case it already had. A first character with no upper case form, such as a digit, is left as it is,
+and an empty string returns empty rather than failing.
+
+**Parameters**
+- `str` — the string to transform.
+
+**Returns** the string with its first character upper cased.
+
+**Examples**
+```pure
+'xOxOxOx'->toUpperFirstCharacter()   // 'XOxOxOx', the rest is untouched
+'XoXoXoX'->toUpperFirstCharacter()   // 'XoXoXoX', already upper
+'1isOne'->toUpperFirstCharacter()    // '1isOne', a digit has no upper case
+''->toUpperFirstCharacter()          // ''
+```
+
+**See also** `toLowerFirstCharacter(String[1]):String[1]`
+'''
+function <<PCT.function>>
+  meta::pure::functions::string::toUpperFirstCharacter(str : String[1]) : String[1]
 {
   if($str->length() == 0,
     |$str,

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-variant/legend-engine-pure-functions-variant-pure/src/main/resources/core_functions_variant/functions/convert/fromJson.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-variant/legend-engine-pure-functions-variant-pure/src/main/resources/core_functions_variant/functions/convert/fromJson.pure
@@ -16,11 +16,33 @@ import meta::pure::test::pct::*;
 import meta::pure::metamodel::variant::*;
 import meta::pure::functions::variant::convert::*;
 
+'''
+Parses JSON text into a variant.
+
+The whole JSON grammar is accepted, so the result may be an object, an array, a string, a number, a
+boolean, or JSON `null` — a variant holding `null` is a value, not an empty result. Use
+`to(Variant[0..1], T[0..1]):T[0..1]` to read a scalar back out, `toMany(Variant[0..1], T[0..1]):T[*]`
+for an array, and `meta::pure::functions::variant::navigation::get(Variant[0..1], String[1]):Variant[0..1]`
+to navigate into it.
+
+**Parameters**
+- `json` — the JSON text to parse.
+
+**Returns** the variant representation of the parsed JSON.
+
+**Examples**
+```pure
+fromJson('[ 1, 2 , 3 ]')->toJson()               // '[1,2,3]'
+fromJson('{ "Hello" : "World" }')->toJson()      // '{"Hello":"World"}'
+fromJson('null')->toJson()                       // 'null'
+fromJson('"1"')->to(@Integer)                    // 1
+```
+
+**See also** `toJson(Variant[1]):String[1]`,
+`toVariant(Any[*]):Variant[1]`
+'''
 native function
     <<PCT.function>>
-    {
-        doc.doc='Parses the given json string and return its variant representation.'
-    }
 meta::pure::functions::variant::convert::fromJson(json: String[1]): Variant[1];
 
 function <<PCT.test, PCTCoreQualifier.variant>> meta::pure::functions::variant::convert::tests::fromJson::testJsonNull<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-variant/legend-engine-pure-functions-variant-pure/src/main/resources/core_functions_variant/functions/convert/to.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-variant/legend-engine-pure-functions-variant-pure/src/main/resources/core_functions_variant/functions/convert/to.pure
@@ -17,27 +17,64 @@ import meta::pure::metamodel::variant::*;
 import meta::pure::functions::variant::convert::*;
 import meta::pure::functions::variant::convert::tests::to::*;
 
-native function
-    <<PCT.function>>
-    {
-        doc.doc='Converts the $variant to the given $type.\n' +
-                 'This allows to extract the variant actual value, like primitives.\n' +
-                 'The type key name and type lookup are leveraged when coercing a complex type (ie Class).\n' +
-                 'This will fail if value cannot be coerced.'
-    }
-meta::pure::functions::variant::convert::to<T>(variant: Variant[0..1], type: T[0..1], typeKeyName: String[1], typeLookup: Pair<String,Class<Any>>[*]): T[0..1];
+'''
+Reads a variant back out as a value of the given type.
 
+Coercion is across JSON types, not merely a check: a JSON string parses into the target primitive
+where it can, so `'"1"'` reads as `1` for `@Integer` and `'"1.25"'` reads as `1.25` for `@Float`.
+It does not truncate — a JSON number with a fractional part fails against `@Integer`. **Anything
+that cannot be coerced fails rather than returning empty**; the one empty result is JSON `null`,
+which reads back as empty for every target type.
+
+Complex targets are supported as well as primitives: a JSON object reads into a `Class`, a
+`Map<String, …>` or a `List<…>`, resolving a subtype from a `_type` key in the payload. Use
+`toMany(Variant[0..1], T[0..1]):T[*]` when the variant holds an array whose elements you want
+individually rather than as a `List`.
+
+**Parameters**
+- `variant` — the variant to read.
+- `type` — the target type, given as a type literal such as `@Integer`.
+
+**Returns** the value, or empty when the variant holds JSON `null`.
+
+**Examples**
+```pure
+fromJson('1')->to(@Integer)                            // 1
+fromJson('"1"')->to(@Integer)                          // 1, a string coerces
+fromJson('1')->to(@Float)                              // 1.0
+fromJson('null')->to(@Integer)                         // empty
+fromJson('"false"')->to(@Boolean)                      // false
+fromJson('"2020-01-01"')->to(@StrictDate)              // %2020-01-01
+fromJson('{"hello":1}')->to(@Map<String, Integer>)     // a map holding 'hello' -> 1
+fromJson('1.25')->to(@Integer)                         // fails: Integer is not managed yet!
+```
+
+**See also** `to(Variant[0..1], T[0..1], String[1], Pair<String, Class<Any>>[*]):T[0..1]`,
+`toMany(Variant[0..1], T[0..1]):T[*]`,
+`toVariant(Any[*]):Variant[1]`
+'''
 native function
     <<PCT.function>>
-    {
-        doc.doc='Converts the $variant to the given $type.\n' +
-                 'This allows to extract the variant actual value, like primitives.\n' +
-                 'This will fail if value cannot be coerced.'
-    }
 meta::pure::functions::variant::convert::to<T>(variant: Variant[0..1], type: T[0..1]): T[0..1];
 //{
 //  to($variant, $type, '_type', [])
 //}
+
+'''
+As `to(Variant[0..1], T[0..1]):T[0..1]`, but resolves a subtype using `typeKeyName` and `typeLookup`
+rather than the defaults that variant applies, which are the key `_type` and an empty lookup.
+
+**Parameters**
+- `variant` — the variant to read.
+- `type` — the target type, given as a type literal such as `@Integer`.
+- `typeKeyName` — the payload key naming the concrete subtype.
+- `typeLookup` — the subtype names to resolve against, paired with their classes.
+
+**Returns** the value, or empty when the variant holds JSON `null`.
+'''
+native function
+    <<PCT.function>>
+meta::pure::functions::variant::convert::to<T>(variant: Variant[0..1], type: T[0..1], typeKeyName: String[1], typeLookup: Pair<String,Class<Any>>[*]): T[0..1];
 
 function <<PCT.test, PCTCoreQualifier.variant>> meta::pure::functions::variant::convert::tests::to::testToNull<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {
@@ -54,6 +91,10 @@ function <<PCT.test, PCTCoreQualifier.variant>> meta::pure::functions::variant::
     assertEquals(1, $f->eval(|fromJson('"1"')->to(@Integer)));
 }
 
+'''
+Coercion does not truncate: a JSON number with a fractional part fails against `@Integer` rather
+than rounding towards zero.
+'''
 function <<PCT.test, PCTCoreQualifier.variant>> meta::pure::functions::variant::convert::tests::to::testToIntegerFromFloat<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {
     assertError(|$f->eval(|fromJson('1.25')->to(@Integer)), 'Integer is not managed yet!');

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-variant/legend-engine-pure-functions-variant-pure/src/main/resources/core_functions_variant/functions/convert/toJson.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-variant/legend-engine-pure-functions-variant-pure/src/main/resources/core_functions_variant/functions/convert/toJson.pure
@@ -16,11 +16,28 @@ import meta::pure::test::pct::*;
 import meta::pure::metamodel::variant::*;
 import meta::pure::functions::variant::convert::*;
 
+'''
+Renders a variant as JSON text.
+
+The output is compact: insignificant whitespace in the JSON the variant was parsed from is not
+preserved.
+
+**Parameters**
+- `variant` — the variant to render.
+
+**Returns** the JSON representation of the variant.
+
+**Examples**
+```pure
+fromJson('{ "Hello" : null }')->toJson()               // '{"Hello":null}'
+fromJson('{ "Hello" : [ "World", "!" ] }')->toJson()   // '{"Hello":["World","!"]}'
+```
+
+**See also** `fromJson(String[1]):Variant[1]`,
+`toVariant(Any[*]):Variant[1]`
+'''
 native function
     <<PCT.function>>
-    {
-        doc.doc='Returns the json representation of the given variant.'
-    }
 meta::pure::functions::variant::convert::toJson(variant: Variant[1]): String[1];
 
 function <<PCT.test, PCTCoreQualifier.variant>> meta::pure::functions::variant::convert::tests::toJson::testObjectToJson<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-variant/legend-engine-pure-functions-variant-pure/src/main/resources/core_functions_variant/functions/convert/toMany.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-variant/legend-engine-pure-functions-variant-pure/src/main/resources/core_functions_variant/functions/convert/toMany.pure
@@ -18,24 +18,55 @@ import meta::pure::metamodel::variant::*;
 import meta::pure::functions::variant::convert::*;
 
 
-native function
-    <<PCT.function>>
-    {
-        doc.doc='Converts the $variant to the given $type if the variant represent an array, failing if is not an array.\n' +
-                 'This will fail if array values cannot be coerced.'
-    }
-meta::pure::functions::variant::convert::toMany<T>(variant: Variant[0..1], type: T[0..1], typeKeyName: String[1], typeLookup: Pair<String,Class<Any>>[*]): T[*];
+'''
+Reads a variant holding a JSON array back out as a collection of the given type.
 
+Each element is coerced individually, on the same rules as `to(Variant[0..1], T[0..1]):T[0..1]`, so
+the whole call fails if any element cannot be coerced. **The variant must hold an array**: a variant
+holding an object, a string or a number fails rather than yielding a single-element collection.
+Reading with `@Variant` leaves the elements as variants, which is the way to walk a heterogeneous
+array.
+
+**Parameters**
+- `variant` — the variant to read, holding a JSON array.
+- `type` — the element type, given as a type literal such as `@Integer`.
+
+**Returns** the array's elements, as values of the given type.
+
+**Examples**
+```pure
+fromJson('[1, 2, 3]')->toMany(@Integer)         // 1, 2, 3
+fromJson('[1, 2, 3]')->toMany(@Variant)         // three variants, each readable with to()
+fromJson('"not an array"')->toMany(@Variant)    // fails: Expect variant that contains an 'ARRAY', but got 'STRING'
+```
+
+**See also** `toMany(Variant[0..1], T[0..1], String[1], Pair<String, Class<Any>>[*]):T[*]`,
+`to(Variant[0..1], T[0..1]):T[0..1]`,
+`toVariant(Any[*]):Variant[1]`
+'''
 native function
     <<PCT.function>>
-    {
-        doc.doc='Converts the $variant to the given $type if the variant represent an array, failing if is not an array.\n' +
-                 'This will fail if array values cannot be coerced.'
-    }
 meta::pure::functions::variant::convert::toMany<T>(variant: Variant[0..1], type: T[0..1]): T[*];
 //{
 //    toMany($variant, $type, '_type', [])
 //}
+
+'''
+As `toMany(Variant[0..1], T[0..1]):T[*]`, but resolves each element's subtype using `typeKeyName` and
+`typeLookup` rather than the defaults that variant applies, which are the key `_type` and an empty
+lookup.
+
+**Parameters**
+- `variant` — the variant to read, holding a JSON array.
+- `type` — the element type, given as a type literal such as `@Integer`.
+- `typeKeyName` — the payload key naming an element's concrete subtype.
+- `typeLookup` — the subtype names to resolve against, paired with their classes.
+
+**Returns** the array's elements, as values of the given type.
+'''
+native function
+    <<PCT.function>>
+meta::pure::functions::variant::convert::toMany<T>(variant: Variant[0..1], type: T[0..1], typeKeyName: String[1], typeLookup: Pair<String,Class<Any>>[*]): T[*];
 
 function <<PCT.test, PCTCoreQualifier.variant>> meta::pure::functions::variant::convert::tests::toMany::testToManyVariant<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-variant/legend-engine-pure-functions-variant-pure/src/main/resources/core_functions_variant/functions/convert/toVariant.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-variant/legend-engine-pure-functions-variant-pure/src/main/resources/core_functions_variant/functions/convert/toVariant.pure
@@ -16,11 +16,34 @@ import meta::pure::test::pct::*;
 import meta::pure::metamodel::variant::*;
 import meta::pure::functions::variant::convert::*;
 
+'''
+Converts a Pure value into its variant representation.
+
+Collections, `List` and `Map` are converted structurally and nest to any depth: a collection or a
+`List` becomes a JSON array, a `Map` becomes a JSON object, and a value that is already a variant is
+carried through unchanged. **An empty collection becomes a variant holding JSON `null`, not an empty
+result** — the return multiplicity is `[1]`.
+
+**Parameters**
+- `value` — the value to convert.
+
+**Returns** the variant representation of the value.
+
+**Examples**
+```pure
+toVariant(1)->toJson()                                    // '1'
+toVariant([1, 2, 3])->toJson()                            // '[1,2,3]'
+toVariant([])->toJson()                                   // 'null'
+toVariant(newMap(pair('hello', 1)))->toJson()             // '{"hello":1}'
+toVariant(list(list(list(1))))->toJson()                  // '[[[1]]]'
+```
+
+**See also** `to(Variant[0..1], T[0..1]):T[0..1]`,
+`fromJson(String[1]):Variant[1]`,
+`toJson(Variant[1]):String[1]`
+'''
 native function
     <<PCT.function>>
-    {
-        doc.doc='Converts the given value to its variant representation.'
-    }
 meta::pure::functions::variant::convert::toVariant(value: Any[*]): Variant[1];
 
 function <<PCT.test, PCTCoreQualifier.variant>> meta::pure::functions::variant::convert::tests::toVariant::testEmpty<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-variant/legend-engine-pure-functions-variant-pure/src/main/resources/core_functions_variant/functions/navigation/get.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-variant/legend-engine-pure-functions-variant-pure/src/main/resources/core_functions_variant/functions/navigation/get.pure
@@ -17,22 +17,63 @@ import meta::pure::metamodel::variant::*;
 import meta::pure::functions::variant::convert::*;
 import meta::pure::functions::variant::navigation::*;
 
+'''
+Reads a key out of a variant holding a JSON object.
+
+The result stays a variant, so calls chain to walk a nested payload, mixing this with
+`get(Variant[0..1], Integer[1]):Variant[0..1]` to step through arrays. **A key that is absent yields
+empty rather than failing**, and an empty variant yields empty too, so navigating a path that does
+not exist is not an error. The variant must hold an object; anything else fails.
+
+**Parameters**
+- `variant` — the variant to read, holding a JSON object.
+- `key` — the key to look up.
+
+**Returns** the value at that key, or empty when the key is absent.
+
+**Examples**
+```pure
+fromJson('{"hello":"world"}')->get('hello')                       // a variant holding "world"
+fromJson('{"hello":"world"}')->get('nonExisting')                 // empty
+fromJson('{"hello":["world", "moon", "sun"]}')->get('hello')->get(2)   // a variant holding "sun"
+```
+
+**See also** `get(Variant[0..1], Integer[1]):Variant[0..1]`,
+`meta::pure::functions::variant::convert::to(Variant[0..1], T[0..1]):T[0..1]`
+'''
 function
     <<PCT.function>>
-    {
-        doc.doc='Returns the value for the given key out of an structure variant. failing if the variant .\n' +
-                 'This will fail if array values cannot be coerced.'
-    }
 meta::pure::functions::variant::navigation::get(variant: Variant[0..1], key: String[1]): Variant[0..1]
 {
     $variant->to(@Map<String, Variant>)->map(x | $x->meta::pure::functions::collection::get($key));
 }
 
+'''
+Reads a zero-based position out of a variant holding a JSON array.
+
+As with `get(Variant[0..1], String[1]):Variant[0..1]`, the result stays a variant so calls chain.
+Unlike the key form, **an index outside the array fails rather than yielding empty** — this reads
+the array through `meta::pure::functions::collection::at(T[*], Integer[1]):T[1]`. The variant must
+hold an array; anything else fails.
+
+**Parameters**
+- `variant` — the variant to read, holding a JSON array.
+- `index` — the zero-based position to read.
+
+**Returns** the value at that position.
+
+**Examples**
+```pure
+fromJson('[1,2,3]')->get(1)                                            // a variant holding 2
+fromJson('[{"hello":"world"}, {"hello":"moon"}]')->get(1)->get('hello')  // a variant holding "moon"
+fromJson('[1,2,3]')->get(7)                                            // fails: The system is trying to get an element at offset 7 where the collection is of size 3
+```
+
+**See also** `get(Variant[0..1], String[1]):Variant[0..1]`,
+`meta::pure::functions::variant::convert::toMany(Variant[0..1], T[0..1]):T[*]`
+'''
 function
     <<PCT.function>>
-    {
-        doc.doc=''
-    }
 meta::pure::functions::variant::navigation::get(variant: Variant[0..1], index: Integer[1]): Variant[0..1]
 {
     $variant->toMany(@Variant)->at($index);
@@ -43,6 +84,10 @@ function <<PCT.test, PCTCoreQualifier.variant>> meta::pure::functions::variant::
     assertEquals('"world"', $f->eval(|fromJson('{"hello":"world"}')->get('hello')->toOne())->toString());
 }
 
+'''
+A key that is absent yields empty rather than failing, so navigating a path that does not exist is
+not an error.
+'''
 function <<PCT.test, PCTCoreQualifier.variant>> meta::pure::functions::variant::navigation::tests::get::testGetFromObjectWhenKeyDoesNotExists<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {
     assertEquals([], $f->eval(|fromJson('{"hello":"world"}')->get('nonExisting')));

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-variant/legend-engine-pure-functions-variant-pure/src/main/resources/core_functions_variant/functions/tests/composition.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-variant/legend-engine-pure-functions-variant-pure/src/main/resources/core_functions_variant/functions/tests/composition.pure
@@ -19,11 +19,19 @@ import meta::pure::functions::variant::tests::convert::to::model::*;
 
 // MAP
 
+'''
+`map` over a variant array unpacked as `@Variant`: each element stays boxed, so the lambda needs
+an explicit `to(@Integer)`.
+'''
 function <<PCT.test, PCTCoreQualifier.variant>> meta::pure::functions::variant::tests::collection::map::testMap_FromVariant<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {
     assertEquals('[2,3,4]', $f->eval(|toVariant([1, 2, 3])->toMany(@Variant)->map(x | $x->to(@Integer)->toOne() + 1)->toVariant())->toString());
 }
 
+'''
+The same `map` with the array unpacked as `@Integer`, so the lambda uses plain arithmetic. Both
+forms must give the same answer.
+'''
 function <<PCT.test, PCTCoreQualifier.variant>> meta::pure::functions::variant::tests::collection::map::testMap_FromVariantAsPrimitive<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {
     assertEquals('[2,3,4]', $f->eval(|toVariant([1, 2, 3])->toMany(@Integer)->map(x | $x + 1)->toVariant())->toString());
@@ -31,11 +39,17 @@ function <<PCT.test, PCTCoreQualifier.variant>> meta::pure::functions::variant::
 
 // FOLD
 
+'''
+`fold` over elements unpacked as `@Variant`, converting each one inside the accumulator lambda.
+'''
 function <<PCT.test, PCTCoreQualifier.variant>> meta::pure::functions::variant::tests::collection::fold::testFold_FromVariant<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {
     assertEquals(7, $f->eval(|toVariant([1, 2, 3])->toMany(@Variant)->fold({val, acc| $acc + $val->to(@Integer)->toOne()}, 1)));
 }
 
+'''
+The same `fold` over elements unpacked as `@Integer`.
+'''
 function <<PCT.test, PCTCoreQualifier.variant>> meta::pure::functions::variant::tests::collection::fold::testFold_FromVariantAsPrimitive<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {
     assertEquals(7, $f->eval(|toVariant([1, 2, 3])->toMany(@Integer)->fold({val, acc| $acc + $val}, 1)));
@@ -43,11 +57,17 @@ function <<PCT.test, PCTCoreQualifier.variant>> meta::pure::functions::variant::
 
 // FILTER
 
+'''
+`filter` over elements unpacked as `@Variant`, comparing after conversion.
+'''
 function <<PCT.test, PCTCoreQualifier.variant>> meta::pure::functions::variant::tests::collection::filter::testFilter_FromVariant<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {
     assertEquals('[1,3]', $f->eval(|toVariant([1, 2, 3])->toMany(@Variant)->filter(x | $x->to(@Integer) != 2)->toVariant())->toString());
 }
 
+'''
+The same `filter` over elements unpacked as `@Integer`.
+'''
 function <<PCT.test, PCTCoreQualifier.variant>> meta::pure::functions::variant::tests::collection::filter::testFilter_FromVariantAsPrimitive<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {
     assertEquals('[1,3]', $f->eval(|toVariant([1, 2, 3])->toMany(@Integer)->filter(x | $x != 2)->toVariant())->toString());
@@ -55,18 +75,27 @@ function <<PCT.test, PCTCoreQualifier.variant>> meta::pure::functions::variant::
 
 // variant to model
 
+'''
+Converting JSON to a model instance and reading a simple property off it.
+'''
 function <<PCT.test, PCTCoreQualifier.variant>> meta::pure::functions::variant::tests::convert::to::model::testToClassAndAccessProperty<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {
     let result = $f->eval(|fromJson('{"firstName": "John", "lastName": "Smith", "address": {"line1": "1234 Hello World Street", "line2": "Unit 5678"}}')->to(@Person).lastName);
     assertEquals('Smith', $result);     
 }
 
+'''
+Reading a qualified property of the converted instance.
+'''
 function <<PCT.test, PCTCoreQualifier.variant>> meta::pure::functions::variant::tests::convert::to::model::testToClassAndAccessQualifiedProperty<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {
     let result = $f->eval(|fromJson('{"firstName": "John", "lastName": "Smith", "address": {"line1": "1234 Hello World Street", "line2": "Unit 5678"}}')->to(@Person).fullName());
     assertEquals('John Smith', $result);     
 }
 
+'''
+Reading through a `[1]` property of a `[1]` property.
+'''
 function <<PCT.test, PCTCoreQualifier.variant>> meta::pure::functions::variant::tests::convert::to::model::testToClassAndAccessNestedProperty_oneToOne<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {
     let result = $f->eval(|fromJson('{"firstName": "John", "lastName": "Smith", "address": {"line1": "1234 Hello World Street", "line2": "Unit 5678"}}')->to(@Person).address.line1);
@@ -74,36 +103,55 @@ function <<PCT.test, PCTCoreQualifier.variant>> meta::pure::functions::variant::
 }
 
 
+'''
+A qualified property that itself reads through a nested `[1]` property.
+'''
 function <<PCT.test, PCTCoreQualifier.variant>> meta::pure::functions::variant::tests::convert::to::model::testToClassAndAccessNestedQualifiedProperty_oneToOne<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {
     let result = $f->eval(|fromJson('{"firstName": "John", "lastName": "Smith", "address": {"line1": "1234 Hello World Street", "line2": "Unit 5678"}}')->to(@Person).addressToString());
     assertEquals('1234 Hello World Street Unit 5678', $result);   
 }
 
+'''
+Reading a `[1]` property of a `[*]` property returns one value per element.
+'''
 function <<PCT.test, PCTCoreQualifier.variant>> meta::pure::functions::variant::tests::convert::to::model::testToClassAndAccessNestedProperty_oneToMany<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {
     let result = $f->eval(|fromJson('{"firstName": "John", "lastName": "Smith", "address": {"line1": "1234 Hello World Street", "line2": "Unit 5678"}, "previousAddresses": [ {"line1": "1234 Hello World Street", "line2": "Unit 0001"}, {"line1": "9876 Hello World Street", "line2": "Unit 1000"} ]}')->to(@Person).previousAddresses.line1);
     assertEquals(['1234 Hello World Street', '9876 Hello World Street'], $result);        
 }
 
+'''
+Reading through `[*]` on both hops flattens in source order — all of the first instance's values,
+then all of the second's.
+'''
 function <<PCT.test, PCTCoreQualifier.variant>> meta::pure::functions::variant::tests::convert::to::model::testToClassAndAccessNestedProperty_manyToMany<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {
     let result = $f->eval(|fromJson('[{"firstName": "Jonh", "lastName": "Smith", "address": {"line1": "9876 Hello World Street", "line2": "Unit 4523"}, "previousAddresses": [ {"line1": "9876 Hello World Street", "line2": "Unit 0001"}, {"line1": "1256 Hello World Street", "line2": "Unit 7000"} ]}, {"firstName": "Jane", "lastName": "Smith", "address": {"line1": "1234 Hello World Street", "line2": "Unit 5678"}, "previousAddresses": [ {"line1": "1234 Hello World Street", "line2": "Unit 0001"}, {"line1": "9876 Hello World Street", "line2": "Unit 1000"} ]}]')->toMany(@Person).previousAddresses.line1);
     assertEquals(['9876 Hello World Street', '1256 Hello World Street', '1234 Hello World Street', '9876 Hello World Street'], $result);        
 }
 
+'''
+Reading a `[1]` property of a `[*]` conversion returns one value per instance.
+'''
 function <<PCT.test, PCTCoreQualifier.variant>> meta::pure::functions::variant::tests::convert::to::model::testToClassAndAccessNestedProperty_manyToOne<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {
     let result = $f->eval(|fromJson('[{"firstName": "Jonh", "lastName": "Smith", "address": {"line1": "9876 Hello World Street", "line2": "Unit 4523"}, "previousAddresses": [ {"line1": "9876 Hello World Street", "line2": "Unit 0001"}, {"line1": "1256 Hello World Street", "line2": "Unit 7000"} ]}, {"firstName": "Jane", "lastName": "Smith", "address": {"line1": "1234 Hello World Street", "line2": "Unit 5678"}, "previousAddresses": [ {"line1": "1234 Hello World Street", "line2": "Unit 0001"}, {"line1": "9876 Hello World Street", "line2": "Unit 1000"} ]}]')->toMany(@Person).firstName);
     assertEquals(['Jonh', 'Jane'], $result);        
 }
 
+'''
+The qualified-property form of the many-to-one case.
+'''
 function <<PCT.test, PCTCoreQualifier.variant>> meta::pure::functions::variant::tests::convert::to::model::testToClassAndAccessNestedQualifiedProperty_manyToOne<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {
     let result = $f->eval(|fromJson('[{"firstName": "Jonh", "lastName": "Smith", "address": {"line1": "9876 Hello World Street", "line2": "Unit 4523"}, "previousAddresses": [ {"line1": "9876 Hello World Street", "line2": "Unit 0001"}, {"line1": "1256 Hello World Street", "line2": "Unit 7000"} ]}, {"firstName": "Jane", "lastName": "Smith", "address": {"line1": "1234 Hello World Street", "line2": "Unit 5678"}, "previousAddresses": [ {"line1": "1234 Hello World Street", "line2": "Unit 0001"}, {"line1": "9876 Hello World Street", "line2": "Unit 1000"} ]}]')->toMany(@Person).fullName());
     assertEquals(['Jonh Smith', 'Jane Smith'], $result);        
 }
 
+'''
+A qualified property returning `[*]` from a `[*]` property.
+'''
 function <<PCT.test, PCTCoreQualifier.variant>> meta::pure::functions::variant::tests::convert::to::model::testToClassAndAccessNestedQualifiedProperty_oneToMany<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {
     let result = $f->eval(|fromJson('{"firstName": "John", "lastName": "Smith", "address": {"line1": "1234 Hello World Street", "line2": "Unit 5678"}, "previousAddresses": [ {"line1": "1234 Hello World Street", "line2": "Unit 0001"}, {"line1": "9876 Hello World Street", "line2": "Unit 1000"} ]}')->to(@Person).previousAddressesToString());
@@ -111,6 +159,9 @@ function <<PCT.test, PCTCoreQualifier.variant>> meta::pure::functions::variant::
 }
 
 
+'''
+A qualified property reached through `[*]` on both hops.
+'''
 function <<PCT.test, PCTCoreQualifier.variant>> meta::pure::functions::variant::tests::convert::to::model::testToClassAndAccessNestedQualifiedProperty_manyToMany<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {
     let result = $f->eval(|fromJson('[{"firstName": "Jonh", "lastName": "Smith", "address": {"line1": "9876 Hello World Street", "line2": "Unit 4523"}, "previousAddresses": [ {"line1": "9876 Hello World Street", "line2": "Unit 0001"}, {"line1": "1256 Hello World Street", "line2": "Unit 7000"} ]}, {"firstName": "John", "lastName": "Smith", "address": {"line1": "1234 Hello World Street", "line2": "Unit 5678"}, "previousAddresses": [ {"line1": "1234 Hello World Street", "line2": "Unit 0001"}, {"line1": "9876 Hello World Street", "line2": "Unit 1000"} ]}]')->toMany(@Person).previousAddresses.toString());
@@ -118,6 +169,9 @@ function <<PCT.test, PCTCoreQualifier.variant>> meta::pure::functions::variant::
 }
 
 
+'''
+The default `_type` key selects the subtype, so a later `cast` to that subtype succeeds.
+'''
 function <<PCT.test, PCTCoreQualifier.variant>> meta::pure::functions::variant::tests::convert::to::model::testToClassWithInheritanceAndAccessProperty<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {
     let dogResult = $f->eval(|fromJson('{"_type": "Dog", "name": "Doggo", "isPuppy": true}')->to(@Pet)->cast(@Dog).isPuppy);
@@ -127,6 +181,9 @@ function <<PCT.test, PCTCoreQualifier.variant>> meta::pure::functions::variant::
     assertEquals(false, $catResult);    
 }
 
+'''
+The discriminator key can be named explicitly instead of defaulting to `_type`.
+'''
 function <<PCT.test, PCTCoreQualifier.variant>> meta::pure::functions::variant::tests::convert::to::model::testToClassWithInheritanceUsingCustomTypeProperty<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {
     let dogResult = $f->eval(|fromJson('{"__type": "Dog", "name": "Doggo", "isPuppy": true}')->to(@Pet, '__type', [])->cast(@Dog).isPuppy);
@@ -136,6 +193,10 @@ function <<PCT.test, PCTCoreQualifier.variant>> meta::pure::functions::variant::
     assertEquals(false, $catResult);    
 }
 
+'''
+A discriminator value that is not a class name resolves through an explicit value-to-class lookup
+table.
+'''
 function <<PCT.test, PCTCoreQualifier.variant>> meta::pure::functions::variant::tests::convert::to::model::testToClassWithInheritanceUsingCustomTypePropertyAndClassToType<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {
     let dogResult = $f->eval(|fromJson('{"__type": "perro", "name": "Doggo", "isPuppy": true}')->to(@Pet, '__type', [pair('gato', Cat), pair('perro',Dog)])->cast(@Dog).isPuppy);
@@ -145,6 +206,9 @@ function <<PCT.test, PCTCoreQualifier.variant>> meta::pure::functions::variant::
     assertEquals(false, $catResult);    
 }
 
+'''
+`instanceOf` distinguishes the converted subtypes within a single collection.
+'''
 function <<PCT.test, PCTCoreQualifier.variant>> meta::pure::functions::variant::tests::convert::to::model::testToClassWithInheritanceAndInstanceOf<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {
     let result1 = $f->eval(|fromJson('[{"_type": "Dog", "name": "Doggo", "isPuppy": true}, {"_type": "Cat", "name": "Gato", "isKitten": false}]')->toMany(@Pet)->filter(x | $x->instanceOf(Dog)).name);
@@ -154,6 +218,9 @@ function <<PCT.test, PCTCoreQualifier.variant>> meta::pure::functions::variant::
     assertEquals('Gato', $result2);
 }
 
+'''
+The same with a custom discriminator key and lookup table.
+'''
 function <<PCT.test, PCTCoreQualifier.variant>> meta::pure::functions::variant::tests::convert::to::model::testToClassWithInheritanceAndInstanceOf_withTypeLookup<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {
     let result3 = $f->eval(|fromJson('[{"@type": "perro", "name": "Doggo", "isPuppy": true}, {"@type": "gato", "name": "Gato", "isKitten": false}]')->toMany(@Pet, '@type', [pair('gato',Cat), pair('perro',Dog)])->filter(x | $x->instanceOf(Dog)).name);

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-scenario-quant-pure/src/main/resources/core_scenario_quant/scenario/quant/gapAnalysis.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-scenario-quant-pure/src/main/resources/core_scenario_quant/scenario/quant/gapAnalysis.pure
@@ -17,6 +17,36 @@ import meta::pure::precisePrimitives::*;
 import meta::pure::test::pct::*;
 import meta::pure::functions::flow::*;
 
+'''
+The overnight gap: how far each bar opened away from the previous close, as a percentage.
+
+`(open - previousClose) / previousClose * 100`, where "previous" is the preceding row for the same
+`symbol` ordered by `time`. A positive figure is a gap up, a negative one a gap down, and `0.0` means
+the bar opened exactly where the last one closed. Rows for different symbols never mix. Rounded to
+two decimal places.
+
+**The first bar of a symbol is not zero.** With no predecessor the comparison falls back to the bar's
+own close, so the figure reported is how far it opened from where it closed — `-0.5` in the example
+below, not `0.0`. Treat the leading row of each symbol as undefined rather than as a real gap.
+
+**Parameters**
+- `rel` — a relation of OHLCV bars: `time`, `symbol`, `open`, `high`, `low`, `close`, `volume`.
+
+**Returns** `symbol`, `time`, `open`, `close`, and the gap as `gapPercentage`.
+
+**Examples**
+```pure
+$bars->gapAnalysis()
+
+// symbol  time        open    close   gapPercentage
+// AAPL    2026-01-07  190.50  191.45  -0.5    no predecessor: measured against its own close
+// AAPL    2026-01-08  191.45  192.80   0.0    opened exactly at the previous close
+// AAPL    2026-01-09  195.00  195.90   1.14   gapped up from 192.80
+```
+
+**See also** `meta::external::scenario::quant::return::logReturn::logReturn`,
+`meta::external::scenario::quant::maxDrawDown::maxDrawDown`
+'''
 function <<PCT.function>> meta::external::scenario::quant::gap::gapAnalysis(rel:Relation<(time:Date[1], symbol:String[1], open:Numeric(19,2)[1], high:Numeric(19,2)[1], low:Numeric(19,2)[1], close:Numeric(19,2)[1], volume:Integer[1])>[1]):Relation<(symbol:String[1], time:Date[1], open:Numeric(19,2)[1], close:Numeric(19,2)[1], gapPercentage:Float[1])>[1]
 {
     $rel

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-scenario-quant-pure/src/main/resources/core_scenario_quant/scenario/quant/logReturn.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-scenario-quant-pure/src/main/resources/core_scenario_quant/scenario/quant/logReturn.pure
@@ -18,6 +18,40 @@ import meta::pure::test::pct::*;
 import meta::pure::functions::flow::*;
 import meta::pure::metamodel::relation::*;
 
+'''
+The natural log return of the closing price against the previous bar, per symbol.
+
+`ln(close / previousClose)`, where "previous" is the preceding row for the same `symbol` ordered by
+`time`. **The first bar of a symbol yields exactly `0.0`, not empty** — with no predecessor the close
+is compared against itself, and `ln(1)` is zero. Rows for different symbols never mix, so interleaved
+symbols in the input are handled without pre-partitioning. The result is rounded to ten decimal
+places.
+
+Log returns rather than simple returns because they add over time, which is what makes the rolling
+standard deviation in
+`meta::external::scenario::quant::volatility::close::annualizedRolling10DaysVolatility` meaningful.
+
+**Parameters**
+- `rel` — a relation of OHLCV bars: `time`, `symbol`, `open`, `high`, `low`, `close`, `volume`.
+
+**Returns** `symbol`, `time`, `close`, and the return as `logReturn`.
+
+**Examples**
+```pure
+// AAPL closing at 185.10, 185.35, 185.55, 185.70 and 185.65 on consecutive minutes
+$bars->logReturn()
+
+// symbol  time      close   logReturn
+// AAPL    09:30     185.10   0.0             no predecessor
+// AAPL    09:31     185.35   0.00134971      ln(185.35 / 185.10)
+// AAPL    09:32     185.55   0.001078458
+// AAPL    09:33     185.70   0.0008080808
+// AAPL    09:34     185.65  -0.0002692878    negative when the price falls
+```
+
+**See also** `meta::external::scenario::quant::volatility::close::annualizedRolling10DaysVolatility`,
+`meta::external::scenario::quant::gap::gapAnalysis`
+'''
 function <<PCT.function>> meta::external::scenario::quant::return::logReturn::logReturn(rel:Relation<(time:Date[1], symbol:String[1], open:Numeric(19,2)[1], high:Numeric(19,2)[1], low:Numeric(19,2)[1], close:Numeric(19,2)[1], volume:Integer[1])>[1]):Relation<(symbol:String[1], time:Date[1], close:Numeric(19,2)[1], logReturn:Float[1])>[1]
 {
     $rel->select(~[symbol, time, close])

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-scenario-quant-pure/src/main/resources/core_scenario_quant/scenario/quant/maxDrawdown.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-scenario-quant-pure/src/main/resources/core_scenario_quant/scenario/quant/maxDrawdown.pure
@@ -17,6 +17,35 @@ import meta::pure::precisePrimitives::*;
 import meta::pure::test::pct::*;
 import meta::pure::functions::date::*;
 
+'''
+The worst peak-to-trough fall, as a percentage, over the whole period, per symbol.
+
+For each bar the running maximum of `high` up to and including that bar is the peak so far; the fall
+is `(low - peak) / peak * 100`. The result is the most negative such fall over the whole input, so it
+is **one row per symbol, not one per bar**, and it is a negative percentage whenever the price ever
+traded below an earlier high.
+
+The peak is taken from `high` and the trough from `low`, so the measure is intra-bar: a price that
+recovered by the close still counts. Because the running maximum starts at the first bar, the figure
+depends on where the input begins — this is drawdown over the period supplied, not over the
+instrument's history. Rounded to two decimal places.
+
+**Parameters**
+- `rel` — a relation of OHLCV bars: `time`, `symbol`, `open`, `high`, `low`, `close`, `volume`.
+
+**Returns** one row per `symbol`, with the worst fall as `maxDrawdown`.
+
+**Examples**
+```pure
+$bars->maxDrawDown()
+
+// symbol  maxDrawdown
+// AAPL    -15.66        the deepest low sat 15.66% below the highest high preceding it
+```
+
+**See also** `meta::external::scenario::quant::volatility::close::annualizedRolling10DaysVolatility`,
+`meta::external::scenario::quant::gap::gapAnalysis`
+'''
 function <<PCT.function>> meta::external::scenario::quant::maxDrawDown::maxDrawDown(rel:Relation<(time:Date[1], symbol:String[1], open:Numeric(19,2)[1], high:Numeric(19,2)[1], low:Numeric(19,2)[1], close:Numeric(19,2)[1], volume:Integer[1])>[1]):Relation<(symbol:String[1],maxDrawdown:Float[1])>[1]
 {
     $rel->extend(

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-scenario-quant-pure/src/main/resources/core_scenario_quant/scenario/quant/sma.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-scenario-quant-pure/src/main/resources/core_scenario_quant/scenario/quant/sma.pure
@@ -16,6 +16,35 @@ import meta::pure::metamodel::relation::*;
 import meta::pure::precisePrimitives::*;
 import meta::pure::test::pct::*;
 
+'''
+The five-day simple moving average of the closing price, per symbol.
+
+Each row's `SMA` averages the close of that row and of the four rows before it, ordered by `time`
+within each `symbol`. **The window does not have to be full**: the first row of a symbol averages one
+value, the second two, and only from the fifth row on is the figure a true five-day average. Rows for
+different symbols never mix. The result is rounded to five decimal places.
+
+**Parameters**
+- `rel` — a relation of OHLCV bars: `time`, `symbol`, `open`, `high`, `low`, `close`, `volume`.
+
+**Returns** `symbol`, `time`, `close`, and the average as `SMA`.
+
+**Examples**
+```pure
+// AAPL closing at 100.00, 101.50, 102.00, 100.80 and 103.00 on five consecutive days
+$bars->simpleMovingAverage5Days()
+
+// symbol  time        close   SMA
+// AAPL    2026-01-07  100.00  100.0        one value in the window
+// AAPL    2026-01-08  101.50  100.75       two
+// AAPL    2026-01-09  102.00  101.16667
+// AAPL    2026-01-10  100.80  101.075
+// AAPL    2026-01-11  103.00  101.46       the first genuine five-day average
+```
+
+**See also** `meta::external::scenario::quant::vwap::monthlyVWAP`,
+`meta::external::scenario::quant::return::logReturn::logReturn`
+'''
 function <<PCT.function>> meta::external::scenario::quant::sma::simpleMovingAverage5Days(rel:Relation<(time:Date[1], symbol:String[1], open:Numeric(19,2)[1], high:Numeric(19,2)[1], low:Numeric(19,2)[1], close:Numeric(19,2)[1], volume:Integer[1])>[1]):Relation<(symbol:String[1], time:Date[1], close:Numeric(19,2)[1], SMA:Float[1])>[1]
 {
     // The expression that should be written (but DBs can't perform a direct operation i.e. round on an aggregate value).

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-scenario-quant-pure/src/main/resources/core_scenario_quant/scenario/quant/volatility/rollingVolatility.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-scenario-quant-pure/src/main/resources/core_scenario_quant/scenario/quant/volatility/rollingVolatility.pure
@@ -17,6 +17,40 @@ import meta::pure::precisePrimitives::*;
 import meta::pure::test::pct::*;
 import meta::pure::functions::flow::*;
 
+'''
+Annualized ten-day rolling volatility of the closing price, per symbol.
+
+Computes `meta::external::scenario::quant::return::logReturn::logReturn` first, then takes the
+**population** standard deviation of those returns over the current row and the nine before it, and
+scales by `sqrt(252)` for the conventional 252 trading days in a year. Ordered by `time` within each
+`symbol`; rows for different symbols never mix. The result is rounded to ten decimal places.
+
+As with the moving average, **the window does not have to be full** — the figure is defined from the
+first row onwards and only becomes a genuine ten-day measure from the tenth. The first row is `0.0`,
+being the deviation of the single zero return that `logReturn` produces for a bar with no
+predecessor.
+
+**Parameters**
+- `rel` — a relation of OHLCV bars: `time`, `symbol`, `open`, `high`, `low`, `close`, `volume`.
+
+**Returns** `symbol`, `time`, `close`, the underlying `logReturn`, and `rollingVolatility`.
+
+**Examples**
+```pure
+// AAPL closing at 151.20, 150.50, 150.90, 151.10 and 151.80 on consecutive days
+$bars->annualizedRolling10DaysVolatility()
+
+// symbol  time        close   logReturn      rollingVolatility
+// AAPL    2026-01-01  151.20   0.0           0.0
+// AAPL    2026-01-02  150.50  -0.0046403795  0.0368318704
+// AAPL    2026-01-03  150.90   0.0026542816  0.0478553192
+// AAPL    2026-01-04  151.10   0.0013245035  0.0436355655
+// AAPL    2026-01-05  151.80   0.0046219957  0.0494706979
+```
+
+**See also** `meta::external::scenario::quant::return::logReturn::logReturn`,
+`meta::external::scenario::quant::maxDrawDown::maxDrawDown`
+'''
 function <<PCT.function>> meta::external::scenario::quant::volatility::close::annualizedRolling10DaysVolatility(rel:Relation<(time:Date[1], symbol:String[1], open:Numeric(19,2)[1], high:Numeric(19,2)[1], low:Numeric(19,2)[1], close:Numeric(19,2)[1], volume:Integer[1])>[1]):Relation<(symbol:String[1], time:Date[1], close:Numeric(19,2)[1], logReturn:Float[1], rollingVolatility:Number[1])>[1]
 {
     // meta::external::scenario::quant::return::logReturn::logReturn($rel)->extend(

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-scenario-quant-pure/src/main/resources/core_scenario_quant/scenario/quant/vwap.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-scenario-quant-pure/src/main/resources/core_scenario_quant/scenario/quant/vwap.pure
@@ -17,6 +17,35 @@ import meta::pure::precisePrimitives::*;
 import meta::pure::test::pct::*;
 import meta::pure::functions::date::*;
 
+'''
+The volume-weighted average price of each symbol, per calendar month.
+
+Weights each bar's **typical price** — `(high + low + close) / 3`, not the close alone — by its
+volume, sums that over the month, and divides by the month's total volume. Bars are bucketed by
+`timeBucket(1, DurationUnit.MONTHS)`, so `month` is the first instant of the month a bar fell in and
+partial months at either end of the input are reported as ordinary months.
+
+Note that `closeByVolSum` is the sum of typical price times volume despite its name, and that both it
+and `vwap` are rounded to two decimal places while `volumeSum` is exact.
+
+**Parameters**
+- `rel` — a relation of OHLCV bars: `time`, `symbol`, `open`, `high`, `low`, `close`, `volume`.
+
+**Returns** one row per `symbol` and `month`, with `closeByVolSum`, `volumeSum` and `vwap`.
+
+**Examples**
+```pure
+$bars->monthlyVWAP()
+
+// symbol  month       closeByVolSum     volumeSum     vwap
+// AAPL    2026-01-01  168177755000.0    872700000     192.71
+// AAPL    2026-02-01  227944933333.33   1097000000    207.79
+// AAPL    2026-03-01  140986233333.33   637000000     221.33
+```
+
+**See also** `meta::external::scenario::quant::sma::simpleMovingAverage5Days`,
+`meta::external::scenario::quant::gap::gapAnalysis`
+'''
 function <<PCT.function>> meta::external::scenario::quant::vwap::monthlyVWAP(rel:Relation<(time:Date[1], symbol:String[1], open:Numeric(19,2)[1], high:Numeric(19,2)[1], low:Numeric(19,2)[1], close:Numeric(19,2)[1], volume:Integer[1])>[1]):Relation<(symbol:String[1], month:DateTime[1], closeByVolSum:Number[1], volumeSum:Integer[1], vwap:Float[1])>[1]
 {
     $rel

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure/src/main/resources/core_dataquality/generation/dataquality_relation_helper.pure
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure/src/main/resources/core_dataquality/generation/dataquality_relation_helper.pure
@@ -20,37 +20,180 @@ import meta::external::dataquality::*;
 import meta::pure::metamodel::relation::*;
 import meta::pure::functions::date::*;
 
+'''
+Whether a relation has no rows.
+
+The building block for a data quality rule that asserts something never happens: filter a relation
+down to the rows that violate the rule, then require the result to be empty. It counts rows, so a
+relation with columns but no rows is empty and the column list makes no difference.
+
+**Parameters**
+- `rel` — the relation to test.
+
+**Returns** `true` when the relation has no rows.
+
+**Examples**
+```pure
+$bars->filter(r | $r.volume < 0)->relationEmpty()   // true when no bar has negative volume
+```
+
+**See also** `relationNotEmpty(Relation<T>[1]):Boolean[1]`,
+`rowCountEqual(Relation<T>[1], Number[1]):Boolean[1]`
+'''
 function <<PCT.function>> meta::external::dataquality::relationEmpty<T>(rel:Relation<T>[1]):Boolean[1]
 {
   $rel->meta::pure::functions::relation::size() == 0;
 }
 
+'''
+Whether a relation has at least one row.
+
+The complement of `relationEmpty(Relation<T>[1]):Boolean[1]`, for rules that assert something must
+be present rather than absent.
+
+**Parameters**
+- `rel` — the relation to test.
+
+**Returns** `true` when the relation has one row or more.
+
+**Examples**
+```pure
+$bars->filter(r | $r.symbol == 'AAPL')->relationNotEmpty()   // true when AAPL appears at all
+```
+
+**See also** `relationEmpty(Relation<T>[1]):Boolean[1]`,
+`rowCountGreaterThan(Relation<T>[1], Number[1]):Boolean[1]`
+'''
 function <<PCT.function>> meta::external::dataquality::relationNotEmpty<T>(rel:Relation<T>[1]):Boolean[1]
 {
   $rel->meta::pure::functions::relation::size() > 0;
 }
 
 // row count
+'''
+Whether a relation has strictly more rows than a limit.
+
+Strict, so a relation of exactly `lowerLimit` rows gives `false`; use
+`rowCountGreaterThanEqual(Relation<T>[1], Number[1]):Boolean[1]` when the limit itself should pass.
+The limit is a `Number`, so a fractional bound is accepted and compares as written.
+
+**Parameters**
+- `rel` — the relation to count.
+- `lowerLimit` — the count the relation must exceed.
+
+**Returns** `true` when the relation has more than `lowerLimit` rows.
+
+**Examples**
+```pure
+$threeRows->rowCountGreaterThan(1)   // true
+$threeRows->rowCountGreaterThan(3)   // false, the comparison is strict
+```
+
+**See also** `rowCountGreaterThanEqual(Relation<T>[1], Number[1]):Boolean[1]`,
+`rowCountLowerThan(Relation<T>[1], Number[1]):Boolean[1]`
+'''
 function <<PCT.function>> meta::external::dataquality::rowCountGreaterThan<T>(rel: Relation<T>[1], lowerLimit: Number[1]): Boolean[1]
 {
   $rel->meta::pure::functions::relation::size() > $lowerLimit;
 }
 
+'''
+Whether a relation has at least as many rows as a limit.
+
+As `rowCountGreaterThan(Relation<T>[1], Number[1]):Boolean[1]`, but a relation of exactly
+`lowerLimit` rows passes.
+
+**Parameters**
+- `rel` — the relation to count.
+- `lowerLimit` — the smallest acceptable count.
+
+**Returns** `true` when the relation has `lowerLimit` rows or more.
+
+**Examples**
+```pure
+$threeRows->rowCountGreaterThanEqual(3)   // true, where rowCountGreaterThan(3) is false
+```
+
+**See also** `rowCountGreaterThan(Relation<T>[1], Number[1]):Boolean[1]`,
+`rowCountLowerThanEqual(Relation<T>[1], Number[1]):Boolean[1]`
+'''
 function <<PCT.function>> meta::external::dataquality::rowCountGreaterThanEqual<T>(rel: Relation<T>[1], lowerLimit: Number[1]): Boolean[1]
 {
   $rel->meta::pure::functions::relation::size() >= $lowerLimit;
 }
 
+'''
+Whether a relation has strictly fewer rows than a limit.
+
+Strict, so a relation of exactly `upperLimit` rows gives `false`; use
+`rowCountLowerThanEqual(Relation<T>[1], Number[1]):Boolean[1]` when the limit itself should pass.
+
+**Parameters**
+- `rel` — the relation to count.
+- `upperLimit` — the count the relation must stay below.
+
+**Returns** `true` when the relation has fewer than `upperLimit` rows.
+
+**Examples**
+```pure
+$threeRows->rowCountLowerThan(4)   // true
+$threeRows->rowCountLowerThan(3)   // false, the comparison is strict
+```
+
+**See also** `rowCountLowerThanEqual(Relation<T>[1], Number[1]):Boolean[1]`,
+`rowCountGreaterThan(Relation<T>[1], Number[1]):Boolean[1]`
+'''
 function <<PCT.function>> meta::external::dataquality::rowCountLowerThan<T>(rel: Relation<T>[1], upperLimit: Number[1]): Boolean[1]
 {
   $rel->meta::pure::functions::relation::size() < $upperLimit;
 }
 
+'''
+Whether a relation has no more rows than a limit.
+
+As `rowCountLowerThan(Relation<T>[1], Number[1]):Boolean[1]`, but a relation of exactly `upperLimit`
+rows passes.
+
+**Parameters**
+- `rel` — the relation to count.
+- `upperLimit` — the largest acceptable count.
+
+**Returns** `true` when the relation has `upperLimit` rows or fewer.
+
+**Examples**
+```pure
+$threeRows->rowCountLowerThanEqual(3)   // true, where rowCountLowerThan(3) is false
+```
+
+**See also** `rowCountLowerThan(Relation<T>[1], Number[1]):Boolean[1]`,
+`rowCountGreaterThanEqual(Relation<T>[1], Number[1]):Boolean[1]`
+'''
 function <<PCT.function>> meta::external::dataquality::rowCountLowerThanEqual<T>(rel: Relation<T>[1], upperLimit: Number[1]): Boolean[1]
 {
   $rel->meta::pure::functions::relation::size() <= $upperLimit;
 }
 
+'''
+Whether a relation has exactly the given number of rows.
+
+Useful where a load is expected to produce a known count — a reference set, a fixed calendar — and
+either a shortfall or a surplus is a fault.
+
+**Parameters**
+- `rel` — the relation to count.
+- `equalTo` — the required count.
+
+**Returns** `true` when the relation has exactly `equalTo` rows.
+
+**Examples**
+```pure
+$threeRows->rowCountEqual(3)   // true
+$threeRows->rowCountEqual(2)   // false
+```
+
+**See also** `relationEmpty(Relation<T>[1]):Boolean[1]`,
+`rowCountGreaterThanEqual(Relation<T>[1], Number[1]):Boolean[1]`
+'''
 function <<PCT.function>> meta::external::dataquality::rowCountEqual<T>(rel: Relation<T>[1], equalTo: Number[1]): Boolean[1]
 {
   $rel->meta::pure::functions::relation::size() == $equalTo;

--- a/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/README.md
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/README.md
@@ -172,4 +172,16 @@ After each run, reports are generated in `target/`:
 - **`failure-details.md`** — Full result set comparisons for every FAIL and ERROR test. Shows the original SQL, rewritten SQL, cell-level diffs, and complete Expected (Postgres) vs Actual (Legend) result tables. Both `function-coverage.md` and `structural-parity.md` link directly to entries in this file — click any error category link (e.g. `FUNCTION_NOT_SUPPORTED`, `RESULT_MISMATCH`) to jump to the full details.
 - **`parity-report.json`** — Machine-readable JSON with all test results
 
+Each markdown report is also rendered to a standalone `.html` file beside it.
+
+## Published reports
+
+The four HTML reports are published to the Legend documentation site on every `master` build, at
+<https://legend.finos.org/sql-parity/summary.html>, and are described for users at
+<https://legend.finos.org/docs/reference/legend-sql>.
+
+The `legend-docs` job in `.github/workflows/build.yml` does the publishing: the `sql` group of `test-modules`
+uploads `target/*.html` as the `sql-parity-report` artifact, and `legend-docs` copies it into
+`website/static/sql-parity/` of `finos/legend`, alongside the PCT reports it collects the same way.
+
 

--- a/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/src/test/java/org/finos/legend/engine/postgres/e2e/coverage/HtmlReportGenerator.java
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/src/test/java/org/finos/legend/engine/postgres/e2e/coverage/HtmlReportGenerator.java
@@ -128,7 +128,7 @@ public class HtmlReportGenerator
             Node document = PARSER.parse(markdown);
             String htmlBody = RENDERER.render(document);
             // Rewrite internal .md links to point to the corresponding .html files
-            htmlBody = htmlBody.replaceAll("href=\"([^\"]*)\\.md(#[^\"]*)?\"", "href=\"$1$2\"");
+            htmlBody = htmlBody.replaceAll("href=\"([^\"]*)\\.md(#[^\"]*)?\"", "href=\"$1.html$2\"");
             String html = String.format(HTML_TEMPLATE, title, htmlBody);
             File htmlFile = new File(outputDir, htmlFileName);
             Files.write(htmlFile.toPath(), html.getBytes(StandardCharsets.UTF_8));


### PR DESCRIPTION
Builds on finos/legend-pure#1305, which brought that repository's platform corpus to 309 of 309
documented signatures and added the `'''…'''` documentation form. legend-engine owns roughly as many
PCT functions and had almost none documented to the same standard: a signature published either
nothing or a single unstructured sentence, where the equivalent platform function published a full
entry.

These strings reach end users through `FUNCTIONS_<repository>.json`, so the gap was visible outside
the repository.

## What changes

**Coverage goes from 25 of 291 signatures to 291 of 291**, across all seven engine Pure
repositories. 150 signatures had no documentation at all and 116 carried a legacy `doc.doc` tagged
value; an element may not hold both forms, so each tagged value is deleted in the edit that replaces
it. `PCT.grammarDoc` and `PCT.grammarCharacters` are different tags and are retained.

| Repository | Signatures |
|---|---|
| `core_functions_relation` | 117 |
| `core_functions_standard` | 114 |
| `core_functions_unclassified` | 37 |
| `core_functions_variant` | 9 |
| `core_dataquality` | 7 |
| `core_scenario_quant` | 6 |
| `core` | 1 |

**101 `<<PCT.test>>` cases are documented too**, concentrated in the two `composition.pure` files
where a test's purpose is least obvious from its body.

**A written standard**, `docs/pct/pct-documentation.md`, adapted from the legend-pure one: the
template, the formatting rules, the overload rule, the cross-reference rule, and how to verify.
`conventions.md`, `purefunction-howto.md` and `native-howto.md` are repointed off the `doc.doc` form.

**A page on the composition tests**, `docs/pct/composition-tests.md`. Those tests compose two or more
functions and are the hardest to read; the page groups the relation suite into eight themes and
records the engine divergences the manifests pin.

**A browsable reference**, `PCT_Report_Functions.html` — a javadoc-style companion to the
compatibility matrix, rendered from the same `pct-docs.json` that `GeneratePCTFiles` already emits,
so there is no new build wiring. One page per function: compatibility per adapter, then every
overload with its documentation rendered, with `See also` references linking to the functions they
name. Screenshots are in the comment below. The last commit publishes the SQL parity report from a
docs job of its own.

## What the documentation says

Behaviour and examples are taken from the PCT assertions in each file rather than from the
signatures. Signatures say what the types are; the assertions say what actually happens:

- a `_range` window frame is decided by ordering value rather than position, so tied rows always
  share a frame — over one test partition both `o=1` rows read `20`, where the equivalent `rows`
  frame gives `10` and then `20`
- `pivot` returns `Relation<Any>` and its generated column names contain literal quote characters,
  so the cast that must follow doubles them
- `lpad` truncates as well as pads, and a multi-character fill discards the string being padded — a
  defect in the underlying `pad`, recorded as such
- `aggregate` keeps only the aggregated columns, unlike `extend`, which repeats the same value across
  every original row
- `lateral` drops a row whose function returns nothing, as an inner join does
- `in` cannot be negated against a relation on any relational store — SQL's `NOT IN` goes `UNKNOWN`
  on a null — so the entry carries the `exists` rewrite the error message suggests. The in-memory
  engines do answer it, so documenting it as simply working would have misled anyone running against
  a database.

## Two things reviewers should know

**Composition test documentation does not publish.** `FunctionsGeneration.addPCTTestToFunctionsDB`
attributes a test to a function by source id, and a `composition.pure` declares no
`<<PCT.function>>`, so the lookup misses and the test is dropped along with its documentation.
Confirmed against the generated report. The literals are still worth having for anyone reading the
source, and `docs/pct/composition-tests.md` carries what would otherwise be lost.

**Two modules emit no PCT report at all.** `legend-engine-xt-dataquality-pure` and
`legend-engine-pure-code-compiled-core` declare no `generate-pct-functions` execution, so their eight
signatures are documented but never published. Wiring dataquality up also needs
`dataquality_relation_helper.pure` split first, since `FunctionsGeneration` permits one PCT function
name per source file. Both are recorded in the standard rather than fixed here.

## Audit

After the first pass, the review threads on legend-pure#1305 were replayed against this corpus. That
found real defects, fixed in later commits:

- **25 relation signatures had never been converted** — every overload of `groupBy`, `pivot`, `rows`
  and `range`, plus `aggregate`, `reduce`, `lateral` and `flatten`. The gap survived verification
  because `Signature.documentation` is populated by the tagged value and the literal alike, so the
  report read *95 of 95 documented* either way. The standard now says a populated `documentation`
  field is not evidence of conversion, and gives the grep that is. This is the same failure the
  reviewer caught on `times`/`plus`/`minus`/`divide`.
- **Three files read back-to-front** — `least`, `stdDevPopulation` and `stdDevSample` each opened
  with the overload whose documentation pointed forward to text below it. The REPL shows the first
  signature that has any, so the reader met the delta first. Reordered, as legend-pure did for
  `greaterThanEqual` and `elementToPath`; those diffs are exact permutations, with no body changed.
- **18 signatures had no runnable example**, against the standard's own rule.

Also checked and clean: no singular prose on a non-`[1]` return (the `fold` class), no predicate
described as failing, no over-claimed direction or monotonicity, and every `See also` cross-reference
resolves against the union PCT index apart from the intra-module ones in `core_dataquality`, which
emits no report and were checked by hand.

## Rebase

Rebased onto master. Four collisions, all resolved in favour of master's newer work:

- **#5085** documented the six regex functions first, and corrected the "full POSIX ERE" claim this
  branch had introduced — the implementation is `java.util.regex`. Master's version is taken
  wholesale; this branch adds nothing to those files.
- **#5104** dropped `functionType.NormalizeRequiredFunction` from `relation::eval`; master's
  declaration is kept with this branch's literal.
- **#5136** collapsed `between`'s `StrictDate` and `DateTime` overloads into one `Date` overload. The
  file keeps master's shape, its `doc.doc` becomes a literal, and the summary's overload count and
  cross-reference are corrected to match.
- Master added composition tests where this branch added literals; both are kept.

Master also brought ten new PCT functions still on a legacy `doc.doc` — the four `joinStrings`
overloads and the `FuncColSpec` families on `groupBy` and `aggregate` — documented here so the
coverage claim stays true.

## Verification

Documentation is parse-time sugar over a tagged value, so no PCT result changes.

- `mvn clean install` green on the `-pure` modules, compiled-state integrity and PCT report tests
  passing
- `mvn checkstyle:check@verify` clean
- 291 of 291 signatures carry a `'''` literal; no legacy `doc.doc` remains on any PCT declaration

🤖 Generated with [Claude Code](https://claude.com/claude-code)
