### PR TITLE
M2M: adapt Nil function returns to declared Java type

### DIFF
--- a/legend-engine-xts-java/legend-engine-xt-javaGeneration-pure/src/main/resources/core_external_language_java/generation/expressionGeneration.pure
+++ b/legend-engine-xts-java/legend-engine-xt-javaGeneration-pure/src/main/resources/core_external_language_java/generation/expressionGeneration.pure
@@ -69,11 +69,11 @@ function <<access.private>> meta::external::language::java::transform::statement
             let lastValueSpecification = $vses->last()->toOne();
 
             if($last->isAssignment(),
-               | $toLast->add($last)->add($last->variableAssigned()->j_return()),
+               | $toLast->add($last)->add($last->variableAssigned()->prepareMethodReturnExpression($lastValueSpecification, $returnType)->j_return()),
                |
             if($last->isDeclaration(),
-               | $toLast->add($last)->add($last->variableDeclared()->j_return()),
-               | $toLast->add($last->j_return())
+               | $toLast->add($last)->add($last->variableDeclared()->prepareMethodReturnExpression($lastValueSpecification, $returnType)->j_return()),
+               | $toLast->add($last->prepareMethodReturnExpression($lastValueSpecification, $returnType)->j_return())
             ));
          }
       ])

--- a/legend-engine-xts-service/legend-engine-test-runner-service/src/test/resources/testable/m2m-optional-from-list/legend-testable-m2m-optional-from-list.pure
+++ b/legend-engine-xts-service/legend-engine-test-runner-service/src/test/resources/testable/m2m-optional-from-list/legend-testable-m2m-optional-from-list.pure
@@ -30,10 +30,15 @@ Class testM2MOptionalFromList::model::TargetEvent
   firstCode: String[0..1];
 }
 
+function testM2MOptionalFromList::model::emptyOptionalCode(): String[0..1]
+{
+  []
+}
+
 function testM2MOptionalFromList::model::firstCodeOrEmpty(src: testM2MOptionalFromList::model::SourceEvent[1]): String[0..1]
 {
   if($src.attributes->isEmpty(),
-    |[],
+    |testM2MOptionalFromList::model::emptyOptionalCode(),
     |'FOUND'
   )
 }


### PR DESCRIPTION
#### What type of PR is this?

- Bug Fix


#### What does this PR do / why is it needed ?

This PR fixes the return type for functions returning nulls in M2M. The fix is required to use the prepareReturnType

