### PR TITLE
M2M: Keep owner-reachability diagnostic inert for constant reference data

### DIFF
--- a/docs/engineering/architecture/source-tree-calculation.md
+++ b/docs/engineering/architecture/source-tree-calculation.md
@@ -459,6 +459,23 @@ subtree where `srcClass != owner` — that is the legitimate cross-branch
 shape where the legacy fallback's silent empty output is correct. The
 precondition stays inert there.
 
+A second gate (`transformsReferenceSource`) handles constant reference data:
+a transform such as `referenceData()->map(w | $w.leaf)->map(l | $l.label)`
+navigates classes that are genuinely unreachable from owner, but the data is
+built by a function from literals — no source data flows into it, so nothing
+needs fetching and the legacy fallback's empty contribution is correct. The
+property tree cannot make this distinction (`$src->badWrap().foreign.y`, the
+genuine-error shape, scans to the same unreachable chains because the scan
+drops the source access inside the constructor's key expressions), so the
+gate is read off the transform expressions directly: the diagnostic fires
+only if at least one of the property mappings' transforms references its
+source parameter (`referencesAnyVariable`, a recursive walk over the
+deactivated expression). A transform that mixes a source reference with
+constant navigation (e.g. `if($src.flag, |referenceData(), |[])...`) is
+conservatively treated as source-referencing. See
+`testConstantReferenceDataNavigation` /
+`testConstantReferenceDataAlongsideSourceProperty`.
+
 `childPropertiesMap` and `propertyTreesBelongingToOwner` are hoisted out of
 the intermediate-handling branch and reused in the dispatch below — both as
 the precondition's input and as the dispatch's input. This avoids

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/graphFetch/graphExtension.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/graphFetch/graphExtension.pure
@@ -644,7 +644,15 @@ function <<access.private>> meta::pure::graphFetch::enrichSourceTreeNodeForPrope
                                                                                                                 || $cGenPaths->contains($rPath)
                                                                                                                 || $r->getAllTypeGeneralisations()->map(t | $t->elementToPath())->contains($cPath););
                                                                        );
-         assert(!$setImplSrcClassMatchesOwner || $propertyTreesBelongingToOwner->isNotEmpty() || $nonTrivialTreeClasses->isEmpty() || $hasReachableTreeClass,
+         // A transform that never references its source parameter reads only constant
+         // reference data (instances built by functions from literals). The navigated
+         // classes hold no source-derived state, so nothing needs fetching - the legacy
+         // fallback's empty contribution is correct and the diagnostic must stay inert.
+         // The property tree cannot make this distinction (both shapes scan to the same
+         // unreachable chains), so it is read off the transform expressions directly.
+         let transformsReferenceSource = $propertyMappings->exists(pm | let paramNames = $pm.transform->functionType().parameters->evaluateAndDeactivate().name;
+                                                                        $pm.transform.expressionSequence->evaluateAndDeactivate()->exists(e | $e->meta::pure::graphFetch::referencesAnyVariable($paramNames)););
+         assert(!$setImplSrcClassMatchesOwner || $propertyTreesBelongingToOwner->isNotEmpty() || $nonTrivialTreeClasses->isEmpty() || $hasReachableTreeClass || !$transformsReferenceSource,
                 |'No intermediate-class property of ' + $owner->elementToPath() + ' returns ' + $nonTrivialTreeClasses->at(0)->elementToPath() + ' - cannot build path back to owner.');
 
          // Property tree root node may not start at owner (e.g. when the source of a mapping is wrapped in a new class and passed to a property mapping).
@@ -835,6 +843,28 @@ function <<access.private>> meta::pure::graphFetch::addPassThroughSubTreesAtPath
       | ^$srcNode(subTrees=$srcNode.subTrees->cast(@PropertyGraphFetchTree)->map(st|if($st.property == $head.property, |$st->addPassThroughSubTrees($tgtPgft, $extensions), |$st))),
       | ^$srcNode(subTrees=$srcNode.subTrees->cast(@PropertyGraphFetchTree)->map(st|if($st.property == $head.property, |$st->addPassThroughSubTreesAtPath(list($tail), $tgtPgft, $extensions), |$st)))
    );
