### PR TITLE
Relation quantified comparison: <op> ANY / <op> ALL against a subquery

### DIFF
--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/handlers/Handlers.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/handlers/Handlers.java
@@ -16,6 +16,7 @@ package org.finos.legend.engine.language.pure.compiler.toPureGraph.handlers;
 
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.collections.api.RichIterable;
+import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.set.ImmutableSet;
@@ -214,7 +215,9 @@ public class Handlers
         }
     }
 
-    public static final ParametersInference InInference = (parameters, valueSpecificationBuilder) ->
+    // Shared by in() and the quantified comparisons, which all take (value, Relation<Z=(?:U)>): the single-column
+    // and matching-type constraints are not expressible in the signature, so they are checked here.
+    public static final Function<String, ParametersInference> SingleColumnRelationInference = functionName -> (parameters, valueSpecificationBuilder) ->
     {
         List<ValueSpecification> processed = parameters.stream().map(p -> p.accept(valueSpecificationBuilder)).collect(Collectors.toList());
         GenericType gt = processed.get(1)._genericType();
@@ -228,12 +231,12 @@ public class Handlers
                 ProcessorSupport processorSupport = valueSpecificationBuilder.getContext().pureModel.getExecutionSupport().getProcessorSupport();
                 if (type._columns().size() != 1)
                 {
-                    throw new EngineException("in(..., Relation) expects a relation with a single column, got " + _RelationType.print(type, processorSupport), parameters.get(1).sourceInformation, EngineErrorType.COMPILATION);
+                    throw new EngineException(functionName + "(..., Relation) expects a relation with a single column, got " + _RelationType.print(type, processorSupport), parameters.get(1).sourceInformation, EngineErrorType.COMPILATION);
                 }
                 GenericType columnType = _Column.getColumnType(type._columns().getOnly());
                 if (!org.finos.legend.pure.m3.navigation.generictype.GenericType.isGenericCompatibleWith(processed.get(0)._genericType(), columnType, processorSupport))
                 {
-                    throw new EngineException("in(..., Relation) expects the value and the relation column to be of the same type, got " +
+                    throw new EngineException(functionName + "(..., Relation) expects the value and the relation column to be of the same type, got " +
                             org.finos.legend.pure.m3.navigation.generictype.GenericType.print(processed.get(0)._genericType(), processorSupport) + " and " +
                             _RelationType.print(type, processorSupport), parameters.get(1).sourceInformation, EngineErrorType.COMPILATION);
                 }
@@ -241,6 +244,14 @@ public class Handlers
         }
         return processed;
     };
+
+    public static final ParametersInference InInference = SingleColumnRelationInference.apply("in");
+
+    // There is no notEqualAny / notEqualAll: !equalAll is the one and !equalAny is the other, by De Morgan.
+    public static final ImmutableList<String> QUANTIFIED_COMPARISONS = Lists.immutable.of(
+            "equalAny", "equalAll",
+            "greaterThanAny", "greaterThanAll", "greaterThanEqualAny", "greaterThanEqualAll",
+            "lessThanAny", "lessThanAll", "lessThanEqualAny", "lessThanEqualAll");
 
     public static final Function<String, ParametersInference> RelationOlapAggregator = colSpecType -> (parameters, valueSpecificationBuilder) ->
     {
@@ -1570,6 +1581,17 @@ public class Handlers
                         ps -> ps.size() == 2 && typeOne(ps.get(1), pureModel.taxonomyTypes("cov_relation_Relation"))),
                 h("meta::pure::functions::collection::in_Any_1__Any_MANY__Boolean_1_", "in", false, ps -> res("Boolean", "one"), ps -> isOne(ps.get(0)._multiplicity())),
                 h("meta::pure::functions::collection::in_Any_$0_1$__Any_MANY__Boolean_1_", "in", false, ps -> res("Boolean", "one"), ps -> isZeroOne(ps.get(0)._multiplicity()))));
+
+        // The quantified comparisons share in()'s signature, so they need the same explicit type arguments. None of
+        // them names a collection overload, so each registers on its own rather than in an ordered group.
+        for (String quantified : QUANTIFIED_COMPARISONS)
+        {
+            register(grp(SingleColumnRelationInference.apply(quantified),
+                    h("meta::pure::functions::relation::" + quantified + "_U_$0_1$__Relation_1__Boolean_1_", quantified, false,
+                            ps -> res("Boolean", "one"),
+                            ps -> Lists.fixedSize.of(ps.get(0)._genericType(), ps.get(1)._genericType()._typeArguments().getOnly()),
+                            ps -> ps.size() == 2 && typeOne(ps.get(1), pureModel.taxonomyTypes("cov_relation_Relation")))));
+        }
 
         register(h("meta::pure::functions::boolean::xor_Boolean_1__Boolean_1__Boolean_1_", "xor", false, ps -> res("Boolean", "one"), ps -> ps.size() == 2));
 

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/resources/handlers_dispatch_functions.txt
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/resources/handlers_dispatch_functions.txt
@@ -491,6 +491,8 @@ meta::pure::functions::relation::descending_ColSpec_1__SortInfo_1_
 meta::pure::functions::relation::distinct_Relation_1__ColSpecArray_1__Relation_1_
 meta::pure::functions::relation::distinct_Relation_1__Relation_1_
 meta::pure::functions::relation::drop_Relation_1__Integer_1__Relation_1_
+meta::pure::functions::relation::equalAll_U_$0_1$__Relation_1__Boolean_1_
+meta::pure::functions::relation::equalAny_U_$0_1$__Relation_1__Boolean_1_
 meta::pure::functions::relation::exists_Relation_1__Function_1__Boolean_1_
 meta::pure::functions::relation::extend_Relation_1__AggColSpecArray_1__Relation_1_
 meta::pure::functions::relation::extend_Relation_1__AggColSpec_1__Relation_1_
@@ -502,6 +504,10 @@ meta::pure::functions::relation::extend_Relation_1___Window_1__FuncColSpecArray_
 meta::pure::functions::relation::extend_Relation_1___Window_1__FuncColSpec_1__Relation_1_
 meta::pure::functions::relation::filter_Relation_1__Function_1__Relation_1_
 meta::pure::functions::relation::first_Relation_1___Window_1__T_1__T_$0_1$_
+meta::pure::functions::relation::greaterThanAll_U_$0_1$__Relation_1__Boolean_1_
+meta::pure::functions::relation::greaterThanAny_U_$0_1$__Relation_1__Boolean_1_
+meta::pure::functions::relation::greaterThanEqualAll_U_$0_1$__Relation_1__Boolean_1_
+meta::pure::functions::relation::greaterThanEqualAny_U_$0_1$__Relation_1__Boolean_1_
 meta::pure::functions::relation::groupBy_Relation_1__ColSpecArray_1__AggColSpecArray_1__Relation_1_
 meta::pure::functions::relation::groupBy_Relation_1__ColSpecArray_1__AggColSpec_1__Relation_1_
 meta::pure::functions::relation::groupBy_Relation_1__ColSpec_1__AggColSpecArray_1__Relation_1_
@@ -515,6 +521,10 @@ meta::pure::functions::relation::lag_Relation_1__T_1__T_$0_1$_
 meta::pure::functions::relation::last_Relation_1___Window_1__T_1__T_$0_1$_
 meta::pure::functions::relation::lead_Relation_1__T_1__Integer_1__T_$0_1$_
 meta::pure::functions::relation::lead_Relation_1__T_1__T_$0_1$_
