### PR TITLE
M2M: Skip cyclic candidates when building source tree back-edges

### DIFF
--- a/docs/engineering/architecture/source-tree-calculation.md
+++ b/docs/engineering/architecture/source-tree-calculation.md
@@ -296,10 +296,12 @@ tree calculation:
 | `enrichSourceTreeNodeAtPath` | 698–729 | Recursion helper that dives into a specific path in the source tree. |
 | `findSubTreeWithOwnerOrPropertyTreesFromOwner` | 736–755 | Walks the property tree finding owner-belonging subtrees. |
 | `collectPropertyTreeClasses` | 723–734 | Collects all class references in a property tree (used by the owner-reachability precondition). |
-| `isTreeRootOwner` | 818–822 | Decides whether the property tree is "rooted at owner" (legacy fast path). |
-| `buildPropertyPathUptoOwner` | 825–866 | Wraps a subtree with the intermediate-class hops needed to rejoin owner. |
-| `pickIntermediateProperty` | 868–874 | Tie-breaker: picks one of several candidate intermediate properties (prefers exact-return-type match, then alphabetical). |
-| `propertyTreeToGraphFetchTree` | 876–880 | Converts a `PropertyPathTree` to a `RootGraphFetchTree<Any>`. |
+| `isTreeRootOwner` | 863–870 | Decides whether the property tree is "rooted at owner" (legacy fast path). |
+| `lookupIntermediateCandidates` | 833–840 | Finds every property whose return type reaches a target class (equal or subtype). |
+| `buildPropertyPathUptoOwner` | 873–928 | Wraps a subtree with the intermediate-class hops needed to rejoin owner. Public 3-arity wrapper plus a private 4-arity overload carrying the `visited` cycle guard. |
+| `pickIntermediateProperty` | 930–936 | Tie-breaker: picks one of several candidate intermediate properties (prefers exact-return-type match, then alphabetical). |
+| `nextIntermediateProperty` | 938–962 | Chooses the next back-edge hop: looks up candidates, drops those that would revisit a class already on the path, then delegates to `pickIntermediateProperty`. See §11.6. |
+| `propertyTreeToGraphFetchTree` | 964–968 | Converts a `PropertyPathTree` to a `RootGraphFetchTree<Any>`. |
 | `addPropertyGraphFetchTrees` (3-arity) | 889–919 | Walks a `PropertyPathTree`, attaching matching properties to a graph-fetch tree. |
 | `addPropertyGraphFetchTrees` (4-arity) | 929–961 | Inner helper. Builds a `SystemGeneratedPropertyGraphFetchTree` and recurses children. |
 | `removeDummyProperties` | ~963 | Strips `dummyProp` markers left by the property-tree builder. |
@@ -1121,6 +1123,86 @@ the test assertions on substrings pass.
 If a future caller requires the multi-rooted shape, the union arm's
 "first + subTypeTrees" combination logic is the natural place to
 specialise it.