+}
+
+// Does the expression reference any variable with one of the given names? Used to decide
+// whether a transform consumes its source parameter at all. Nested lambdas are entered
+// without tracking shadowing: a nested parameter reusing the source's name would read as
+// a source reference, which errs on the side of keeping the owner-reachability diagnostic
+// active - the pre-existing conservative behaviour.
+function <<access.private>> meta::pure::graphFetch::referencesAnyVariable(vs:ValueSpecification[1], names:String[*]) : Boolean[1]
+{
+   $vs->match([
+      ve   : VariableExpression[1]               | $ve.name->in($names),
+      fe   : FunctionExpression[1]               | $fe.parametersValues->evaluateAndDeactivate()->exists(p | $p->referencesAnyVariable($names)),
+      iv   : InstanceValue[1]                    | $iv.values->evaluateAndDeactivate()->exists(v | $v->match([
+                                                      ivs : ValueSpecification[1]      | $ivs->referencesAnyVariable($names),
+                                                      k   : KeyExpression[1]           | $k.expression->evaluateAndDeactivate()->referencesAnyVariable($names),
+                                                      f   : FunctionDefinition<Any>[1] | $f.expressionSequence->evaluateAndDeactivate()->exists(e | $e->referencesAnyVariable($names)),
+                                                      a   : Any[1]                     | false
+                                                   ])),
+      ervs : meta::pure::router::metamodel::ExtendedRoutedValueSpecification[1] | $ervs.value->referencesAnyVariable($names),
+      frvs : meta::pure::router::FunctionRoutedValueSpecification[1] | $frvs.value->referencesAnyVariable($names),
+      other: ValueSpecification[1]               | false
+   ]);
 }
 
 function <<access.private>> meta::pure::graphFetch::collectPropertyTreeClasses(pTree:PropertyPathTree[1]) : Class<Any>[*]

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/graphFetch/tests/sourceTreeCalc/testSourceTreeCalc.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/graphFetch/tests/sourceTreeCalc/testSourceTreeCalc.pure
@@ -3952,3 +3952,115 @@ Mapping meta::pure::graphFetch::tests::sourceTreeCalc::mutualCycle::MutualCycleM
     txId : $src.txId
   }
 )
+
+###Pure
+import meta::pure::graphFetch::tests::sourceTreeCalc::constantRef::*;
+import meta::pure::graphFetch::*;
+import meta::pure::graphFetch::routing::*;
+
+// Regression: a transform may navigate properties of purely constant reference data -
+// instances built by a function that consumes nothing from the source. The navigated
+// classes (CrRefWrap/CrRefLeaf) are unreachable from the source class, but no source
+// data flows into them, so nothing needs fetching: the correct source tree is the bare
+// root. The owner-reachability diagnostic must stay inert for this shape.
+Class meta::pure::graphFetch::tests::sourceTreeCalc::constantRef::CrSrcRoot
+{
+  x : String[1];
+}
+
+Class meta::pure::graphFetch::tests::sourceTreeCalc::constantRef::CrRefLeaf
+{
+  supported : Boolean[1];
+  label     : String[1];
+}
+
+Class meta::pure::graphFetch::tests::sourceTreeCalc::constantRef::CrRefWrap
+{
+  leaf : meta::pure::graphFetch::tests::sourceTreeCalc::constantRef::CrRefLeaf[1];
+}
+
+Class meta::pure::graphFetch::tests::sourceTreeCalc::constantRef::CrTgt
+{
+  label : String[1];
+}
+
+Class meta::pure::graphFetch::tests::sourceTreeCalc::constantRef::CrMixedTgt
+{
+  label : String[1];
+  xOut  : String[1];
+}
+
+function meta::pure::graphFetch::tests::sourceTreeCalc::constantRef::referenceData() : meta::pure::graphFetch::tests::sourceTreeCalc::constantRef::CrRefWrap[*]
+{
+  [
+    ^CrRefWrap(leaf = ^CrRefLeaf(supported = true, label = 'A')),
+    ^CrRefWrap(leaf = ^CrRefLeaf(supported = true, label = 'B'))
+  ]
+}
+
+function <<test.Test>>
+  meta::pure::graphFetch::tests::sourceTreeCalc::constantRef::testConstantReferenceDataNavigation():Boolean[1]
+{
+  let tree = #{
+    meta::pure::graphFetch::tests::sourceTreeCalc::constantRef::CrTgt {
+      label
+    }
+  }#;
+  let sourceTree = meta::pure::graphFetch::calculateSourceTree(
+                     $tree,
+                     meta::pure::graphFetch::tests::sourceTreeCalc::constantRef::ConstantReferenceMapping,
+                     meta::pure::extension::defaultExtensions());
+  let str = $sourceTree->meta::pure::graphFetch::sortTree()->meta::pure::graphFetch::treeToString();
+  assert($str->contains('CrSrcRoot'), | 'expected root class in source tree: '                             + $str);
+  assert(!$str->contains('leaf'),     | 'constant-derived leaf must not appear in the source tree: '       + $str);
+  assert(!$str->contains('label'),    | 'constant-derived label must not appear in the source tree: '      + $str);
+  assert(!$str->contains('supported'),| 'constant-derived supported must not appear in the source tree: '  + $str);
+  true;
+}
+
+function <<test.Test>>
+  meta::pure::graphFetch::tests::sourceTreeCalc::constantRef::testConstantReferenceDataAlongsideSourceProperty():Boolean[1]
+{
+  let tree = #{
+    meta::pure::graphFetch::tests::sourceTreeCalc::constantRef::CrMixedTgt {
+      label,
+      xOut
+    }
+  }#;
+  let sourceTree = meta::pure::graphFetch::calculateSourceTree(
+                     $tree,
+                     meta::pure::graphFetch::tests::sourceTreeCalc::constantRef::ConstantReferenceMixedMapping,
+                     meta::pure::extension::defaultExtensions());
+  let str = $sourceTree->meta::pure::graphFetch::sortTree()->meta::pure::graphFetch::treeToString();
+  assert($str->contains('x'),         | 'source-mapped x must appear in the source tree: '                 + $str);
+  assert(!$str->contains('leaf'),     | 'constant-derived leaf must not appear in the source tree: '       + $str);
+  assert(!$str->contains('label'),    | 'constant-derived label must not appear in the source tree: '      + $str);
+  assert(!$str->contains('supported'),| 'constant-derived supported must not appear in the source tree: '  + $str);
+  true;
+}
+
+###Mapping
+Mapping meta::pure::graphFetch::tests::sourceTreeCalc::constantRef::ConstantReferenceMapping
+(
+  *meta::pure::graphFetch::tests::sourceTreeCalc::constantRef::CrTgt : Pure
+  {
+    ~src meta::pure::graphFetch::tests::sourceTreeCalc::constantRef::CrSrcRoot
+    label : meta::pure::graphFetch::tests::sourceTreeCalc::constantRef::referenceData()
+              ->map(w | $w.leaf)
+              ->map(l | $l.label)
+              ->joinStrings(',')
+  }
+)
+
+Mapping meta::pure::graphFetch::tests::sourceTreeCalc::constantRef::ConstantReferenceMixedMapping
+(
+  *meta::pure::graphFetch::tests::sourceTreeCalc::constantRef::CrMixedTgt : Pure
+  {
+    ~src meta::pure::graphFetch::tests::sourceTreeCalc::constantRef::CrSrcRoot
+    label : meta::pure::graphFetch::tests::sourceTreeCalc::constantRef::referenceData()
+              ->map(w | $w.leaf)
+              ->map(l | $l.label)
+              ->joinStrings(','),
+    xOut  : $src.x
+  }
+)