+meta::pure::functions::relation::lessThanAll_U_$0_1$__Relation_1__Boolean_1_
+meta::pure::functions::relation::lessThanAny_U_$0_1$__Relation_1__Boolean_1_
+meta::pure::functions::relation::lessThanEqualAll_U_$0_1$__Relation_1__Boolean_1_
+meta::pure::functions::relation::lessThanEqualAny_U_$0_1$__Relation_1__Boolean_1_
 meta::pure::functions::relation::limit_Relation_1__Integer_1__Relation_1_
 meta::pure::functions::relation::nth_Relation_1___Window_1__T_1__Integer_1__T_$0_1$_
 meta::pure::functions::relation::ntile_Relation_1__T_1__Integer_1__Integer_1_

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/routing/router_routing.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/routing/router_routing.pure
@@ -1037,7 +1037,17 @@ function meta::pure::router::routing::shouldStopFunctions(extensions:meta::pure:
     flatten_T_MANY__ColSpec_1__Relation_1_,
     lateral_Relation_1__Function_1__Relation_1_,
     meta::pure::functions::relation::exists_Relation_1__Function_1__Boolean_1_,
-    meta::pure::functions::relation::in_U_$0_1$__Relation_1__Boolean_1_
+    meta::pure::functions::relation::in_U_$0_1$__Relation_1__Boolean_1_,
+    meta::pure::functions::relation::equalAny_U_$0_1$__Relation_1__Boolean_1_,
+    meta::pure::functions::relation::equalAll_U_$0_1$__Relation_1__Boolean_1_,
+    meta::pure::functions::relation::greaterThanAny_U_$0_1$__Relation_1__Boolean_1_,
+    meta::pure::functions::relation::greaterThanAll_U_$0_1$__Relation_1__Boolean_1_,
+    meta::pure::functions::relation::greaterThanEqualAny_U_$0_1$__Relation_1__Boolean_1_,
+    meta::pure::functions::relation::greaterThanEqualAll_U_$0_1$__Relation_1__Boolean_1_,
+    meta::pure::functions::relation::lessThanAny_U_$0_1$__Relation_1__Boolean_1_,
+    meta::pure::functions::relation::lessThanAll_U_$0_1$__Relation_1__Boolean_1_,
+    meta::pure::functions::relation::lessThanEqualAny_U_$0_1$__Relation_1__Boolean_1_,
+    meta::pure::functions::relation::lessThanEqualAll_U_$0_1$__Relation_1__Boolean_1_
   ]->concatenate($extensions.routerExtensions().shouldStopRouting)
 }
 

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/quantification/equalAll.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/quantification/equalAll.pure
@@ -1,0 +1,189 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::pure::test::pct::*;
+import meta::pure::metamodel::relation::*;
+import meta::pure::functions::relation::*;
+
+'''
+Whether the given value is equal to every value in the single column of the given relation.
+
+The relation must carry exactly one column, of the same type as the value; the compiler
+rejects anything else. Nulls in that column are ignored rather than making the comparison
+undecided, which is where this parts company with the SQL `= ALL` it generates -- `Boolean[1]`
+is two-valued and has no UNKNOWN to return.
+
+An empty relation answers `true`, as `= ALL` does over an empty subquery, and so does a column
+holding only nulls. An empty value still answers `false`: absence is not a value the comparison
+holds for, matching the scalar `=`.
+
+Negation is exact. `!$value->equalAll($rel)` is `true` for precisely the cases this answers `false`
+for, empty values included, and on relational stores it generates a plain `not` over a decided
+predicate rather than a disjunction.
+
+There is no `notEqualAny`: `!$v->equalAll($r)` is it, by De Morgan.
+
+**Parameters**
+- `value` — the value to compare; may be empty.
+- `rel` — a relation with a single column of the same type as `value`.
+
+**Returns** `true` when every non-null value `c` in the column satisfies `value = c`.
+
+**Examples**
+```pure
+let limits = #TDS
+               threshold
+               250
+               250
+             #->select(~threshold);
+
+#TDS
+  productId, price
+  1, 100
+  2, 250
+  3, 400
+#->filter(p | $p.price->equalAll($limits))   // keeps 2
+```
+
+**See also** `equalAny(U[0..1], Relation<Z=(?:U)>[1]):Boolean[1]`,
+`in(U[0..1], Relation<Z=(?:U)>[1]):Boolean[1]`,
+`exists(Relation<T>[1], Function<{T[1]->Boolean[1]}>[1]):Boolean[1]`
+'''
+function <<PCT.function, functionType.NormalizeRequiredFunction>> meta::pure::functions::relation::equalAll<U,Z>(value:U[0..1], rel:Relation<Z=(?:U)>[1]):Boolean[1]
+{
+   let col = $rel->genericType().typeArguments->at(0).rawType->toOne()->cast(@RelationType<Any>).columns->toOne()->cast(@Column<Nil,U|0..1>);
+   $value->isNotEmpty() && !$rel->meta::pure::functions::relation::exists({row:Z[1] | $col->eval($row)->isNotEmpty() && ($col->eval($row) != $value)});
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::equalAll::testEqualAll<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productId, price
+                                   1, 100
+                                   2, 250
+                                   3, 400
+                                 #;
+                  let limits = #TDS
+                                 threshold
+                                 250
+                                 250
+                               #;
+                  $products->filter(p | $p.price->equalAll($limits->select(~threshold)));
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productId,price\n'+
+                 '   2,250\n'+
+                 '#', $res->sort(~productId->ascending())->toString());
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::equalAll::testEqualAll_Negated<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productId, price
+                                   1, 100
+                                   2, 250
+                                   3, 400
+                                 #;
+                  let limits = #TDS
+                                 threshold
+                                 250
+                                 250
+                               #;
+                  $products->filter(p | !$p.price->equalAll($limits->select(~threshold)));
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productId,price\n'+
+                 '   1,100\n'+
+                 '   3,400\n'+
+                 '#', $res->sort(~productId->ascending())->toString());
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::equalAll::testEqualAll_EmptyRelation<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productId, price
+                                   1, 100
+                                   2, 250
+                                 #;
+                  let limits = #TDS
+                                 threshold
+                                 150
+                               #->filter(l | $l.threshold > 1000);
+                  $products->filter(p | $p.price->equalAll($limits->select(~threshold)));
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productId,price\n'+
+                 '   1,100\n'+
+                 '   2,250\n'+
+                 '#', $res->sort(~productId->ascending())->toString());
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::equalAll::testEqualAll_NullValue<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productId, price
+                                   1, 100
+                                   2, null
+                                 #;
+                  let limits = #TDS
+                                 threshold
+                                 100
+                               #;
+                  $products->filter(p | $p.price->equalAll($limits->select(~threshold)));
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productId,price\n'+
+                 '   1,100\n'+
+                 '#', $res->sort(~productId->ascending())->toString());
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::equalAll::testEqualAll_NullInRelation<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productId, price
+                                   1, 100
+                                   2, 250
+                                 #;
+                  let limits = #TDS
+                                 threshold
+                                 100
+                                 null
+                               #;
+                  $products->filter(p | $p.price->equalAll($limits->select(~threshold)));
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productId,price\n'+
+                 '   1,100\n'+
+                 '#', $res->sort(~productId->ascending())->toString());
+}

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/quantification/equalAny.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/quantification/equalAny.pure
@@ -1,0 +1,188 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::pure::test::pct::*;
+import meta::pure::metamodel::relation::*;
+import meta::pure::functions::relation::*;
+
+'''
+Whether the given value is equal to at least one value in the single column of the given relation.
+
+The relation must carry exactly one column, of the same type as the value; the compiler
+rejects anything else. Nulls in that column are ignored rather than making the comparison
+undecided, which is where this parts company with the SQL `= ANY` it generates -- `Boolean[1]`
+is two-valued and has no UNKNOWN to return.
+
+An empty value answers `false`, as the scalar `=` does when an operand is absent. An empty
+relation, and a column holding only nulls, answer `false` too: there is no value there to be
+equal to.
+
+Negation is exact. `!$value->equalAny($rel)` is `true` for precisely the cases this answers `false`
+for, empty values included, and on relational stores it generates a plain `not` over a decided
+predicate rather than a disjunction.
+
+There is no `notEqualAll`: `!$v->equalAny($r)` is it, by De Morgan.
+
+**Parameters**
+- `value` — the value to compare; may be empty.
+- `rel` — a relation with a single column of the same type as `value`.
+
+**Returns** `true` when at least one non-null value `c` in the column satisfies `value = c`.
+
+**Examples**
+```pure
+let limits = #TDS
+               threshold
+               100
+               400
+             #->select(~threshold);
+
+#TDS
+  productId, price
+  1, 100
+  2, 250
+  3, 400
+#->filter(p | $p.price->equalAny($limits))   // keeps 1 and 3
+```
+
+**See also** `equalAll(U[0..1], Relation<Z=(?:U)>[1]):Boolean[1]`,
+`in(U[0..1], Relation<Z=(?:U)>[1]):Boolean[1]`,
+`exists(Relation<T>[1], Function<{T[1]->Boolean[1]}>[1]):Boolean[1]`
+'''
+function <<PCT.function, functionType.NormalizeRequiredFunction>> meta::pure::functions::relation::equalAny<U,Z>(value:U[0..1], rel:Relation<Z=(?:U)>[1]):Boolean[1]
+{
+   let col = $rel->genericType().typeArguments->at(0).rawType->toOne()->cast(@RelationType<Any>).columns->toOne()->cast(@Column<Nil,U|0..1>);
+   $value->isNotEmpty() && $rel->meta::pure::functions::relation::exists({row:Z[1] | $col->eval($row)->isNotEmpty() && ($col->eval($row) == $value)});
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::equalAny::testEqualAny<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productId, price
+                                   1, 100
+                                   2, 250
+                                   3, 400
+                                 #;
+                  let limits = #TDS
+                                 threshold
+                                 100
+                                 400
+                               #;
+                  $products->filter(p | $p.price->equalAny($limits->select(~threshold)));
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productId,price\n'+
+                 '   1,100\n'+
+                 '   3,400\n'+
+                 '#', $res->sort(~productId->ascending())->toString());
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::equalAny::testEqualAny_Negated<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productId, price
+                                   1, 100
+                                   2, 250
+                                   3, 400
+                                 #;
+                  let limits = #TDS
+                                 threshold
+                                 100
+                                 400
+                               #;
+                  $products->filter(p | !$p.price->equalAny($limits->select(~threshold)));
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productId,price\n'+
+                 '   2,250\n'+
+                 '#', $res->sort(~productId->ascending())->toString());
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::equalAny::testEqualAny_EmptyRelation<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productId, price
+                                   1, 100
+                                   2, 250
+                                 #;
+                  let limits = #TDS
+                                 threshold
+                                 150
+                               #->filter(l | $l.threshold > 1000);
+                  $products->filter(p | $p.price->equalAny($limits->select(~threshold)));
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productId,price\n'+
+                 '\n'+
+                 '#', $res->sort(~productId->ascending())->toString());
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::equalAny::testEqualAny_NullValue<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productId, price
+                                   1, 100
+                                   2, null
+                                 #;
+                  let limits = #TDS
+                                 threshold
+                                 100
+                               #;
+                  $products->filter(p | $p.price->equalAny($limits->select(~threshold)));
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productId,price\n'+
+                 '   1,100\n'+
+                 '#', $res->sort(~productId->ascending())->toString());
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::equalAny::testEqualAny_NullInRelation<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productId, price
+                                   1, 100
+                                   2, 250
+                                 #;
+                  let limits = #TDS
+                                 threshold
+                                 100
+                                 null
+                               #;
+                  $products->filter(p | $p.price->equalAny($limits->select(~threshold)));
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productId,price\n'+
+                 '   1,100\n'+
+                 '#', $res->sort(~productId->ascending())->toString());
+}

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/quantification/greaterThanAll.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/quantification/greaterThanAll.pure
@@ -1,0 +1,433 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::pure::test::pct::*;
+import meta::pure::metamodel::relation::*;
+import meta::pure::functions::relation::*;
+
+'''
+Whether the given value is greater than every value in the single column of the given relation.
+
+The relation must carry exactly one column, of the same type as the value; the compiler
+rejects anything else. Nulls in that column are ignored rather than making the comparison
+undecided, which is where this parts company with the SQL `> ALL` it generates -- `Boolean[1]`
+is two-valued and has no UNKNOWN to return.
+
+An empty relation answers `true`, as `> ALL` does over an empty subquery, and so does a column
+holding only nulls. An empty value still answers `false`: absence is not a value the comparison
+holds for, matching the scalar `>`.
+
+Negation is exact. `!$value->greaterThanAll($rel)` is `true` for precisely the cases this answers `false`
+for, empty values included, and on relational stores it generates a plain `not` over a decided
+predicate rather than a disjunction.
+
+**Parameters**
+- `value` — the value to compare; may be empty.
+- `rel` — a relation with a single column of the same type as `value`.
+
+**Returns** `true` when every non-null value `c` in the column satisfies `value > c`.
+
+**Examples**
+```pure
+let limits = #TDS
+               threshold
+               150
+               300
+             #->select(~threshold);
+
+#TDS
+  productId, price
+  1, 100
+  2, 250
+  3, 400
+#->filter(p | $p.price->greaterThanAll($limits))   // keeps 3
+```
+
+**See also** `greaterThanAny(U[0..1], Relation<Z=(?:U)>[1]):Boolean[1]`,
+`in(U[0..1], Relation<Z=(?:U)>[1]):Boolean[1]`,
+`exists(Relation<T>[1], Function<{T[1]->Boolean[1]}>[1]):Boolean[1]`
+'''
+function <<PCT.function, functionType.NormalizeRequiredFunction>> meta::pure::functions::relation::greaterThanAll<U,Z>(value:U[0..1], rel:Relation<Z=(?:U)>[1]):Boolean[1]
+{
+   let col = $rel->genericType().typeArguments->at(0).rawType->toOne()->cast(@RelationType<Any>).columns->toOne()->cast(@Column<Nil,U|0..1>);
+   $value->isNotEmpty() && !$rel->meta::pure::functions::relation::exists({row:Z[1] | $col->eval($row)->isNotEmpty() && (meta::pure::functions::lang::compare($value->toOne(), $col->eval($row)->toOne()) <= 0)});
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::greaterThanAll::testSimpleGreaterThanAll<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productId, price
+                                   1, 100
+                                   2, 250
+                                   3, 400
+                                 #;
+                  let limits = #TDS
+                                 threshold
+                                 150
+                                 300
+                               #;
+                  $products->filter(p | $p.price->greaterThanAll($limits->select(~threshold)));
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productId,price\n'+
+                 '   3,400\n'+
+                 '#', $res->sort(~productId->ascending())->toString());
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_Negated<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productId, price
+                                   1, 100
+                                   2, 250
+                                   3, 400
+                                 #;
+                  let limits = #TDS
+                                 threshold
+                                 150
+                                 300
+                               #;
+                  $products->filter(p | !$p.price->greaterThanAll($limits->select(~threshold)));
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productId,price\n'+
+                 '   1,100\n'+
+                 '   2,250\n'+
+                 '#', $res->sort(~productId->ascending())->toString());
+}
+
+// Vacuous truth: with nothing to compare against, every present value is greater than all of them.
+function <<PCT.test>> meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_EmptyRelation<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productId, price
+                                   1, 100
+                                   2, 250
+                                 #;
+                  let limits = #TDS
+                                 threshold
+                                 150
+                               #->filter(l | $l.threshold > 1000);
+                  $products->filter(p | $p.price->greaterThanAll($limits->select(~threshold)));
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productId,price\n'+
+                 '   1,100\n'+
+                 '   2,250\n'+
+                 '#', $res->sort(~productId->ascending())->toString());
+}
+
+// A column of nothing but nulls is the empty relation as far as the comparison is concerned.
+function <<PCT.test>> meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_OnlyNullsInRelation<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productId, price
+                                   1, 100
+                                   2, 250
+                                 #;
+                  let limits = #TDS
+                                 threshold, tag
+                                 150, 1
+                                 null, 2
+                                 null, 2
+                               #->filter(l | $l.tag == 2)->select(~threshold);
+                  $products->filter(p | $p.price->greaterThanAll($limits));
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productId,price\n'+
+                 '   1,100\n'+
+                 '   2,250\n'+
+                 '#', $res->sort(~productId->ascending())->toString());
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_NullInRelation<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productId, price
+                                   1, 100
+                                   2, 250
+                                 #;
+                  let limits = #TDS
+                                 threshold
+                                 150
+                                 null
+                               #;
+                  $products->filter(p | $p.price->greaterThanAll($limits->select(~threshold)));
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productId,price\n'+
+                 '   2,250\n'+
+                 '#', $res->sort(~productId->ascending())->toString());
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_NullValue<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productId, price
+                                   1, 100
+                                   2, null
+                                 #;
+                  let limits = #TDS
+                                 threshold
+                                 50
+                               #;
+                  $products->filter(p | $p.price->greaterThanAll($limits->select(~threshold)));
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productId,price\n'+
+                 '   1,100\n'+
+                 '#', $res->sort(~productId->ascending())->toString());
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_NullValueAndNullInRelation<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productId, price
+                                   1, 100
+                                   2, null
+                                 #;
+                  let limits = #TDS
+                                 threshold
+                                 50
+                                 null
+                               #;
+                  $products->filter(p | $p.price->greaterThanAll($limits->select(~threshold)));
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productId,price\n'+
+                 '   1,100\n'+
+                 '#', $res->sort(~productId->ascending())->toString());
+}
+
+// The predicate column is deliberately left out of the projection: that is the shape a NOT IN (subquery)
+// under OR could not be unnested in, and the isNotNull guard is what keeps this one a plain conjunction.
+function <<PCT.test>> meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_Negated_NullValueAndNullInRelation<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productName, price
+                                   widget, 100
+                                   gadget, null
+                                 #;
+                  let limits = #TDS
+                                 threshold
+                                 50
+                                 null
+                               #;
+                  $products->filter(p | !$p.price->greaterThanAll($limits->select(~threshold)))
+                           ->select(~productName);
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productName\n'+
+                 '   gadget\n'+
+                 '#', $res->sort(~productName->ascending())->toString());
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_String<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let codes = #TDS
+                                codeId, code
+                                1, alpha
+                                2, delta
+                              #;
+                  let markers = #TDS
+                                  marker
+                                  alpha
+                                  bravo
+                                #;
+                  $codes->filter(c | $c.code->greaterThanAll($markers->select(~marker)));
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   codeId,code\n'+
+                 '   2,delta\n'+
+                 '#', $res->sort(~codeId->ascending())->toString());
+}
+
+// select outer_customer.id, outer_customer.name from customers as outer_customer
+// where outer_customer.score > all (select inner_bands.minScore from bands as inner_bands
+//                                   where inner_bands.tier = outer_customer.tier)
+function <<PCT.test>> meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_CorrelatedSubQuery<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let customers = #TDS
+                                    id, name, score, tier
+                                    1, Alice, 70, 10
+                                    2, Bob, 20, 10
+                                    3, Carol, 90, 20
+                                  #;
+                  let bands = #TDS
+                                tier, minScore
+                                10, 50
+                                10, 60
+                                20, 95
+                              #;
+                  $customers->filter(c | $c.score->greaterThanAll($bands->filter(b | $b.tier == $c.tier)->select(~minScore)))
+                            ->select(~[id, name]);
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   id,name\n'+
+                 '   1,Alice\n'+
+                 '#', $res->sort(~id->ascending())->toString());
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_InExtend<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productName, price
+                                   widget, 100
+                                   gadget, null
+                                 #;
+                  let limits = #TDS
+                                 threshold
+                                 50
+                                 null
+                               #;
+                  $products->extend(~beatsEvery : p | $p.price->greaterThanAll($limits->select(~threshold)))
+                           ->select(~[productName, beatsEvery]);
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productName,beatsEvery\n'+
+                 '   gadget,false\n'+
+                 '   widget,true\n'+
+                 '#', $res->sort(~productName->ascending())->toString());
+}
+
+// The searched column is a grouping key, so the null has to be excluded through HAVING rather than WHERE.
+function <<PCT.test>> meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_GroupedRelationWithNull<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productId, price
+                                   1, 100
+                                   2, 250
+                                   3, 400
+                                 #;
+                  let bands = #TDS
+                                bandId, minScore, weight
+                                101, 300, 900
+                                102, 300, 900
+                                103, 150, 100
+                                104, null, 900
+                              #->groupBy(~minScore, ~total : x | $x.weight : y | $y->plus())
+                               ->filter(g | $g.total > 500)
+                               ->select(~minScore);
+                  $products->filter(p | $p.price->greaterThanAll($bands));
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productId,price\n'+
+                 '   3,400\n'+
+                 '#', $res->sort(~productId->ascending())->toString());
+}
+
+// A limit fixes which rows reach the comparison, so the null cannot be dropped inside the limited query the
+// way it is elsewhere -- the sub-select is isolated first and the null dropped outside it. This test
+// discriminates that on its own: excluding the null inside the limit would keep {150, 900} and make
+// 250 > all false, and not excluding it at all would leave the comparison unknown and drop the row.
+//
+// The sort is what makes the limit deterministic -- SQL keeps an arbitrary two rows otherwise -- and it is on
+// a separate non-null column because NULLS FIRST/LAST defaults differ by dialect.
+function <<PCT.test>> meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_LimitedRelationWithNull<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productId, price
+                                   1, 100
+                                   2, 250
+                                 #;
+                  let limits = #TDS
+                                 tag, threshold
+                                 1, 150
+                                 2, null
+                                 3, 900
+                               #;
+                  $products->filter(p | $p.price->greaterThanAll($limits->sort(~tag->ascending())->limit(2)->select(~threshold)));
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productId,price\n'+
+                 '   2,250\n'+
+                 '#', $res->sort(~productId->ascending())->toString());
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_DerivedRelation<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productId, price
+                                   1, 100
+                                   2, 250
+                                   3, 400
+                                 #;
+                  let bands = #TDS
+                                bandId, minScore, weight
+                                101, 150, 100
+                                102, 300, 900
+                              #->filter(b | $b.weight > 500)->select(~minScore);
+                  $products->filter(p | $p.price->greaterThanAll($bands));
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productId,price\n'+
+                 '   3,400\n'+
+                 '#', $res->sort(~productId->ascending())->toString());
+}

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/quantification/greaterThanAny.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/quantification/greaterThanAny.pure
@@ -1,0 +1,400 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::pure::test::pct::*;
+import meta::pure::metamodel::relation::*;
+import meta::pure::functions::relation::*;
+
+'''
+Whether the given value is greater than at least one value in the single column of the given relation.
+
+The relation must carry exactly one column, of the same type as the value; the compiler
+rejects anything else. Nulls in that column are ignored rather than making the comparison
+undecided, which is where this parts company with the SQL `> ANY` it generates -- `Boolean[1]`
+is two-valued and has no UNKNOWN to return.
+
+An empty value answers `false`, as the scalar `>` does when an operand is absent. An empty
+relation, and a column holding only nulls, answer `false` too: there is no value there to be
+greater than.
+
+Negation is exact. `!$value->greaterThanAny($rel)` is `true` for precisely the cases this answers `false`
+for, empty values included, and on relational stores it generates a plain `not` over a decided
+predicate rather than a disjunction.
+
+**Parameters**
+- `value` — the value to compare; may be empty.
+- `rel` — a relation with a single column of the same type as `value`.
+
+**Returns** `true` when at least one non-null value `c` in the column satisfies `value > c`.
+
+**Examples**
+```pure
+let limits = #TDS
+               threshold
+               150
+               300
+             #->select(~threshold);
+
+#TDS
+  productId, price
+  1, 100
+  2, 250
+  3, 400
+#->filter(p | $p.price->greaterThanAny($limits))   // keeps 2 and 3
+```
+
+**See also** `greaterThanAll(U[0..1], Relation<Z=(?:U)>[1]):Boolean[1]`,
+`in(U[0..1], Relation<Z=(?:U)>[1]):Boolean[1]`,
+`exists(Relation<T>[1], Function<{T[1]->Boolean[1]}>[1]):Boolean[1]`
+'''
+function <<PCT.function, functionType.NormalizeRequiredFunction>> meta::pure::functions::relation::greaterThanAny<U,Z>(value:U[0..1], rel:Relation<Z=(?:U)>[1]):Boolean[1]
+{
+   // lang::compare rather than `>`: the inequality functions are declared per primitive type and cannot take
+   // the type variable U. The whole family does this.
+   let col = $rel->genericType().typeArguments->at(0).rawType->toOne()->cast(@RelationType<Any>).columns->toOne()->cast(@Column<Nil,U|0..1>);
+   $value->isNotEmpty() && $rel->meta::pure::functions::relation::exists({row:Z[1] | $col->eval($row)->isNotEmpty() && (meta::pure::functions::lang::compare($value->toOne(), $col->eval($row)->toOne()) > 0)});
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::greaterThanAny::testSimpleGreaterThanAny<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productId, price
+                                   1, 100
+                                   2, 250
+                                   3, 400
+                                 #;
+                  let limits = #TDS
+                                 threshold
+                                 150
+                                 300
+                               #;
+                  $products->filter(p | $p.price->greaterThanAny($limits->select(~threshold)));
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productId,price\n'+
+                 '   2,250\n'+
+                 '   3,400\n'+
+                 '#', $res->sort(~productId->ascending())->toString());
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_Negated<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productId, price
+                                   1, 100
+                                   2, 250
+                                   3, 400
+                                 #;
+                  let limits = #TDS
+                                 threshold
+                                 150
+                                 300
+                               #;
+                  $products->filter(p | !$p.price->greaterThanAny($limits->select(~threshold)));
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productId,price\n'+
+                 '   1,100\n'+
+                 '#', $res->sort(~productId->ascending())->toString());
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_EmptyRelation<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productId, price
+                                   1, 100
+                                   2, 250
+                                 #;
+                  let limits = #TDS
+                                 threshold
+                                 150
+                               #->filter(l | $l.threshold > 1000);
+                  $products->filter(p | $p.price->greaterThanAny($limits->select(~threshold)));
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productId,price\n'+
+                 '\n'+
+                 '#', $res->sort(~productId->ascending())->toString());
+}
+
+// A column of nothing but nulls is the empty relation as far as the comparison is concerned.
+function <<PCT.test>> meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_OnlyNullsInRelation<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productId, price
+                                   1, 100
+                                   2, 250
+                                 #;
+                  let limits = #TDS
+                                 threshold, tag
+                                 150, 1
+                                 null, 2
+                                 null, 2
+                               #->filter(l | $l.tag == 2)->select(~threshold);
+                  $products->filter(p | $p.price->greaterThanAny($limits));
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productId,price\n'+
+                 '\n'+
+                 '#', $res->sort(~productId->ascending())->toString());
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_NullInRelation<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productId, price
+                                   1, 100
+                                   2, 250
+                                 #;
+                  let limits = #TDS
+                                 threshold
+                                 150
+                                 null
+                               #;
+                  $products->filter(p | $p.price->greaterThanAny($limits->select(~threshold)));
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productId,price\n'+
+                 '   2,250\n'+
+                 '#', $res->sort(~productId->ascending())->toString());
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_NullValue<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productId, price
+                                   1, 100
+                                   2, null
+                                 #;
+                  let limits = #TDS
+                                 threshold
+                                 50
+                               #;
+                  $products->filter(p | $p.price->greaterThanAny($limits->select(~threshold)));
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productId,price\n'+
+                 '   1,100\n'+
+                 '#', $res->sort(~productId->ascending())->toString());
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_NullValueAndNullInRelation<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productId, price
+                                   1, 100
+                                   2, null
+                                 #;
+                  let limits = #TDS
+                                 threshold
+                                 50
+                                 null
+                               #;
+                  $products->filter(p | $p.price->greaterThanAny($limits->select(~threshold)));
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productId,price\n'+
+                 '   1,100\n'+
+                 '#', $res->sort(~productId->ascending())->toString());
+}
+
+// The predicate column is deliberately left out of the projection: that is the shape a NOT IN (subquery)
+// under OR could not be unnested in, and the isNotNull guard is what keeps this one a plain conjunction.
+function <<PCT.test>> meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_Negated_NullValueAndNullInRelation<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productName, price
+                                   widget, 100
+                                   gadget, null
+                                 #;
+                  let limits = #TDS
+                                 threshold
+                                 50
+                                 null
+                               #;
+                  $products->filter(p | !$p.price->greaterThanAny($limits->select(~threshold)))
+                           ->select(~productName);
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productName\n'+
+                 '   gadget\n'+
+                 '#', $res->sort(~productName->ascending())->toString());
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_String<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let codes = #TDS
+                                codeId, code
+                                1, alpha
+                                2, delta
+                              #;
+                  let markers = #TDS
+                                  marker
+                                  bravo
+                                  echo
+                                #;
+                  $codes->filter(c | $c.code->greaterThanAny($markers->select(~marker)));
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   codeId,code\n'+
+                 '   2,delta\n'+
+                 '#', $res->sort(~codeId->ascending())->toString());
+}
+
+// select outer_customer.id, outer_customer.name from customers as outer_customer
+// where outer_customer.score > any (select inner_bands.minScore from bands as inner_bands
+//                                   where inner_bands.tier = outer_customer.tier)
+function <<PCT.test>> meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_CorrelatedSubQuery<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let customers = #TDS
+                                    id, name, score, tier
+                                    1, Alice, 70, 10
+                                    2, Bob, 20, 10
+                                    3, Carol, 90, 20
+                                  #;
+                  let bands = #TDS
+                                tier, minScore
+                                10, 50
+                                10, 80
+                                20, 95
+                              #;
+                  $customers->filter(c | $c.score->greaterThanAny($bands->filter(b | $b.tier == $c.tier)->select(~minScore)))
+                            ->select(~[id, name]);
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   id,name\n'+
+                 '   1,Alice\n'+
+                 '#', $res->sort(~id->ascending())->toString());
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_InExtend<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productName, price
+                                   widget, 100
+                                   gadget, null
+                                 #;
+                  let limits = #TDS
+                                 threshold
+                                 50
+                                 null
+                               #;
+                  $products->extend(~beatsSome : p | $p.price->greaterThanAny($limits->select(~threshold)))
+                           ->select(~[productName, beatsSome]);
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productName,beatsSome\n'+
+                 '   gadget,false\n'+
+                 '   widget,true\n'+
+                 '#', $res->sort(~productName->ascending())->toString());
+}
+
+// The searched column is a grouping key, so the null has to be excluded through HAVING rather than WHERE.
+function <<PCT.test>> meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_GroupedRelationWithNull<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productId, price
+                                   1, 100
+                                   2, 250
+                                   3, 400
+                                 #;
+                  let bands = #TDS
+                                bandId, minScore, weight
+                                101, 300, 900
+                                102, 300, 900
+                                103, 150, 100
+                                104, null, 900
+                              #->groupBy(~minScore, ~total : x | $x.weight : y | $y->plus())
+                               ->filter(g | $g.total > 500)
+                               ->select(~minScore);
+                  $products->filter(p | $p.price->greaterThanAny($bands));
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productId,price\n'+
+                 '   3,400\n'+
+                 '#', $res->sort(~productId->ascending())->toString());
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_DerivedRelation<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productId, price
+                                   1, 100
+                                   2, 250
+                                   3, 400
+                                 #;
+                  let bands = #TDS
+                                bandId, minScore, weight
+                                101, 150, 100
+                                102, 300, 900
+                              #->filter(b | $b.weight > 500)->select(~minScore);
+                  $products->filter(p | $p.price->greaterThanAny($bands));
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productId,price\n'+
+                 '   3,400\n'+
+                 '#', $res->sort(~productId->ascending())->toString());
+}

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/quantification/greaterThanEqualAll.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/quantification/greaterThanEqualAll.pure
@@ -1,0 +1,187 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::pure::test::pct::*;
+import meta::pure::metamodel::relation::*;
+import meta::pure::functions::relation::*;
+
+'''
+Whether the given value is greater than or equal to every value in the single column of the given relation.
+
+The relation must carry exactly one column, of the same type as the value; the compiler
+rejects anything else. Nulls in that column are ignored rather than making the comparison
+undecided, which is where this parts company with the SQL `>= ALL` it generates -- `Boolean[1]`
+is two-valued and has no UNKNOWN to return.
+
+An empty relation answers `true`, as `>= ALL` does over an empty subquery, and so does a column
+holding only nulls. An empty value still answers `false`: absence is not a value the comparison
+holds for, matching the scalar `>=`.
+
+Negation is exact. `!$value->greaterThanEqualAll($rel)` is `true` for precisely the cases this answers `false`
+for, empty values included, and on relational stores it generates a plain `not` over a decided
+predicate rather than a disjunction.
+
+**Parameters**
+- `value` — the value to compare; may be empty.
+- `rel` — a relation with a single column of the same type as `value`.
+
+**Returns** `true` when every non-null value `c` in the column satisfies `value >= c`.
+
+**Examples**
+```pure
+let limits = #TDS
+               threshold
+               150
+               300
+             #->select(~threshold);
+
+#TDS
+  productId, price
+  1, 100
+  2, 250
+  3, 400
+#->filter(p | $p.price->greaterThanEqualAll($limits))   // keeps 3
+```
+
+**See also** `greaterThanEqualAny(U[0..1], Relation<Z=(?:U)>[1]):Boolean[1]`,
+`in(U[0..1], Relation<Z=(?:U)>[1]):Boolean[1]`,
+`exists(Relation<T>[1], Function<{T[1]->Boolean[1]}>[1]):Boolean[1]`
+'''
+function <<PCT.function, functionType.NormalizeRequiredFunction>> meta::pure::functions::relation::greaterThanEqualAll<U,Z>(value:U[0..1], rel:Relation<Z=(?:U)>[1]):Boolean[1]
+{
+   let col = $rel->genericType().typeArguments->at(0).rawType->toOne()->cast(@RelationType<Any>).columns->toOne()->cast(@Column<Nil,U|0..1>);
+   $value->isNotEmpty() && !$rel->meta::pure::functions::relation::exists({row:Z[1] | $col->eval($row)->isNotEmpty() && (meta::pure::functions::lang::compare($value->toOne(), $col->eval($row)->toOne()) < 0)});
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::greaterThanEqualAll::testGreaterThanEqualAll<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productId, price
+                                   1, 100
+                                   2, 250
+                                   3, 400
+                                 #;
+                  let limits = #TDS
+                                 threshold
+                                 150
+                                 300
+                               #;
+                  $products->filter(p | $p.price->greaterThanEqualAll($limits->select(~threshold)));
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productId,price\n'+
+                 '   3,400\n'+
+                 '#', $res->sort(~productId->ascending())->toString());
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::greaterThanEqualAll::testGreaterThanEqualAll_Negated<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productId, price
+                                   1, 100
+                                   2, 250
+                                   3, 400
+                                 #;
+                  let limits = #TDS
+                                 threshold
+                                 150
+                                 300
+                               #;
+                  $products->filter(p | !$p.price->greaterThanEqualAll($limits->select(~threshold)));
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productId,price\n'+
+                 '   1,100\n'+
+                 '   2,250\n'+
+                 '#', $res->sort(~productId->ascending())->toString());
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::greaterThanEqualAll::testGreaterThanEqualAll_EmptyRelation<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productId, price
+                                   1, 100
+                                   2, 250
+                                 #;
+                  let limits = #TDS
+                                 threshold
+                                 150
+                               #->filter(l | $l.threshold > 1000);
+                  $products->filter(p | $p.price->greaterThanEqualAll($limits->select(~threshold)));
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productId,price\n'+
+                 '   1,100\n'+
+                 '   2,250\n'+
+                 '#', $res->sort(~productId->ascending())->toString());
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::greaterThanEqualAll::testGreaterThanEqualAll_NullValue<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productId, price
+                                   1, 100
+                                   2, null
+                                 #;
+                  let limits = #TDS
+                                 threshold
+                                 50
+                               #;
+                  $products->filter(p | $p.price->greaterThanEqualAll($limits->select(~threshold)));
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productId,price\n'+
+                 '   1,100\n'+
+                 '#', $res->sort(~productId->ascending())->toString());
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::greaterThanEqualAll::testGreaterThanEqualAll_NullInRelation<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productId, price
+                                   1, 100
+                                   2, 250
+                                 #;
+                  let limits = #TDS
+                                 threshold
+                                 150
+                                 null
+                               #;
+                  $products->filter(p | $p.price->greaterThanEqualAll($limits->select(~threshold)));
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productId,price\n'+
+                 '   2,250\n'+
+                 '#', $res->sort(~productId->ascending())->toString());
+}

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/quantification/greaterThanEqualAny.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/quantification/greaterThanEqualAny.pure
@@ -1,0 +1,186 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::pure::test::pct::*;
+import meta::pure::metamodel::relation::*;
+import meta::pure::functions::relation::*;
+
+'''
+Whether the given value is greater than or equal to at least one value in the single column of the given relation.
+
+The relation must carry exactly one column, of the same type as the value; the compiler
+rejects anything else. Nulls in that column are ignored rather than making the comparison
+undecided, which is where this parts company with the SQL `>= ANY` it generates -- `Boolean[1]`
+is two-valued and has no UNKNOWN to return.
+
+An empty value answers `false`, as the scalar `>=` does when an operand is absent. An empty
+relation, and a column holding only nulls, answer `false` too: there is no value there to be
+greater than or equal to.
+
+Negation is exact. `!$value->greaterThanEqualAny($rel)` is `true` for precisely the cases this answers `false`
+for, empty values included, and on relational stores it generates a plain `not` over a decided
+predicate rather than a disjunction.
+
+**Parameters**
+- `value` — the value to compare; may be empty.
+- `rel` — a relation with a single column of the same type as `value`.
+
+**Returns** `true` when at least one non-null value `c` in the column satisfies `value >= c`.
+
+**Examples**
+```pure
+let limits = #TDS
+               threshold
+               150
+               300
+             #->select(~threshold);
+
+#TDS
+  productId, price
+  1, 100
+  2, 250
+  3, 400
+#->filter(p | $p.price->greaterThanEqualAny($limits))   // keeps 2 and 3
+```
+
+**See also** `greaterThanEqualAll(U[0..1], Relation<Z=(?:U)>[1]):Boolean[1]`,
+`in(U[0..1], Relation<Z=(?:U)>[1]):Boolean[1]`,
+`exists(Relation<T>[1], Function<{T[1]->Boolean[1]}>[1]):Boolean[1]`
+'''
+function <<PCT.function, functionType.NormalizeRequiredFunction>> meta::pure::functions::relation::greaterThanEqualAny<U,Z>(value:U[0..1], rel:Relation<Z=(?:U)>[1]):Boolean[1]
+{
+   let col = $rel->genericType().typeArguments->at(0).rawType->toOne()->cast(@RelationType<Any>).columns->toOne()->cast(@Column<Nil,U|0..1>);
+   $value->isNotEmpty() && $rel->meta::pure::functions::relation::exists({row:Z[1] | $col->eval($row)->isNotEmpty() && (meta::pure::functions::lang::compare($value->toOne(), $col->eval($row)->toOne()) >= 0)});
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::greaterThanEqualAny::testGreaterThanEqualAny<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productId, price
+                                   1, 100
+                                   2, 250
+                                   3, 400
+                                 #;
+                  let limits = #TDS
+                                 threshold
+                                 150
+                                 300
+                               #;
+                  $products->filter(p | $p.price->greaterThanEqualAny($limits->select(~threshold)));
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productId,price\n'+
+                 '   2,250\n'+
+                 '   3,400\n'+
+                 '#', $res->sort(~productId->ascending())->toString());
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::greaterThanEqualAny::testGreaterThanEqualAny_Negated<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productId, price
+                                   1, 100
+                                   2, 250
+                                   3, 400
+                                 #;
+                  let limits = #TDS
+                                 threshold
+                                 150
+                                 300
+                               #;
+                  $products->filter(p | !$p.price->greaterThanEqualAny($limits->select(~threshold)));
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productId,price\n'+
+                 '   1,100\n'+
+                 '#', $res->sort(~productId->ascending())->toString());
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::greaterThanEqualAny::testGreaterThanEqualAny_EmptyRelation<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productId, price
+                                   1, 100
+                                   2, 250
+                                 #;
+                  let limits = #TDS
+                                 threshold
+                                 150
+                               #->filter(l | $l.threshold > 1000);
+                  $products->filter(p | $p.price->greaterThanEqualAny($limits->select(~threshold)));
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productId,price\n'+
+                 '\n'+
+                 '#', $res->sort(~productId->ascending())->toString());
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::greaterThanEqualAny::testGreaterThanEqualAny_NullValue<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productId, price
+                                   1, 100
+                                   2, null
+                                 #;
+                  let limits = #TDS
+                                 threshold
+                                 50
+                               #;
+                  $products->filter(p | $p.price->greaterThanEqualAny($limits->select(~threshold)));
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productId,price\n'+
+                 '   1,100\n'+
+                 '#', $res->sort(~productId->ascending())->toString());
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::greaterThanEqualAny::testGreaterThanEqualAny_NullInRelation<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productId, price
+                                   1, 100
+                                   2, 250
+                                 #;
+                  let limits = #TDS
+                                 threshold
+                                 150
+                                 null
+                               #;
+                  $products->filter(p | $p.price->greaterThanEqualAny($limits->select(~threshold)));
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productId,price\n'+
+                 '   2,250\n'+
+                 '#', $res->sort(~productId->ascending())->toString());
+}

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/quantification/lessThanAll.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/quantification/lessThanAll.pure
@@ -1,0 +1,187 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::pure::test::pct::*;
+import meta::pure::metamodel::relation::*;
+import meta::pure::functions::relation::*;
+
+'''
+Whether the given value is less than every value in the single column of the given relation.
+
+The relation must carry exactly one column, of the same type as the value; the compiler
+rejects anything else. Nulls in that column are ignored rather than making the comparison
+undecided, which is where this parts company with the SQL `< ALL` it generates -- `Boolean[1]`
+is two-valued and has no UNKNOWN to return.
+
+An empty relation answers `true`, as `< ALL` does over an empty subquery, and so does a column
+holding only nulls. An empty value still answers `false`: absence is not a value the comparison
+holds for, matching the scalar `<`.
+
+Negation is exact. `!$value->lessThanAll($rel)` is `true` for precisely the cases this answers `false`
+for, empty values included, and on relational stores it generates a plain `not` over a decided
+predicate rather than a disjunction.
+
+**Parameters**
+- `value` — the value to compare; may be empty.
+- `rel` — a relation with a single column of the same type as `value`.
+
+**Returns** `true` when every non-null value `c` in the column satisfies `value < c`.
+
+**Examples**
+```pure
+let limits = #TDS
+               threshold
+               150
+               300
+             #->select(~threshold);
+
+#TDS
+  productId, price
+  1, 100
+  2, 250
+  3, 400
+#->filter(p | $p.price->lessThanAll($limits))   // keeps 1
+```
+
+**See also** `lessThanAny(U[0..1], Relation<Z=(?:U)>[1]):Boolean[1]`,
+`in(U[0..1], Relation<Z=(?:U)>[1]):Boolean[1]`,
+`exists(Relation<T>[1], Function<{T[1]->Boolean[1]}>[1]):Boolean[1]`
+'''
+function <<PCT.function, functionType.NormalizeRequiredFunction>> meta::pure::functions::relation::lessThanAll<U,Z>(value:U[0..1], rel:Relation<Z=(?:U)>[1]):Boolean[1]
+{
+   let col = $rel->genericType().typeArguments->at(0).rawType->toOne()->cast(@RelationType<Any>).columns->toOne()->cast(@Column<Nil,U|0..1>);
+   $value->isNotEmpty() && !$rel->meta::pure::functions::relation::exists({row:Z[1] | $col->eval($row)->isNotEmpty() && (meta::pure::functions::lang::compare($value->toOne(), $col->eval($row)->toOne()) >= 0)});
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::lessThanAll::testLessThanAll<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productId, price
+                                   1, 100
+                                   2, 250
+                                   3, 400
+                                 #;
+                  let limits = #TDS
+                                 threshold
+                                 150
+                                 300
+                               #;
+                  $products->filter(p | $p.price->lessThanAll($limits->select(~threshold)));
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productId,price\n'+
+                 '   1,100\n'+
+                 '#', $res->sort(~productId->ascending())->toString());
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::lessThanAll::testLessThanAll_Negated<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productId, price
+                                   1, 100
+                                   2, 250
+                                   3, 400
+                                 #;
+                  let limits = #TDS
+                                 threshold
+                                 150
+                                 300
+                               #;
+                  $products->filter(p | !$p.price->lessThanAll($limits->select(~threshold)));
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productId,price\n'+
+                 '   2,250\n'+
+                 '   3,400\n'+
+                 '#', $res->sort(~productId->ascending())->toString());
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::lessThanAll::testLessThanAll_EmptyRelation<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productId, price
+                                   1, 100
+                                   2, 250
+                                 #;
+                  let limits = #TDS
+                                 threshold
+                                 150
+                               #->filter(l | $l.threshold > 1000);
+                  $products->filter(p | $p.price->lessThanAll($limits->select(~threshold)));
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productId,price\n'+
+                 '   1,100\n'+
+                 '   2,250\n'+
+                 '#', $res->sort(~productId->ascending())->toString());
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::lessThanAll::testLessThanAll_NullValue<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productId, price
+                                   1, 100
+                                   2, null
+                                 #;
+                  let limits = #TDS
+                                 threshold
+                                 500
+                               #;
+                  $products->filter(p | $p.price->lessThanAll($limits->select(~threshold)));
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productId,price\n'+
+                 '   1,100\n'+
+                 '#', $res->sort(~productId->ascending())->toString());
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::lessThanAll::testLessThanAll_NullInRelation<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productId, price
+                                   1, 100
+                                   2, 250
+                                 #;
+                  let limits = #TDS
+                                 threshold
+                                 150
+                                 null
+                               #;
+                  $products->filter(p | $p.price->lessThanAll($limits->select(~threshold)));
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productId,price\n'+
+                 '   1,100\n'+
+                 '#', $res->sort(~productId->ascending())->toString());
+}

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/quantification/lessThanAny.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/quantification/lessThanAny.pure
@@ -1,0 +1,186 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::pure::test::pct::*;
+import meta::pure::metamodel::relation::*;
+import meta::pure::functions::relation::*;
+
+'''
+Whether the given value is less than at least one value in the single column of the given relation.
+
+The relation must carry exactly one column, of the same type as the value; the compiler
+rejects anything else. Nulls in that column are ignored rather than making the comparison
+undecided, which is where this parts company with the SQL `< ANY` it generates -- `Boolean[1]`
+is two-valued and has no UNKNOWN to return.
+
+An empty value answers `false`, as the scalar `<` does when an operand is absent. An empty
+relation, and a column holding only nulls, answer `false` too: there is no value there to be
+less than.
+
+Negation is exact. `!$value->lessThanAny($rel)` is `true` for precisely the cases this answers `false`
+for, empty values included, and on relational stores it generates a plain `not` over a decided
+predicate rather than a disjunction.
+
+**Parameters**
+- `value` — the value to compare; may be empty.
+- `rel` — a relation with a single column of the same type as `value`.
+
+**Returns** `true` when at least one non-null value `c` in the column satisfies `value < c`.
+
+**Examples**
+```pure
+let limits = #TDS
+               threshold
+               150
+               300
+             #->select(~threshold);
+
+#TDS
+  productId, price
+  1, 100
+  2, 250
+  3, 400
+#->filter(p | $p.price->lessThanAny($limits))   // keeps 1 and 2
+```
+
+**See also** `lessThanAll(U[0..1], Relation<Z=(?:U)>[1]):Boolean[1]`,
+`in(U[0..1], Relation<Z=(?:U)>[1]):Boolean[1]`,
+`exists(Relation<T>[1], Function<{T[1]->Boolean[1]}>[1]):Boolean[1]`
+'''
+function <<PCT.function, functionType.NormalizeRequiredFunction>> meta::pure::functions::relation::lessThanAny<U,Z>(value:U[0..1], rel:Relation<Z=(?:U)>[1]):Boolean[1]
+{
+   let col = $rel->genericType().typeArguments->at(0).rawType->toOne()->cast(@RelationType<Any>).columns->toOne()->cast(@Column<Nil,U|0..1>);
+   $value->isNotEmpty() && $rel->meta::pure::functions::relation::exists({row:Z[1] | $col->eval($row)->isNotEmpty() && (meta::pure::functions::lang::compare($value->toOne(), $col->eval($row)->toOne()) < 0)});
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::lessThanAny::testLessThanAny<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productId, price
+                                   1, 100
+                                   2, 250
+                                   3, 400
+                                 #;
+                  let limits = #TDS
+                                 threshold
+                                 150
+                                 300
+                               #;
+                  $products->filter(p | $p.price->lessThanAny($limits->select(~threshold)));
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productId,price\n'+
+                 '   1,100\n'+
+                 '   2,250\n'+
+                 '#', $res->sort(~productId->ascending())->toString());
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::lessThanAny::testLessThanAny_Negated<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productId, price
+                                   1, 100
+                                   2, 250
+                                   3, 400
+                                 #;
+                  let limits = #TDS
+                                 threshold
+                                 150
+                                 300
+                               #;
+                  $products->filter(p | !$p.price->lessThanAny($limits->select(~threshold)));
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productId,price\n'+
+                 '   3,400\n'+
+                 '#', $res->sort(~productId->ascending())->toString());
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::lessThanAny::testLessThanAny_EmptyRelation<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productId, price
+                                   1, 100
+                                   2, 250
+                                 #;
+                  let limits = #TDS
+                                 threshold
+                                 150
+                               #->filter(l | $l.threshold > 1000);
+                  $products->filter(p | $p.price->lessThanAny($limits->select(~threshold)));
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productId,price\n'+
+                 '\n'+
+                 '#', $res->sort(~productId->ascending())->toString());
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::lessThanAny::testLessThanAny_NullValue<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productId, price
+                                   1, 100
+                                   2, null
+                                 #;
+                  let limits = #TDS
+                                 threshold
+                                 500
+                               #;
+                  $products->filter(p | $p.price->lessThanAny($limits->select(~threshold)));
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productId,price\n'+
+                 '   1,100\n'+
+                 '#', $res->sort(~productId->ascending())->toString());
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::lessThanAny::testLessThanAny_NullInRelation<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productId, price
+                                   1, 100
+                                   2, 250
+                                 #;
+                  let limits = #TDS
+                                 threshold
+                                 150
+                                 null
+                               #;
+                  $products->filter(p | $p.price->lessThanAny($limits->select(~threshold)));
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productId,price\n'+
+                 '   1,100\n'+
+                 '#', $res->sort(~productId->ascending())->toString());
+}

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/quantification/lessThanEqualAll.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/quantification/lessThanEqualAll.pure
@@ -1,0 +1,187 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::pure::test::pct::*;
+import meta::pure::metamodel::relation::*;
+import meta::pure::functions::relation::*;
+
+'''
+Whether the given value is less than or equal to every value in the single column of the given relation.
+
+The relation must carry exactly one column, of the same type as the value; the compiler
+rejects anything else. Nulls in that column are ignored rather than making the comparison
+undecided, which is where this parts company with the SQL `<= ALL` it generates -- `Boolean[1]`
+is two-valued and has no UNKNOWN to return.
+
+An empty relation answers `true`, as `<= ALL` does over an empty subquery, and so does a column
+holding only nulls. An empty value still answers `false`: absence is not a value the comparison
+holds for, matching the scalar `<=`.
+
+Negation is exact. `!$value->lessThanEqualAll($rel)` is `true` for precisely the cases this answers `false`
+for, empty values included, and on relational stores it generates a plain `not` over a decided
+predicate rather than a disjunction.
+
+**Parameters**
+- `value` — the value to compare; may be empty.
+- `rel` — a relation with a single column of the same type as `value`.
+
+**Returns** `true` when every non-null value `c` in the column satisfies `value <= c`.
+
+**Examples**
+```pure
+let limits = #TDS
+               threshold
+               150
+               300
+             #->select(~threshold);
+
+#TDS
+  productId, price
+  1, 100
+  2, 250
+  3, 400
+#->filter(p | $p.price->lessThanEqualAll($limits))   // keeps 1
+```
+
+**See also** `lessThanEqualAny(U[0..1], Relation<Z=(?:U)>[1]):Boolean[1]`,
+`in(U[0..1], Relation<Z=(?:U)>[1]):Boolean[1]`,
+`exists(Relation<T>[1], Function<{T[1]->Boolean[1]}>[1]):Boolean[1]`
+'''
+function <<PCT.function, functionType.NormalizeRequiredFunction>> meta::pure::functions::relation::lessThanEqualAll<U,Z>(value:U[0..1], rel:Relation<Z=(?:U)>[1]):Boolean[1]
+{
+   let col = $rel->genericType().typeArguments->at(0).rawType->toOne()->cast(@RelationType<Any>).columns->toOne()->cast(@Column<Nil,U|0..1>);
+   $value->isNotEmpty() && !$rel->meta::pure::functions::relation::exists({row:Z[1] | $col->eval($row)->isNotEmpty() && (meta::pure::functions::lang::compare($value->toOne(), $col->eval($row)->toOne()) > 0)});
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::lessThanEqualAll::testLessThanEqualAll<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productId, price
+                                   1, 100
+                                   2, 250
+                                   3, 400
+                                 #;
+                  let limits = #TDS
+                                 threshold
+                                 150
+                                 300
+                               #;
+                  $products->filter(p | $p.price->lessThanEqualAll($limits->select(~threshold)));
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productId,price\n'+
+                 '   1,100\n'+
+                 '#', $res->sort(~productId->ascending())->toString());
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::lessThanEqualAll::testLessThanEqualAll_Negated<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productId, price
+                                   1, 100
+                                   2, 250
+                                   3, 400
+                                 #;
+                  let limits = #TDS
+                                 threshold
+                                 150
+                                 300
+                               #;
+                  $products->filter(p | !$p.price->lessThanEqualAll($limits->select(~threshold)));
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productId,price\n'+
+                 '   2,250\n'+
+                 '   3,400\n'+
+                 '#', $res->sort(~productId->ascending())->toString());
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::lessThanEqualAll::testLessThanEqualAll_EmptyRelation<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productId, price
+                                   1, 100
+                                   2, 250
+                                 #;
+                  let limits = #TDS
+                                 threshold
+                                 150
+                               #->filter(l | $l.threshold > 1000);
+                  $products->filter(p | $p.price->lessThanEqualAll($limits->select(~threshold)));
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productId,price\n'+
+                 '   1,100\n'+
+                 '   2,250\n'+
+                 '#', $res->sort(~productId->ascending())->toString());
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::lessThanEqualAll::testLessThanEqualAll_NullValue<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productId, price
+                                   1, 100
+                                   2, null
+                                 #;
+                  let limits = #TDS
+                                 threshold
+                                 500
+                               #;
+                  $products->filter(p | $p.price->lessThanEqualAll($limits->select(~threshold)));
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productId,price\n'+
+                 '   1,100\n'+
+                 '#', $res->sort(~productId->ascending())->toString());
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::lessThanEqualAll::testLessThanEqualAll_NullInRelation<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productId, price
+                                   1, 100
+                                   2, 250
+                                 #;
+                  let limits = #TDS
+                                 threshold
+                                 150
+                                 null
+                               #;
+                  $products->filter(p | $p.price->lessThanEqualAll($limits->select(~threshold)));
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productId,price\n'+
+                 '   1,100\n'+
+                 '#', $res->sort(~productId->ascending())->toString());
+}

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/quantification/lessThanEqualAny.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/quantification/lessThanEqualAny.pure
@@ -1,0 +1,186 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::pure::test::pct::*;
+import meta::pure::metamodel::relation::*;
+import meta::pure::functions::relation::*;
+
+'''
+Whether the given value is less than or equal to at least one value in the single column of the given relation.
+
+The relation must carry exactly one column, of the same type as the value; the compiler
+rejects anything else. Nulls in that column are ignored rather than making the comparison
+undecided, which is where this parts company with the SQL `<= ANY` it generates -- `Boolean[1]`
+is two-valued and has no UNKNOWN to return.
+
+An empty value answers `false`, as the scalar `<=` does when an operand is absent. An empty
+relation, and a column holding only nulls, answer `false` too: there is no value there to be
+less than or equal to.
+
+Negation is exact. `!$value->lessThanEqualAny($rel)` is `true` for precisely the cases this answers `false`
+for, empty values included, and on relational stores it generates a plain `not` over a decided
+predicate rather than a disjunction.
+
+**Parameters**
+- `value` — the value to compare; may be empty.
+- `rel` — a relation with a single column of the same type as `value`.
+
+**Returns** `true` when at least one non-null value `c` in the column satisfies `value <= c`.
+
+**Examples**
+```pure
+let limits = #TDS
+               threshold
+               150
+               300
+             #->select(~threshold);
+
+#TDS
+  productId, price
+  1, 100
+  2, 250
+  3, 400
+#->filter(p | $p.price->lessThanEqualAny($limits))   // keeps 1 and 2
+```
+
+**See also** `lessThanEqualAll(U[0..1], Relation<Z=(?:U)>[1]):Boolean[1]`,
+`in(U[0..1], Relation<Z=(?:U)>[1]):Boolean[1]`,
+`exists(Relation<T>[1], Function<{T[1]->Boolean[1]}>[1]):Boolean[1]`
+'''
+function <<PCT.function, functionType.NormalizeRequiredFunction>> meta::pure::functions::relation::lessThanEqualAny<U,Z>(value:U[0..1], rel:Relation<Z=(?:U)>[1]):Boolean[1]
+{
+   let col = $rel->genericType().typeArguments->at(0).rawType->toOne()->cast(@RelationType<Any>).columns->toOne()->cast(@Column<Nil,U|0..1>);
+   $value->isNotEmpty() && $rel->meta::pure::functions::relation::exists({row:Z[1] | $col->eval($row)->isNotEmpty() && (meta::pure::functions::lang::compare($value->toOne(), $col->eval($row)->toOne()) <= 0)});
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::lessThanEqualAny::testLessThanEqualAny<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productId, price
+                                   1, 100
+                                   2, 250
+                                   3, 400
+                                 #;
+                  let limits = #TDS
+                                 threshold
+                                 150
+                                 300
+                               #;
+                  $products->filter(p | $p.price->lessThanEqualAny($limits->select(~threshold)));
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productId,price\n'+
+                 '   1,100\n'+
+                 '   2,250\n'+
+                 '#', $res->sort(~productId->ascending())->toString());
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::lessThanEqualAny::testLessThanEqualAny_Negated<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productId, price
+                                   1, 100
+                                   2, 250
+                                   3, 400
+                                 #;
+                  let limits = #TDS
+                                 threshold
+                                 150
+                                 300
+                               #;
+                  $products->filter(p | !$p.price->lessThanEqualAny($limits->select(~threshold)));
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productId,price\n'+
+                 '   3,400\n'+
+                 '#', $res->sort(~productId->ascending())->toString());
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::lessThanEqualAny::testLessThanEqualAny_EmptyRelation<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productId, price
+                                   1, 100
+                                   2, 250
+                                 #;
+                  let limits = #TDS
+                                 threshold
+                                 150
+                               #->filter(l | $l.threshold > 1000);
+                  $products->filter(p | $p.price->lessThanEqualAny($limits->select(~threshold)));
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productId,price\n'+
+                 '\n'+
+                 '#', $res->sort(~productId->ascending())->toString());
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::lessThanEqualAny::testLessThanEqualAny_NullValue<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productId, price
+                                   1, 100
+                                   2, null
+                                 #;
+                  let limits = #TDS
+                                 threshold
+                                 500
+                               #;
+                  $products->filter(p | $p.price->lessThanEqualAny($limits->select(~threshold)));
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productId,price\n'+
+                 '   1,100\n'+
+                 '#', $res->sort(~productId->ascending())->toString());
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::lessThanEqualAny::testLessThanEqualAny_NullInRelation<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let products = #TDS
+                                   productId, price
+                                   1, 100
+                                   2, 250
+                                 #;
+                  let limits = #TDS
+                                 threshold
+                                 150
+                                 null
+                               #;
+                  $products->filter(p | $p.price->lessThanEqualAny($limits->select(~threshold)));
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   productId,price\n'+
+                 '   1,100\n'+
+                 '#', $res->sort(~productId->ascending())->toString());
+}