+
+### 11.6 Replace the greedy back-edge walk with a backtracking search
+
+**Background.** `buildPropertyPathUptoOwner` walks *backwards* from an
+intermediate class to the owner: look up every property whose return
+type is `target`, pick one, set `target := picked.ownerClass()`,
+recurse. Originally it kept no record of the classes it had already
+stood on, so any cycle in the class graph made it non-terminating —
+it spun until the 64-level backstop fired with the misleading
+"owner ... is not reachable from the intermediate property tree".
+
+Two shapes trigger this, both legitimate modelling:
+
+- a **self-referencing** property (`Tx.interco : Tx[*]`), which leaves
+  `target` unchanged;
+- a **mutually-referencing** pair (`A.b : B` / `B.a : A`), which
+  oscillates between two classes.
+
+The shipped fix threads a `visited` set of element paths through the
+recursion and has `nextIntermediateProperty` drop candidates declared
+on a class already on the path. Termination becomes structural: each
+level consumes one class from a finite set. It is behaviour-preserving
+— in a run that already terminated, no class repeats, so the candidate
+that run would have picked always survives the filter. (It also cannot
+flip `pickIntermediateProperty`'s exact-return-type pool to its
+fallback branch, since the surviving candidate stays in `exact`.)
+
+**Idea:** go further and make the search backtrack, so a wrong first
+pick is retried rather than fatal:
+
+```pure
+findBackEdgeChain(t, target, owner, visited) : List<AbstractProperty<Any>>[0..1]
+```
+
+`[]` means no path; a present `List` is the chain (possibly empty, when
+`target` is already `owner`). Try candidates in `pickIntermediateProperty`
+preference order, first success wins, backtrack on failure. This is also
+behaviour-preserving — the preferred candidate is still tried first, so
+models that work today follow the identical path — and it closes the one
+gap the visited-set guard leaves.
+
+**Why we didn't do it (yet):** roughly 2–3× the Pure, in three places.
+
+1. `pickIntermediateProperty` has to be recast as an *ordering* rather
+   than a single pick, so the fallback sequence is well-defined.
+2. Pure's `fold` does not short-circuit, so first-success-wins needs
+   explicit recursion over the candidate list or every branch is
+   explored regardless.
+3. Tree construction moves out of the recursion. Today each level wraps
+   as it goes; with a chain returned up front you resolve
+   `startTarget`/`baseChildren` once from the entry arm, run the DFS
+   over the class graph, then fold the chain into wrapper nodes. Note
+   that both match arms set `value = ^PropertyPathNode(...)`, so the
+   `Class` arm — the one that uses `children = $pTree.children` rather
+   than `children = $pTree` — can only ever execute on the *initial*
+   invocation from `enrichSourceTreeNodeForProperty`. The DFS itself
+   never needs to know about that distinction.
+
+**The gap this leaves.** The greedy walk can still take a wrong turn
+into a cul-de-sac and fail on a model where a valid path exists. It
+fails *fast and accurately* rather than hanging — see the distinct
+assertion in `nextIntermediateProperty`, which deliberately does not
+claim that no property returns the target. The trigger is a class whose
+every producer is declared on a class already on the path, reached
+because a better-sorting sibling candidate led elsewhere.
+
+`sourceTreeCalc::mutualCycle::testMutualCycleGivesClearError` in
+`testSourceTreeCalc.pure` pins exactly that shape and is the ready-made
+fixture for this work: if §11.6 is implemented, that test flips from
+asserting an error to asserting the source tree
+`McPayload { event { transaction { txId } } }`.
+
+**Rejected outright: BFS shortest-path.** Replacing greedy with a
+breadth-first search finds a path whenever one exists and removes the
+dependence on candidate ordering, but it is *not* behaviour-preserving.
+Measured against a real 1753-class model (134 classes reachable from the
+owner), BFS changed the selected path for 33 of the 116 back-edges that
+resolve correctly today — silently altering which data the synthesised
+source trees fetch. The visited-set guard left all 116 byte-identical
+while fixing all 17 that looped.
 
 ---
 

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/graphFetch/graphExtension.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/graphFetch/graphExtension.pure
@@ -897,13 +897,24 @@ function meta::pure::graphFetch::isTreeRootOwner(pTree:PropertyPathTree[1], owne
 
 function meta::pure::graphFetch::buildPropertyPathUptoOwner(pTree:PropertyPathTree[1], owner:Class<Any>[1], t : Map<Type, List<AbstractProperty<Any>>>[1]): PropertyPathTree[1]
 {
-   meta::pure::graphFetch::buildPropertyPathUptoOwner($pTree, $owner, $t, 0)
+   meta::pure::graphFetch::buildPropertyPathUptoOwner($pTree, $owner, $t, [])
 }
 
+// visited carries the element paths of the classes already on the path being built, so
+// that nextIntermediateProperty can reject candidates that would revisit one. Without it
+// a class-graph cycle - a self-referencing property, or a mutually-referencing pair -
+// makes this walk non-terminating. Both are legitimate in a domain model, so the cycle is
+// broken here. Termination is then structural: each level consumes one class from a finite
+// set. Note the walk is greedy and does not backtrack, so it can still fail on a model
+// where the preferred candidate leads into a cul-de-sac; the alternative that closes that
+// gap is recorded in docs/engineering/architecture/source-tree-calculation.md section 11.6.
+// Mirrors meta::pure::functions::meta::allNestedProperties, which is cycle-guarded the
+// same way (public wrapper, private overload with a visited parameter keyed on element path).
 function <<access.private>>
-   meta::pure::graphFetch::buildPropertyPathUptoOwner(pTree:PropertyPathTree[1], owner:Class<Any>[1], t : Map<Type, List<AbstractProperty<Any>>>[1], depth:Integer[1]): PropertyPathTree[1]
+   meta::pure::graphFetch::buildPropertyPathUptoOwner(pTree:PropertyPathTree[1], owner:Class<Any>[1], t : Map<Type, List<AbstractProperty<Any>>>[1], visited:String[*]): PropertyPathTree[1]
 {
-   assert($depth <= 64, | 'buildPropertyPathUptoOwner recursion exceeded 64 levels - owner ' + $owner->elementToPath() + ' is not reachable from the intermediate property tree.');
+   // Defensive only - the visited set above already guarantees termination.
+   assert($visited->size() <= 64, | 'buildPropertyPathUptoOwner recursion exceeded 64 levels building a path back to owner ' + $owner->elementToPath() + ' - internal error, the cycle guard should have prevented this.');
    $pTree.value->match(
       [
          p:PropertyPathNode[1] | let prop     = $p.property;
@@ -913,16 +924,14 @@ function <<access.private>>
                                     // or a supertype of owner (inheritance). The supertype-of-owner case relies on
                                     // addPropertyGraphFetchTrees accepting the property under owner via inheritance.
                                     | $pTree,
-                                    | let candidates = meta::pure::graphFetch::lookupIntermediateCandidates($t, $propOwner);
-                                      assert($candidates->isNotEmpty(),
-                                             | 'No intermediate-class property of ' + $owner->elementToPath() + ' returns ' + $propOwner->elementToPath() + ' - cannot build path back to owner.');
-                                      let picked = meta::pure::graphFetch::pickIntermediateProperty($candidates, $propOwner);
+                                    | let visitedNow = $visited->concatenate($propOwner->elementToPath());
+                                      let picked = meta::pure::graphFetch::nextIntermediateProperty($t, $propOwner, $owner, $visitedNow);
                                       let newptree = ^PropertyPathTree(
                                                         display  = $picked.name->toOne(),
                                                         value    = ^PropertyPathNode(class = $picked->meta::pure::functions::meta::ownerClass(), property = $picked),
                                                         children = $pTree
                                                      );
-                                      meta::pure::graphFetch::buildPropertyPathUptoOwner($newptree, $owner, $t, $depth + 1);
+                                      meta::pure::graphFetch::buildPropertyPathUptoOwner($newptree, $owner, $t, $visitedNow);
                                  );,
          clz : Class<Any>[1] | if($clz == $owner || $clz->isStrictSubType($owner) || $owner->isStrictSubType($clz),
                                   // Same inheritance case as the PropertyPathNode arm above: owner can
@@ -930,16 +939,14 @@ function <<access.private>>
                                   // `$src->typeName()` transform on _S_PersonC puts a _S_Person Class
                                   // node in the property tree; _S_PersonC instances inherit access).
                                   | $pTree,
-                                  | let candidates = meta::pure::graphFetch::lookupIntermediateCandidates($t, $clz);
-                                    assert($candidates->isNotEmpty(),
-                                           | 'No intermediate-class property of ' + $owner->elementToPath() + ' returns ' + $clz->elementToPath() + ' - cannot build path back to owner.');
-                                    let picked = meta::pure::graphFetch::pickIntermediateProperty($candidates, $clz);
+                                  | let visitedNow = $visited->concatenate($clz->elementToPath());
+                                    let picked = meta::pure::graphFetch::nextIntermediateProperty($t, $clz, $owner, $visitedNow);
                                     let newptree = ^PropertyPathTree(
                                                       display  = $picked.name->toOne(),
                                                       value    = ^PropertyPathNode(class = $picked->meta::pure::functions::meta::ownerClass(), property = $picked),
                                                       children = $pTree.children
                                                    );
-                                    meta::pure::graphFetch::buildPropertyPathUptoOwner($newptree, $owner, $t, $depth + 1);
+                                    meta::pure::graphFetch::buildPropertyPathUptoOwner($newptree, $owner, $t, $visitedNow);
                               )
       ]
    );
@@ -951,6 +958,32 @@ function <<access.private>>
    let exact = $candidates->filter(p | $p.genericType.rawType->toOne() == $target);
    let pool  = if($exact->isNotEmpty(), | $exact, | $candidates);
    $pool->sortBy(p | $p.name->toOne())->at(0);
+}
+
+// Choose the next hop of the back-edge walk: a property returning target, declared on a
+// class we have not already stood on. Candidates declared on a class in visited make no
+// progress toward owner - a self-referencing property (Tx.interco : Tx[*]) leaves target
+// unchanged, and a mutually-referencing pair (A.b : B / B.a : A) oscillates between two
+// classes - so the walk would recurse until the depth backstop fired. Both shapes are
+// legitimate modelling, so they are filtered here rather than rejected in the model.
+function <<access.private>>
+   meta::pure::graphFetch::nextIntermediateProperty(t : Map<Type, List<AbstractProperty<Any>>>[1], target:Class<Any>[1], owner:Class<Any>[1], visited:String[*]) : AbstractProperty<Any>[1]
+{
+   let candidates = meta::pure::graphFetch::lookupIntermediateCandidates($t, $target);
+   assert($candidates->isNotEmpty(),
+          | 'No intermediate-class property of ' + $owner->elementToPath() + ' returns ' + $target->elementToPath() + ' - cannot build path back to owner.');
+
+   // Compare by element path, not object identity: Pure's lazy evaluation can produce
+   // multiple objects for the same Class (see the same treatment at ownerGenPaths above).
+   let progressing = $candidates->filter(c | !$visited->contains($c->meta::pure::functions::meta::ownerClass()->elementToPath()));
+   // Deliberately not a claim that no property returns target - one does, and a valid path
+   // may well exist down a branch this walk did not take. The search is greedy with no
+   // backtracking; see docs/engineering/architecture/source-tree-calculation.md section 11.6.
+   assert($progressing->isNotEmpty(),
+          | 'Could not build an acyclic path from ' + $owner->elementToPath() + ' back to ' + $target->elementToPath()
+            + ': every property returning it is declared on a class already on the path. The back-edge search does not backtrack - see source-tree-calculation.md section 11.6.');
+
+   meta::pure::graphFetch::pickIntermediateProperty($progressing, $target);
 }
 
 function meta::pure::graphFetch::propertyTreeToGraphFetchTree(pTree:PropertyPathTree[1], ownerClass:Class<Any>[1]): RootGraphFetchTree<Any>[1]

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/graphFetch/tests/sourceTreeCalc/testSourceTreeCalc.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/graphFetch/tests/sourceTreeCalc/testSourceTreeCalc.pure
@@ -3692,3 +3692,173 @@ Mapping meta::pure::graphFetch::tests::sourceTreeCalc::unionInheritedProp::Phant
     chargedPartyId : $src.executionCommission.payBy.oe.identifier->toOne()
   }
 )
