### PR TITLE
Legend SQL - handle order by index after join on realiased columns

### DIFF
--- a/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/src/test/resources/parity-tests/compositions/multi_join_agg.yaml
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/src/test/resources/parity-tests/compositions/multi_join_agg.yaml
@@ -60,8 +60,8 @@ tests:
     sql: "SELECT p.name, d.name AS dept, o.amount FROM persons p INNER JOIN departments d ON p.dept_id = d.id INNER JOIN orders o ON o.person_id = p.id WHERE o.amount > 100 AND d.budget > 500000 ORDER BY 1, 3"
     feature: "3-table JOIN + filter"
     category: "compositions"
-    expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_tds_status: PASS
+    expected_rel_status: PASS
 
   # JOIN with derived table
   - id: comp_join_derived

--- a/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/src/test/resources/parity-tests/structural/aliases.yaml
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/src/test/resources/parity-tests/structural/aliases.yaml
@@ -33,8 +33,8 @@ tests:
     sql: "SELECT p1.name, p2.name AS colleague FROM persons p1 JOIN persons p2 ON p1.dept_id = p2.dept_id AND p1.id < p2.id ORDER BY 1, 2"
     feature: "self-join with aliases"
     category: "aliases"
-    expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_tds_status: PASS
+    expected_rel_status: PASS
 
   # Alias usage in clauses
   - id: alias_in_order_by

--- a/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/src/test/resources/parity-tests/structural/joins.yaml
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/src/test/resources/parity-tests/structural/joins.yaml
@@ -4,44 +4,44 @@ tests:
     sql: "SELECT p.name, d.name AS dept_name FROM persons p INNER JOIN departments d ON p.dept_id = d.id ORDER BY 1"
     feature: "INNER JOIN"
     category: "joins"
-    expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_tds_status: PASS
+    expected_rel_status: PASS
 
   - id: join_inner_multi_condition
     sql: "SELECT p.name, d.name AS dept_name FROM persons p INNER JOIN departments d ON p.dept_id = d.id AND d.budget > 500000 ORDER BY 1"
     feature: "INNER JOIN"
     category: "joins"
-    expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_tds_status: PASS
+    expected_rel_status: PASS
 
   - id: join_inner_with_where
     sql: "SELECT p.name, d.name AS dept_name FROM persons p INNER JOIN departments d ON p.dept_id = d.id WHERE p.salary > 60000 ORDER BY 1"
     feature: "INNER JOIN"
     category: "joins"
-    expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_tds_status: PASS
+    expected_rel_status: PASS
 
   - id: join_inner_implicit
     sql: "SELECT p.name, d.name AS dept_name FROM persons p JOIN departments d ON p.dept_id = d.id ORDER BY 1"
     feature: "INNER JOIN"
     category: "joins"
-    expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_tds_status: PASS
+    expected_rel_status: PASS
 
   # LEFT JOIN
   - id: join_left_basic
     sql: "SELECT p.name, d.name AS dept_name FROM persons p LEFT JOIN departments d ON p.dept_id = d.id ORDER BY 1"
     feature: "LEFT JOIN"
     category: "joins"
-    expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_tds_status: PASS
+    expected_rel_status: PASS
 
   - id: join_left_null_fk
     sql: "SELECT p.name, COALESCE(d.name, 'No Dept') AS dept_name FROM persons p LEFT JOIN departments d ON p.dept_id = d.id WHERE d.id IS NULL ORDER BY 1"
     feature: "LEFT JOIN"
     category: "joins"
-    expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_tds_status: PASS
+    expected_rel_status: PASS
 
   - id: join_left_with_agg
     sql: "SELECT d.name AS dept_name, COUNT(p.id) AS cnt FROM departments d LEFT JOIN persons p ON p.dept_id = d.id GROUP BY d.name ORDER BY 1"
@@ -55,8 +55,8 @@ tests:
     sql: "SELECT p.name, d.name AS dept_name FROM persons p RIGHT JOIN departments d ON p.dept_id = d.id ORDER BY 1"
     feature: "RIGHT JOIN"
     category: "joins"
-    expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_tds_status: PASS
+    expected_rel_status: PASS
 
   - id: join_right_unmatched
     sql: "SELECT COALESCE(p.name, 'N/A') AS person, d.name AS dept_name FROM persons p RIGHT JOIN departments d ON p.dept_id = d.id ORDER BY 2"