--- a/legend-engine-xts-deephaven/legend-engine-xt-deephaven-PCT/src/main/resources/pct-manifests/deephaven/RelationFunctions_manifest.json
+++ b/legend-engine-xts-deephaven/legend-engine-xt-deephaven-PCT/src/main/resources/pct-manifests/deephaven/RelationFunctions_manifest.json
@@ -277,6 +277,36 @@
     "test" : "meta::pure::functions::relation::tests::drop::testSimpleDrop_MultipleExpressions_Function_1__Boolean_1_",
     "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
   }, {
+    "test" : "meta::pure::functions::relation::tests::equalAll::testEqualAll_EmptyRelation_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::equalAll::testEqualAll_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::equalAll::testEqualAll_Negated_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::equalAll::testEqualAll_NullInRelation_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::equalAll::testEqualAll_NullValue_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::equalAny::testEqualAny_EmptyRelation_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::equalAny::testEqualAny_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::equalAny::testEqualAny_Negated_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::equalAny::testEqualAny_NullInRelation_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::equalAny::testEqualAny_NullValue_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
     "test" : "meta::pure::functions::relation::tests::eval::testSimpleEval_Function_1__Boolean_1_",
     "expectedError" : "Match failure: PlatformClusteredValueSpecificationObject instanceOf PlatformClusteredValueSpecification"
   }, {
@@ -445,6 +475,117 @@
     "test" : "meta::pure::functions::relation::tests::filter::testVariantColumn_filterOutputFromLambda_Function_1__Boolean_1_",
     "expectedError" : "Cannot cast a collection of size 0 to multiplicity [1]"
   }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_CorrelatedSubQuery_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_DerivedRelation_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_EmptyRelation_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_GroupedRelationWithNull_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_InExtend_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_LimitedRelationWithNull_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_Negated_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_Negated_NullValueAndNullInRelation_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_NullInRelation_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_NullValueAndNullInRelation_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_NullValue_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_OnlyNullsInRelation_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_String_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAll::testSimpleGreaterThanAll_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_CorrelatedSubQuery_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_DerivedRelation_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_EmptyRelation_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_GroupedRelationWithNull_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_InExtend_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_Negated_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_Negated_NullValueAndNullInRelation_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_NullInRelation_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_NullValueAndNullInRelation_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_NullValue_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_OnlyNullsInRelation_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_String_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAny::testSimpleGreaterThanAny_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanEqualAll::testGreaterThanEqualAll_EmptyRelation_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanEqualAll::testGreaterThanEqualAll_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanEqualAll::testGreaterThanEqualAll_Negated_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanEqualAll::testGreaterThanEqualAll_NullInRelation_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanEqualAll::testGreaterThanEqualAll_NullValue_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanEqualAny::testGreaterThanEqualAny_EmptyRelation_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanEqualAny::testGreaterThanEqualAny_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanEqualAny::testGreaterThanEqualAny_Negated_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanEqualAny::testGreaterThanEqualAny_NullInRelation_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanEqualAny::testGreaterThanEqualAny_NullValue_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
     "test" : "meta::pure::functions::relation::tests::groupBy::testSimpleGroupBy_MultipleMultiple_Function_1__Boolean_1_",
     "expectedError" : "function not supported yet: meta::pure::functions::relation::groupBy_Relation_1__ColSpecArray_1__AggColSpecArray_1__Relation_1_"
   }, {
@@ -527,6 +668,66 @@
     "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
   }, {
     "test" : "meta::pure::functions::relation::tests::lateral::testLateralJoin_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanAll::testLessThanAll_EmptyRelation_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanAll::testLessThanAll_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanAll::testLessThanAll_Negated_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanAll::testLessThanAll_NullInRelation_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanAll::testLessThanAll_NullValue_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanAny::testLessThanAny_EmptyRelation_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanAny::testLessThanAny_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanAny::testLessThanAny_Negated_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanAny::testLessThanAny_NullInRelation_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanAny::testLessThanAny_NullValue_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanEqualAll::testLessThanEqualAll_EmptyRelation_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanEqualAll::testLessThanEqualAll_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanEqualAll::testLessThanEqualAll_Negated_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanEqualAll::testLessThanEqualAll_NullInRelation_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanEqualAll::testLessThanEqualAll_NullValue_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanEqualAny::testLessThanEqualAny_EmptyRelation_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanEqualAny::testLessThanEqualAny_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanEqualAny::testLessThanEqualAny_Negated_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanEqualAny::testLessThanEqualAny_NullInRelation_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanEqualAny::testLessThanEqualAny_NullValue_Function_1__Boolean_1_",
     "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
   }, {
     "test" : "meta::pure::functions::relation::tests::limit::testSimpleLimitShared_Function_1__Boolean_1_",

--- a/legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-PCT/src/main/resources/pct-manifests/java/Test_JAVA_RelationFunction_manifest.json
+++ b/legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-PCT/src/main/resources/pct-manifests/java/Test_JAVA_RelationFunction_manifest.json
@@ -374,6 +374,46 @@
       "expectedError": "\"Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated\""
     },
     {
+      "test": "meta::pure::functions::relation::tests::equalAll::testEqualAll_EmptyRelation_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::equalAll::testEqualAll_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::equalAll::testEqualAll_Negated_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::equalAll::testEqualAll_NullInRelation_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::equalAll::testEqualAll_NullValue_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::equalAny::testEqualAny_EmptyRelation_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::equalAny::testEqualAny_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::equalAny::testEqualAny_Negated_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::equalAny::testEqualAny_NullInRelation_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::equalAny::testEqualAny_NullValue_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
       "test": "meta::pure::functions::relation::tests::eval::testSimpleEval_Function_1__Boolean_1_",
       "expectedError": "\"Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated\""
     },