+
+###Pure
+import meta::pure::graphFetch::tests::sourceTreeCalc::selfRef::*;
+import meta::pure::graphFetch::*;
+import meta::pure::graphFetch::routing::*;
+
+// Regression: a class that declares a property returning its own type is legitimate
+// modelling, but it made the back-edge walk non-terminating. buildPropertyPathUptoOwner
+// walks backwards from the intermediate class to the owner - find a property returning
+// target, pick one, set target := picked.ownerClass(), recurse - and kept no record of
+// where it had been. Here the candidates returning SrTx are SrTx.interco (declared on
+// SrTx itself) and SrCollateral.tx; pickIntermediateProperty sorts by name, so 'interco'
+// wins, target never changes, and the walk spun until the 64-level backstop fired with
+// "buildPropertyPathUptoOwner recursion exceeded 64 levels".
+// Derived from a real model in which
+// TripartyRepoCollateralTransaction.intercoContract returns TripartyRepoCollateralTransaction.
+Class meta::pure::graphFetch::tests::sourceTreeCalc::selfRef::SrTx
+{
+  txId    : String[1];
+  interco : meta::pure::graphFetch::tests::sourceTreeCalc::selfRef::SrTx[*];
+}
+
+Class meta::pure::graphFetch::tests::sourceTreeCalc::selfRef::SrCollateral
+{
+  tx : meta::pure::graphFetch::tests::sourceTreeCalc::selfRef::SrTx[0..1];
+}
+
+Class meta::pure::graphFetch::tests::sourceTreeCalc::selfRef::SrEvent
+{
+  collateral : meta::pure::graphFetch::tests::sourceTreeCalc::selfRef::SrCollateral[*];
+}
+
+Class meta::pure::graphFetch::tests::sourceTreeCalc::selfRef::SrPayload
+{
+  event : meta::pure::graphFetch::tests::sourceTreeCalc::selfRef::SrEvent[1];
+}
+
+Class meta::pure::graphFetch::tests::sourceTreeCalc::selfRef::SrOut
+{
+  txInfo : meta::pure::graphFetch::tests::sourceTreeCalc::selfRef::SrTxOut[0..1];
+}
+
+Class meta::pure::graphFetch::tests::sourceTreeCalc::selfRef::SrTxOut
+{
+  txId : String[0..1];
+}
+
+function <<test.Test>>
+  meta::pure::graphFetch::tests::sourceTreeCalc::selfRef::testSelfReferencingPropertyBackEdge():Boolean[1]
+{
+  let tree = #{
+    meta::pure::graphFetch::tests::sourceTreeCalc::selfRef::SrOut {
+      txInfo { txId }
+    }
+  }#;
+  let sourceTree = meta::pure::graphFetch::calculateSourceTree(
+                     $tree,
+                     meta::pure::graphFetch::tests::sourceTreeCalc::selfRef::SelfRefMapping,
+                     meta::pure::extension::defaultExtensions());
+  let str = $sourceTree->meta::pure::graphFetch::sortTree()->meta::pure::graphFetch::treeToString();
+  // The back-edge must route around the self-reference: SrPayload -> event -> collateral
+  // -> tx -> txId. The self-referencing property must not appear in the source tree.
+  assert($str->contains('event'),      | 'expected event in source tree: '      + $str);
+  assert($str->contains('collateral'), | 'expected collateral in source tree: ' + $str);
+  assert($str->contains('tx'),         | 'expected tx in source tree: '         + $str);
+  assert($str->contains('txId'),       | 'expected txId in source tree: '       + $str);
+  assert(!$str->contains('interco'),   | 'self-referencing property must not be synthesised into the source tree: ' + $str);
+  true;
+}
+
+###Mapping
+Mapping meta::pure::graphFetch::tests::sourceTreeCalc::selfRef::SelfRefMapping
+(
+  *meta::pure::graphFetch::tests::sourceTreeCalc::selfRef::SrOut : Pure
+  {
+    ~src meta::pure::graphFetch::tests::sourceTreeCalc::selfRef::SrPayload
+    txInfo[srTxCM] : ^meta::pure::graphFetch::tests::sourceTreeCalc::selfRef::SrTx(
+       txId = $src.event.collateral.tx.txId->toOne()
+    )
+  }
+  meta::pure::graphFetch::tests::sourceTreeCalc::selfRef::SrTxOut[srTxCM] : Pure
+  {
+    ~src meta::pure::graphFetch::tests::sourceTreeCalc::selfRef::SrTx
+    txId : $src.txId
+  }
+)
+
+###Pure
+import meta::pure::graphFetch::tests::sourceTreeCalc::mutualCycle::*;
+import meta::pure::graphFetch::*;
+import meta::pure::graphFetch::routing::*;
+
+// Boundary case for the visited-set cycle guard. The guard makes the back-edge walk
+// terminate, but the walk is still greedy and does not backtrack, so it can take a wrong
+// turn into a cul-de-sac. Candidates returning McTx are McProfile.altTx and
+// McEvent.transaction; pickIntermediateProperty sorts by name so 'altTx' wins and the walk
+// steps into McProfile, whose only producer (McTx.profile) is already on the path. The
+// walk therefore fails - even though McEvent.transaction -> McPayload.event was a perfectly
+// good route. Before the guard this shape hung on the McTx <-> McProfile 2-cycle until the
+// depth backstop fired; now it fails immediately with an accurate diagnostic.
+//
+// If the DFS-with-backtracking alternative in
+// docs/engineering/architecture/source-tree-calculation.md section 11.6 is ever
+// implemented, this test flips from asserting an error to asserting the source tree
+// McPayload { event { transaction { txId } } }.
+Class meta::pure::graphFetch::tests::sourceTreeCalc::mutualCycle::McProfile
+{
+  altTx : meta::pure::graphFetch::tests::sourceTreeCalc::mutualCycle::McTx[0..1];
+}
+
+Class meta::pure::graphFetch::tests::sourceTreeCalc::mutualCycle::McTx
+{
+  txId    : String[1];
+  profile : meta::pure::graphFetch::tests::sourceTreeCalc::mutualCycle::McProfile[1];
+}
+
+Class meta::pure::graphFetch::tests::sourceTreeCalc::mutualCycle::McEvent
+{
+  transaction : meta::pure::graphFetch::tests::sourceTreeCalc::mutualCycle::McTx[*];
+}
+
+Class meta::pure::graphFetch::tests::sourceTreeCalc::mutualCycle::McPayload
+{
+  event : meta::pure::graphFetch::tests::sourceTreeCalc::mutualCycle::McEvent[1];
+}
+
+Class meta::pure::graphFetch::tests::sourceTreeCalc::mutualCycle::McOut
+{
+  txInfo : meta::pure::graphFetch::tests::sourceTreeCalc::mutualCycle::McTxOut[0..1];
+}
+
+Class meta::pure::graphFetch::tests::sourceTreeCalc::mutualCycle::McTxOut
+{
+  txId : String[0..1];
+}
+
+function <<test.Test>>
+  meta::pure::graphFetch::tests::sourceTreeCalc::mutualCycle::testMutualCycleGivesClearError():Boolean[1]
+{
+  let tree = #{
+    meta::pure::graphFetch::tests::sourceTreeCalc::mutualCycle::McOut {
+      txInfo { txId }
+    }
+  }#;
+  assertError(
+    | meta::pure::graphFetch::calculateSourceTree(
+        $tree,
+        meta::pure::graphFetch::tests::sourceTreeCalc::mutualCycle::MutualCycleMapping,
+        meta::pure::extension::defaultExtensions());,
+    'Could not build an acyclic path from meta::pure::graphFetch::tests::sourceTreeCalc::mutualCycle::McPayload back to meta::pure::graphFetch::tests::sourceTreeCalc::mutualCycle::McProfile: every property returning it is declared on a class already on the path. The back-edge search does not backtrack - see source-tree-calculation.md section 11.6.'
+  );
+}
+
+###Mapping
+Mapping meta::pure::graphFetch::tests::sourceTreeCalc::mutualCycle::MutualCycleMapping
+(
+  *meta::pure::graphFetch::tests::sourceTreeCalc::mutualCycle::McOut : Pure
+  {
+    ~src meta::pure::graphFetch::tests::sourceTreeCalc::mutualCycle::McPayload
+    txInfo[mcTxCM] : ^meta::pure::graphFetch::tests::sourceTreeCalc::mutualCycle::McTx(
+       txId    = $src.event.transaction.txId->toOne(),
+       profile = ^meta::pure::graphFetch::tests::sourceTreeCalc::mutualCycle::McProfile()
+    )
+  }
+  meta::pure::graphFetch::tests::sourceTreeCalc::mutualCycle::McTxOut[mcTxCM] : Pure
+  {
+    ~src meta::pure::graphFetch::tests::sourceTreeCalc::mutualCycle::McTx
+    txId : $src.txId
+  }
+)


### PR DESCRIPTION
Handle cycles in domain models when constructing paths from intermediate classes to source class