@@ -85,8 +85,8 @@ tests:
     sql: "SELECT p.name, d.name AS dept_name FROM persons p CROSS JOIN departments d WHERE p.id <= 2 ORDER BY 1, 2"
     feature: "CROSS JOIN"
     category: "joins"
-    expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_tds_status: PASS
+    expected_rel_status: PASS
 
   - id: join_cross_count
     sql: "SELECT COUNT(*) AS total FROM persons p CROSS JOIN departments d WHERE p.id <= 3"
@@ -115,15 +115,15 @@ tests:
     sql: "SELECT p.name, d.name AS dept_name, o.amount FROM persons p INNER JOIN departments d ON p.dept_id = d.id INNER JOIN orders o ON o.person_id = p.id ORDER BY 1, 3"
     feature: "Multi-table JOIN"
     category: "joins"
-    expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_tds_status: PASS
+    expected_rel_status: PASS
 
   - id: join_three_tables_mixed
     sql: "SELECT p.name, d.name AS dept_name, COALESCE(o.amount, 0) AS amount FROM persons p INNER JOIN departments d ON p.dept_id = d.id LEFT JOIN orders o ON o.person_id = p.id WHERE p.salary IS NOT NULL ORDER BY 1, 3"
     feature: "Multi-table JOIN"
     category: "joins"
-    expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_tds_status: PASS
+    expected_rel_status: PASS
 
   - id: join_three_tables_agg
     sql: "SELECT d.name AS dept, COUNT(DISTINCT p.id) AS emps, COUNT(o.id) AS orders FROM departments d LEFT JOIN persons p ON p.dept_id = d.id LEFT JOIN orders o ON o.person_id = p.id GROUP BY d.name ORDER BY 1"

--- a/legend-engine-xts-sql/legend-engine-xt-sql-transformation/legend-engine-xt-sql-pure/src/main/resources/core_external_query_sql/binding/fromPure/fromPure.pure
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-transformation/legend-engine-xt-sql-pure/src/main/resources/core_external_query_sql/binding/fromPure/fromPure.pure
@@ -560,13 +560,9 @@ function <<access.private>> meta::external::query::sql::transformation::queryToP
 
       let projection = $querySpec.select->processProjection($querySpec.groupBy, $querySpec.having, $querySpec.orderBy.sortKey, $withWhere);
 
-      let query = $querySpec.limit->processLimitOffset($querySpec.offset,
-        $querySpec.orderBy->processOrderBy($projection.second.selectItems,
-          $querySpec.having->processHaving($projection.second,
-            $projection.first
-          )
-        )
-      );
+      let having = $querySpec.having->processHaving($projection.second,$projection.first);
+      let orderBy = $querySpec.orderBy->processOrderBy($projection.second.selectItems, $having);
+      let query = $querySpec.limit->processLimitOffset($querySpec.offset, $orderBy);
 
       //pair(sql specified name, sql column alias object)
       let expectedWithRealias = $querySpec.select.selectItems->map(si |
@@ -780,7 +776,10 @@ function <<access.private>> meta::external::query::sql::transformation::queryToP
       let index = $i.value - 1; //0 index offset in sql is 1;
       assert($index < $selectItems->size(), 'No select column at index ' + $i.value->toString());
       assert($selectItems->at($index)->instanceOf(SingleColumn), 'select * not currently supported for index group by');
-      $selectItems->at($index)->cast(@SingleColumn)->extractNameFromSingleColumn($context);,
+      let sc = $selectItems->at($index)->cast(@SingleColumn);
+      let originalName = $sc->extractNameFromSingleColumn([]);
+      let resolved = $context.columnByName($originalName, false);
+      if ($resolved->isEmpty(), | $originalName, | $resolved->toOne().name);,
     e:meta::external::query::sql::metamodel::Expression[1] | $e->extractNameFromExpression($context)
   ]);
 }


### PR DESCRIPTION
#### What type of PR is this?
Bug Fix

#### What does this PR do / why is it needed ?
currently using index on order by can fail on joins where columns have re-aliased. This ensures we check against the original column name so we don't accidently pick up wrong column name

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