@@ -618,6 +658,154 @@
       "expectedError": "\"Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated\""
     },
     {
+      "test": "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_CorrelatedSubQuery_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_DerivedRelation_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_EmptyRelation_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_GroupedRelationWithNull_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_InExtend_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_LimitedRelationWithNull_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_Negated_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_Negated_NullValueAndNullInRelation_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_NullInRelation_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_NullValueAndNullInRelation_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_NullValue_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_OnlyNullsInRelation_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_String_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::greaterThanAll::testSimpleGreaterThanAll_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_CorrelatedSubQuery_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_DerivedRelation_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_EmptyRelation_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_GroupedRelationWithNull_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_InExtend_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_Negated_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_Negated_NullValueAndNullInRelation_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_NullInRelation_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_NullValueAndNullInRelation_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_NullValue_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_OnlyNullsInRelation_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_String_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::greaterThanAny::testSimpleGreaterThanAny_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::greaterThanEqualAll::testGreaterThanEqualAll_EmptyRelation_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::greaterThanEqualAll::testGreaterThanEqualAll_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::greaterThanEqualAll::testGreaterThanEqualAll_Negated_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::greaterThanEqualAll::testGreaterThanEqualAll_NullInRelation_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::greaterThanEqualAll::testGreaterThanEqualAll_NullValue_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::greaterThanEqualAny::testGreaterThanEqualAny_EmptyRelation_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::greaterThanEqualAny::testGreaterThanEqualAny_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::greaterThanEqualAny::testGreaterThanEqualAny_Negated_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::greaterThanEqualAny::testGreaterThanEqualAny_NullInRelation_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::greaterThanEqualAny::testGreaterThanEqualAny_NullValue_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
       "test": "meta::pure::functions::relation::tests::groupBy::testSimpleGroupBy_MultipleMultiple_Function_1__Boolean_1_",
       "expectedError": "\"Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated\""
     },
@@ -740,6 +928,86 @@
     {
       "test": "meta::pure::functions::relation::tests::lead::testOLAPWithPartitionAndOrderWindow_Function_1__Boolean_1_",
       "expectedError": "\"Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated\""
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::lessThanAll::testLessThanAll_EmptyRelation_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::lessThanAll::testLessThanAll_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::lessThanAll::testLessThanAll_Negated_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::lessThanAll::testLessThanAll_NullInRelation_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::lessThanAll::testLessThanAll_NullValue_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::lessThanAny::testLessThanAny_EmptyRelation_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::lessThanAny::testLessThanAny_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::lessThanAny::testLessThanAny_Negated_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::lessThanAny::testLessThanAny_NullInRelation_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::lessThanAny::testLessThanAny_NullValue_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::lessThanEqualAll::testLessThanEqualAll_EmptyRelation_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::lessThanEqualAll::testLessThanEqualAll_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::lessThanEqualAll::testLessThanEqualAll_Negated_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::lessThanEqualAll::testLessThanEqualAll_NullInRelation_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::lessThanEqualAll::testLessThanEqualAll_NullValue_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::lessThanEqualAny::testLessThanEqualAny_EmptyRelation_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::lessThanEqualAny::testLessThanEqualAny_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::lessThanEqualAny::testLessThanEqualAny_Negated_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::lessThanEqualAny::testLessThanEqualAny_NullInRelation_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::lessThanEqualAny::testLessThanEqualAny_NullValue_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
     },
     {
       "test": "meta::pure::functions::relation::tests::limit::testSimpleLimitShared_Function_1__Boolean_1_",

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-clickhouse/legend-engine-xt-relationalStore-clickhouse-PCT/src/main/resources/pct-manifests/relational-clickhouse/RelationFunctions_manifest.json
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-clickhouse/legend-engine-xt-relationalStore-clickhouse-PCT/src/main/resources/pct-manifests/relational-clickhouse/RelationFunctions_manifest.json
@@ -121,6 +121,9 @@
     "test" : "meta::pure::functions::relation::tests::cumulativeDistribution::testOLAPWithPartitionAndOrderCummulativeDistribution_Function_1__Boolean_1_",
     "expectedError" : "Aggregate function with name 'cume_dist' does not exist"
   }, {
+    "test" : "meta::pure::functions::relation::tests::equalAll::testEqualAll_EmptyRelation_Function_1__Boolean_1_",
+    "expectedError" : "\nexpected: '#TDS\\n   productId,price\\n   1,100\\n   2,250\\n#'\nactual:   '#TDS\\n   productId,price\\n\\n#'"
+  }, {
     "test" : "meta::pure::functions::relation::tests::exists::testExistsCorrelated_ExtraInnerPredicate_Function_1__Boolean_1_",
     "expectedError" : "from parent scope only supported for constants and CTE"
   }, {
@@ -226,6 +229,21 @@
     "test" : "meta::pure::functions::relation::tests::filter::testVariantColumn_filterOutputFromLambda_Function_1__Boolean_1_",
     "expectedError" : "\"[unsupported-api] The function 'array_size' (state: [Where, false]) is not supported yet\""
   }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_CorrelatedSubQuery_Function_1__Boolean_1_",
+    "expectedError" : "from parent scope only supported for constants and CTE"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_EmptyRelation_Function_1__Boolean_1_",
+    "expectedError" : "\nexpected: '#TDS\\n   productId,price\\n   1,100\\n   2,250\\n#'\nactual:   '#TDS\\n   productId,price\\n\\n#'"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_OnlyNullsInRelation_Function_1__Boolean_1_",
+    "expectedError" : "\nexpected: '#TDS\\n   productId,price\\n   1,100\\n   2,250\\n#'\nactual:   '#TDS\\n   productId,price\\n\\n#'"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_CorrelatedSubQuery_Function_1__Boolean_1_",
+    "expectedError" : "from parent scope only supported for constants and CTE"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanEqualAll::testGreaterThanEqualAll_EmptyRelation_Function_1__Boolean_1_",
+    "expectedError" : "\nexpected: '#TDS\\n   productId,price\\n   1,100\\n   2,250\\n#'\nactual:   '#TDS\\n   productId,price\\n\\n#'"
+  }, {
     "test" : "meta::pure::functions::relation::tests::groupBy::testSimpleGroupBy_MultipleMultiple_Function_1__Boolean_1_",
     "expectedError" : "name is not under aggregate function and not in GROUP BY keys"
   }, {
@@ -273,6 +291,12 @@
   }, {
     "test" : "meta::pure::functions::relation::tests::lead::testOLAPWithPartitionAndOrderWindow_Function_1__Boolean_1_",
     "expectedError" : "Aggregate function with name 'lead' does not exist"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanAll::testLessThanAll_EmptyRelation_Function_1__Boolean_1_",
+    "expectedError" : "\nexpected: '#TDS\\n   productId,price\\n   1,100\\n   2,250\\n#'\nactual:   '#TDS\\n   productId,price\\n\\n#'"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanEqualAll::testLessThanEqualAll_EmptyRelation_Function_1__Boolean_1_",
+    "expectedError" : "\nexpected: '#TDS\\n   productId,price\\n   1,100\\n   2,250\\n#'\nactual:   '#TDS\\n   productId,price\\n\\n#'"
   }, {
     "test" : "meta::pure::functions::relation::tests::over::testRangeInterval_CurrentRow_NFollowing_WithSinglePartition_WithOrderByASC_Function_1__Boolean_1_",
     "expectedError" : "\"Window function with range frame using interval is not supported for this database type: ClickHouse\""

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-databricks/legend-engine-xt-relationalStore-databricks-PCT/src/main/resources/pct-manifests/relational-databricks/RelationFunctions_manifest.json
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-databricks/legend-engine-xt-relationalStore-databricks-PCT/src/main/resources/pct-manifests/relational-databricks/RelationFunctions_manifest.json
@@ -55,6 +55,36 @@
     "test" : "meta::pure::functions::relation::tests::composition::test_Static_Pivot_Filter_Function_1__Boolean_1_",
     "expectedError" : "\"pivot is not supported\""
   }, {
+    "test" : "meta::pure::functions::relation::tests::equalAll::testEqualAll_EmptyRelation_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::equalAll::testEqualAll_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::equalAll::testEqualAll_Negated_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::equalAll::testEqualAll_NullInRelation_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::equalAll::testEqualAll_NullValue_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::equalAny::testEqualAny_EmptyRelation_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::equalAny::testEqualAny_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::equalAny::testEqualAny_Negated_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::equalAny::testEqualAny_NullInRelation_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::equalAny::testEqualAny_NullValue_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
     "test" : "meta::pure::functions::relation::tests::extend::testOLAPAggStringWithPartitionAndOrderASCUnboundedWindow_Function_1__Boolean_1_",
     "expectedError" : "[MISSING_GROUP_BY]"
   }, {
@@ -94,8 +124,179 @@
     "test" : "meta::pure::functions::relation::tests::extend::testVariantColumn_fold_Function_1__Boolean_1_",
     "expectedError" : "The third parameter requires the \"INT\" type"
   }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_CorrelatedSubQuery_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_DerivedRelation_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_EmptyRelation_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_GroupedRelationWithNull_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_InExtend_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_LimitedRelationWithNull_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_Negated_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_Negated_NullValueAndNullInRelation_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_NullInRelation_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_NullValueAndNullInRelation_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_NullValue_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_OnlyNullsInRelation_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_String_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAll::testSimpleGreaterThanAll_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_CorrelatedSubQuery_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_DerivedRelation_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_EmptyRelation_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_GroupedRelationWithNull_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_InExtend_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_Negated_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_Negated_NullValueAndNullInRelation_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_NullInRelation_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_NullValueAndNullInRelation_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_NullValue_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_OnlyNullsInRelation_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_String_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAny::testSimpleGreaterThanAny_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanEqualAll::testGreaterThanEqualAll_EmptyRelation_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanEqualAll::testGreaterThanEqualAll_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanEqualAll::testGreaterThanEqualAll_Negated_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanEqualAll::testGreaterThanEqualAll_NullInRelation_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanEqualAll::testGreaterThanEqualAll_NullValue_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanEqualAny::testGreaterThanEqualAny_EmptyRelation_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanEqualAny::testGreaterThanEqualAny_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanEqualAny::testGreaterThanEqualAny_Negated_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanEqualAny::testGreaterThanEqualAny_NullInRelation_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanEqualAny::testGreaterThanEqualAny_NullValue_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
     "test" : "meta::pure::functions::relation::tests::in::testSimpleIn_Negated_Function_1__Boolean_1_",
     "expectedError" : "Negating in(value, Relation) is not supported on relational stores. Use not exists instead, for example replace !$d.departmentId->in($employees->select(~department)) with $d.departmentId->isEmpty() || !$employees->exists(e | $e.department == $d.departmentId)"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanAll::testLessThanAll_EmptyRelation_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanAll::testLessThanAll_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanAll::testLessThanAll_Negated_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanAll::testLessThanAll_NullInRelation_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanAll::testLessThanAll_NullValue_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanAny::testLessThanAny_EmptyRelation_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanAny::testLessThanAny_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanAny::testLessThanAny_Negated_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanAny::testLessThanAny_NullInRelation_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanAny::testLessThanAny_NullValue_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanEqualAll::testLessThanEqualAll_EmptyRelation_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanEqualAll::testLessThanEqualAll_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanEqualAll::testLessThanEqualAll_Negated_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanEqualAll::testLessThanEqualAll_NullInRelation_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanEqualAll::testLessThanEqualAll_NullValue_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanEqualAny::testLessThanEqualAny_EmptyRelation_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanEqualAny::testLessThanEqualAny_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanEqualAny::testLessThanEqualAny_Negated_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanEqualAny::testLessThanEqualAny_NullInRelation_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanEqualAny::testLessThanEqualAny_NullValue_Function_1__Boolean_1_",
+    "expectedError" : "[PARSE_SYNTAX_ERROR]"
   }, {
     "test" : "meta::pure::functions::relation::tests::over::testRangeInterval_CurrentRow_NFollowing_WithSinglePartition_WithOrderByASC_Function_1__Boolean_1_",
     "expectedError" : "\"Window function with range frame using interval is not supported for this database type: Databricks\""

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-duckdb/legend-engine-xt-relationalStore-duckdb-sqlDialectTranslation-pure/src/main/resources/core_external_store_relational_sql_dialect_translation_duckdb/duckDBSqlDialect.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-duckdb/legend-engine-xt-relationalStore-duckdb-sqlDialectTranslation-pure/src/main/resources/core_external_store_relational_sql_dialect_translation_duckdb/duckDBSqlDialect.pure
@@ -223,6 +223,7 @@ function <<access.private>> meta::external::store::relational::sqlDialectTransla
     inListExpressionProcessor_default(),
     inPredicateProcessor_default(),
     existsPredicateProcessor_default(),
+    quantifiedComparisonExpressionProcessor_default(),
     extractProcessor_default(),
     betweenPredicateProcessor_default(),
     functionCallProcessor_default(),

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-h2/legend-engine-xt-relationalStore-h2-PCT/src/main/resources/pct-manifests/relational-h2/RelationFunctions_manifest.json
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-h2/legend-engine-xt-relationalStore-h2-PCT/src/main/resources/pct-manifests/relational-h2/RelationFunctions_manifest.json
@@ -79,6 +79,9 @@
     "test" : "meta::pure::functions::relation::tests::composition::test_Static_Pivot_Filter_Function_1__Boolean_1_",
     "expectedError" : "Dialect translation for node of type \"meta::external::query::sql::metamodel::extension::PivotedRelation\" not implemented in SqlDialect for database type \"H2\""
   }, {
+    "test" : "meta::pure::functions::relation::tests::equalAll::testEqualAll_EmptyRelation_Function_1__Boolean_1_",
+    "expectedError" : "\nexpected: '#TDS\\n   productId,price\\n   1,100\\n   2,250\\n#'\nactual:   '#TDS\\n   productId,price\\n\\n#'"
+  }, {
     "test" : "meta::pure::functions::relation::tests::extend::testVariantColumn_filter_Function_1__Boolean_1_",
     "expectedError" : "Match failure: FilterRelationalLambdaObject instanceOf FilterRelationalLambda"
   }, {

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-h2/legend-engine-xt-relationalStore-h2-sqlDialectTranslation-pure/src/main/resources/core_external_store_relational_sql_dialect_translation_h2/h2SqlDialect.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-h2/legend-engine-xt-relationalStore-h2-sqlDialectTranslation-pure/src/main/resources/core_external_store_relational_sql_dialect_translation_h2/h2SqlDialect.pure
@@ -211,6 +211,7 @@ function <<access.private>> meta::external::store::relational::sqlDialectTransla
     inListExpressionProcessor_default(),
     inPredicateProcessor_default(),
     existsPredicateProcessor_default(),
+    quantifiedComparisonExpressionProcessor_default(),
     extractProcessor_default(),
     betweenPredicateProcessor_default(),
     functionCallProcessor_default(),

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-PCT/src/main/resources/pct-manifests/relational-memsql/RelationFunctions_manifest.json
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-PCT/src/main/resources/pct-manifests/relational-memsql/RelationFunctions_manifest.json
@@ -109,6 +109,36 @@
     "test" : "meta::pure::functions::relation::tests::drop::testSimpleDrop_MultipleExpressions_Function_1__Boolean_1_",
     "expectedError" : "Execution error at (resource:/core_relational/relational/sqlQueryToString/extensionDefaults.pure line:102 column:46), \"Cast exception: TableAliasColumn cannot be cast to Alias\""
   }, {
+    "test" : "meta::pure::functions::relation::tests::equalAll::testEqualAll_EmptyRelation_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::equalAll::testEqualAll_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::equalAll::testEqualAll_Negated_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::equalAll::testEqualAll_NullInRelation_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::equalAll::testEqualAll_NullValue_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::equalAny::testEqualAny_EmptyRelation_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::equalAny::testEqualAny_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::equalAny::testEqualAny_Negated_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::equalAny::testEqualAny_NullInRelation_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::equalAny::testEqualAny_NullValue_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
     "test" : "meta::pure::functions::relation::tests::exists::testExistsCorrelated_ExtraInnerPredicate_Function_1__Boolean_1_",
     "expectedError" : "cannot appear in the definition of common table expression."
   }, {
@@ -235,6 +265,117 @@
     "test" : "meta::pure::functions::relation::tests::filter::testVariantColumn_filterOutputFromLambda_Function_1__Boolean_1_",
     "expectedError" : "[unsupported-api] The function 'array_size' (state: [Where, false]) is not supported yet"
   }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_CorrelatedSubQuery_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_DerivedRelation_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_EmptyRelation_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_GroupedRelationWithNull_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_InExtend_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_LimitedRelationWithNull_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_Negated_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_Negated_NullValueAndNullInRelation_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_NullInRelation_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_NullValueAndNullInRelation_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_NullValue_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_OnlyNullsInRelation_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_String_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAll::testSimpleGreaterThanAll_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_CorrelatedSubQuery_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_DerivedRelation_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_EmptyRelation_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_GroupedRelationWithNull_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_InExtend_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_Negated_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_Negated_NullValueAndNullInRelation_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_NullInRelation_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_NullValueAndNullInRelation_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_NullValue_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_OnlyNullsInRelation_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_String_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAny::testSimpleGreaterThanAny_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanEqualAll::testGreaterThanEqualAll_EmptyRelation_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanEqualAll::testGreaterThanEqualAll_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanEqualAll::testGreaterThanEqualAll_Negated_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanEqualAll::testGreaterThanEqualAll_NullInRelation_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanEqualAll::testGreaterThanEqualAll_NullValue_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanEqualAny::testGreaterThanEqualAny_EmptyRelation_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanEqualAny::testGreaterThanEqualAny_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanEqualAny::testGreaterThanEqualAny_Negated_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanEqualAny::testGreaterThanEqualAny_NullInRelation_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanEqualAny::testGreaterThanEqualAny_NullValue_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
     "test" : "meta::pure::functions::relation::tests::groupBy::testSimpleGroupBy_MultipleMultiple_MultipleExpressions_Function_1__Boolean_1_",
     "expectedError" : "cannot appear in the definition of common table expression."
   }, {
@@ -297,6 +438,66 @@
   }, {
     "test" : "meta::pure::functions::relation::tests::lateral::testLateralJoin_Function_1__Boolean_1_",
     "expectedError" : "[unsupported-api] Lateral operation not supported for Database Type: MemSQL"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanAll::testLessThanAll_EmptyRelation_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanAll::testLessThanAll_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanAll::testLessThanAll_Negated_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanAll::testLessThanAll_NullInRelation_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanAll::testLessThanAll_NullValue_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanAny::testLessThanAny_EmptyRelation_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanAny::testLessThanAny_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanAny::testLessThanAny_Negated_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanAny::testLessThanAny_NullInRelation_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanAny::testLessThanAny_NullValue_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanEqualAll::testLessThanEqualAll_EmptyRelation_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanEqualAll::testLessThanEqualAll_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanEqualAll::testLessThanEqualAll_Negated_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanEqualAll::testLessThanEqualAll_NullInRelation_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanEqualAll::testLessThanEqualAll_NullValue_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanEqualAny::testLessThanEqualAny_EmptyRelation_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanEqualAny::testLessThanEqualAny_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanEqualAny::testLessThanEqualAny_Negated_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanEqualAny::testLessThanEqualAny_NullInRelation_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanEqualAny::testLessThanEqualAny_NullValue_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
   }, {
     "test" : "meta::pure::functions::relation::tests::limit::testSimpleLimit_MultipleExpressions_Function_1__Boolean_1_",
     "expectedError" : "cannot appear in the definition of common table expression."

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-sqlDialectTranslation-pure/src/main/resources/core_external_store_relational_sql_dialect_translation_memsql/memSQLSqlDialect.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-sqlDialectTranslation-pure/src/main/resources/core_external_store_relational_sql_dialect_translation_memsql/memSQLSqlDialect.pure
@@ -248,6 +248,7 @@ function <<access.private>> meta::external::store::relational::sqlDialectTransla
     inListExpressionProcessor_default(),
     inPredicateProcessor_default(),
     existsPredicateProcessor_default(),
+    quantifiedComparisonExpressionProcessor_default(),
     extractProcessor_default(),
     betweenPredicateProcessor_default(),
     functionCallProcessor_default(),

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-sqlDialectTranslation-pure/src/main/resources/core_external_store_relational_sql_dialect_translation_snowflake/snowflakeSqlDialect.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-sqlDialectTranslation-pure/src/main/resources/core_external_store_relational_sql_dialect_translation_snowflake/snowflakeSqlDialect.pure
@@ -251,7 +251,8 @@ function <<access.private>> meta::external::store::relational::sqlDialectTransla
     bitwiseNotExpressionNodeProcessorForSnowflake(),
     bitwiseShiftExpressionNodeProcessorForSnowflake(),
     likePredicateProcessor_default(),
-    existsPredicateProcessor_default()    
+    existsPredicateProcessor_default(),
+    quantifiedComparisonExpressionProcessor_default()
   ]
 }
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-spanner/legend-engine-xt-relationalStore-spanner-PCT/src/main/resources/pct-manifests/relational-spanner/RelationFunctions_manifest.json
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-spanner/legend-engine-xt-relationalStore-spanner-PCT/src/main/resources/pct-manifests/relational-spanner/RelationFunctions_manifest.json
@@ -145,6 +145,21 @@
     "test" : "meta::pure::functions::relation::tests::drop::testSimpleDrop_MultipleExpressions_Function_1__Boolean_1_",
     "expectedError" : "\nexpected: '#TDS\\n   val,str\\n   5,wwe\\n   6,weq\\n#'\nactual:   '#TDS\\n   val,str\\n   4,qw\\n   5,wwe\\n#'"
   }, {
+    "test" : "meta::pure::functions::relation::tests::equalAll::testEqualAll_EmptyRelation_Function_1__Boolean_1_",
+    "expectedError" : "ALL subqueries with operators other than <>/!= are not supported"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::equalAll::testEqualAll_Function_1__Boolean_1_",
+    "expectedError" : "ALL subqueries with operators other than <>/!= are not supported"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::equalAll::testEqualAll_Negated_Function_1__Boolean_1_",
+    "expectedError" : "ALL subqueries with operators other than <>/!= are not supported"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::equalAll::testEqualAll_NullInRelation_Function_1__Boolean_1_",
+    "expectedError" : "ALL subqueries with operators other than <>/!= are not supported"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::equalAll::testEqualAll_NullValue_Function_1__Boolean_1_",
+    "expectedError" : "ALL subqueries with operators other than <>/!= are not supported"
+  }, {
     "test" : "meta::pure::functions::relation::tests::extend::testOLAPAggIntegerWithPartitionAndOrderWindow_Function_1__Boolean_1_",
     "expectedError" : "[unsupported-api] Window Columns not supported for Database Type: Spanner"
   }, {
@@ -268,6 +283,117 @@
     "test" : "meta::pure::functions::relation::tests::first::testOLAPWithPartitionAndOrderFirstWindow_Function_1__Boolean_1_",
     "expectedError" : "[unsupported-api] Window Columns not supported for Database Type: Spanner"
   }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_CorrelatedSubQuery_Function_1__Boolean_1_",