### PR DESCRIPTION
## What

Stops `calculateSourceTree`'s owner-reachability diagnostic from rejecting M2M transforms that navigate purely constant reference data, e.g.

```pure
*test::Tgt : Pure
{
  ~src test::SrcRoot
  label : referenceData()->map(w | $w.leaf)->map(l | $l.label)->joinStrings(',')
}
```

where `referenceData()` builds instances from literals and takes no source input. Since #5083 this shape failed plan generation with:

```
No intermediate-class property of test::SrcRoot returns test::RefWrap - cannot build path back to owner.
```

## Why

The navigated classes are genuinely unreachable from the source class, but no source data flows into them, so nothing needs fetching — the legacy fallback's empty source-tree contribution is the correct output. The diagnostic exists to catch the case where an unreachable chain *does* carry source-derived state (see `testUnreachableOwnerGivesClearError`) and silently dropping it would lose data.

The property tree cannot distinguish the two shapes: the scan drops source accesses inside constructor key expressions, so `$src->badWrap().foreign.y` and `referenceData()->map(...)` both reduce to the same unreachable chains by the time the precondition runs.

## How

The distinction is read off the transform expressions directly. A new private helper `referencesAnyVariable` walks the deactivated transform expression (function arguments, instance key expressions, nested lambdas, routed wrappers) looking for a reference to the transform lambda's source parameter. The precondition gains one disjunct: it only fires if at least one of the property mappings' transforms references its source parameter.

Transforms mixing a source reference with constant navigation (e.g. `if($src.flag, |referenceData(), |[])->...`) are conservatively treated as source-referencing, so the diagnostic stays as strict as before wherever source data is involved. `docs/engineering/architecture/source-tree-calculation.md` §7.4 documents the new gate.

## Tests

New regression tests in `testSourceTreeCalc.pure` (`constantRef` package):

- `testConstantReferenceDataNavigation` — property mapped purely from a constant chain; asserts the source tree contains only the root and none of the constant-derived properties.
- `testConstantReferenceDataAlongsideSourceProperty` — constant chain alongside a normal `$src.x` property; asserts `x` is kept and the constant-derived properties are absent.

Verified: full `legend-engine-pure-code-compiled-core` suite green (`Test_Pure_Core` 1141/1141, including the pinned error-message tests `testUnreachableOwnerGivesClearError` and `testMutualCycleGivesClearError`).