+    "expectedError" : "ALL subqueries with operators other than <>/!= are not supported"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_DerivedRelation_Function_1__Boolean_1_",
+    "expectedError" : "ALL subqueries with operators other than <>/!= are not supported"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_EmptyRelation_Function_1__Boolean_1_",
+    "expectedError" : "ALL subqueries with operators other than <>/!= are not supported"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_GroupedRelationWithNull_Function_1__Boolean_1_",
+    "expectedError" : "ALL subqueries with operators other than <>/!= are not supported"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_InExtend_Function_1__Boolean_1_",
+    "expectedError" : "ALL subqueries with operators other than <>/!= are not supported"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_LimitedRelationWithNull_Function_1__Boolean_1_",
+    "expectedError" : "ALL subqueries with operators other than <>/!= are not supported"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_Negated_Function_1__Boolean_1_",
+    "expectedError" : "ALL subqueries with operators other than <>/!= are not supported"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_Negated_NullValueAndNullInRelation_Function_1__Boolean_1_",
+    "expectedError" : "ALL subqueries with operators other than <>/!= are not supported"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_NullInRelation_Function_1__Boolean_1_",
+    "expectedError" : "ALL subqueries with operators other than <>/!= are not supported"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_NullValueAndNullInRelation_Function_1__Boolean_1_",
+    "expectedError" : "ALL subqueries with operators other than <>/!= are not supported"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_NullValue_Function_1__Boolean_1_",
+    "expectedError" : "ALL subqueries with operators other than <>/!= are not supported"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_OnlyNullsInRelation_Function_1__Boolean_1_",
+    "expectedError" : "ALL subqueries with operators other than <>/!= are not supported"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_String_Function_1__Boolean_1_",
+    "expectedError" : "ALL subqueries with operators other than <>/!= are not supported"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAll::testSimpleGreaterThanAll_Function_1__Boolean_1_",
+    "expectedError" : "ALL subqueries with operators other than <>/!= are not supported"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_CorrelatedSubQuery_Function_1__Boolean_1_",
+    "expectedError" : "ANY/SOME subqueries with non-equality operators are not supported"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_DerivedRelation_Function_1__Boolean_1_",
+    "expectedError" : "ANY/SOME subqueries with non-equality operators are not supported"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_EmptyRelation_Function_1__Boolean_1_",
+    "expectedError" : "ANY/SOME subqueries with non-equality operators are not supported"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_GroupedRelationWithNull_Function_1__Boolean_1_",
+    "expectedError" : "ANY/SOME subqueries with non-equality operators are not supported"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_InExtend_Function_1__Boolean_1_",
+    "expectedError" : "ANY/SOME subqueries with non-equality operators are not supported"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_Negated_Function_1__Boolean_1_",
+    "expectedError" : "ANY/SOME subqueries with non-equality operators are not supported"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_Negated_NullValueAndNullInRelation_Function_1__Boolean_1_",
+    "expectedError" : "ANY/SOME subqueries with non-equality operators are not supported"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_NullInRelation_Function_1__Boolean_1_",
+    "expectedError" : "ANY/SOME subqueries with non-equality operators are not supported"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_NullValueAndNullInRelation_Function_1__Boolean_1_",
+    "expectedError" : "ANY/SOME subqueries with non-equality operators are not supported"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_NullValue_Function_1__Boolean_1_",
+    "expectedError" : "ANY/SOME subqueries with non-equality operators are not supported"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_OnlyNullsInRelation_Function_1__Boolean_1_",
+    "expectedError" : "ANY/SOME subqueries with non-equality operators are not supported"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAny::testGreaterThanAny_String_Function_1__Boolean_1_",
+    "expectedError" : "ANY/SOME subqueries with non-equality operators are not supported"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanAny::testSimpleGreaterThanAny_Function_1__Boolean_1_",
+    "expectedError" : "ANY/SOME subqueries with non-equality operators are not supported"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanEqualAll::testGreaterThanEqualAll_EmptyRelation_Function_1__Boolean_1_",
+    "expectedError" : "ALL subqueries with operators other than <>/!= are not supported"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanEqualAll::testGreaterThanEqualAll_Function_1__Boolean_1_",
+    "expectedError" : "ALL subqueries with operators other than <>/!= are not supported"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanEqualAll::testGreaterThanEqualAll_Negated_Function_1__Boolean_1_",
+    "expectedError" : "ALL subqueries with operators other than <>/!= are not supported"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanEqualAll::testGreaterThanEqualAll_NullInRelation_Function_1__Boolean_1_",
+    "expectedError" : "ALL subqueries with operators other than <>/!= are not supported"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanEqualAll::testGreaterThanEqualAll_NullValue_Function_1__Boolean_1_",
+    "expectedError" : "ALL subqueries with operators other than <>/!= are not supported"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanEqualAny::testGreaterThanEqualAny_EmptyRelation_Function_1__Boolean_1_",
+    "expectedError" : "ANY/SOME subqueries with non-equality operators are not supported"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanEqualAny::testGreaterThanEqualAny_Function_1__Boolean_1_",
+    "expectedError" : "ANY/SOME subqueries with non-equality operators are not supported"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanEqualAny::testGreaterThanEqualAny_Negated_Function_1__Boolean_1_",
+    "expectedError" : "ANY/SOME subqueries with non-equality operators are not supported"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanEqualAny::testGreaterThanEqualAny_NullInRelation_Function_1__Boolean_1_",
+    "expectedError" : "ANY/SOME subqueries with non-equality operators are not supported"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::greaterThanEqualAny::testGreaterThanEqualAny_NullValue_Function_1__Boolean_1_",
+    "expectedError" : "ANY/SOME subqueries with non-equality operators are not supported"
+  }, {
     "test" : "meta::pure::functions::relation::tests::in::testSimpleIn_Negated_Function_1__Boolean_1_",
     "expectedError" : "Negating in(value, Relation) is not supported on relational stores. Use not exists instead, for example replace !$d.departmentId->in($employees->select(~department)) with $d.departmentId->isEmpty() || !$employees->exists(e | $e.department == $d.departmentId)"
   }, {
@@ -291,6 +417,66 @@
   }, {
     "test" : "meta::pure::functions::relation::tests::lead::testOLAPWithPartitionAndOrderWindow_Function_1__Boolean_1_",
     "expectedError" : "[unsupported-api] Window Columns not supported for Database Type: Spanner"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanAll::testLessThanAll_EmptyRelation_Function_1__Boolean_1_",
+    "expectedError" : "ALL subqueries with operators other than <>/!= are not supported"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanAll::testLessThanAll_Function_1__Boolean_1_",
+    "expectedError" : "ALL subqueries with operators other than <>/!= are not supported"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanAll::testLessThanAll_Negated_Function_1__Boolean_1_",
+    "expectedError" : "ALL subqueries with operators other than <>/!= are not supported"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanAll::testLessThanAll_NullInRelation_Function_1__Boolean_1_",
+    "expectedError" : "ALL subqueries with operators other than <>/!= are not supported"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanAll::testLessThanAll_NullValue_Function_1__Boolean_1_",
+    "expectedError" : "ALL subqueries with operators other than <>/!= are not supported"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanAny::testLessThanAny_EmptyRelation_Function_1__Boolean_1_",
+    "expectedError" : "ANY/SOME subqueries with non-equality operators are not supported"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanAny::testLessThanAny_Function_1__Boolean_1_",
+    "expectedError" : "ANY/SOME subqueries with non-equality operators are not supported"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanAny::testLessThanAny_Negated_Function_1__Boolean_1_",
+    "expectedError" : "ANY/SOME subqueries with non-equality operators are not supported"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanAny::testLessThanAny_NullInRelation_Function_1__Boolean_1_",
+    "expectedError" : "ANY/SOME subqueries with non-equality operators are not supported"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanAny::testLessThanAny_NullValue_Function_1__Boolean_1_",
+    "expectedError" : "ANY/SOME subqueries with non-equality operators are not supported"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanEqualAll::testLessThanEqualAll_EmptyRelation_Function_1__Boolean_1_",
+    "expectedError" : "ALL subqueries with operators other than <>/!= are not supported"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanEqualAll::testLessThanEqualAll_Function_1__Boolean_1_",
+    "expectedError" : "ALL subqueries with operators other than <>/!= are not supported"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanEqualAll::testLessThanEqualAll_Negated_Function_1__Boolean_1_",
+    "expectedError" : "ALL subqueries with operators other than <>/!= are not supported"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanEqualAll::testLessThanEqualAll_NullInRelation_Function_1__Boolean_1_",
+    "expectedError" : "ALL subqueries with operators other than <>/!= are not supported"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanEqualAll::testLessThanEqualAll_NullValue_Function_1__Boolean_1_",
+    "expectedError" : "ALL subqueries with operators other than <>/!= are not supported"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanEqualAny::testLessThanEqualAny_EmptyRelation_Function_1__Boolean_1_",
+    "expectedError" : "ANY/SOME subqueries with non-equality operators are not supported"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanEqualAny::testLessThanEqualAny_Function_1__Boolean_1_",
+    "expectedError" : "ANY/SOME subqueries with non-equality operators are not supported"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanEqualAny::testLessThanEqualAny_Negated_Function_1__Boolean_1_",
+    "expectedError" : "ANY/SOME subqueries with non-equality operators are not supported"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanEqualAny::testLessThanEqualAny_NullInRelation_Function_1__Boolean_1_",
+    "expectedError" : "ANY/SOME subqueries with non-equality operators are not supported"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::lessThanEqualAny::testLessThanEqualAny_NullValue_Function_1__Boolean_1_",
+    "expectedError" : "ANY/SOME subqueries with non-equality operators are not supported"
   }, {
     "test" : "meta::pure::functions::relation::tests::nth::testOLAPWithPartitionAndOrderNthWindow2_Function_1__Boolean_1_",
     "expectedError" : "[unsupported-api] Window Columns not supported for Database Type: Spanner"

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/test/java/org/finos/legend/engine/language/pure/compiler/test/TestRelationFunctions.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/test/java/org/finos/legend/engine/language/pure/compiler/test/TestRelationFunctions.java
@@ -1432,6 +1432,50 @@ public class TestRelationFunctions extends TestCompilationFromGrammar.TestCompil
         );
     }
 
+    @Test
+    public void testQuantifiedComparisonWithSingleColumnRelation()
+    {
+        test(
+                "###Relational\n" +
+                        "Database a::A (Table tb(id Integer, name VARCHAR(200)))\n" +
+                        "\n" +
+                        "###Pure\n" +
+                        "function test::f():Any[*]\n" +
+                        "{\n" +
+                        "   #>{a::A.tb}#->filter(x|$x.id->greaterThanAny(#>{a::A.tb}#->select(~id)))\n" +
+                        "}");
+    }
+
+    @Test
+    public void testQuantifiedComparisonWithMultiColumnRelationError()
+    {
+        test(
+                "###Relational\n" +
+                        "Database a::A (Table tb(id Integer, name VARCHAR(200)))\n" +
+                        "\n" +
+                        "###Pure\n" +
+                        "function test::f():Any[*]\n" +
+                        "{\n" +
+                        "   #>{a::A.tb}#->filter(x|$x.id->greaterThanAny(#>{a::A.tb}#->select(~[id, name])))\n" +
+                        "}", "COMPILATION error at [7:63-68]: greaterThanAny(..., Relation) expects a relation with a single column, got (id:Int, name:Varchar(200))"
+        );
+    }
+
+    @Test
+    public void testQuantifiedComparisonWithMismatchedColumnTypeError()
+    {
+        test(
+                "###Relational\n" +
+                        "Database a::A (Table tb(id Integer, name VARCHAR(200)))\n" +
+                        "\n" +
+                        "###Pure\n" +
+                        "function test::f():Any[*]\n" +
+                        "{\n" +
+                        "   #>{a::A.tb}#->filter(x|$x.id->lessThanEqualAll(#>{a::A.tb}#->select(~name)))\n" +
+                        "}", "COMPILATION error at [7:65-70]: lessThanEqualAll(..., Relation) expects the value and the relation column to be of the same type, got Int and (name:Varchar(200))"
+        );
+    }
+
     @Override
     public String getDuplicatedElementTestCode()
     {

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-postgresSql/legend-engine-xt-relationalStore-postgresSql-grammar/src/main/java/org/finos/legend/engine/language/sql/grammar/from/SqlVisitor.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-postgresSql/legend-engine-xt-relationalStore-postgresSql-grammar/src/main/java/org/finos/legend/engine/language/sql/grammar/from/SqlVisitor.java
@@ -29,6 +29,7 @@ import org.finos.legend.engine.language.sql.grammar.from.antlr4.SqlBaseParserBas
 import org.finos.legend.engine.protocol.sql.metamodel.*;
 
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -40,6 +41,12 @@ import java.util.stream.Collectors;
 class SqlVisitor extends SqlBaseParserBaseVisitor<Node>
 {
     private static final Pattern LITERAL_VALUE_PATTERN = Pattern.compile("(([\\+-]?[0-9]+)\\s([year|years|month|months|week|weeks|day|days|hour|hours|minute|minutes|second|seconds|millisecond|milliseconds|microsecond|microseconds]+))+");
+
+    //cmpOp also covers the regex and like operators, which SQL does not allow a quantifier on
+    private static final EnumSet<ComparisonOperator> QUANTIFIABLE_OPERATORS = EnumSet.of(
+            ComparisonOperator.EQUAL, ComparisonOperator.NOT_EQUAL,
+            ComparisonOperator.LESS_THAN, ComparisonOperator.LESS_THAN_OR_EQUAL,
+            ComparisonOperator.GREATER_THAN, ComparisonOperator.GREATER_THAN_OR_EQUAL);
 
     private long positionalIndex = 1;
 
@@ -1327,8 +1334,35 @@ class SqlVisitor extends SqlBaseParserBaseVisitor<Node>
     @Override
     public Node visitQuantifiedComparison(SqlBaseParser.QuantifiedComparisonContext context)
     {
-        //TODO
-        return unsupported("Quantified Comparison");
+        ComparisonOperator operator = getComparisonOperator(((TerminalNode) context.cmpOp().getChild(0)).getSymbol());
+        if (!QUANTIFIABLE_OPERATORS.contains(operator))
+        {
+            return unsupported("Quantified Comparison with operator " + operator.name());
+        }
+
+        //cmpOp ANY/ALL also accepts an array operand (x = ANY(ARRAY[...])), which has no subquery to compare against
+        Node operand = visit(context.primaryExpression());
+        if (!(operand instanceof SubqueryExpression))
+        {
+            return unsupported("Quantified Comparison against a non-subquery operand");
+        }
+
+        QuantifiedComparisonExpression comparison = new QuantifiedComparisonExpression();
+        comparison.value = (Expression) visit(context.value);
+        comparison.operator = operator;
+        comparison.quantifier = getQuantifier(context.setCmpQuantifier());
+        comparison.subQuery = (SubqueryExpression) operand;
+
+        return comparison;
+    }
+
+    private static Quantifier getQuantifier(SqlBaseParser.SetCmpQuantifierContext context)
+    {
+        if (context.ALL() != null)
+        {
+            return Quantifier.ALL;
+        }
+        return context.SOME() != null ? Quantifier.SOME : Quantifier.ANY;
     }
 
     @Override

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-postgresSql/legend-engine-xt-relationalStore-postgresSql-grammar/src/main/java/org/finos/legend/engine/language/sql/grammar/to/SQLGrammarComposer.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-postgresSql/legend-engine-xt-relationalStore-postgresSql-grammar/src/main/java/org/finos/legend/engine/language/sql/grammar/to/SQLGrammarComposer.java
@@ -290,6 +290,13 @@ public class SQLGrammarComposer
             }
 
             @Override
+            public String visit(QuantifiedComparisonExpression val)
+            {
+                //a subquery already renders its own brackets
+                return val.value.accept(this) + " " + COMPARATOR.get(val.operator) + " " + val.quantifier.name() + " " + val.subQuery.accept(this);
+            }
+
+            @Override
             public String visit(Expression val)
             {
                 return val.accept(this);

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-postgresSql/legend-engine-xt-relationalStore-postgresSql-grammar/src/test/java/org/finos/legend/engine/language/sql/grammar/test/roundtrip/TestSQLRoundTrip.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-postgresSql/legend-engine-xt-relationalStore-postgresSql-grammar/src/test/java/org/finos/legend/engine/language/sql/grammar/test/roundtrip/TestSQLRoundTrip.java
@@ -515,6 +515,19 @@ public class TestSQLRoundTrip
     }
 
     @Test
+    public void testQuantifiedComparison()
+    {
+        check("SELECT * FROM myTable WHERE myTable.id > ANY (SELECT myTable2.id FROM myTable2)");
+        check("SELECT * FROM myTable WHERE myTable.id >= ALL (SELECT myTable2.id FROM myTable2)");
+        check("SELECT * FROM myTable WHERE myTable.id < SOME (SELECT myTable2.id FROM myTable2)");
+        check("SELECT * FROM myTable WHERE myTable.id = ANY (SELECT myTable2.id FROM myTable2 WHERE myTable2.name = myTable.name)");
+        //the composer writes NOT_EQUAL as !=, the form the parser also accepts
+        check("SELECT * FROM myTable WHERE myTable.id <> ALL (SELECT myTable2.id FROM myTable2)",
+                "SELECT * FROM myTable WHERE myTable.id != ALL (SELECT myTable2.id FROM myTable2)");
+        check("SELECT * FROM myTable WHERE NOT myTable.id <= ANY (SELECT myTable2.id FROM myTable2)");
+    }
+
+    @Test
     public void testLateralSubquery()
     {
         check("SELECT * FROM myTable, LATERAL (SELECT * FROM myTable2 WHERE myTable2.id = myTable.id) AS t");

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-postgresSql/legend-engine-xt-relationalStore-postgresSql-protocol/src/main/java/org/finos/legend/engine/protocol/sql/visitors/BaseNodeCollectorVisitor.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-postgresSql/legend-engine-xt-relationalStore-postgresSql-protocol/src/main/java/org/finos/legend/engine/protocol/sql/visitors/BaseNodeCollectorVisitor.java
@@ -70,6 +70,7 @@ import org.finos.legend.engine.protocol.sql.metamodel.NullLiteral;
 import org.finos.legend.engine.protocol.sql.metamodel.ParameterPlaceholderExpression;
 import org.finos.legend.engine.protocol.sql.metamodel.PositionalParameterExpression;
 import org.finos.legend.engine.protocol.sql.metamodel.QualifiedNameReference;
+import org.finos.legend.engine.protocol.sql.metamodel.QuantifiedComparisonExpression;
 import org.finos.legend.engine.protocol.sql.metamodel.Query;
 import org.finos.legend.engine.protocol.sql.metamodel.QueryBody;
 import org.finos.legend.engine.protocol.sql.metamodel.QuerySpecification;
@@ -256,6 +257,12 @@ public class BaseNodeCollectorVisitor<T> implements NodeVisitor<T>
     public T visit(ExistsPredicate val)
     {
         return collect(val.query);
+    }
+
+    @Override
+    public T visit(QuantifiedComparisonExpression val)
+    {
+        return collect(val.value, val.subQuery);
     }
 
     @Override

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-postgresSql/legend-engine-xt-relationalStore-postgresSql-protocol/src/main/java/org/finos/legend/engine/protocol/sql/visitors/BaseNodeModifierVisitor.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-postgresSql/legend-engine-xt-relationalStore-postgresSql-protocol/src/main/java/org/finos/legend/engine/protocol/sql/visitors/BaseNodeModifierVisitor.java
@@ -65,6 +65,7 @@ import org.finos.legend.engine.protocol.sql.metamodel.NullLiteral;
 import org.finos.legend.engine.protocol.sql.metamodel.ParameterPlaceholderExpression;
 import org.finos.legend.engine.protocol.sql.metamodel.PositionalParameterExpression;
 import org.finos.legend.engine.protocol.sql.metamodel.QualifiedNameReference;
+import org.finos.legend.engine.protocol.sql.metamodel.QuantifiedComparisonExpression;
 import org.finos.legend.engine.protocol.sql.metamodel.Query;
 import org.finos.legend.engine.protocol.sql.metamodel.QueryBody;
 import org.finos.legend.engine.protocol.sql.metamodel.QuerySpecification;
@@ -248,6 +249,15 @@ public class BaseNodeModifierVisitor implements NodeVisitor<Node>
     public Node visit(ExistsPredicate val)
     {
         val.query = _visit(val.query);
+
+        return val;
+    }
+
+    @Override
+    public Node visit(QuantifiedComparisonExpression val)
+    {
+        val.value = _visit(val.value);
+        val.subQuery = _visit(val.subQuery);
 
         return val;
     }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-postgresSql/legend-engine-xt-relationalStore-postgresSqlModel-pure/src/main/resources/core_external_store_relational_postgres_sql_model/metamodel.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-postgresSql/legend-engine-xt-relationalStore-postgresSqlModel-pure/src/main/resources/core_external_store_relational_postgres_sql_model/metamodel.pure
@@ -414,6 +414,14 @@ Class meta::external::query::sql::metamodel::ExistsPredicate extends meta::exter
   <<equality.Key>> query: meta::external::query::sql::metamodel::TableSubquery[1];
 }
 
+Class meta::external::query::sql::metamodel::QuantifiedComparisonExpression extends meta::external::query::sql::metamodel::Expression
+{
+  <<equality.Key>> value: meta::external::query::sql::metamodel::Expression[1];
+  <<equality.Key>> operator: meta::external::query::sql::metamodel::ComparisonOperator[1];
+  <<equality.Key>> quantifier: meta::external::query::sql::metamodel::Quantifier[1];
+  <<equality.Key>> subQuery: meta::external::query::sql::metamodel::SubqueryExpression[1];
+}
+
 Class meta::external::query::sql::metamodel::BetweenPredicate extends meta::external::query::sql::metamodel::Expression
 {
   <<equality.Key>> min: meta::external::query::sql::metamodel::Expression[1];
@@ -521,6 +529,15 @@ Enum meta::external::query::sql::metamodel::LogicalBinaryType
 {
   AND,
   OR
+}
+
+// SOME is a synonym for ANY in the standard; the grammar accepts it, and it is kept distinct here only so a
+// parsed query can be composed back the way it was written.
+Enum meta::external::query::sql::metamodel::Quantifier
+{
+  ANY,
+  SOME,
+  ALL
 }
 
 Enum meta::external::query::sql::metamodel::ArithmeticType

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery.pure
@@ -6694,6 +6694,96 @@ function meta::relational::functions::pureToSqlQuery::processRelationIn(expressi
                                $state);
 }
 
+function meta::relational::functions::pureToSqlQuery::processRelationEqualAny(expression:FunctionExpression[1], currentPropertyMapping:PropertyMapping[*], operation:SelectWithCursor[1], vars:Map<VariableExpression, ValueSpecification>[1], state:State[1], joinType:JoinType[1], nodeId:String[1], aggFromMap:List<ColumnGroup>[1], context:DebugContext[1], extensions:Extension[*]):RelationalOperationElement[1]
+{
+   processRelationQuantifiedComparison('equal', 'anyOf', $expression, $currentPropertyMapping, $operation, $vars, $state, $nodeId, $aggFromMap, $context, $extensions);
+}
+
+function meta::relational::functions::pureToSqlQuery::processRelationEqualAll(expression:FunctionExpression[1], currentPropertyMapping:PropertyMapping[*], operation:SelectWithCursor[1], vars:Map<VariableExpression, ValueSpecification>[1], state:State[1], joinType:JoinType[1], nodeId:String[1], aggFromMap:List<ColumnGroup>[1], context:DebugContext[1], extensions:Extension[*]):RelationalOperationElement[1]
+{
+   processRelationQuantifiedComparison('equal', 'allOf', $expression, $currentPropertyMapping, $operation, $vars, $state, $nodeId, $aggFromMap, $context, $extensions);
+}
+
+function meta::relational::functions::pureToSqlQuery::processRelationGreaterThanAny(expression:FunctionExpression[1], currentPropertyMapping:PropertyMapping[*], operation:SelectWithCursor[1], vars:Map<VariableExpression, ValueSpecification>[1], state:State[1], joinType:JoinType[1], nodeId:String[1], aggFromMap:List<ColumnGroup>[1], context:DebugContext[1], extensions:Extension[*]):RelationalOperationElement[1]
+{
+   processRelationQuantifiedComparison('greaterThan', 'anyOf', $expression, $currentPropertyMapping, $operation, $vars, $state, $nodeId, $aggFromMap, $context, $extensions);
+}
+
+function meta::relational::functions::pureToSqlQuery::processRelationGreaterThanAll(expression:FunctionExpression[1], currentPropertyMapping:PropertyMapping[*], operation:SelectWithCursor[1], vars:Map<VariableExpression, ValueSpecification>[1], state:State[1], joinType:JoinType[1], nodeId:String[1], aggFromMap:List<ColumnGroup>[1], context:DebugContext[1], extensions:Extension[*]):RelationalOperationElement[1]
+{
+   processRelationQuantifiedComparison('greaterThan', 'allOf', $expression, $currentPropertyMapping, $operation, $vars, $state, $nodeId, $aggFromMap, $context, $extensions);
+}
+
+function meta::relational::functions::pureToSqlQuery::processRelationGreaterThanEqualAny(expression:FunctionExpression[1], currentPropertyMapping:PropertyMapping[*], operation:SelectWithCursor[1], vars:Map<VariableExpression, ValueSpecification>[1], state:State[1], joinType:JoinType[1], nodeId:String[1], aggFromMap:List<ColumnGroup>[1], context:DebugContext[1], extensions:Extension[*]):RelationalOperationElement[1]
+{
+   processRelationQuantifiedComparison('greaterThanEqual', 'anyOf', $expression, $currentPropertyMapping, $operation, $vars, $state, $nodeId, $aggFromMap, $context, $extensions);
+}
+
+function meta::relational::functions::pureToSqlQuery::processRelationGreaterThanEqualAll(expression:FunctionExpression[1], currentPropertyMapping:PropertyMapping[*], operation:SelectWithCursor[1], vars:Map<VariableExpression, ValueSpecification>[1], state:State[1], joinType:JoinType[1], nodeId:String[1], aggFromMap:List<ColumnGroup>[1], context:DebugContext[1], extensions:Extension[*]):RelationalOperationElement[1]
+{
+   processRelationQuantifiedComparison('greaterThanEqual', 'allOf', $expression, $currentPropertyMapping, $operation, $vars, $state, $nodeId, $aggFromMap, $context, $extensions);
+}
+
+function meta::relational::functions::pureToSqlQuery::processRelationLessThanAny(expression:FunctionExpression[1], currentPropertyMapping:PropertyMapping[*], operation:SelectWithCursor[1], vars:Map<VariableExpression, ValueSpecification>[1], state:State[1], joinType:JoinType[1], nodeId:String[1], aggFromMap:List<ColumnGroup>[1], context:DebugContext[1], extensions:Extension[*]):RelationalOperationElement[1]
+{
+   processRelationQuantifiedComparison('lessThan', 'anyOf', $expression, $currentPropertyMapping, $operation, $vars, $state, $nodeId, $aggFromMap, $context, $extensions);
+}
+
+function meta::relational::functions::pureToSqlQuery::processRelationLessThanAll(expression:FunctionExpression[1], currentPropertyMapping:PropertyMapping[*], operation:SelectWithCursor[1], vars:Map<VariableExpression, ValueSpecification>[1], state:State[1], joinType:JoinType[1], nodeId:String[1], aggFromMap:List<ColumnGroup>[1], context:DebugContext[1], extensions:Extension[*]):RelationalOperationElement[1]
+{
+   processRelationQuantifiedComparison('lessThan', 'allOf', $expression, $currentPropertyMapping, $operation, $vars, $state, $nodeId, $aggFromMap, $context, $extensions);
+}
+
+function meta::relational::functions::pureToSqlQuery::processRelationLessThanEqualAny(expression:FunctionExpression[1], currentPropertyMapping:PropertyMapping[*], operation:SelectWithCursor[1], vars:Map<VariableExpression, ValueSpecification>[1], state:State[1], joinType:JoinType[1], nodeId:String[1], aggFromMap:List<ColumnGroup>[1], context:DebugContext[1], extensions:Extension[*]):RelationalOperationElement[1]
+{
+   processRelationQuantifiedComparison('lessThanEqual', 'anyOf', $expression, $currentPropertyMapping, $operation, $vars, $state, $nodeId, $aggFromMap, $context, $extensions);
+}
+
+function meta::relational::functions::pureToSqlQuery::processRelationLessThanEqualAll(expression:FunctionExpression[1], currentPropertyMapping:PropertyMapping[*], operation:SelectWithCursor[1], vars:Map<VariableExpression, ValueSpecification>[1], state:State[1], joinType:JoinType[1], nodeId:String[1], aggFromMap:List<ColumnGroup>[1], context:DebugContext[1], extensions:Extension[*]):RelationalOperationElement[1]
+{
+   processRelationQuantifiedComparison('lessThanEqual', 'allOf', $expression, $currentPropertyMapping, $operation, $vars, $state, $nodeId, $aggFromMap, $context, $extensions);
+}
+
+function <<access.private>> meta::relational::functions::pureToSqlQuery::processRelationQuantifiedComparison(comparison:String[1], quantifier:String[1], expression:FunctionExpression[1], currentPropertyMapping:PropertyMapping[*], operation:SelectWithCursor[1], vars:Map<VariableExpression, ValueSpecification>[1], state:State[1], nodeId:String[1], aggFromMap:List<ColumnGroup>[1], context:DebugContext[1], extensions:Extension[*]):RelationalOperationElement[1]
+{
+   let valueCursor = processValueSpecification($expression.parametersValues->at(0), $currentPropertyMapping, $operation, $vars, ^$state(inFilter = true), JoinType.LEFT_OUTER, buildNodeId($nodeId, '_v'), $aggFromMap, $context, $extensions)
+                       ->toOne()->cast(@SelectWithCursor);
+   let value = $valueCursor.select.filteringOperation->toOne();
+
+   let subSelect = buildRelationSubSelect($expression, 1, $currentPropertyMapping, $operation, $vars, $state, $nodeId, $aggFromMap, $context, $extensions);
+
+   // The Relation<Z=(?:U)> signature guarantees a single column, so the sub-select already projects exactly
+   // what the quantifier compares against.
+   assert($subSelect.columns->size() == 1, | 'A quantified comparison expects a single-column relation, got ' + $subSelect.columns->size()->toString() + ' columns');
+
+   // The quantifier wraps the sub-select rather than fusing into the operator, so the ordinary comparison dyna
+   // functions render this: greaterThan(value, anyOf(subSelect)) is `value > any (select ...)`.
+   let quantified = ^DynaFunction(name = $quantifier, parameters = $subSelect->excludeNullsFromQuantifiedSubSelect($nodeId, $extensions));
+   let comparisonOp = ^DynaFunction(name = $comparison, parameters = [$value, $quantified]);
+
+   // Unlike `in`, the isNotNull conjunct is emitted in filter position too. An empty value answers false, and
+   // `false and unknown` is false in SQL where the quantifier alone would be unknown -- which is what makes the
+   // negation exact: `not` then sees a decided predicate and needs no `or ... is null` disjunct, so no subquery
+   // ever lands under an OR. `> all` over an empty subquery is true, and this conjunct is also what keeps an
+   // empty value from inheriting that.
+   $operation->attachPredicate(^DynaFunction(name = 'group',
+                                             parameters = ^DynaFunction(name = 'and', parameters = [^DynaFunction(name = 'isNotNull', parameters = $value), $comparisonOp])),
+                               $state);
+}
+
+// A limit decides which rows reach the comparison, so the null cannot be dropped inside the limited query the
+// way excludeNullsFromSearchedColumn does elsewhere -- isolate it first and drop the null outside, where the
+// row set is already fixed. Both quantifiers need this: an undecided ANY is false either way, but its negation
+// would be undecided too, and ALL is wrong in both polarities.
+function <<access.private>> meta::relational::functions::pureToSqlQuery::excludeNullsFromQuantifiedSubSelect(subSelect:SelectSQLQuery[1], nodeId:String[1], extensions:Extension[*]):SelectSQLQuery[1]
+{
+   if($subSelect.fromRow->isEmpty() && $subSelect.toRow->isEmpty(),
+      | $subSelect->excludeNullsFromSearchedColumn($extensions),
+      | let alias = ^TableAlias(name = buildNodeId($nodeId, '_q'), relationalElement = $subSelect->pushExtraFilteringOperation($extensions));
+        let isolated = ^SelectSQLQuery(data = ^RootJoinTreeNode(alias = $alias), columns = $alias->switchAliasForColumns($subSelect.columns));
+        $isolated->excludeNullsFromSearchedColumn($extensions););
+}
+
 // A null in the searched column is what makes SQL's `in` three-valued: `x in (sub)` is UNKNOWN rather than
 // false when nothing matches, and `x not in (sub)` is UNKNOWN for every row. Dropping those rows inside the
 // subquery makes both two-valued -- the answer relation::in gives -- and leaves the predicate a predicate,
@@ -10656,6 +10746,16 @@ function meta::relational::functions::pureToSqlQuery::getSupportedFunctions():Ma
         ^PureFunctionToRelationalFunctionPair(first=meta::pure::functions::relation::filter_Relation_1__Function_1__Relation_1_, second=meta::relational::functions::pureToSqlQuery::processTdsFilter_FunctionExpression_1__PropertyMapping_MANY__SelectWithCursor_1__Map_1__State_1__JoinType_1__String_1__List_1__DebugContext_1__Extension_MANY__RelationalOperationElement_1_),
         ^PureFunctionToRelationalFunctionPair(first=meta::pure::functions::relation::exists_Relation_1__Function_1__Boolean_1_, second=meta::relational::functions::pureToSqlQuery::processRelationExists_FunctionExpression_1__PropertyMapping_MANY__SelectWithCursor_1__Map_1__State_1__JoinType_1__String_1__List_1__DebugContext_1__Extension_MANY__RelationalOperationElement_1_),
         ^PureFunctionToRelationalFunctionPair(first=meta::pure::functions::relation::in_U_$0_1$__Relation_1__Boolean_1_, second=meta::relational::functions::pureToSqlQuery::processRelationIn_FunctionExpression_1__PropertyMapping_MANY__SelectWithCursor_1__Map_1__State_1__JoinType_1__String_1__List_1__DebugContext_1__Extension_MANY__RelationalOperationElement_1_),
+        ^PureFunctionToRelationalFunctionPair(first=meta::pure::functions::relation::equalAny_U_$0_1$__Relation_1__Boolean_1_, second=meta::relational::functions::pureToSqlQuery::processRelationEqualAny_FunctionExpression_1__PropertyMapping_MANY__SelectWithCursor_1__Map_1__State_1__JoinType_1__String_1__List_1__DebugContext_1__Extension_MANY__RelationalOperationElement_1_),
+        ^PureFunctionToRelationalFunctionPair(first=meta::pure::functions::relation::equalAll_U_$0_1$__Relation_1__Boolean_1_, second=meta::relational::functions::pureToSqlQuery::processRelationEqualAll_FunctionExpression_1__PropertyMapping_MANY__SelectWithCursor_1__Map_1__State_1__JoinType_1__String_1__List_1__DebugContext_1__Extension_MANY__RelationalOperationElement_1_),
+        ^PureFunctionToRelationalFunctionPair(first=meta::pure::functions::relation::greaterThanAny_U_$0_1$__Relation_1__Boolean_1_, second=meta::relational::functions::pureToSqlQuery::processRelationGreaterThanAny_FunctionExpression_1__PropertyMapping_MANY__SelectWithCursor_1__Map_1__State_1__JoinType_1__String_1__List_1__DebugContext_1__Extension_MANY__RelationalOperationElement_1_),
+        ^PureFunctionToRelationalFunctionPair(first=meta::pure::functions::relation::greaterThanAll_U_$0_1$__Relation_1__Boolean_1_, second=meta::relational::functions::pureToSqlQuery::processRelationGreaterThanAll_FunctionExpression_1__PropertyMapping_MANY__SelectWithCursor_1__Map_1__State_1__JoinType_1__String_1__List_1__DebugContext_1__Extension_MANY__RelationalOperationElement_1_),
+        ^PureFunctionToRelationalFunctionPair(first=meta::pure::functions::relation::greaterThanEqualAny_U_$0_1$__Relation_1__Boolean_1_, second=meta::relational::functions::pureToSqlQuery::processRelationGreaterThanEqualAny_FunctionExpression_1__PropertyMapping_MANY__SelectWithCursor_1__Map_1__State_1__JoinType_1__String_1__List_1__DebugContext_1__Extension_MANY__RelationalOperationElement_1_),
+        ^PureFunctionToRelationalFunctionPair(first=meta::pure::functions::relation::greaterThanEqualAll_U_$0_1$__Relation_1__Boolean_1_, second=meta::relational::functions::pureToSqlQuery::processRelationGreaterThanEqualAll_FunctionExpression_1__PropertyMapping_MANY__SelectWithCursor_1__Map_1__State_1__JoinType_1__String_1__List_1__DebugContext_1__Extension_MANY__RelationalOperationElement_1_),
+        ^PureFunctionToRelationalFunctionPair(first=meta::pure::functions::relation::lessThanAny_U_$0_1$__Relation_1__Boolean_1_, second=meta::relational::functions::pureToSqlQuery::processRelationLessThanAny_FunctionExpression_1__PropertyMapping_MANY__SelectWithCursor_1__Map_1__State_1__JoinType_1__String_1__List_1__DebugContext_1__Extension_MANY__RelationalOperationElement_1_),
+        ^PureFunctionToRelationalFunctionPair(first=meta::pure::functions::relation::lessThanAll_U_$0_1$__Relation_1__Boolean_1_, second=meta::relational::functions::pureToSqlQuery::processRelationLessThanAll_FunctionExpression_1__PropertyMapping_MANY__SelectWithCursor_1__Map_1__State_1__JoinType_1__String_1__List_1__DebugContext_1__Extension_MANY__RelationalOperationElement_1_),
+        ^PureFunctionToRelationalFunctionPair(first=meta::pure::functions::relation::lessThanEqualAny_U_$0_1$__Relation_1__Boolean_1_, second=meta::relational::functions::pureToSqlQuery::processRelationLessThanEqualAny_FunctionExpression_1__PropertyMapping_MANY__SelectWithCursor_1__Map_1__State_1__JoinType_1__String_1__List_1__DebugContext_1__Extension_MANY__RelationalOperationElement_1_),
+        ^PureFunctionToRelationalFunctionPair(first=meta::pure::functions::relation::lessThanEqualAll_U_$0_1$__Relation_1__Boolean_1_, second=meta::relational::functions::pureToSqlQuery::processRelationLessThanEqualAll_FunctionExpression_1__PropertyMapping_MANY__SelectWithCursor_1__Map_1__State_1__JoinType_1__String_1__List_1__DebugContext_1__Extension_MANY__RelationalOperationElement_1_),
         ^PureFunctionToRelationalFunctionPair(first=meta::pure::functions::relation::distinct_Relation_1__Relation_1_, second=meta::relational::functions::pureToSqlQuery::processDistinct_FunctionExpression_1__PropertyMapping_MANY__SelectWithCursor_1__Map_1__State_1__JoinType_1__String_1__List_1__DebugContext_1__Extension_MANY__RelationalOperationElement_1_),
         ^PureFunctionToRelationalFunctionPair(first=meta::pure::functions::relation::distinct_Relation_1__ColSpecArray_1__Relation_1_, second=meta::relational::functions::pureToSqlQuery::processDistinctByColumns_FunctionExpression_1__PropertyMapping_MANY__SelectWithCursor_1__Map_1__State_1__JoinType_1__String_1__List_1__DebugContext_1__Extension_MANY__RelationalOperationElement_1_),
         ^PureFunctionToRelationalFunctionPair(first=meta::pure::functions::relation::concatenate_Relation_1__Relation_1__Relation_1_, second=meta::relational::functions::pureToSqlQuery::processConcatenate_FunctionExpression_1__PropertyMapping_MANY__SelectWithCursor_1__Map_1__State_1__JoinType_1__String_1__List_1__DebugContext_1__Extension_MANY__RelationalOperationElement_1_),

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/relationalExtension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/relationalExtension.pure
@@ -721,6 +721,26 @@ function <<access.private>> meta::relational::functions::typeInference::getDynaF
       ),
 
       pair(
+         'anyOf',
+         list([
+            pair(
+               {params: RelationalOperationElement[*] | true},
+               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType()}
+            )
+         ])
+      ),
+
+      pair(
+         'allOf',
+         list([
+            pair(
+               {params: RelationalOperationElement[*] | true},
+               {params: RelationalOperationElement[*] | $params->at(0)->inferRelationalType()}
+            )
+         ])
+      ),
+
+      pair(
          'exists',
          list([
             pair(

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/sqlDialectTranslation/toPostgresModel.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/sqlDialectTranslation/toPostgresModel.pure
@@ -257,6 +257,7 @@ function <<access.private>> meta::relational::functions::toPostgresModel::conver
     [
       pair(| $d.name == 'exists',                 | ^ExistsPredicate(query = $d.parameters->toOne()->convertElement($operandState)->cast(@TableSubquery))),
       pair(| $d.name == 'not',                    | convertNot($d, $state)),
+      pair(| isQuantifiedComparison($d),          | convertQuantifiedComparison($d, $state)),
       pair(| isFunctionWithDistinct($d, $state),  | convertFunctionWithDistinct($d, $state)),
       pair(| isEqualsFromFilter($d, $state),      | convertEqualFromFilter($d, $state)),
       pair(| $d->instanceOf(UnionOrJoin),         | convertDynaFunction($d.parameters->reverse()->orFilters($state.extensions)->toOne()->cast(@DynaFunction), $state)),
@@ -496,6 +497,36 @@ function <<access.private>> meta::relational::functions::toPostgresModel::binary
 function <<access.private>> meta::relational::functions::toPostgresModel::comparisonExpression(co:ComparisonOperator[1]):Function<{meta::external::query::sql::metamodel::Expression[*]->Node[1]}>[1]
 {
   {p:meta::external::query::sql::metamodel::Expression[*]| comparisonExpression($co, $p->at(0), $p->at(1))};
+}
+
+// A quantifier is carried as an anyOf/allOf wrapper around the sub-select rather than being fused into the
+// operator name, so the comparison is recognised by the shape of its right operand.
+function <<access.private>> meta::relational::functions::toPostgresModel::isQuantifiedComparison(d:DynaFunction[1]):Boolean[1]
+{
+  $d.name->in(['equal', 'lessThan', 'lessThanEqual', 'greaterThan', 'greaterThanEqual'])
+    && $d.parameters->size() == 2
+    && $d.parameters->at(1)->match([q:DynaFunction[1] | $q.name->in(['anyOf', 'allOf']), a:RelationalOperationElement[1] | false]);
+}
+
+function <<access.private>> meta::relational::functions::toPostgresModel::convertQuantifiedComparison(d:DynaFunction[1], state:ModelConversionState[1]):Node[1]
+{
+  let operandState = ^$state(isRootSelect = false);
+  let quantifierFunc = $d.parameters->at(1)->cast(@DynaFunction);
+  let comparator = [
+    pair('equal', ComparisonOperator.EQUAL),
+    pair('lessThan', ComparisonOperator.LESS_THAN),
+    pair('lessThanEqual', ComparisonOperator.LESS_THAN_OR_EQUAL),
+    pair('greaterThan', ComparisonOperator.GREATER_THAN),
+    pair('greaterThanEqual', ComparisonOperator.GREATER_THAN_OR_EQUAL)
+  ]->newMap()->get($d.name)->toOne();
+
+  // The sub-select is converted with isRootSelect = false, so it arrives as a SubqueryExpression already.
+  ^QuantifiedComparisonExpression(
+    operator = $comparator,
+    quantifier = if($quantifierFunc.name == 'anyOf', | Quantifier.ANY, | Quantifier.ALL),
+    value = $d.parameters->at(0)->convertElementToExpression($operandState),
+    subQuery = $quantifierFunc.parameters->toOne()->convertElementToExpression($operandState)->cast(@SubqueryExpression)
+  );
 }
 
 function <<access.private>> meta::relational::functions::toPostgresModel::comparisonExpression(co:ComparisonOperator[1], left:meta::external::query::sql::metamodel::Expression[1], right:meta::external::query::sql::metamodel::Expression[1]):ComparisonExpression[1]

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/sqlQueryToString/dbExtension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/sqlQueryToString/dbExtension.pure
@@ -1081,6 +1081,8 @@ Enum meta::relational::functions::sqlQueryToString::DynaFunctionRegistry
   add,
   adjust,
   and,
+  allOf,
+  anyOf,
   array_first,
   array_last,
   array_init,

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/sqlQueryToString/extensionDefaults.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/sqlQueryToString/extensionDefaults.pure
@@ -177,6 +177,12 @@ function meta::relational::functions::sqlQueryToString::default::processJoinStri
    processJoinStringsOperation($js, $sgc, [], {strs, sep| $strs->joinStrings('concat(', if('\'\'' == $sep, |', ', |',' + $sep + ',') , ')')});
 }
 
+// A rendered sub-select already carries its own brackets; a bare operand does not.
+function meta::relational::functions::sqlQueryToString::default::bracketSubQuery(p:String[1]):String[1]
+{
+   if($p->startsWith('(') && $p->endsWith(')'), | $p, | '(' + $p + ')');
+}
+
 function meta::relational::functions::sqlQueryToString::default::getDynaFunctionToSqlDefault(literalProcessor: meta::pure::metamodel::function::Function<{Type[1] -> LiteralProcessor[1]}>[1]): DynaFunctionToSql[*]
 {
   let allStates = allGenerationStates();
@@ -187,6 +193,8 @@ function meta::relational::functions::sqlQueryToString::default::getDynaFunction
     dynaFnToSql('acos',                   $allStates,            ^ToSql(format='acos(%s)')),
     dynaFnToSql('add',                    $allStates,            ^ToSql(format='%s',  transform=getTransformForAddPlus())),
     dynaFnToSql('and',                    $allStates,            ^ToSql(format='%s', transform={p:String[*]|$p->makeString(' and ')})),
+    dynaFnToSql('anyOf',                  $allStates,            ^ToSql(format='any %s', transform={p:String[1] | $p->meta::relational::functions::sqlQueryToString::default::bracketSubQuery()})),
+    dynaFnToSql('allOf',                  $allStates,            ^ToSql(format='all %s', transform={p:String[1] | $p->meta::relational::functions::sqlQueryToString::default::bracketSubQuery()})),
     dynaFnToSql('asin',                   $allStates,            ^ToSql(format='asin(%s)')),
     dynaFnToSql('atan',                   $allStates,            ^ToSql(format='atan(%s)')),
     dynaFnToSql('atan2',                  $allStates,            ^ToSql(format='atan2(%s,%s)')),

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-sqlDialectTranslation-pure/src/main/resources/core_external_store_relational_sql_dialect_translation/defaults/sqlDialectDefaults.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-sqlDialectTranslation-pure/src/main/resources/core_external_store_relational_sql_dialect_translation/defaults/sqlDialectDefaults.pure
@@ -99,6 +99,7 @@ function meta::external::store::relational::sqlDialectTranslation::defaults::fin
     {i: IsNotNullPredicate[1] | SqlOperatorTypes_default.IS_CHECK},
     {i: NegativeExpression[1] | SqlOperatorTypes_default.UNARY_PLUS_MINUS},
     {i: InPredicate[1] | SqlOperatorTypes_default.IN},
+    {q: QuantifiedComparisonExpression[1] | SqlOperatorTypes_default.BASIC_COMPARISON},
     {b: BetweenPredicate[1] | SqlOperatorTypes_default.BETWEEN},
     a: meta::external::query::sql::metamodel::Expression[1] | fail('Unknown expression type - ' + $e->class()->elementToPath()); SqlOperatorTypes_default.OTHER_NATIVE_USER_DEFINED_OPERATOR;
   ])->toString()

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-sqlDialectTranslation-pure/src/main/resources/core_external_store_relational_sql_dialect_translation/defaults/sqlDialectExtensionDefaults.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-sqlDialectTranslation-pure/src/main/resources/core_external_store_relational_sql_dialect_translation/defaults/sqlDialectExtensionDefaults.pure
@@ -186,6 +186,36 @@ function meta::external::store::relational::sqlDialectTranslation::defaults::exi
   )
 }
 
+function meta::external::store::relational::sqlDialectTranslation::defaults::quantifiedComparisonExpressionProcessor_default(): NodeProcessor<QuantifiedComparisonExpression>[1]
+{
+  nodeProcessor(
+    QuantifiedComparisonExpression,
+    {sqlDialect, q, state, config |
+      let comparator = if(
+        [
+          pair(|$q.operator == ComparisonOperator.EQUAL, | '='),
+          pair(|$q.operator == ComparisonOperator.NOT_EQUAL, | '<>'),
+          pair(|$q.operator == ComparisonOperator.LESS_THAN, | '<'),
+          pair(|$q.operator == ComparisonOperator.LESS_THAN_OR_EQUAL, | '<='),
+          pair(|$q.operator == ComparisonOperator.GREATER_THAN, | '>'),
+          pair(|$q.operator == ComparisonOperator.GREATER_THAN_OR_EQUAL, | '>=')
+        ],
+        | fail('Unsupported operator for a quantified comparison: ' + $q.operator->toString()); '';
+      );
+      let quantifier = if(
+        [
+          pair(|$q.quantifier == Quantifier.ANY, | $sqlDialect->keyword('any', $state, $config)),
+          pair(|$q.quantifier == Quantifier.SOME, | $sqlDialect->keyword('some', $state, $config))
+        ],
+        | $sqlDialect->keyword('all', $state, $config);
+      );
+      $sqlDialect->executeNodeProcessor($q.value, $q, $state, $config) + ' ' + $comparator + ' ' + $quantifier + ' ' +
+        $sqlDialect->executeNodeProcessor($q.subQuery, $q, $state, $config);
+    },
+    {n | true}
+  )
+}
+
 function meta::external::store::relational::sqlDialectTranslation::defaults::allColumnsReferenceNodeProcessor_default(): NodeProcessor<AllColumnsReference>[1]
 {
   nodeProcessor(

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-sqlDialectTranslation-pure/src/main/resources/core_external_store_relational_sql_dialect_translation/postgres/postgresSqlDialect.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-sqlDialectTranslation-pure/src/main/resources/core_external_store_relational_sql_dialect_translation/postgres/postgresSqlDialect.pure
@@ -269,6 +269,7 @@ function <<access.private>> meta::external::store::relational::sqlDialectTransla
     functionCallProcessor_default(),
     subQueryExpressionProcessor_default(),
     existsPredicateProcessor_default(),
+    quantifiedComparisonExpressionProcessor_default(),
     trimProcessor_default(),
     likePredicateProcessor_default(),
     allColumnsReferenceNodeProcessor_default(),

--- a/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/src/test/resources/parity-tests/structural/subqueries.yaml
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/src/test/resources/parity-tests/structural/subqueries.yaml
@@ -215,3 +215,107 @@ tests:
     category: "subqueries"
     expected_tds_status: ERROR
     expected_rel_status: PASS
+
+  # Quantified comparison - <op> ANY / <op> ALL against a subquery
+  - id: subquery_quant_gt_any
+    sql: "SELECT p.name FROM persons p WHERE p.age > ANY (SELECT p2.age FROM persons p2 WHERE p2.dept_id = 2) ORDER BY 1"
+    feature: "Quantified comparison ANY"
+    category: "subqueries"
+    expected_tds_status: ERROR
+    expected_rel_status: PASS
+
+  - id: subquery_quant_gt_all
+    sql: "SELECT p.name FROM persons p WHERE p.age > ALL (SELECT p2.age FROM persons p2 WHERE p2.dept_id = 2) ORDER BY 1"
+    feature: "Quantified comparison ALL"
+    category: "subqueries"
+    expected_tds_status: ERROR
+    expected_rel_status: PASS
+
+  # SOME is a synonym for ANY
+  - id: subquery_quant_ge_some
+    sql: "SELECT p.name FROM persons p WHERE p.age >= SOME (SELECT p2.age FROM persons p2 WHERE p2.dept_id = 2) ORDER BY 1"
+    feature: "Quantified comparison SOME"
+    category: "subqueries"
+    expected_tds_status: ERROR
+    expected_rel_status: PASS
+
+  - id: subquery_quant_eq_any
+    sql: "SELECT p.name FROM persons p WHERE p.dept_id = ANY (SELECT d.id FROM departments d WHERE d.budget > 700000) ORDER BY 1"
+    feature: "Quantified comparison ANY"
+    category: "subqueries"
+    expected_tds_status: ERROR
+    expected_rel_status: PASS
+
+  # != has no relation function of its own - it is the negation of the opposite quantifier
+  - id: subquery_quant_neq_any
+    sql: "SELECT p.name FROM persons p WHERE p.dept_id <> ANY (SELECT d.id FROM departments d WHERE d.budget > 700000) ORDER BY 1"
+    feature: "Quantified comparison ANY"
+    category: "subqueries"
+    expected_tds_status: ERROR
+    expected_rel_status: PASS
+
+  - id: subquery_quant_neq_all
+    sql: "SELECT p.name FROM persons p WHERE p.dept_id <> ALL (SELECT d.id FROM departments d WHERE d.budget > 700000) ORDER BY 1"
+    feature: "Quantified comparison ALL"
+    category: "subqueries"
+    expected_tds_status: ERROR
+    expected_rel_status: PASS
+
+  # a null in the subquery makes ALL unknown, which the relation function alone would answer true - dept 1
+  # holds Hank's null salary, so Postgres returns nothing. This is what the null guard is for: without it
+  # the five higher-paid people come back.
+  - id: subquery_quant_all_null_in_subquery
+    sql: "SELECT p.name FROM persons p WHERE p.salary > ALL (SELECT p2.salary FROM persons p2 WHERE p2.dept_id = 1) ORDER BY 1"
+    feature: "Quantified comparison ALL over a nullable column"
+    category: "subqueries"
+    expected_tds_status: ERROR
+    expected_rel_status: PASS
+
+  # correlated, and vacuously true for the persons with no orders. ERROR for the same reason
+  # subquery_in_correlated is: a correlated column cannot be resolved when the outer and inner relations
+  # share the 'root' alias (#5048), which predates quantified comparison.
+  - id: subquery_quant_all_correlated_empty
+    sql: "SELECT p.name FROM persons p WHERE p.id < ALL (SELECT o.id FROM orders o WHERE o.person_id = p.id) ORDER BY 1"
+    feature: "Correlated quantified comparison"
+    category: "subqueries"
+    expected_tds_status: ERROR
+    expected_rel_status: ERROR
+
+  - id: subquery_quant_all_empty
+    sql: "SELECT p.name FROM persons p WHERE p.id > ALL (SELECT p2.id FROM persons p2 WHERE p2.id > 100) ORDER BY 1"
+    feature: "Quantified comparison ALL over an empty subquery"
+    category: "subqueries"
+    expected_tds_status: ERROR
+    expected_rel_status: PASS
+
+  - id: subquery_quant_any_empty
+    sql: "SELECT p.name FROM persons p WHERE p.id > ANY (SELECT p2.id FROM persons p2 WHERE p2.id > 100) ORDER BY 1"
+    feature: "Quantified comparison ANY over an empty subquery"
+    category: "subqueries"
+    expected_tds_status: ERROR
+    expected_rel_status: PASS
+
+  # known divergence: over an empty subquery SQL performs no comparison at all, so ALL is true even for a
+  # null value, where relation::greaterThanAll answers false for an absent value by definition. Closing it
+  # needs a subquery under OR, the shape that cannot be unnested on Snowflake.
+  - id: subquery_quant_all_empty_null_value
+    sql: "SELECT p.name FROM persons p WHERE p.age > ALL (SELECT p2.age FROM persons p2 WHERE p2.id > 100) ORDER BY 1"
+    feature: "Quantified comparison ALL over an empty subquery"
+    category: "subqueries"
+    expected_tds_status: ERROR
+    expected_rel_status: FAIL
+
+  # negation has to reproduce when SQL is false rather than true, which moves the null guard from ALL onto ANY
+  - id: subquery_quant_not_gt_any
+    sql: "SELECT p.name FROM persons p WHERE NOT (p.age > ANY (SELECT p2.age FROM persons p2 WHERE p2.dept_id = 2)) ORDER BY 1"
+    feature: "Negated quantified comparison"
+    category: "subqueries"
+    expected_tds_status: ERROR
+    expected_rel_status: PASS
+
+  - id: subquery_quant_not_gt_all_null_in_subquery
+    sql: "SELECT p.name FROM persons p WHERE NOT (p.salary > ALL (SELECT p2.salary FROM persons p2 WHERE p2.dept_id = 1)) ORDER BY 1"
+    feature: "Negated quantified comparison"
+    category: "subqueries"
+    expected_tds_status: ERROR
+    expected_rel_status: PASS

--- a/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/src/test/resources/parity-tests/structural/where_predicates.yaml
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/src/test/resources/parity-tests/structural/where_predicates.yaml
@@ -119,14 +119,14 @@ tests:
     feature: "ANY"
     category: "where_predicates"
     expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   - id: where_all
     sql: "SELECT name, salary FROM persons WHERE salary > ALL(SELECT salary FROM persons WHERE dept_id = 2) ORDER BY 1"
     feature: "ALL"
     category: "where_predicates"
     expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   # Compound predicates
   - id: where_and_or

--- a/legend-engine-xts-sql/legend-engine-xt-sql-http-api/src/test/java/org/finos/legend/engine/query/sql/api/TestQueryRealiaser.java
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-http-api/src/test/java/org/finos/legend/engine/query/sql/api/TestQueryRealiaser.java
@@ -79,6 +79,8 @@ public class TestQueryRealiaser
                 "select p.a from myTable as p where exists (select 1 from myTable2 as o_1 where o_1.b = p.a)");
 
         test("select p.a from myTable as p where p.a in (select o.b from myTable2 as o where o.c = p.a)");
+
+        test("select p.a from myTable as p where p.a > all (select o.b from myTable2 as o where o.c = p.a)");
     }
 
     @Test

--- a/legend-engine-xts-sql/legend-engine-xt-sql-transformation/legend-engine-xt-sql-pure/src/main/resources/core_external_query_sql/binding/fromPure/fromPure.pure
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-transformation/legend-engine-xt-sql-pure/src/main/resources/core_external_query_sql/binding/fromPure/fromPure.pure
@@ -2129,26 +2129,7 @@ function meta::external::query::sql::transformation::queryToPure::extractNameFro
       $b.value->extractNameFromExpression($context) + ' ' + $operator + ' ' + $b.shift->extractNameFromExpression($context);,
     c:Cast[1] | 'CAST(' + $c.expression->extractNameFromExpression($context) + ' AS ' + $c.type->extractNameFromExpression($context) + ')',
     c:ComparisonExpression[1] |
-      let operator = [
-        pair(ComparisonOperator.EQUAL,                '='),
-        pair(ComparisonOperator.NOT_EQUAL,            '!='),
-        pair(ComparisonOperator.LESS_THAN,            '<'),
-        pair(ComparisonOperator.LESS_THAN_OR_EQUAL,   '<='),
-        pair(ComparisonOperator.GREATER_THAN,         '>'),
-        pair(ComparisonOperator.GREATER_THAN_OR_EQUAL,'>='),
-        pair(ComparisonOperator.IS_DISTINCT_FROM,     'IS DISTINCT FROM'),
-        pair(ComparisonOperator.IS_NOT_DISTINCT_FROM, 'IS NOT DISTINCT FROM'),
-        pair(ComparisonOperator.REGEX_MATCH,          '~'),
-        pair(ComparisonOperator.REGEX_MATCH_CI,       '~*'),
-        pair(ComparisonOperator.REGEX_NO_MATCH,       '!~'),
-        pair(ComparisonOperator.REGEX_NO_MATCH_CI,    '!~*'),
-        pair(ComparisonOperator.LIKE,                 '~~'),
-        pair(ComparisonOperator.ILIKE,                '~~*'),
-        pair(ComparisonOperator.NOT_LIKE,             '!~~'),
-        pair(ComparisonOperator.NOT_ILIKE,            '!~~*')
-      ]->getValue($c.operator);
-
-      $c.left->extractNameFromExpression($context) + ' ' + $operator + ' ' + $c.right->extractNameFromExpression($context);,
+      $c.left->extractNameFromExpression($context) + ' ' + $c.operator->comparisonOperatorSymbol() + ' ' + $c.right->extractNameFromExpression($context),
     c:CurrentTime[1] |
       let param = if ($c.precision->isEmpty(), | '', | '(' + $c.precision->toOne()->toString() + ')');
       [
@@ -2185,6 +2166,7 @@ function meta::external::query::sql::transformation::queryToPure::extractNameFro
     p:ParameterPlaceholderExpression[1] | '?',
     p:PositionalParameterExpression[1] | '$' + $p.index->toString(),
     q:QualifiedNameReference[1] | $q.name->extractNameFromQualifiedName($context),
+    q:QuantifiedComparisonExpression[1] | $q.value->extractNameFromExpression($context) + ' ' + $q.operator->comparisonOperatorSymbol() + ' ' + $q.quantifier.name + ' (subquery)',
     s:SimpleCaseExpression[1] | $s->convertToSearchedCaseExpression()->extractNameFromExpression($context),
     s:SearchedCaseExpression[1] |
       let when = $s.whenClauses->map(w | $w->extractNameFromExpression($context))->joinStrings(' ');
@@ -2199,6 +2181,28 @@ function meta::external::query::sql::transformation::queryToPure::extractNameFro
     w:WhenClause[1] | 'WHEN ' + $w.operand->extractNameFromExpression($context) + ' THEN ' + $w.result->extractNameFromExpression($context),
     e:meta::external::query::sql::metamodel::Expression[1] | ''
   ])
+}
+
+function <<access.private>> meta::external::query::sql::transformation::queryToPure::comparisonOperatorSymbol(operator:ComparisonOperator[1]):String[1]
+{
+  [
+    pair(ComparisonOperator.EQUAL,                '='),
+    pair(ComparisonOperator.NOT_EQUAL,            '!='),
+    pair(ComparisonOperator.LESS_THAN,            '<'),
+    pair(ComparisonOperator.LESS_THAN_OR_EQUAL,   '<='),
+    pair(ComparisonOperator.GREATER_THAN,         '>'),
+    pair(ComparisonOperator.GREATER_THAN_OR_EQUAL,'>='),
+    pair(ComparisonOperator.IS_DISTINCT_FROM,     'IS DISTINCT FROM'),
+    pair(ComparisonOperator.IS_NOT_DISTINCT_FROM, 'IS NOT DISTINCT FROM'),
+    pair(ComparisonOperator.REGEX_MATCH,          '~'),
+    pair(ComparisonOperator.REGEX_MATCH_CI,       '~*'),
+    pair(ComparisonOperator.REGEX_NO_MATCH,       '!~'),
+    pair(ComparisonOperator.REGEX_NO_MATCH_CI,    '!~*'),
+    pair(ComparisonOperator.LIKE,                 '~~'),
+    pair(ComparisonOperator.ILIKE,                '~~*'),
+    pair(ComparisonOperator.NOT_LIKE,             '!~~'),
+    pair(ComparisonOperator.NOT_ILIKE,            '!~~*')
+  ]->getValue($operator);
 }
 
 function <<access.private>> meta::external::query::sql::transformation::queryToPure::extractAliasFromColumn(column:SingleColumn[1]):SQLColumnAlias[1]
@@ -2284,6 +2288,7 @@ function <<access.private>> meta::external::query::sql::transformation::queryToP
     n:NotExpression[1] | processNotExpression($n, $expContext, $context),
     p:PositionalParameterExpression[1] | processPositionalParameterExpression($p, $expContext, $context),
     q:QualifiedNameReference[1] | processQualifiedNameReference($q, $expContext, $context),
+    q:QuantifiedComparisonExpression[1] | processQuantifiedComparisonExpression($q, $expContext, $context),
     s:SimpleCaseExpression[1] | processSimpleCaseExpression($s, $expContext, $context),
     s:SearchedCaseExpression[1] | processSearchedCaseExpression($s, $expContext, $context),
     s:StringConcatenate[1] | processStringConcatenate($s, $expContext, $context),
@@ -2650,6 +2655,82 @@ function <<access.private>> meta::external::query::sql::transformation::queryToP
   debug(|'processInListExpression', $context.debug);
 
   $i.values->map(v | processExpression($v, $expContext, $context))->iv();
+}
+
+function <<access.private>> meta::external::query::sql::transformation::queryToPure::processQuantifiedComparisonExpression(q:QuantifiedComparisonExpression[1], expContext:SqlTransformExpressionContext[1], context:SqlTransformContext[1]):ValueSpecification[1]
+{
+  processQuantifiedComparisonExpression($q, false, $expContext, $context);
+}
+
+// SQL evaluates a quantified comparison in three-valued logic, and a WHERE drops an unknown exactly as it
+// drops a false, so what has to be reproduced is when the comparison is TRUE. The relation functions are
+// two-valued and ignore nulls in the subquery, which agrees with SQL for ANY - an unknown can only arise
+// there when nothing matched, so the row goes either way - but not for ALL, where a null makes SQL unknown
+// while the function still answers true.
+//
+// Negating swaps that around, because it is now FALSE that has to be reproduced. ALL is false as soon as
+// one row fails, nulls or not, so the guard drops; ANY is only false when every row failed *and* none was
+// null, so the guard appears. The negated forms also need the value present: the functions answer false
+// for an empty value where SQL is unknown, and negating would turn that into a kept row.
+function <<access.private>> meta::external::query::sql::transformation::queryToPure::processQuantifiedComparisonExpression(q:QuantifiedComparisonExpression[1], negated:Boolean[1], expContext:SqlTransformExpressionContext[1], context:SqlTransformContext[1]):ValueSpecification[1]
+{
+  debug(|'processQuantifiedComparisonExpression', $context.debug);
+  assertRelation($context.relation, 'quantified comparison');
+
+  //there is no notEqualAny/notEqualAll - != ANY is the negation of = ALL, and != ALL of = ANY
+  if ($q.operator == ComparisonOperator.NOT_EQUAL,
+    | processQuantifiedComparisonExpression(^$q(operator = ComparisonOperator.EQUAL, quantifier = if ($q.quantifier == Quantifier.ALL, | Quantifier.ANY, | Quantifier.ALL)), !$negated, $expContext, $context),
+    |
+      let all = $q.quantifier == Quantifier.ALL;
+      let value = $q.value->processExpression($expContext, $context);
+
+      //unlike EXISTS the select list is the column being compared, so the subquery is processed as-is
+      let relContext = processSubRelation($q.subQuery.query, $expContext, $context);
+      let rel = $relContext.expression->toOne();
+
+      //the resolved schema rather than the expression's own type arguments, because a source whose schema
+      //is only known at compile time - a table function, say - carries no type arguments to read
+      let columns = $relContext.columns;
+      assert($columns->size() == 1, | 'a quantified comparison requires the subquery to return exactly one column, got ' + $columns->size()->toString());
+
+      let comparison = sfe(quantifiedComparisonFunction($q.operator, $all), [$value, $rel]);
+
+      let parts = if ($negated, | sfe(isNotEmpty_Any_$0_1$__Boolean_1_, $value), | [])
+        ->concatenate(if ($negated, | sfe(not_Boolean_1__Boolean_1_, $comparison), | $comparison))
+        ->concatenate(if ($all == $negated, | [], | createNullFreeGuard($rel, $columns->toOne().name, $relContext)));
+
+      $parts->tail()->fold({p, acc | sfe(and_Boolean_1__Boolean_1__Boolean_1_, [$acc, $p])}, $parts->first()->toOne());
+  );
+}
+
+// The guard tests the subquery's output column, so it is a predicate over the already-processed
+// sub-relation rather than a WHERE pushed into the subquery - the latter would apply before a GROUP BY
+// or LIMIT rather than after it, and so would test a different set of values.
+function <<access.private>> meta::external::query::sql::transformation::queryToPure::createNullFreeGuard(rel:ValueSpecification[1], columnName:String[1], relContext:SqlTransformContext[1]):ValueSpecification[1]
+{
+  let column = ^QualifiedNameReference(name = ^QualifiedName(parts = $columnName));
+
+  sfe(not_Boolean_1__Boolean_1_,
+      sfe(exists_Relation_1__Function_1__Boolean_1_, [$rel, iv(createExistsLambda(^IsNullPredicate(value = $column), $relContext))]));
+}
+
+function <<access.private>> meta::external::query::sql::transformation::queryToPure::quantifiedComparisonFunction(operator:ComparisonOperator[1], all:Boolean[1]):meta::pure::metamodel::function::Function<Any>[1]
+{
+  if ($all,
+      | [
+          pair(ComparisonOperator.EQUAL,                 meta::pure::functions::relation::equalAll_U_$0_1$__Relation_1__Boolean_1_),
+          pair(ComparisonOperator.GREATER_THAN,          meta::pure::functions::relation::greaterThanAll_U_$0_1$__Relation_1__Boolean_1_),
+          pair(ComparisonOperator.GREATER_THAN_OR_EQUAL, meta::pure::functions::relation::greaterThanEqualAll_U_$0_1$__Relation_1__Boolean_1_),
+          pair(ComparisonOperator.LESS_THAN,             meta::pure::functions::relation::lessThanAll_U_$0_1$__Relation_1__Boolean_1_),
+          pair(ComparisonOperator.LESS_THAN_OR_EQUAL,    meta::pure::functions::relation::lessThanEqualAll_U_$0_1$__Relation_1__Boolean_1_)
+        ],
+      | [
+          pair(ComparisonOperator.EQUAL,                 meta::pure::functions::relation::equalAny_U_$0_1$__Relation_1__Boolean_1_),
+          pair(ComparisonOperator.GREATER_THAN,          meta::pure::functions::relation::greaterThanAny_U_$0_1$__Relation_1__Boolean_1_),
+          pair(ComparisonOperator.GREATER_THAN_OR_EQUAL, meta::pure::functions::relation::greaterThanEqualAny_U_$0_1$__Relation_1__Boolean_1_),
+          pair(ComparisonOperator.LESS_THAN,             meta::pure::functions::relation::lessThanAny_U_$0_1$__Relation_1__Boolean_1_),
+          pair(ComparisonOperator.LESS_THAN_OR_EQUAL,    meta::pure::functions::relation::lessThanEqualAny_U_$0_1$__Relation_1__Boolean_1_)
+        ])->getValue($operator);
 }
 
 function <<access.private>> meta::external::query::sql::transformation::queryToPure::processQualifiedNameReference(q:QualifiedNameReference[1], expContext:SqlTransformExpressionContext[1], context:SqlTransformContext[1]):ValueSpecification[1]
@@ -3431,9 +3512,13 @@ function meta::external::query::sql::transformation::queryToPure::processRound(a
 function <<access.private>> meta::external::query::sql::transformation::queryToPure::processNotExpression(n:NotExpression[1], expContext:SqlTransformExpressionContext[1], context:SqlTransformContext[1]):ValueSpecification[1]
 {
   debug(|'processNotExpression', $context.debug);
-  let value = $n.value->processExpression($expContext, $context);
 
-  nullOrSfe(not_Boolean_1__Boolean_1_, $value);
+  //a quantified comparison builds its own negation, since negating its two-valued result would keep the
+  //rows SQL leaves unknown
+  $n.value->match([
+    q:QuantifiedComparisonExpression[1] | processQuantifiedComparisonExpression($q, true, $expContext, $context),
+    e:meta::external::query::sql::metamodel::Expression[1] | nullOrSfe(not_Boolean_1__Boolean_1_, $e->processExpression($expContext, $context))
+  ]);
 }
 
 function <<access.private>> meta::external::query::sql::transformation::queryToPure::processNegativeExpression(n:NegativeExpression[1], expContext:SqlTransformExpressionContext[1], context:SqlTransformContext[1]):ValueSpecification[1]
@@ -3495,6 +3580,7 @@ function <<access.private>> meta::external::query::sql::transformation::queryToP
     n:NotExpression[1] | Boolean,
     p:PositionalParameterExpression[1] | $context.positional($p, [], false)->evaluateAndDeactivate().genericType.rawType->toOne(),
     q:QualifiedNameReference[1] | $context.columnByNameParts($q.name.parts, true).type->toOne(),
+    q:QuantifiedComparisonExpression[1] | Boolean,
     s:SearchedCaseExpression[1] | caseExpressionType($s.whenClauses, $s.defaultValue, $context),
     s:StringConcatenate[1] | String,
     s:SimpleCaseExpression[1] | caseExpressionType($s.whenClauses, $s.defaultValue, $context),
@@ -4066,6 +4152,7 @@ function <<access.private>> meta::external::query::sql::transformation::queryToP
     l:LogicalBinaryExpression[1] | walk($l.left, $l.right, $accumulator, $extras),
     n:NegativeExpression[1] | walk($n.value, $accumulator, $extras),
     n:NotExpression[1] | walk($n.value, $accumulator, $extras),
+    q:QuantifiedComparisonExpression[1] | walk($q.value, $accumulator, $extras),
     s:SimpleCaseExpression[1] | $s->convertToSearchedCaseExpression()->walk($accumulator, $extras),
     s:SearchedCaseExpression[1] | $s.whenClauses->map(w | walk($w.operand, $w.result, $accumulator, $extras))->concatenate(walk($s.defaultValue, $accumulator, $extras)),
     s:SubqueryExpression[1] | walk($s.query, $accumulator, $extras),

--- a/legend-engine-xts-sql/legend-engine-xt-sql-transformation/legend-engine-xt-sql-pure/src/main/resources/core_external_query_sql/binding/fromPure/tests/testTranspile.pure
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-transformation/legend-engine-xt-sql-pure/src/main/resources/core_external_query_sql/binding/fromPure/tests/testTranspile.pure
@@ -4524,6 +4524,237 @@ function <<test.Test>> meta::external::query::sql::transformation::queryToPure::
   );
 }
 
+function <<test.Test>> meta::external::query::sql::transformation::queryToPure::tests::testQuantifiedComparisonAnyUncorrelated():Boolean[1]
+{
+  test(
+    'SELECT table1."Boolean" FROM service."/service/service1" table1 WHERE table1."Integer" > ANY (SELECT t2."Integer" FROM service."/service/service2" t2)',
+
+    [
+      c({|
+        meta::external::query::sql::transformation::queryToPure::tests::FlatInput.all()
+          ->project(~[Boolean : x | $x.booleanIn, Integer : x | $x.integerIn, Float : x | $x.floatIn, Decimal : x | $x.decimalIn, StrictDate : x | $x.strictDateIn, DateTime : x | $x.dateTimeIn, String : x | $x.stringIn])
+          ->filter(x |
+              $x.Integer->greaterThanAny(
+                meta::external::query::sql::transformation::queryToPure::tests::FlatInput.all()
+                  ->project(~[ID : x | $x.idIn, Integer : x | $x.integerIn, String : x | $x.stringIn])
+                  ->select(~[Integer])
+              )
+          )
+          ->select(~[Boolean])
+      })
+    ]
+  )
+}
+
+function <<test.Test>> meta::external::query::sql::transformation::queryToPure::tests::testQuantifiedComparisonSomeIsAny():Boolean[1]
+{
+  test(
+    'SELECT table1."Boolean" FROM service."/service/service1" table1 WHERE table1."Integer" <= SOME (SELECT t2."Integer" FROM service."/service/service2" t2)',
+
+    [
+      c({|
+        meta::external::query::sql::transformation::queryToPure::tests::FlatInput.all()
+          ->project(~[Boolean : x | $x.booleanIn, Integer : x | $x.integerIn, Float : x | $x.floatIn, Decimal : x | $x.decimalIn, StrictDate : x | $x.strictDateIn, DateTime : x | $x.dateTimeIn, String : x | $x.stringIn])
+          ->filter(x |
+              $x.Integer->lessThanEqualAny(
+                meta::external::query::sql::transformation::queryToPure::tests::FlatInput.all()
+                  ->project(~[ID : x | $x.idIn, Integer : x | $x.integerIn, String : x | $x.stringIn])
+                  ->select(~[Integer])
+              )
+          )
+          ->select(~[Boolean])
+      })
+    ]
+  )
+}
+
+//the extra guard is what keeps ALL faithful to SQL: a null in the subquery makes SQL unknown, which a
+//WHERE drops, where the relation function ignores it and answers true
+function <<test.Test>> meta::external::query::sql::transformation::queryToPure::tests::testQuantifiedComparisonAllUncorrelated():Boolean[1]
+{
+  test(
+    'SELECT table1."Boolean" FROM service."/service/service1" table1 WHERE table1."Integer" >= ALL (SELECT t2."Integer" FROM service."/service/service2" t2)',
+
+    [
+      c({|
+        meta::external::query::sql::transformation::queryToPure::tests::FlatInput.all()
+          ->project(~[Boolean : x | $x.booleanIn, Integer : x | $x.integerIn, Float : x | $x.floatIn, Decimal : x | $x.decimalIn, StrictDate : x | $x.strictDateIn, DateTime : x | $x.dateTimeIn, String : x | $x.stringIn])
+          ->filter(x |
+              $x.Integer->greaterThanEqualAll(
+                meta::external::query::sql::transformation::queryToPure::tests::FlatInput.all()
+                  ->project(~[ID : x | $x.idIn, Integer : x | $x.integerIn, String : x | $x.stringIn])
+                  ->select(~[Integer])
+              )
+              && !(meta::external::query::sql::transformation::queryToPure::tests::FlatInput.all()
+                    ->project(~[ID : x | $x.idIn, Integer : x | $x.integerIn, String : x | $x.stringIn])
+                    ->select(~[Integer])
+                    ->exists(e | $e.Integer->isEmpty()))
+          )
+          ->select(~[Boolean])
+      })
+    ]
+  )
+}
+
+function <<test.Test>> meta::external::query::sql::transformation::queryToPure::tests::testQuantifiedComparisonAllCorrelated():Boolean[1]
+{
+  test(
+    'SELECT table1."Boolean" FROM service."/service/service1" table1 WHERE table1."Integer" < ALL (SELECT t2."Integer" FROM service."/service/service2" t2 WHERE t2."String" = table1."String")',
+
+    [
+      c({|
+        meta::external::query::sql::transformation::queryToPure::tests::FlatInput.all()
+          ->project(~[Boolean : x | $x.booleanIn, Integer : x | $x.integerIn, Float : x | $x.floatIn, Decimal : x | $x.decimalIn, StrictDate : x | $x.strictDateIn, DateTime : x | $x.dateTimeIn, String : x | $x.stringIn])
+          ->filter(x |
+              $x.Integer->lessThanAll(
+                meta::external::query::sql::transformation::queryToPure::tests::FlatInput.all()
+                  ->project(~[ID : x | $x.idIn, Integer : x | $x.integerIn, String : x | $x.stringIn])
+                  ->filter(e | $e.String == $x.String)
+                  ->select(~[Integer])
+              )
+              && !(meta::external::query::sql::transformation::queryToPure::tests::FlatInput.all()
+                    ->project(~[ID : x | $x.idIn, Integer : x | $x.integerIn, String : x | $x.stringIn])
+                    ->filter(e | $e.String == $x.String)
+                    ->select(~[Integer])
+                    ->exists(e | $e.Integer->isEmpty()))
+          )
+          ->select(~[Boolean])
+      })
+    ]
+  )
+}
+
+//there is no notEqualAny, so this is !equalAll - but only once the value is guarded, since equalAll
+//already answers false for an empty value and the negation would turn that into true
+function <<test.Test>> meta::external::query::sql::transformation::queryToPure::tests::testQuantifiedComparisonNotEqualAny():Boolean[1]
+{
+  test(
+    'SELECT table1."Boolean" FROM service."/service/service1" table1 WHERE table1."Integer" <> ANY (SELECT t2."Integer" FROM service."/service/service2" t2)',
+
+    [
+      c({|
+        meta::external::query::sql::transformation::queryToPure::tests::FlatInput.all()
+          ->project(~[Boolean : x | $x.booleanIn, Integer : x | $x.integerIn, Float : x | $x.floatIn, Decimal : x | $x.decimalIn, StrictDate : x | $x.strictDateIn, DateTime : x | $x.dateTimeIn, String : x | $x.stringIn])
+          ->filter(x |
+              $x.Integer->isNotEmpty()
+              && !($x.Integer->equalAll(
+                    meta::external::query::sql::transformation::queryToPure::tests::FlatInput.all()
+                      ->project(~[ID : x | $x.idIn, Integer : x | $x.integerIn, String : x | $x.stringIn])
+                      ->select(~[Integer])))
+          )
+          ->select(~[Boolean])
+      })
+    ]
+  )
+}
+
+function <<test.Test>> meta::external::query::sql::transformation::queryToPure::tests::testQuantifiedComparisonNotEqualAll():Boolean[1]
+{
+  test(
+    'SELECT table1."Boolean" FROM service."/service/service1" table1 WHERE table1."Integer" <> ALL (SELECT t2."Integer" FROM service."/service/service2" t2)',
+
+    [
+      c({|
+        meta::external::query::sql::transformation::queryToPure::tests::FlatInput.all()
+          ->project(~[Boolean : x | $x.booleanIn, Integer : x | $x.integerIn, Float : x | $x.floatIn, Decimal : x | $x.decimalIn, StrictDate : x | $x.strictDateIn, DateTime : x | $x.dateTimeIn, String : x | $x.stringIn])
+          ->filter(x |
+              $x.Integer->isNotEmpty()
+              && !($x.Integer->equalAny(
+                    meta::external::query::sql::transformation::queryToPure::tests::FlatInput.all()
+                      ->project(~[ID : x | $x.idIn, Integer : x | $x.integerIn, String : x | $x.stringIn])
+                      ->select(~[Integer])))
+              && !(meta::external::query::sql::transformation::queryToPure::tests::FlatInput.all()
+                    ->project(~[ID : x | $x.idIn, Integer : x | $x.integerIn, String : x | $x.stringIn])
+                    ->select(~[Integer])
+                    ->exists(e | $e.Integer->isEmpty()))
+          )
+          ->select(~[Boolean])
+      })
+    ]
+  )
+}
+
+//negating ANY needs the null guard that the plain form does not: ANY is only false when every row failed
+//and none of them was null
+function <<test.Test>> meta::external::query::sql::transformation::queryToPure::tests::testQuantifiedComparisonNotAny():Boolean[1]
+{
+  test(
+    'SELECT table1."Boolean" FROM service."/service/service1" table1 WHERE NOT table1."Integer" > ANY (SELECT t2."Integer" FROM service."/service/service2" t2)',
+
+    [
+      c({|
+        meta::external::query::sql::transformation::queryToPure::tests::FlatInput.all()
+          ->project(~[Boolean : x | $x.booleanIn, Integer : x | $x.integerIn, Float : x | $x.floatIn, Decimal : x | $x.decimalIn, StrictDate : x | $x.strictDateIn, DateTime : x | $x.dateTimeIn, String : x | $x.stringIn])
+          ->filter(x |
+              $x.Integer->isNotEmpty()
+              && !($x.Integer->greaterThanAny(
+                    meta::external::query::sql::transformation::queryToPure::tests::FlatInput.all()
+                      ->project(~[ID : x | $x.idIn, Integer : x | $x.integerIn, String : x | $x.stringIn])
+                      ->select(~[Integer])))
+              && !(meta::external::query::sql::transformation::queryToPure::tests::FlatInput.all()
+                    ->project(~[ID : x | $x.idIn, Integer : x | $x.integerIn, String : x | $x.stringIn])
+                    ->select(~[Integer])
+                    ->exists(e | $e.Integer->isEmpty()))
+          )
+          ->select(~[Boolean])
+      })
+    ]
+  )
+}
+
+//and negating ALL drops it: ALL is false as soon as one row fails, whether or not another holds a null
+function <<test.Test>> meta::external::query::sql::transformation::queryToPure::tests::testQuantifiedComparisonNotAll():Boolean[1]
+{
+  test(
+    'SELECT table1."Boolean" FROM service."/service/service1" table1 WHERE NOT table1."Integer" > ALL (SELECT t2."Integer" FROM service."/service/service2" t2)',
+
+    [
+      c({|
+        meta::external::query::sql::transformation::queryToPure::tests::FlatInput.all()
+          ->project(~[Boolean : x | $x.booleanIn, Integer : x | $x.integerIn, Float : x | $x.floatIn, Decimal : x | $x.decimalIn, StrictDate : x | $x.strictDateIn, DateTime : x | $x.dateTimeIn, String : x | $x.stringIn])
+          ->filter(x |
+              $x.Integer->isNotEmpty()
+              && !($x.Integer->greaterThanAll(
+                    meta::external::query::sql::transformation::queryToPure::tests::FlatInput.all()
+                      ->project(~[ID : x | $x.idIn, Integer : x | $x.integerIn, String : x | $x.stringIn])
+                      ->select(~[Integer])))
+          )
+          ->select(~[Boolean])
+      })
+    ]
+  )
+}
+
+function <<test.Test>> meta::external::query::sql::transformation::queryToPure::tests::testQuantifiedComparisonNotNotEqualAll():Boolean[1]
+{
+  test(
+    'SELECT table1."Boolean" FROM service."/service/service1" table1 WHERE NOT table1."Integer" <> ALL (SELECT t2."Integer" FROM service."/service/service2" t2)',
+
+    [
+      c({|
+        meta::external::query::sql::transformation::queryToPure::tests::FlatInput.all()
+          ->project(~[Boolean : x | $x.booleanIn, Integer : x | $x.integerIn, Float : x | $x.floatIn, Decimal : x | $x.decimalIn, StrictDate : x | $x.strictDateIn, DateTime : x | $x.dateTimeIn, String : x | $x.stringIn])
+          ->filter(x |
+              $x.Integer->equalAny(
+                meta::external::query::sql::transformation::queryToPure::tests::FlatInput.all()
+                  ->project(~[ID : x | $x.idIn, Integer : x | $x.integerIn, String : x | $x.stringIn])
+                  ->select(~[Integer])
+              )
+          )
+          ->select(~[Boolean])
+      })
+    ]
+  )
+}
+
+function <<test.Test>> meta::external::query::sql::transformation::queryToPure::tests::testQuantifiedComparisonMultipleColumnsUnsupported():Boolean[1]
+{
+  error(
+    'SELECT table1."Boolean" FROM service."/service/service1" table1 WHERE table1."Integer" > ANY (SELECT t2."Integer", t2."ID" FROM service."/service/service2" t2)',
+    'a quantified comparison requires the subquery to return exactly one column, got 2'
+  );
+}
+
 function <<test.Test>> meta::external::query::sql::transformation::queryToPure::tests::testVariant():Boolean[1]
 {
   test(


### PR DESCRIPTION
Completes the subquery-predicate family that `exists()` and `in()` started (#5054), adding SQL's quantified comparison for `=`, `>`, `>=`, `<`, `<=`.

## The functions

```pure
greaterThanAny<U,Z>(value:U[0..1], rel:Relation<Z=(?:U)>[1]):Boolean[1]
```

Ten of them — `equalAny`/`equalAll`, `greaterThanAny`/`greaterThanAll`, `greaterThanEqualAny`/`greaterThanEqualAll`, `lessThanAny`/`lessThanAll`, `lessThanEqualAny`/`lessThanEqualAll` — all shaped like `in()`, and all implemented **in Pure on top of `relation::exists`** rather than as natives. Ordering comparisons go through `lang::compare` because the inequality functions are declared per primitive type and cannot take the type variable.

There is deliberately no `notEqualAny`/`notEqualAll`: `!equalAll` is the one and `!equalAny` is the other, by De Morgan.

## Semantics

Two-valued, matching `in()`.

| Case | `<op>Any(v, R)` | `<op>All(v, R)` |
|---|---|---|
| `v` empty | false | false |
| `R` empty | false | **true** (vacuous) |
| column all nulls | false | true |
| nulls mixed in | ignored | ignored |

## Negation is exact, and that is the point

The router emits, in **both** filter and projection position:

```
group( and( isNotNull(v), <cmp>( v, anyOf|allOf( <null-excluded sub-select> ) ) ) )
```

Two pieces do the work. The sub-select drops nulls from the searched column, so the quantifier is decided whenever `v` is non-null. And the `isNotNull` conjunct is emitted **unconditionally**, not only when the result is projected — `FALSE AND UNKNOWN` is `FALSE` in SQL, so `not` sees a decided predicate and needs no `or v is null` disjunct. No subquery ever lands under an `OR`, which is the shape that forced #5066 to reject a negated `in()`.

Verified on Snowflake: every generated query compiles, negated ones included, with zero `Unsupported subquery type cannot be evaluated`.

## The quantifier is a wrapper, not a fused operator

`greaterThan(value, anyOf(subSelect))` renders `value > any (select …)` through the **existing** comparison dyna functions. So the default extension gains two entries — `anyOf` → `any %s`, `allOf` → `all %s` — instead of ten, and the boolean-predicate allow-list needs no change at all.

## One thing that was not obvious

Quantified comparison had no node in the postgres SQL metamodel, and **every** dialect routes Pure→SQL through `toPostgresModel` — H2 alone produced 66 errors before this was fixed. So `QuantifiedComparisonExpression` and a `Quantifier` enum are added there (protocol-generated, so the Java POJO comes free), with a shape-based converter arm, a `NodeProcessor`, and arms in the three hand-written `NodeVisitor` implementors.

## Testing

77 new PCT tests. Run locally against every adapter:

| Adapter | New exclusions |
|---|---|
| core-compiled, core-interpreted | **0** |
| DuckDB, Postgres, SqlServer, Oracle, Trino | **0** |
| Snowflake | **0** (compiles; results unverifiable locally, see below) |
| H2 | 1 |
| ClickHouse | 8 |
| Spanner | 62 |
| MemSQL, Databricks, javaPlatformBinding, Deephaven | 67 each |

Where the exclusions come from:

- **Spanner** supports only `= ANY` and `<>`/`!= ALL` — `INVALID_ARGUMENT: ALL subqueries with operators other than <>/!= are not supported`.
- **Databricks** cannot *parse* quantified comparison — Spark SQL has only IN/EXISTS subqueries (`PARSE_SYNTAX_ERROR`).
- **ClickHouse** rejects correlated subqueries and does not give `<op> ALL (empty)` the vacuous `true`.
- **MemSQL, javaPlatformBinding, Deephaven** exclude the family exactly as they already do for `exists`/`in`.
- **H2's single exclusion is an H2 bug**, reproduced with plain JDBC and no Legend involved: `= ALL` over an *empty CTE-backed* subquery wrongly answers false, while `>`, `>=`, `<`, `<=` are correct and `= ALL` over the same empty set *without* a CTE is correct.

The limit/slice path is implemented and covered. A limit fixes which rows reach the comparison, so the null cannot be dropped inside the limited query; the sub-select is isolated as a derived table and the null dropped outside it. `testGreaterThanAll_LimitedRelationWithNull` discriminates that on its own — excluding the null inside the limit would keep the wrong rows, and not excluding it would leave the comparison unknown.

Also green: 2730 relational core tests, 81 SQL round-trip, 72 relational grammar tests (including three new compile-error tests), `TestHandlersValidation`, and checkstyle.

Snowflake result assertions could not be checked locally — all its errors are the pre-existing `Fail to retrieve row count for first arrow chunk` environment failure, which hits untouched tests equally. SQL compilation errors do still surface, which is what the run was for.

## SQL → Pure

Legend SQL now transpiles quantified comparison to these functions, so `x > ANY (SELECT ...)` works through the wire protocol. `SqlVisitor` restricts it to the six comparable operators — `cmpOp` also admits the regex and like operators, which SQL does not allow a quantifier on — and to a subquery operand, so the array form `x = ANY(ARRAY[...])` reports unsupported rather than failing a cast. `SOME` stays distinct from `ANY` so a parsed query composes back the way it was written.

**The semantics are not a direct mapping.** SQL is three-valued and a `WHERE` drops an unknown exactly as it drops a false, so what has to be reproduced is *when the comparison is TRUE*. The relation functions are two-valued and ignore nulls in the subquery. That agrees with SQL for `ANY` — an unknown can only arise there when nothing matched, so the row goes either way — but not for `ALL`, where a null makes SQL unknown while the function still answers true. `ALL` therefore carries a `!rel->exists(r | col is null)` guard:

```sql
where ((root.age is not null and root.age > all (select persons_1.age from persons persons_1
                                                 where persons_1.age is not null and persons_1.id > 100))
       and not exists (select 1 from persons persons_2 where persons_2.id > 100 and persons_2.age is null))
```

Negation inverts it, because it is now FALSE that has to be reproduced. `ALL` is false as soon as one row fails, nulls or not, so the guard **drops**; `ANY` is only false when every row failed *and* none was null, so the guard **appears**. The negated forms also need the value present, since the functions answer false for an absent value where SQL is unknown. `processNotExpression` hands a quantified comparison back to its own processor rather than wrapping it in `not`. `!=` needs no function of its own: `!= ANY` is the negation of `= ALL` and `!= ALL` of `= ANY`, which falls out of the same flag.

The guard's column comes from the transform context's resolved schema, not the expression's type arguments — those are empty for a function-backed source, which is the shape the wire protocol always produces.

**Parity, against a real Postgres 16** (`legend-engine-xt-sql-e2e-tests`): 2510 tests, zero failures with the baseline written in and fix-detection armed. Eleven of the thirteen new cases pass, and the pre-existing `where_any` / `where_all` move `ERROR → PASS`. The two that do not pass are recorded deliberately:

- `subquery_quant_all_null_in_subquery` **passes**, and is what the null guard is for — dept 1 holds Hank's null salary, so Postgres returns nothing; without the guard the five higher-paid people come back.
- `subquery_quant_all_empty_null_value` is **FAIL**: over an empty subquery SQL performs no comparison at all, so `ALL` is true even for a null value, where the function answers false for an absent value by definition. Closing it needs a subquery under `OR` — the shape that cannot be unnested on Snowflake.
- `subquery_quant_all_correlated_empty` is **ERROR** for the pre-existing correlated-alias limitation (#5048) that already blocks `subquery_in_correlated`: `Column 'id' of the enclosing query cannot be referenced from this subquery: both use the table alias 'root'`.

Also green: 176 Pure transpile tests, 82 SQL round-trip, 1309 reverse-PCT, and the SQL http-api suite.

## Not included

Reverse-PCT entries. Its `reverses()` list is opt-in and carries no entry for `exists` or `in` either, so quantification follows the same convention.
