### PR TITLE
Express JSON navigation and array operations in the relational store language

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,33 @@ mvn checkstyle:check                               # Checkstyle (blocking in CI)
 
 Always pass `clean` — several Pure Maven plugins are buggy and fail with "duplicate artifact present" errors when building over a prior target directory.
 
+### Isolate your build from the shared `~/.m2` cache
+
+All checkouts share one local repository, and every branch builds the same
+`<version>-SNAPSHOT` coordinates. If two working copies are built at different times, whichever
+installed last wins, and the other silently runs against the wrong jars. This is especially
+dangerous for Pure modules, whose `.pure` sources are compiled to bytecode inside the installed
+jar — a stale jar produces failures with no connection to anything you changed.
+
+**Before starting work on a branch, stamp the reactor with a unique version:**
+
+```bash
+mvn versions:set -DnewVersion=$(git rev-parse --abbrev-ref HEAD)-SNAPSHOT \
+    -DprocessAllModules=true -DgenerateBackupPoms=false
+```
+
+Every install then lands under its own coordinates and cannot collide with another session.
+To undo before opening a PR (the version bump must **not** be committed):
+
+```bash
+mvn versions:set -DnewVersion=<original-version> -DprocessAllModules=true -DgenerateBackupPoms=false
+# or, if backup poms were kept:  mvn versions:revert
+```
+
+Symptoms of a collision, when you have skipped this: tests failing in modules you never touched,
+a test count that changes between identical runs, or a failure that disappears after rebuilding
+an unrelated module. Suspect the cache before you suspect your change.
+
 Run the server (main: `org.finos.legend.engine.server.Server`):
 ```
 server legend-engine-config/legend-engine-server/legend-engine-server-http-server/src/test/resources/org/finos/legend/engine/server/test/userTestConfig.json

--- a/docs/emit/emit.md
+++ b/docs/emit/emit.md
@@ -903,6 +903,13 @@ so live in the `mapping:` domain alongside their relational counterparts:
 | `store:relational-nested-join` | Nested (chained) join |
 | `store:relational-outer-join` | Full outer join |
 | `store:relational-right-outer-join` | Right outer join |
+| `store:relational-semistructured` | `SEMISTRUCTURED` column holding a JSON document |
+| `store:relational-semistructured-array-functions` | Collection functions over a semi-structured array |
+| `store:relational-semistructured-array-index` | Fixed-index access into a semi-structured array |
+| `store:relational-semistructured-binding` | JSON document typed as a model via an ExternalFormat binding |
+| `store:relational-semistructured-explode` | `explodeSemiStructured` fanning a JSON array into rows |
+| `store:relational-semistructured-flatten` | Lateral flatten of a to-many semi-structured property |
+| `store:relational-semistructured-navigation` | Path navigation into a semi-structured document |
 | `store:service-store` | Service store |
 | `store:flat-data-store` | Flat-data store |
 

--- a/docs/engineering/README.md
+++ b/docs/engineering/README.md
@@ -107,6 +107,7 @@ all backends. See [Testing Strategy — PCT](testing/testing-strategy.md#5-pct-p
 | [Router & Pure-to-SQL](architecture/router-and-pure-to-sql.md) | Routing strategies, clustering, SQL generation pipeline, dialect extension                                                      |
 | [ModelJoin](architecture/model-join.md)                       | Store-agnostic model-level associations: parser, compiler, router, and Relational SQL translation                               |
 | [Relation Mappings](architecture/relation-mapping.md)         | End-to-end guide for class-to-Relation (`~func`) mappings: grammar, compiler passes, transformation, routing, and SQL generation |
+| [Relational DynaFunctions](architecture/relational-dynafunctions.md) | Dyna functions authored in `###Relational` `Filter`/`Join`/`View` bodies: what is supported, how it is dispatched, the validation gap, and a proposal for contracts and self-documenting coverage |
 | [Pre-Evaluation (preeval)](architecture/preeval.md)           | AST simplification pass that runs before the router: constant folding, let inlining, short-circuiting                           |
 | [Source Tree Calculation](architecture/source-tree-calculation.md) | calculateSourceTree pipeline and the new-instance operator pattern: intermediate-class handling, edge cases, design alternatives |
 

--- a/docs/engineering/architecture/relational-dynafunctions.md
+++ b/docs/engineering/architecture/relational-dynafunctions.md
@@ -1,0 +1,1060 @@
+# DynaFunctions in the Relational Database DSL
+
+> **Scope.** This document covers dyna functions **as written by a modeller** in the
+> `###Relational` Database DSL — inside `Filter`, `MultiGrainFilter`, `Join`, `View` column
+> mappings, and relational property mappings. It documents what is supported today, how the
+> support is implemented, where it breaks, and a proposal for improving it.
+>
+> Dyna functions **synthesised by the router** while translating a Pure query to SQL are a
+> different producer feeding the same registry. Their dispatch, dialect registration, and
+> null-safe-equality handling are already documented in
+> [Router & Pure-to-SQL §5.3–5.7](router-and-pure-to-sql.md#53-dbconfig--dbextension). This
+> document cross-references that material rather than restating it, and returns to the
+> producer distinction in §10.1, where it constrains the design.
+
+---
+
+## 0. The short version
+
+The working belief is *"we support a small subset of dyna functions (filter, joins)"*. That
+is half right, and the half that is wrong is the half that matters:
+
+| Layer | What it constrains |
+|---|---|
+| Grammar | **Nothing.** `functionOperation: identifier PAREN_OPEN (args)? PAREN_CLOSE` — any name, any arity, including zero. |
+| Parse-tree walker | Nothing. The identifier is copied verbatim into `DynaFunc.funcName`. |
+| Compiler | Nothing. No name check, no arity check, no type check. |
+| Composer | Arity only, for 12 names — and on mismatch it emits a **comment string into the regenerated grammar** rather than failing (§9.1). |
+| SQL generation | Everything. A raw Pure `assert`, at plan-generation time, with no `SourceInformation`. |
+
+So the surface is not small because the engine restricts it. It is small because only a
+handful of dyna functions are ergonomic, tested, or known-good — and nothing tells a
+modeller which ones. `Filter Foo(bogusFunc(t.a, t.b, t.c))` parses, compiles, and passes
+validation; it fails only when someone runs a query that touches it.
+
+---
+
+## 1. Where you can write a dyna function
+
+All entry points are in
+`legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/RelationalParserGrammar.g4`:
+
+| Construct | Rule |
+|---|---|
+| `Filter <name>(<operation>)` | `filter` — `RelationalParserGrammar.g4:158` |
+| `MultiGrainFilter <name>(<operation>)` | `multiGrainFilter` — `:160` |
+| `Join <name>(<operation>)` | `join` — `:162` |
+| `View` column mapping | `viewColumnMapping` — `:145` |
+| Relational property mapping (`###Mapping`) | `relationalPropertyMapping` — `:296` |
+
+The operation sub-grammar is `:165-229`:
+
+```antlr
+operation:                  booleanOperation | joinOperation
+booleanOperation:           atomicOperation booleanOperationRight?
+booleanOperationRight:      booleanOperator operation
+booleanOperator:            AND | OR
+atomicOperation:            (groupOperation
+                             | (databasePointer? functionOperation)
+                             | columnOperation
+                             | joinOperation
+                             | constant) atomicOperationRight?
+atomicOperationRight:       (atomicOperator atomicOperation) | atomicSelfOperator
+atomicOperator:             EQUAL | TEST_NOT_EQUAL | NOT_EQUAL | GREATER_THAN
+                            | LESS_THAN | GREATER_OR_EQUAL | LESS_OR_EQUAL
+atomicSelfOperator:         IS_NULL | IS_NOT_NULL
+groupOperation:             PAREN_OPEN operation PAREN_CLOSE
+functionOperation:          identifier PAREN_OPEN (functionOperationArgument
+                              (COMMA functionOperationArgument)*)? PAREN_CLOSE
+functionOperationArgument:  operation | functionOperationArgumentArray
+functionOperationArgumentArray:
+                            BRACKET_OPEN (functionOperationArgument
+                              (COMMA functionOperationArgument)*)? BRACKET_CLOSE
+```
+
+Line 208 — `functionOperation` — is the whole story for names: it is `identifier`-based, so
+**there is no `dynaFunc` rule and no keyword list**. `functionOperationArgumentArray` is what
+lets you write `in(firmTable.ID, [2, 3, 4])`.
+
+Column references are `tableAliasColumnOperation` (`:216-220`). There is no `this`/`that`
+keyword pair in this grammar — `{target}` is the only reserved alias
+(`RelationalLexerGrammar.g4:26`), used for directed self-joins.
+
+---
+
+## 2. Two notations, and the 12 names that have sugar
+
+A `DynaFunc` reaches the protocol by one of two routes, both in
+`.../grammar/from/RelationalParseTreeWalker.java`.
+
+### 2.1 Operator sugar — a closed set of 12
+
+| Walker method | Grammar | `DynaFunc.funcName` |
+|---|---|---|
+| `visitAtomicOperator` `:812-843` | `=` `>` `<` `>=` `<=` `!=` `<>` | `equal`, `greaterThan`, `lessThan`, `greaterThanEqual`, `lessThanEqual`, `notEqual`, `notEqualAnsi` |
+| `visitAtomicSelfOperator` `:799-810` | `is null`, `is not null` | `isNull`, `isNotNull` |
+| `visitBooleanOperation` `:745-777` | `and`, `or` | `and`, `or` |
+| `visitGroupOperation` `:734-743` | `( … )` | `group` |
+
+`group` is synthetic — a modeller never writes it. The walker creates it for parentheses, and
+again at `:765-770` to force precedence when `and` and `or` mix. `visitBooleanOperation` also
+flattens same-operator chains (`:757-760`), so `a and b and c` becomes a single three-argument
+`and` rather than nested pairs.
+
+### 2.2 Functional notation — unconstrained
+
+```java
+// RelationalParseTreeWalker.java:845-852
+private RelationalOperationElement visitFunctionOperation(...)
+{
+    DynaFunc operation = new DynaFunc();
+    operation.sourceInformation = this.walkerSourceInformation.getSourceInformation(ctx);
+    operation.funcName = PureGrammarParserUtility.fromIdentifier(ctx.identifier());
+    operation.parameters = ListIterate.collect(ctx.functionOperationArgument(), ...);
+    return operation;
+}
+```
+
+The name is whatever was typed. Nothing looks it up.
+
+### 2.3 The protocol object
+
+`.../legend-engine-xt-relationalStore-protocol/src/main/java/.../store/relational/model/operation/DynaFunc.java`
+is the entire class:
+
+```java
+public class DynaFunc extends RelationalOperationElement
+{
+    public String funcName;
+    public List<RelationalOperationElement> parameters = Collections.emptyList();
+}
+```
+
+Dispatch across `RelationalOperationElement` subtypes is Jackson-only (`@JsonSubTypes` in
+`RelationalOperationElement.java:21-28`, discriminator `"dynaFunc"`). There is no
+`RelationalOperationElementVisitor` anywhere in the repo — both directions use `instanceof`
+chains, in `HelperRelationalBuilder.processRelationalOperationElement` and
+`HelperRelationalGrammarComposer.renderRelationalOperationElement`.
+
+### 2.4 Round-trip: Database bodies get sugar, mapping bodies do not
+
+`HelperRelationalGrammarComposer.renderDynaFunc` (`:82-200`) mirrors exactly the same 12
+names back to operator form — but only when `useDynaFunctionName` is `false`:
+
+```java
+// HelperRelationalGrammarComposer.java:85
+if (context.getUseDynaFunctionName() && (!dynaFunc.funcName.equals("group")))
+{
+    return defaultDynaFunctionRender(dynaFunc, context);   // funcName(a, b)
+}
+```
+
+`withNoDynaFunctionNames()` is called from **exactly one site** in the repo —
+`RelationalGrammarComposerExtension:281`, inside `renderDatabase` — and the default is `true`
+(`RelationalGrammarComposerContext:71`). Hence the asymmetry, which is deliberate (see the
+comment at `HelperRelationalGrammarComposer.java:85`):
+
+- inside a `Database`, `equal(a, b)` round-trips to `a = b`;
+- inside a `Mapping`, `a = b` round-trips to `equal(a, b)`.
+
+`TestRelationalGrammarRoundtrip.testRelationalAtomicOperationInFunctionalForm()` (`:618`)
+asserts precisely this normalisation. Both notations are accepted on input:
+
+```
+// input — functional form
+Join Abe(and(greaterThan([test::TEST_DB2]a.col1, 2),
+             group(or(greaterThan([test::TEST_DB2]b.col1, 3),
+                      greaterThan([test::TEST_DB2]b.col1, 4)))))
+
+// output — always operator form inside a Database
+Join Abe([test::TEST_DB2]a.col1 > 2 and ([test::TEST_DB2]b.col1 > 3
+                                         or [test::TEST_DB2]b.col1 > 4))
+```
+
+A second, lower-fidelity composer exists on the Pure side —
+`core_relational/relational/extensions/grammarSerializerExtension.pure:228-266` — covering the
+same 12 names (`dynaFunc2` `:230-236`, `dynaFunc1` `:237-238`, `group` `:239`, `and`/`or`
+`:240`, fallback `:242`).
+
+---
+
+## 3. Pipeline walk-through
+
+Take `Filter activeOnly(in(firmTable.LEGALNAME, ['Firm C', 'Firm A']))`.
+
+**Parse** — `visitFilter` (`RelationalParseTreeWalker:637-645`) → `visitOperation` →
+`visitFunctionOperation` (`:845`) produces
+`DynaFunc{funcName: "in", parameters: [TableAliasColumn, LiteralList]}` with source
+information attached.
+
+**Compile** — `RelationalCompilerExtension` runs `processDatabaseFilterFirstPass` (`:215`,
+name + database shell only) then `processDatabaseFilterSecondPass` (`:236`, the operation).
+The conversion is a plain `instanceof` chain:
+
+```java
+// HelperRelationalBuilder.processRelationalOperationElement:851-858
+else if (operationElement instanceof DynaFunc)
+{
+    DynaFunc dynaFunc = (DynaFunc) operationElement;
+    MutableList<RelationalOperationElement> ps = ListIterate.collect(dynaFunc.parameters,
+            e -> processRelationalOperationElement(e, context, aliasMap, selfJoinTargets));
+    return new Root_meta_relational_metamodel_DynaFunction_Impl("", m3SourceInformation,
+                   context.pureModel.getClass("meta::relational::metamodel::DynaFunction"))
+            ._name(dynaFunc.funcName)
+            ._parameters(ps);
+}
+```
+
+`._name(dynaFunc.funcName)` is the whole validation story. The string goes straight into the
+M3 graph.
+
+**Generate SQL** — the chain lives in
+`.../legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/sqlQueryToString/dbExtension.pure`:
+
+```
+processOperation                     (:526)   d:DynaFunction[1] | processDynaFunction($d, $sgc)
+  └─ processDynaFunction             (:862-892)
+       ├─ isEqualsFromFilter         (:864)   → processEqualFromFilter  (see §5)
+       ├─ 'case'                     (:867)   → processCase             (:916)
+       ├─ 'not'                      (:870)   → processNot              (:949)
+       ├─ 'extractFromSemiStructured'(:873)   → processExtractFromSemiStructured (:894)
+       └─ DbConfig.dynaFuncDispatch  (:170-174)  ← registry membership assert
+            └─ getDynaFunctionDispatcher (:1029-1037) ← per-dialect lookup
+                 └─ DynaFunctionToSql.toSql (:1045-1056) ← format-string substitution
+```
+
+Those four intercepted names never reach the registry lookup at all.
+
+The registry-membership check:
+
+```pure
+// dbExtension.pure:170-174
+dynaFuncDispatch(dynaFn: DynaFunction[1], sgc: SqlGenerationContext[1])
+{
+   assert(DynaFunctionRegistry->enumValues().name->contains($dynaFn.name),
+          'dyna function [' + $dynaFn.name +
+          '] is not registered in meta::relational::functions::sqlQueryToString::DynaFunctionRegistry');
+   $this.dbExtension.dynaFuncDispatch->eval($dynaFn, $sgc);
+}
+```
+
+and the per-dialect lookup:
+
+```pure
+// dbExtension.pure:1029-1037
+let result = $dispatch->get($func.name)->cast(@List<DynaFunctionToSql>).values
+              ->filter(d | $d.stateMatch->isEmpty() || $sgc.generationState->in($d.stateMatch));
+assertSize($result, 1, | '[unsupported-api] The function \'' + $func.name +
+                         '\' (state: [...]) is not supported yet');
+```
+
+For the mechanics of `DynaFunctionToSql`, `ToSql`, `GenerationState` and how a dialect
+registers overrides, see
+[Router & Pure-to-SQL §5.4–5.5](router-and-pure-to-sql.md#54-dynafunction-dispatch).
+
+---
+
+## 4. Compile-time guards that *do* exist
+
+None of them concern the dyna function itself, but they are the only compile-time safety in
+this area and are worth knowing:
+
+| Guard | Location | Behaviour |
+|---|---|---|
+| Duplicate `Join` / `Filter` names | `RelationalCompilerExtension:212-213` | `EngineException` |
+| Join refers to no table | `HelperRelationalBuilder:659-673` | `"A join must refer to at least one table"` |
+| Join refers to > 2 tables | same | `"A join can only contain 2 tables. Please use Join chains (using '>')…"` |
+| Self-join without `{target}` | `HelperRelationalBuilder:667-699` | `"The system can only find one table in the join. Please use the '{target}' notation…"` |
+| `{target}` column not found | `:695` | `"The column 'X' can't be found in the table 'Y'"` |
+| `sqlNull()` in a join condition | `RelationalValidator:237-265` | **Warning only**, and only reachable from *mapping* validation (`:270`) — not from `Database` compilation |
+
+Note how join sides are identified: positionally, by alias count
+(`processDatabaseJoinSecondPass`, `HelperRelationalBuilder:648-714`), never by dyna function
+name. No dyna function name is special-cased in the compiler at all.
+
+The `sqlNull` warning is the single piece of dyna-function-aware semantic checking in Java:
+
+```java
+// RelationalValidator.java:248-254
+if ("sqlNull".equals(funcName))
+{
+    pureModel.addWarnings(Lists.mutable.with(new Warning(
+        SourceInformationHelper.fromM3SourceInformation(dynaFunction.getSourceInformation()),
+        "Invalid use of sqlNull() in join condition. Use 'column is NULL' instead of "
+        + "'column = sqlNull()' in join condition.")));
+}
+```
+
+It is a useful precedent for §10: it shows the mechanism (a `Warning` carrying
+`SourceInformation`, produced during a graph walk) already exists and works.
+
+---
+
+## 5. `Filter` and `Join` are not the same
+
+This surprises people, so it deserves its own section.
+
+`Config.callingFromFilter` (`dbExtension.pure:28`) is set to `true` in exactly one situation
+per dialect: while rendering `SelectSQLQuery.filteringOperation`, i.e. the `WHERE` clause
+(e.g. `extensionDefaults.pure:357`, `postgresExtension.pure:337`, `snowflakeExtension.pure:638`).
+**Join conditions never set it.**
+
+```pure
+// dbExtension.pure:927-931
+isEqualsFromFilter(...)  // name == 'equal'
+                         // && callingFromFilter == true
+                         // && all params are TableAliasColumn with column.nullable != false
+
+// dbExtension.pure:943-947
+processEqualFromFilter(...)  // rewrites to nullSafeEqual and reprocesses
+```
+
+Consequence:
+
+- `Filter F(t.a = t.b)` over nullable columns emits **null-safe** SQL.
+- `Join J(t.a = t.b)` over the same columns emits a plain `=`.
+
+`:888` resets `callingFromFilter` when descending into non-`and`/`or` children, so the rewrite
+applies only at the top boolean level of the filter.
+
+Two further behaviours worth knowing:
+
+- **Boolean coercion.** `isBooleanOperation` (`dbExtension.pure:801-806`) lists the 25 dyna
+  functions treated as predicates. Anything else appearing in a boolean position is wrapped by
+  `maybeWrapAsBooleanOperation` (`:778-785`) as `equal(expr, true)`. This is why
+  `Filter kerbFilter(startsWith(traderTable.kerberos, 'gs_') = 'true')`
+  (`graphFetch/tests/testCrossStoreGraphFetch.pure:108`) looks odd but works. The list is
+  extensible per store via `RelationalExtension.sqlQueryToString_isBooleanOperation`
+  (`relational/extensions/extension.pure:56`).
+- **Parameter wrapping.** `processDynaFunction:877-885` wraps `and`/`or` parameters as boolean
+  operations, wraps only the head of `if`, and wraps parameters of non-boolean functions as
+  boolean *case* operations.
+
+---
+
+## 6. What is actually supported — three different numbers
+
+These are three answers to three different questions. Conflating them is the most common
+mistake in discussions about dyna function support.
+
+| Question | Answer | Source |
+|---|---|---|
+| Which names are **registered**? | **231** | `DynaFunctionRegistry` enum, `dbExtension.pure:1077-1309` |
+| Which names **render** on a given dialect? | default **113**, ∪ that dialect's overrides — e.g. **179 / 231** on H2, **224 / 231** on Snowflake | `extensionDefaults.pure:186-305` + `<db>Extension.pure` |
+| Which names are **exercised in this repository's fixtures**? | **15** in call form, of which 10 are not operator sugar | scan of all `Filter` / `MultiGrainFilter` / `Join` bodies |
+
+### 6.1 Registered ≠ renderable
+
+`getDynaFunctionToSqlDefault` (`extensionDefaults.pure:186-305`) supplies 113 entries, all
+registered for every generation state. The other 118 registered names have **no default
+rendering** — each dialect must supply its own. That is not the same as "unsupported": it
+means support is per-dialect, and a filter that works on Snowflake may fail on Redshift.
+
+Per-dialect override counts (distinct `dynaFnToSql` names in each `<db>Extension.pure`):
+
+| Dialect | Overrides | Dialect | Overrides |
+|---|---|---|---|
+| DuckDB | 128 | SparkSQL / Postgres | 68 |
+| Snowflake | 122 | Oracle | 67 |
+| Databricks | 108 | SQL Server | 66 |
+| H2 (all versions) | 75 | Trino | 63 |
+| Sybase ASE / Spanner | 73 | Presto | 57 |
+| Sybase IQ | 72 | BigQuery | 50 |
+| ClickHouse | 71 | Redshift | 48 |
+| MemSQL | 70 | DB2 | 45 |
+| | | Composite | 7 |
+| | | **Hive** | **0** (default table only) |
+
+**`putAll` is replace, not merge.** The dispatcher map value is `List<DynaFunctionToSql>`, and
+a dialect entry replaces the whole list for that key. A dialect that overrides a name must
+therefore re-supply *every* generation state it needs; a partial override leaves the other
+states hitting `[unsupported-api]`. ClickHouse `:84-87` splits `nullSafeEqual` /
+`nullSafeNotEqual` across `selectOutsideWhenGenerationState()` and
+`notSelectOutsideWhenGenerationStates()` for exactly this reason, as do SQL Server `:98-99`,
+Sybase ASE `:88-89`, SparkSQL `:78-79`, Oracle `:188-189` and Sybase IQ `:79-80`.
+
+Five registered names have **no** `dynaFnToSql` entry in any dialect: `between`, `case`,
+`explodeSemiStructured`, `not`, `pair` — and for four of them that is by design, not a gap.
+`case` and `not` are intercepted upstream (`processDynaFunction:867`, `:870`); `pair` is
+router-internal (`pureToSQLQuery.pure:4007` builds `newDynaFunction('pair', $roes)` and consumes
+it structurally, never rendering it); `explodeSemiStructured` is lowered by the router into a
+lateral flatten join before SQL generation and so never reaches dispatch — see §11.7.
+
+### 6.2 Renderable ≠ used
+
+A balanced-paren scan of every `Filter` / `MultiGrainFilter` / `Join` body in the repository —
+**671 definitions** across production and test resources — finds only 15 registry dyna
+functions written in call form:
+
+| Name | Occurrences | Name | Occurrences |
+|---|---|---|---|
+| `and` | 5 | `extractFromSemiStructured` | 1 |
+| `in` | 3 | `toString` | 1 |
+| `length` | 3 | `case` | 1 |
+| `or` | 2 | `isNull` | 1 |
+| `greaterThan` | 2 | `now` | 1 |
+| `datePart` | 1 | `convertVarchar128` | 1 |
+| `explodeSemiStructured` | 1 | `startsWith` | 1 |
+| | | `lessThan` | 1 |
+
+Strip the operator-sugar names and **10 of the 231 registered dyna functions are exercised
+anywhere in Database-DSL text in this repository**.
+
+> **Read that number carefully.** It measures this repository's fixtures, not the world.
+> Production Legend models plausibly use more. It is evidence that our *coverage* is thin,
+> not proof that anything else is broken.
+
+Only four Pure fixtures put a dyna function inside a Database `Filter` or `Join`:
+
+| Fixture | What it exercises |
+|---|---|
+| `tests/mapping/inClause/testInClauseForJoinsAndFilters.pure:78` | `in(…)` in both a `Filter` and a `Join`, with `assertSameSQL` expectations at `:29`, `:37`, `:45`, `:54` — **the copyable pattern** |
+| `tests/mapping/union/testUnion.pure:839-840` | `greaterThan(length(A.name_s1), 0)` in a `Join` |
+| `validation/tests/testComplexValidations.pure:218` | `lessThan(length(locationTable.STREET), 10)` in a `Filter` |
+| `graphFetch/tests/testCrossStoreGraphFetch.pure:108` | `startsWith(...)` in a `Filter` |
+
+On the Java side the coverage is `TestRelationalGrammarRoundtrip.testRelationalOperations()`
+(`:573`) and `testRelationalAtomicOperationInFunctionalForm()` (`:618`) — both grammar-level,
+both limited to the 12 operator-sugar names plus `case`, `substring` and `sqlNull`.
+
+---
+
+## 7. Four registries that should agree, and do not
+
+| Registry | Location | Size | Purpose |
+|---|---|---|---|
+| `DynaFunctionRegistry` enum | `dbExtension.pure:1077-1309` | **231** | Canonical name list; membership asserted at `:172` |
+| Type-inference overload table | `relationalExtension.pure:189-~1400` | **158** unique names (163 `pair`s) | Return-type inference for View columns, test-data generation, result columns |
+| Default `dynaFnToSql` table | `extensionDefaults.pure:186-305` | **113** | Base SQL rendering, per generation state |
+| Grammar operator sugar | walker `:799-843` + composer `:82-200` | **12** | Infix notation and round-trip |
+| Boolean-valued classification | `dbExtension.pure:801-806` | 25 | **Not an allow-list.** Decides which functions are predicates, for `maybeWrapAsBooleanOperation` |
+
+The type-inference map has five duplicate keys — `corr`, `covarPopulation`, `covarSample`,
+`mod`, `mostRecentDayOfWeek` — which is why 163 `pair` entries yield 158 unique names. `PureMap`
+is backed by an eclipse-collections `MutableMap`, which strongly suggests `newMap()` is
+last-write-wins and silent; if so, one entire `list([...])` of inference rules for each of those
+five names is unreachable dead code. **Confirm `newMap`'s duplicate-key semantics before acting
+on this** — it is a check to run, not yet a finding. If confirmed it is a small, clean,
+fully independent fix.
+
+A further, independent name-keyed dispatch exists on the newer SQL-dialect-translation path:
+`sqlDialectTranslation/toPostgresModel.pure`, `convertDynaFunction` (`:251-266`) and
+`getDynaFunctionConverterMap` (`:268-465`). It is the only one that self-validates — at
+`:454-461` it asserts every key it holds is present in `DynaFunctionRegistry`.
+
+---
+
+## 8. Error taxonomy — six ways this fails, none at compile time
+
+| # | Trigger | Where | Message |
+|---|---|---|---|
+| 1 | Name not in the registry | `dbExtension.pure:172` | `dyna function [X] is not registered in meta::relational::functions::sqlQueryToString::DynaFunctionRegistry` |
+| 2 | Registered, but no handler for this dialect + generation state (or two handlers match) | `dbExtension.pure:1033` | `[unsupported-api] The function 'X' (state: [Select, false]) is not supported yet` |
+| 3 | Wrong arity | *nowhere* — falls through to `format(...)` at `:1054` | a generic `%s`-count error from `meta::pure::functions::string::format` |
+| 4 | Wrong arity for one of the 12 sugared names, on compose | `HelperRelationalGrammarComposer:82-200` | a **comment string emitted into the grammar** — see §9.1 |
+| 5 | Unknown name on the SQL-dialect-translation path | `toPostgresModel.pure:264` | `Couldn't find DynaFunction to Postgres model translation for X().` |
+| 6 | Type inference has no matching overload | `relationalExtension.pure:116` | `Type inference not supported yet! Dyna function: X` |
+
+None of these is an `EngineException`. None carries `SourceInformation`. Rows 1, 2, 3, 5 and 6
+surface at **plan generation**, long after the model compiled cleanly — which contradicts the
+error convention in [Coding Standards](../standards/coding-standards.md). Row 4 is worse: it
+does not surface at all (§9.1).
+
+The only per-function arity assertions in the entire codebase are ad hoc:
+
+- `processExtractFromSemiStructured` — `dbExtension.pure:897`:
+  `assertSize($params, 3, $func.name + ' takes 3 arguments, was called with N instead')`,
+  plus a path-regex assert `:903` and a type-name whitelist `:906`.
+- `isDistinct` — `extensionDefaults.pure:228`.
+- `date` and `dayOfWeekNumber` on the Postgres-model path — `toPostgresModel.pure:590`, `:560`.
+- The `ToSql` class constraint `dbExtension.pure:1060` and the `parametersWithinWhenClause`
+  count check `:1034` — structural, not per-function.
+
+---
+
+## 9. Known defects
+
+### 9.1 Silent model corruption on round-trip
+
+This is the most serious defect in this area.
+
+`HelperRelationalGrammarComposer.renderDynaFunc` (`:82-200`) is the only place in the whole
+pipeline that checks dyna function arity — and when the check fails it *returns a comment
+string as the rendered operation*:
+
+```java
+// HelperRelationalGrammarComposer.java:138-145
+case "equal":
+{
+    if (dynaFunc.parameters.size() != 2)
+    {
+        return "/* Unable to transform operation: exactly 2 parameters are expected for '=' operation */";
+    }
+    return renderRelationalOperationElement(dynaFunc.parameters.get(0), context)
+           + " = " + renderRelationalOperationElement(dynaFunc.parameters.get(1), context);
+}
+```
+
+The same pattern appears for `group` (`:95`), `isNull` (`:124`), `isNotNull` (`:132`),
+`greaterThan` (`:148`), `lessThan` (`:156`), `greaterThanEqual` (`:164`), `lessThanEqual`
+(`:172`), `notEqual` (`:180`) and `notEqualAnsi` (`:188`).
+
+Repro shape: a `PureModelContextData` containing
+`DynaFunc{funcName: "equal", parameters: [<one element>]}` — reachable via the protocol API,
+or via any producer that builds `DynaFunc` objects directly — composed back to grammar. The
+resulting Database body contains a comment where a predicate used to be:
+
+```
+Join Firm_Person(/* Unable to transform operation: exactly 2 parameters are expected for '=' operation */)
+```
+
+That text then re-parses as an empty join condition. No error is raised at any point.
+
+The Pure-side composer has the same design plus a copy-paste bug:
+`grammarSerializerExtension.pure:263`, where `dynaFunc1`'s assert message says *"exactly 2
+parameters"* while the check is `size() == 1`.
+
+### 9.2 Exceptions without source information
+
+- `HelperRelationalBuilder:869` — the `instanceof` chain's fallthrough throws a bare
+  `UnsupportedOperationException`.
+- `HelperRelationalBuilder:653` and `:728` cast the compiled operation to `(Operation)`.
+  `DynaFunction` extends `Operation`, so dyna functions are fine — but a `Filter` or `Join`
+  whose top-level operation is a `Literal`, `TableAliasColumn` or `ElementWithJoins` throws a
+  bare `ClassCastException` with no source information.
+
+### 9.3 Duplicated grammar implementations
+
+A second, independent `###Relational` parser and composer live upstream in the
+`legend-pure-m2-store-relational-grammar` jar, and a second composer lives in-repo at
+`grammarSerializerExtension.pure`. Any grammar-layer change has to be made in more than one
+place or the implementations diverge.
+
+---
+
+## 10. Proposal — parameter validation
+
+### 10.1 The seam
+
+The constraint that makes a naive "validate the name at compile time" proposal wrong is that
+the dyna function registry has **three producers**, not one:
+
+1. **Engine protocol path** — a modeller authors `###Relational` text, the engine parses it to
+   protocol `DynaFunc` objects, and `HelperRelationalBuilder` compiles them. This document's
+   main subject.
+2. **Router synthesis** — the router constructs `^DynaFunction(...)` directly in Pure against
+   the M3 metamodel while translating Pure to SQL (`pureToSQLQuery.pure`, `calendarFunctions.pure`,
+   `milestoning.pure`, graphFetch, postprocessors). These legitimately use names, shapes and
+   arities no human writes. `pair` (`pureToSQLQuery.pure:4007`) is the clean example: a
+   registered name that exists only to carry a tuple between router stages.
+3. **Upstream Pure grammar** — `###Relational` written in a `.pure` source file is parsed by an
+   independent ANTLR implementation in the `legend-pure-m2-store-relational-grammar` jar, which
+   builds the M3 `Database` graph **without ever entering engine Java**. This is not a corner
+   case: `core_relational` alone ships **91** `.pure` files containing `###Relational` Database
+   definitions, and it declares that jar as both a Pure-repo and a Maven dependency
+   (`legend-engine-xt-relationalStore-core-pure/pom.xml:46`, `:170`).
+
+Validation must cover producers 1 and 3 without constraining producer 2.
+
+**The seam between 1 and 2 is structural, and it is a language boundary.**
+Every call site of `HelperRelationalBuilder.processRelationalOperationElement` — joins `:653`,
+filters `:728`, View column mappings `:503`/`:506`, property mappings `:1069`/`:1805`, primary
+keys `:1159`, class-mapping groupBy (`RelationalCompilerExtension:314`) — consumes the
+**protocol** `DynaFunc` type. The router never produces protocol `DynaFunc`; it builds M3
+`DynaFunction` instances in Pure. Nothing crosses. A check installed on the protocol → graph
+path is therefore *structurally incapable* of seeing a router-generated dyna function. That
+means it:
+
+- applies to exactly the human-authored operations, and nothing else;
+- needs **no** feature flag and no `callingFromFilter`-style context threading;
+- needs **no** protocol change, so no new `v1_XX` sub-package and no transfer function;
+- can raise a proper `EngineException` with the `SourceInformation` that
+  `DynaFunc.sourceInformation` already carries (set at `RelationalParseTreeWalker:848`) and that
+  survives into M3 (`HelperRelationalBuilder:855` passes `m3SourceInformation` into the
+  `DynaFunction` constructor).
+
+That last point is the practical win: the same mistake that today produces
+`[unsupported-api] The function 'X' … is not supported yet` at plan generation would produce
+a compile error pointing at the exact character offset in the `Filter`.
+
+**Producer 3 is why the check should not live only in Java.** A Java-side validator is blind
+to `.pure`-source databases. Put the checking *algorithm* in a Pure function over the M3 graph
+— walking `db._joins()._operation()`, `db._filters()._operation()` and view column mappings —
+and make the Java validator a thin adapter that calls it and converts issues to `Warning` /
+`EngineException` via `SourceInformationHelper.fromM3SourceInformation`, exactly as the
+existing `sqlNull` warning does (`RelationalValidator:250-254`). A `core_relational` Pure test
+can then sweep every `Database` in the graph through the identical rules, closing producer 3
+without any change to the upstream jar.
+
+### 10.2 Why the existing overload table is not enough
+
+`getDynaFunctionTypeInferenceMap` (`relationalExtension.pure:189+`) keys a list of
+(guard predicate, return-type function) pairs by function name, which *looks* like a
+signature table:
+
+```pure
+Map<String, List<Pair<Function<{RelationalOperationElement[*] -> Boolean[1]}>,
+                      Function<{RelationalOperationElement[*] -> DataType[0..1]}>>>>
+```
+
+It is not one. Of the 364 lambdas in it, **150 guards are literally `true`**, and only 13
+mention `->size()` at all. `abs` is `{params | true}`; `add` indexes `$params->at(0)` and
+`->at(1)`, so a wrong-arity call dies with a Pure index error rather than a diagnostic. And
+the map is consumed only for View column typing, test-data generation and result-column
+typing (`relationalMappingExecution.pure:207`, `testDataGeneration.pure:440`, `:912`, `:1156`)
+— never for filters, never for joins, never for validation.
+
+So the parameter contract has to be **added**, not merely surfaced. That is the main cost of
+this proposal and should be planned for as such.
+
+### 10.3 Recommended shape — mirror `SqlFunction`, do not reuse it
+
+The newer SQL-dialect-translation subsystem already has a well-designed function descriptor, at
+`.../legend-engine-xt-relationalStore-sqlDialectTranslation-pure/.../functionRegistry/functionRegistry.pure`:
+
+```pure
+Class <<typemodifiers.abstract>> …::functionRegistry::SqlFunction
+{
+  name          : String[*];
+  variations    : SqlFunctionVariation[1..*];
+  tests         : SqlFunctionTest[1..*];
+  documentation : String[1];              // mandatory
+}
+
+Class …::functionRegistry::SqlFunctionVariation
+{
+  parameterTypes : Class<SqlType>[*];
+  returnType     : Class<SqlType>[1];
+  documentation  : String[0..1];
+  identifier()   { … }: String[1];
+}
+
+Class …::functionRegistry::VariadicSqlFunctionVariation extends SqlFunctionVariation
+[ hasAtLeastOneArgument: … ]
+```
+
+Copy this **shape** — mandatory `documentation`, one-or-more typed variations, a variadic
+subclass, tests attached to the declaration. Do **not** reuse the types themselves:
+
+- `SqlFunctionVariation.parameterTypes` is `Class<SqlType>[*]`, typed in **postgres-model
+  SqlTypes**. The dyna path's types are `meta::relational::metamodel::datatype::*`. Wrong type
+  lattice.
+- `sqlFunctionRegistry()` is keyed by `Class<SqlFunction>`; dyna functions are keyed by
+  `String` name, and ~118 dyna names have no `SqlFunction` to hang off.
+- A fixed `parameterTypes` list cannot express what actually matters when validating authored
+  grammar: "arity 2 or 3", "argument 1 must be a column reference", "argument 2 must be a
+  string literal from a fixed domain" (`mostRecentDayOfWeek`).
+- `VariadicSqlFunctionVariation`'s only constraint, `hasAtLeastOneArgument`, `println`s rather
+  than failing — not a foundation for compile-time errors.
+
+So: a dyna-specific descriptor table, living beside `dbExtension.pure` in `core_relational` so
+that both the Java compiler and the Pure sweep can reach it. It should carry name, arity, and
+argument *kind* (column reference / literal / literal list / nested operation / join chain);
+keep `SqlFunction`'s **mandatory `documentation`**, which is what makes §11 self-documenting
+rather than a bare pass/fail grid; and add one field `SqlFunction` has no need for:
+
+- **`producers`** — `Grammar`, `Router`, or both. This expresses the §10.1 seam *in data* as a
+  second line of defence: `pair` declares `Router` only, so grammar-authored use is reported,
+  while router use is unaffected because it never reaches the validator.
+
+Derive everything else from that table: registry membership, the documentation catalogue, and
+the test table of §11.
+
+Start with the names actually reachable from the DSL, not all 231. The 12 sugared names plus
+the 10 empirically used ones (§6.2) is a tractable first tranche and covers the overwhelming
+majority of real filters and joins.
+
+**Be honest about the ceiling.** Name existence, arity, argument kind, literal domains and
+producer are all achievable. **Relational datatype checking is not** — verifying that
+`add(col, 'x')` is type-consistent needs the return type of nested dyna functions, which means
+`getDynaFunctionTypeInferenceMap`, which covers only 158 of 231 names. Datatype validation is
+gated on closing that gap; do not promise it in an early phase.
+
+**Keep the lookup cheap.** Materialising a 231-entry descriptor map through the generated
+`core_relational_*` statics on every `Database` compile is on the hot compile path. Memoize it
+— once per `PureModel`, keyed by name into a map — and measure rather than assume.
+
+### 10.4 Rollout must be warning-first
+
+Models in the wild may already contain names or arities that a new check would reject, and a
+compile error on an existing model is an outage. Stage it:
+
+1. **Warn.** Emit `pureModel.addWarnings(...)` with `SourceInformation`, using
+   `RelationalValidator:250-254` as the working precedent. Ship, then watch.
+2. **Error.** Promote to `EngineException` with `EngineErrorType.COMPILATION` once the warning
+   is quiet across CI and known model corpora.
+3. **Keep one escape hatch**, keyed off the same declaration table — a name may be declared
+   "known, unvalidated" so that adding a function is never blocked on writing its signature.
+
+Names with no declaration should warn, never hard-fail, until step 2 — otherwise every
+router-adjacent or externally-produced model becomes uncompilable on upgrade.
+
+Promote in this order: **unknown name first**, then arity, then argument kind. Unknown name is
+already a hard failure today (`dbExtension.pure:172`) — just a late, source-info-less one — so
+promoting it moves an existing failure earlier and cannot break a model that works now. Arity
+and kind are genuinely new judgements and will be wrong on some of the long tail; they should
+sit as warnings for at least one release while the descriptor table is corrected against real
+models.
+
+**One backwards-compatibility trap.** A deployment may load a custom `DbExtension` that
+registers dyna names outside the core enum, and those models work today. So "unknown name" must
+mean *absent from the enum **and** from every loaded `DbExtension`'s dispatch table* — not
+merely absent from the enum. Pair this with a severity flag
+(`off` / `warn` / `strict`) so a deployment blocked by a bad descriptor can downgrade without a
+rollback.
+
+**Sync is one test, not a process.** A Pure test asserting
+`DynaFunctionRegistry->enumValues().name->sort() == descriptors().name->sort()` makes
+divergence impossible rather than merely discouraged: adding an enum value without a descriptor
+fails the build, and so does the reverse. Java should read the canonical name set from the enum
+at runtime (`PureModel.getEnumeration(...)`) rather than keeping a duplicate list.
+
+---
+
+
+## 11. Proposal — test coverage that documents itself
+
+### 11.1 Scope: parse, compile, valid — deliberately not per-dialect
+
+The goal is narrow and worth stating precisely, because it determines the whole design:
+
+> For every dyna function, one checked-in row asserting that a canonical `###Relational`
+> snippet using it **parses**, **compiles**, and produces **no unexpected errors or warnings**.
+
+Not covered by *this* layer: whether a function renders on any particular dialect, which would
+need a live server per dialect and a per-dialect exclusion manifest. A second, complementary
+layer covering **execution on DuckDB** now exists — see §11.6. §11.5 states the residual risk
+that remains after both.
+
+PCT is also the wrong vehicle, for a structural reason rather than a scoping one. PCT starts
+from a `<<PCT.test>>` **Pure function** and asserts every adapter produces the same answer. A
+dyna function written in a Database `Filter` has no Pure function in front of it — it is a
+store-level operation, unreachable from any `meta::pure::functions::*` entry point. PCT cannot
+enumerate this surface at all.
+
+### 11.2 Both harnesses already exist
+
+Nothing new needs building. Two existing classes cover the two levels.
+
+**Level 1 — the operation in isolation.** `TestRelationalOperationElementGrammarRoundtrip`
+(`:37-60`) parses a bare operation, round-trips it through protocol JSON, composes it back, and
+asserts the text is unchanged:
+
+```java
+protected static void test(String val, String expectedErrorMsg)
+{
+    RelationalOperationElement op = RelationalGrammarParserExtension
+            .parseRelationalOperationElement(val, "", 0, 0, true);
+    String json = objectMapper.writeValueAsString(op);
+    operation = objectMapper.readValue(json, RelationalOperationElement.class);
+    …
+    Assert.assertEquals(null, val, renderedOperation);
+}
+```
+
+This is the cheapest possible check and it catches the §9.1 corruption directly — a wrong-arity
+operation must produce an error, not a comment string. It has **one** test case today (`:63`).
+
+> **Fix its error path first.** The compose call and the final `assertEquals` run
+> *unconditionally* after a caught parse error, when `operation` is still `null`.
+> `renderRelationalOperationElement(null, …)` falls through every `instanceof` to
+> `PureGrammarComposerUtility.unsupported(op.getClass(), …)` and throws an NPE; even surviving
+> that, `assertEquals(val, null)` fails. So today only the round-trips-cleanly case works and
+> the `expectedErrorMsg` parameter is effectively dead — which is why the class has exactly one
+> test. Guarding the compose on `operation != null` is a two-line change.
+
+**Level 2 — the operation inside a real `Database`, compiled.**
+`TestRelationalCompilationFromGrammar` already extends
+`TestCompilationFromGrammar.TestCompilationFromGrammarTestSuite`, whose `test` helper is
+exactly the "parses, compiles, and is valid" assertion:
+
+```java
+// TestCompilationFromGrammar.java:84
+public static Pair<PureModelContextData, PureModel> test(
+        String str, String expectedErrorMsg, List<String> expectedWarnings)
+{
+    PureModelContextData modelData = PureGrammarParser.newInstance().parseModel(str);
+    // full JSON re-serialisation round-trip when no error is expected
+    …
+    PureModel pureModel = Compiler.compile(modelData, DeploymentMode.TEST, …);
+    modelData.getElements().parallelStream().forEach(pureModel::getPackageableElement);
+    if (expectedErrorMsg != null) { Assert.fail("Expected compilation error …"); }
+    if (expectedWarnings == null)
+    {
+        Assert.assertTrue("expected no warnings but found …", pureModel.getDefects().isEmpty());
+    }
+    …
+}
+```
+
+It parses, re-serialises the protocol through JSON, compiles to a `PureModel`, forces every
+element to be built, and asserts **no defects** unless the row declares them. That is the
+definition of "valid" this proposal needs, already written and already used by 4,800 lines of
+relational compilation tests.
+
+The `expectedWarnings` parameter matters more than it looks — see §11.4.
+
+### 11.3 The table
+
+One row per dyna function, in `TestRelationalCompilationFromGrammar` (or a focused sibling
+class), each row a small self-contained `Database`:
+
+```java
+test("###Relational\n" +
+     "Database test::db\n" +
+     "(\n" +
+     "  Table firmTable (ID INT PRIMARY KEY, LEGALNAME VARCHAR(200))\n" +
+     "  Filter f_in(in(firmTable.LEGALNAME, ['Firm A', 'Firm C']))\n" +
+     ")\n");
+```
+
+That snippet is modelled on the working fixture at
+`tests/mapping/inClause/testInClauseForJoinsAndFilters.pure:78`, so the shape is known to
+parse and compile. Add the Level-1 round-trip row alongside it where the function has operator
+sugar. Properties that follow:
+
+- **The table is the documentation of the authoring surface.** It is the only place that says,
+  in copy-pasteable form, how each dyna function is actually written — including the
+  `functionOperationArgumentArray` (`[…]`) form, the `{target}` self-join notation, and which
+  functions need the `= 'true'` boolean-coercion idiom of §5.
+- **Coverage is enforced, not aspirational.** A name in the declaration table of §10.3 with no
+  row fails the build, so the catalogue and its examples cannot drift apart.
+- **Failure rows are documentation too.** A function that is *not* meant to be authorable —
+  `pair`, and anything else declaring `producers = [Router]` — gets a row with an
+  `expectedErrorMsg`, which records the intent in an executable form.
+
+Cost is close to zero: no new module, no new framework, no test server, two existing classes.
+
+### 11.4 The catch: this only documents *support* once §10 lands
+
+This must be stated plainly or the suite will be over-trusted.
+
+Today the compiler validates nothing (§3, §4). So
+`Filter f(bogusFunc(t.a, t.b, t.c))` **passes** a parse-and-compile test. Right now the table
+proves that a snippet is syntactically well-formed and survives protocol round-tripping — real
+value, and it locks in the §9.1 fix — but it says nothing about whether the function works.
+
+The two become the same thing only after §10's validation exists. Then:
+
+- an unknown or wrongly-shaped dyna function fails to compile, so a passing row genuinely means
+  "this is a supported way to write this function";
+- `expectedWarnings` carries the warning-first rollout of §10.4 directly: during the warn stage
+  a row records the exact warning text, and promoting to an error is a mechanical edit from
+  `expectedWarnings` to `expectedErrorMsg` — the diff *is* the changelog of what got stricter.
+
+Practical consequence for sequencing: build the table **with** the validation work, not before
+it. Ahead of validation it is a syntax catalogue; after, it is the support contract.
+
+### 11.5 What this leaves uncovered
+
+Skipping per-dialect testing is a reasonable trade, but it leaves one real gap, and the
+document should not pretend otherwise: **compiling successfully does not mean the query will
+run.** Failure modes 2 and 6 of §8 — `[unsupported-api] The function 'X' … is not supported
+yet`, and missing type inference — are inherently per-dialect and per-generation-state, and no
+amount of parse-and-compile testing detects them. A `Filter` using a function that H2 renders
+and Redshift does not will pass every row in this suite and fail at plan generation against
+Redshift.
+
+If that risk ever needs closing, the cheap version does not require test servers: the
+per-dialect dispatcher tables are ordinary Pure maps, so a build-time test can reflect over
+`DynaFunctionRegistry->enumValues()` against each dialect's dispatcher and assert renderability
+statically. The idiom is already proven at `debugPrintExtension.pure:261-268`. That is a
+strictly additive follow-on, not a prerequisite, and it is out of scope here.
+
+**Update:** the risk is now closed *for DuckDB* by the execution layer in §11.6. Every other
+dialect remains uncovered.
+
+### 11.6 Execution layer — EMIT on DuckDB
+
+`legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/duckdb-dyna-semistructured`
+executes dyna functions against a real, in-process DuckDB.
+
+**How DuckDB is selected.** EMIT names no database anywhere — not in the `.emit.yaml`, not in
+the runner. `RelationalConnectionFactory:187-189` picks DuckDB when `hints.isRelation()`, and
+that hint comes from the *return type of the test-suite query*
+(`MappingTestRunner:534-538` → `TestReturnTypeHelper.isRelationReturnType`). A query written
+`->project([...], ['names'])` returns a TDS and gets H2; one written `->project(~[...])`
+returns a `Relation` and gets DuckDB. No framework change is needed — only the query form.
+
+That silent-fallback risk is real, so the model pins it down: it maps a property with `toJson`,
+which has **no H2 rendering at all**. If the suite ever reverted to H2 the test would fail with
+`[unsupported-api]` rather than passing quietly.
+
+What it covers that nothing else did:
+
+| | Notes |
+|---|---|
+| First emit model on DuckDB | the other 55 are all H2 |
+| First `SEMISTRUCTURED` column in emit | becomes DuckDB `JSON` (`typeConversion.pure:78`) |
+| Array indexing `orders[0].price` | the path regex always allowed `[n]`; nothing used it |
+| Nested indexing `matrix[0][1]`, `items[0].tags[1]` | consecutive indices, and index→property→index |
+| Dyna function inside a `Filter` predicate | no `Filter` in the emit corpus does this |
+
+**Seed data.** JSON goes into a `Relation #{ … }#` block as CSV with doubled double-quotes
+(`1,"{""legalName"":""Firm X""}"`). Expected JSON in an `EqualToJson` assert is a *Pure string
+literal*, so a quote inside it needs `\\"` to survive both layers — the double-escaping is
+easy to get wrong and the model demonstrates the working form.
+
+### 11.7 Arrays and lateral flatten — what works, and the narrow gap
+
+Array flattening from the Database DSL **already works**. The gap is narrower than it looks, and
+sits in *where* you may write the call rather than in missing machinery.
+
+**The lowering exists.** `applyJoinWithExplodeInCondition`
+(`pureToSQLQuery.pure:9229-9337`, triggered at `:9159` by `explodeInCurrentJoinOperation`)
+rewrites a grammar-authored `explodeSemiStructured` into a `SemiStructuredArrayFlatten` relation,
+a `JoinTreeNode(lateral = true)`, and a `SemiStructuredArrayFlattenOutput` column named `VALUE`,
+then substitutes the dyna node out of the predicate (`:9288`). After lowering the outer predicate
+sees an ordinary subquery column, not a dyna function.
+
+**So array-backed `[*]` properties are authorable today.**
+`core_relational/relational/tests/semistructured/model/explodeSemiStructuredMapping.legend`
+maps `trades: trade[*]`, `orders: order[*]` and a chained-join `products: String[*]`
+(`:51-53`, `:215-217`) through joins whose conditions explode a JSON array (`:119-122`):
+
+```
+Join Block_Trade(extractFromSemiStructured(explodeSemiStructured(Semistructured.Blocks.BLOCKDATA,
+    'relatedEntities', 'SEMISTRUCTURED'), 'tag', 'VARCHAR') = 'trade' and …)
+```
+
+The property mapping itself is unchanged from the ordinary one-to-many form —
+`prop[setId]: [store]@JoinName`.
+
+**What is actually still missing:**
+
+| Gap | Where |
+|---|---|
+| Flatten fires **only** inside a `Join` operation | In a `View` column or `Filter`, `explodeSemiStructured` reaches `processDynaFunction` (`dbExtension.pure:869-899`, where it is deliberately absent), finds no `dynaFnToSql`, and fails |
+| One explode per join | `assert($allExplodeCalls->size() == 1, …)` `:9236` — in-source comment: *"needs to be relaxed to support many-to-many"* |
+| No nested explosion | `assert(…instanceOf(TableAliasColumn), …)` `:9239` — the operand must be a plain column |
+| No array-valued scalar | `extractFromSemiStructured`'s whitelist (`dbExtension.pure:912`) admits no array/semi-structured return, so `array_*` stay unreachable outside the explode path |
+
+**Lateral is fully supported in the SQL layer, but not equally.** `JoinTreeNode.lateral`
+(`relational.pure:155` in legend-pure 5.94.0) is set only by the planner — three sites, all in
+`pureToSQLQuery*` — and read only by emitters. Five dialects register a
+`DbExtension.lateralJoinProcessor`:
+
+| Dialect | Emits |
+|---|---|
+| DuckDB (`duckdbExtension.pure:39`, impl `:724-730`) | `, lateral <alias>` — comma-join form |
+| Snowflake / Databricks | `inner join lateral <alias>`, no `ON` |
+| **H2** (`h2Extension2_1_214.pure:32`, impl `:319-335`) | **no LATERAL at all** — a faked `left outer join … on ("a"."__INPUT__" = <navigation>)` |
+
+H2's emitter asserts the join operation is exactly `1 = 1` *and* the right side is a
+`SemiStructuredArrayFlatten`, so **H2 can only execute the flatten shape** — all seven
+`tests::lateral::*` / `flatten::testFlatten_LateralJoin*` PCT tests are expected failures there
+(`Cast exception: TableSubquery cannot be cast to SemiStructuredArrayFlatten`). DuckDB passes
+every one: zero `lateral` entries across its PCT manifests.
+
+Note there are **two** SQL emitters — `sqlQueryToString`'s `DbExtension` hook and
+`sqlDialectTranslation`'s `NodeProcessor<LateralJoin>` — and only H2 implements the second.
+Any authoring feature has to be rendered in both.
+
+**Authoring a lateral join** would be grammar + compiler work only: no `lateral` token exists in
+`RelationalParserGrammar.g4`, `Join` carries no lateral flag, and there is no protocol field —
+but the metamodel already has one, so nothing upstream needs to change. `TabularFunction`
+(`c3ba1be1e92`) is the precedent for shipping such syntax engine-first: its token is absent from
+the upstream `legend-pure-m2-store-relational-grammar` parser.
+
+**Higher-order array functions already push down.** `map` / `filter` / `fold` over a Variant
+array are not dyna functions — they become `MapRelationalLambda` / `FilterRelationalLambda` /
+`FoldRelationalLambda` (`pureToSQLQuery_variant.pure:669`, `:820`, `:636`) and render on DuckDB as
+`apply(arr, lambda x : …)`, `filter(arr, lambda x : …)`, `reduce(arr, lambda acc, x : …, init)`
+(`duckdbExtension.pure:685-722`). They are reachable from the **Pure/relation** path only; the
+operation grammar has no lambda (`functionOperationArgument: operation | functionOperationArgumentArray`),
+so they cannot be written in a `Filter` or `View`. They are also unreachable from a
+*class-mapping* query — routing a Variant navigation through a mapped class fails with
+`Error mapping not found for class Map`; the working vehicle is a relation-store accessor
+(`#>{DB.TABLE}#`), where the array work happens inside the relation source.
+
+---
+
+## 12. Phased roadmap
+
+**Phase 0 — Publish and instrument.** This document. Add the cross-check tests that turn
+implicit drift into reviewable data: default `dynaFnToSql` ⊆ enum, each per-dialect union ⊆
+enum, type-inference keys ⊆ enum with the 73-name delta emitted as a named gap list. Confirm
+the `newMap` duplicate-key question (§7) and fix the five duplicates if it holds. Fix the bare
+`UnsupportedOperationException` (`HelperRelationalBuilder:869`) and the unguarded `(Operation)`
+casts (`:653`, `:728`) to typed `EngineException`s with `SourceInformation`. Zero behaviour
+change beyond error quality, zero dependencies, and it establishes the true size of the gap
+before anyone commits to filling it.
+
+**Phase 1 — Make failures diagnosable.** Convert the plan-generation asserts (§8, rows 1, 2, 5
+and 6) to carry `SourceInformation` and surface as `EngineException`. Fix §9.1 so a composer arity
+mismatch fails loudly instead of writing a comment into the model — in **both** composers, the
+Java one and `grammarSerializerExtension.pure:228-266`, or they drift further apart. No new
+contracts required; this is the highest value-per-risk phase and should not wait behind the
+contract work.
+
+**Phase 2 — Declare contracts, with the table.** Add the descriptor table (§10.3) for the
+Database-DSL-reachable names, with the enum ↔ descriptor sync test. Put the checking algorithm
+in Pure, wire the Java adapter from the Database processor pass that populates `_operation()`,
+and emit **warnings only** (§10.4). Build the §11.3 parse-and-compile table in the *same*
+change: per §11.4 the table only documents support once validation exists, so the two belong
+together — each declaration lands with its documentation, its example, and its test row.
+
+**Phase 3 — Enforce.** Promote warnings to errors in the §10.4 order, which for the test suite
+is a mechanical `expectedWarnings` → `expectedErrorMsg` edit per row. Then collapse the §7
+registries onto the declaration table only if Phase 2 has shown the descriptor shape covers the
+real cases — see §13 for why unification may not be worth doing at all.
+
+Each phase is independently shippable and independently valuable: Phase 0 fixes bugs and makes
+the gap visible, Phase 1 puts errors in the right place, Phase 2 gives authors feedback in
+Studio plus an executable catalogue of how each function is written, and Phase 3 makes the
+catalogue binding.
+
+---
+
+## 13. Risks and open questions
+
+**Should the four registries actually be unified?** The tempting answer is yes; the honest
+answer is probably no. They are not four copies of one thing — they answer four different
+questions ("does this name exist", "what does it return", "how does it render in ANSI-ish SQL",
+"how does it render *here*"). Collapsing them would force every dialect to declare an opinion
+about all 231 names, which is both false and a large mechanical change with no user-visible
+benefit: the per-dialect variation *is* the product. Prefer declaring `DynaFunctionRegistry`
+canonical, adding the subset-check tests of Phase 0, and publishing the deltas as data.
+
+**Two ANTLR implementations of one language, with no conformance test.** The engine grammar and
+the upstream `legend-pure-m2-store-relational-grammar` grammar are independent implementations
+of `###Relational`. §10.1's Pure-side check closes the validation gap, but only if someone runs
+the sweep. The standing risk is larger than dyna functions: a future engine-side grammar change
+can add syntax the upstream parser rejects, and nothing would catch it.
+
+**Descriptor accuracy for the long tail.** Roughly 73 of the 231 names have no type-inference
+entry and thin real-world usage. Descriptors written by reading `dynaFnToSql` format strings
+will be wrong for some of them. Warning-only rollout is the mitigation; the risk is that nobody
+reads the warnings and a later phase promotes a wrong rule to an error.
+
+**Open questions**
+
+- **Should unregistered names ever be permitted?** A store extension may want to introduce a
+  dyna function without touching the core enum. Today the enum is a hard gate at
+  `dbExtension.pure:172`, and §10.4 proposes consulting loaded `DbExtension`s as well. If
+  first-class extensibility matters, the descriptor table needs its own extension point.
+- **Is `producers` per-descriptor or per-signature?** Some names are legitimately both
+  grammar-authored and router-synthesised with *different* arities — `case` is one. Per-signature
+  is more correct and more expensive.
+- **How much of the 118-name dialect-only gap is intentional?** Some entries are genuinely
+  dialect-specific; others are almost certainly unfinished. Nothing in the proposed test scope
+  distinguishes the two — that is the deliberate omission of §11.5, and closing it needs the
+  static renderability sweep described there.
+- **Who writes the documentation strings?** If `documentation` is mandatory on the descriptor,
+  that is ~22 prose entries for the first tranche and eventually 231. It is the largest chunk of
+  the contract work and the highest-value output; it probably warrants its own sub-phase with
+  several contributors.
+- **Is the `withNoDynaFunctionNames()` asymmetry (§2.4) intentional or calcified?** The comment
+  at `HelperRelationalGrammarComposer.java:85` says intentional. Worth confirming before anyone
+  "fixes" it, because it affects whether composer unification should also unify rendering.
+
+---
+
+## 14. See also
+
+| Document | Relevance |
+|---|---|
+| [Router & Pure-to-SQL](router-and-pure-to-sql.md) §5.3–5.7 | `DbExtension`, `DynaFunctionToSql` dispatch, dialect registration, null-safe equality — the router-side producer |
+| [ModelJoin](model-join.md) | `mergeSQLQueryData` and `processDynaFunction` interaction |
+| [`docs/pct/wiring-howto.md`](../../pct/wiring-howto.md) `:47-60`, `:185-202` | Pure function → DynaFunction → SQL wiring, and the Postgres-model translation error |
+| [Coding Standards](../standards/coding-standards.md) | `EngineException` / `SourceInformation` conventions referenced in §8 |

--- a/docs/engineering/architecture/relational-dynafunctions.md
+++ b/docs/engineering/architecture/relational-dynafunctions.md
@@ -1085,7 +1085,7 @@ with `[]`:
 
 ```
 array_max(extractFromSemiStructured(TEAM_TABLE.SCORES, 'values', 'INTEGER[]'))
-tags: Binding TagBinding : extractFromSemiStructured(T.CONTENT, 'payload.tags', 'VARCHAR[]')
+tags: Binding TagBinding : extractFromSemiStructured(T.CONTENT, 'payload.tags', 'SEMISTRUCTURED[]')
 ```
 
 Before this, `extractFromSemiStructured` returned one of ten scalars or nothing. That single
@@ -1124,13 +1124,24 @@ are asserted in a mapping property, a filter predicate and a computed view colum
 `[*]` bindings in `relational-semistructured-binding-source` dropped `parseJson` while returning
 byte-identical results.
 
-**Not yet done.** Only DuckDB has the renderer branch — each dialect needs its own, and
-`sqlTextToRelationalDataTypeMap` still maps bare `'ARRAY'` to an element-less `Array()`. An array
-*of objects* is still not expressible: the whitelist admits scalars only, so `Tag[*]` is bound via
-`'VARCHAR[]'` and the elements are re-navigated as JSON text. Admitting a semi-structured element
-type would close that last case. `extractFromSemiStructured` and the `array_*` family also remain
-absent from `getDynaFunctionTypeInferenceMap` (`relationalExtension.pure:189`), so a view column
-built from them carries no inferred datatype — execution is unaffected.
+**`SEMISTRUCTURED` is a target type too**, and it is what the three dialects in the semi-structured
+suite needed. Declaring an extraction `'VARCHAR'` when it yields a *sub-document* is what broke
+bindings fed by a navigation: Snowflake rendered `to_varchar(get_path(...))` and its `GET` rejected
+the string, while Databricks silently produced nulls — the same defect wearing two faces, and its
+recorded reason on Databricks blamed "a binding-selection bug in the union router", which was
+wrong. Declaring `'SEMISTRUCTURED'` leaves the value a document and both pass. `'SEMISTRUCTURED[]'`
+composes for an array of documents, which is how a `[*]` binding types its elements without
+`parseJson`.
+
+That single whitelist entry retired four expected-failure records: two on Snowflake, leaving it
+with none, and two on Databricks.
+
+**Not yet done.** Renderer branches exist for DuckDB, Snowflake and Databricks; Postgres, MemSQL
+and ClickHouse have none, deliberately, since they are outside the parameterised suite and the
+code would be unverifiable. `sqlTextToRelationalDataTypeMap` still maps bare `'ARRAY'` to an
+element-less `Array()`, superseded by the `[]` form. `extractFromSemiStructured` and the `array_*`
+family remain absent from `getDynaFunctionTypeInferenceMap` (`relationalExtension.pure:189`), so a
+view column built from them carries no inferred datatype — execution is unaffected.
 
 **What a binding can be attached to.** The operation on the right of a `Binding` is not limited to
 a bare column, and the bound property is not limited to `[1]`. All of the following are supported

--- a/docs/engineering/architecture/relational-dynafunctions.md
+++ b/docs/engineering/architecture/relational-dynafunctions.md
@@ -1001,10 +1001,44 @@ every one of these.
    *Workaround, used by the model:* declare the fold as a derived property in `###Pure`, where the
    ordinary domain grammar applies, and project the derived property.
 
-2. **`sort` and `distinct` on a semi-structured array fail at the database.**
-   `Binder Error: No function matches the given name and argument types 'array_sort(INTEGER)'` —
-   the element is passed as a scalar where DuckDB needs a LIST. Same defect class as the
-   JSON-vs-LIST cast bugs in §11.7. Neither operation is covered anywhere in the repo.
+2. **Most array functions never reach their `array_*` dyna function — they silently flatten
+   instead.** This is the most consequential finding here, because three of the four affected
+   operations *return the right answer by the wrong route* and therefore look like passes.
+
+   The contract is that an operation on a semi-structured array lowers to the matching
+   `array_*` dyna function (`array_sort`, `array_max`, `array_distinct`, …). Reaching it
+   requires the processor to set `disableAutoFlatten`, so the array survives as one value
+   instead of being fanned into rows. `processVariantSize` does this, with the comment
+   *"disable auto-flatten so the array stays as a scalar column"*
+   (`pureToSQLQuery_variant.pure:354-357`). `processVariantSort` (`:345`),
+   `processVariantReverse` (`:349`) and `processVariantRemoveDuplicates` (`:427`) **do not** —
+   each calls `processDynaFunction` with `$state` unchanged.
+
+   `max`/`min` fail one level earlier: their dispatch entries (`pureToSQLQuery.pure:10101-10122`)
+   pair only with `isVariantInputWithInstanceValue`, and carry no `isSemiStructuredArrayInput`
+   guard of the kind `size` has at `:10163`. So they never reach `processVariantMax` on a bound
+   to-many property at all.
+
+   Observed on DuckDB:
+
+   | Expression | Outcome |
+   |---|---|
+   | `scores->sort()` | **error** — `No function matches ... 'array_sort(INTEGER)'` |
+   | `addresses->map(a\|$a.name)->sort()` | **error** — `array_sort(VARCHAR)` |
+   | `addresses->map(a\|$a.name)->distinct()` | **silent flatten** — 4 fanned rows, no `array_distinct` |
+   | `addresses->map(a\|$a.rank)->max()` | **silent flatten** — right value via SQL `max()` over flattened rows |
+
+   `sort` errors only because `array_sort` rejects a scalar; `distinct`, `max` and `min` are the
+   same defect without the safety net. **A passing result is not evidence the array path ran.**
+
+   Note an earlier reading of this — that the split was primitive vs Class element type
+   (`isClassType` in `isSemiStructuredArrayExpression:187`) — was **refuted by experiment**:
+   `sort` fails identically for `Integer[*]` and for a `String` chain rooted at a Class-typed
+   property. The cause is the missing guard, not the element type.
+
+   Fix shape: give the unguarded processors the same `effectiveState` guard `processVariantSize`
+   has, and add an `isSemiStructuredArrayInput` dispatch pair for `max`/`min`. Any new `array_*`
+   processor needs both, so this is worth a cross-check test rather than a one-off fix.
 
 3. **`first()` and `exists()` do not collapse the flatten** when applied directly to a bound
    to-many property. For a firm with three addresses, `addresses->first().name` returns **three**
@@ -1062,9 +1096,14 @@ before changing anything — the whole model is asserted on DuckDB here, which c
 containing a space and a dot; index-leading paths against an array-rooted document; four-level
 typed navigation through a binding, including an absent optional branch; primitive, object, and
 nested-inside-nested collections via implicit lateral flatten; `size`, `isEmpty`, `isNotEmpty`,
-`at`, `filter`, `map`, `fold` (via a derived property), and — new ground — **`max` and `min`**;
-explosion inside a join with a view supplying the exploded column; a join keyed on a scalar read
-out of a document; and every binding source form in the table above.
+`at`, `filter`, `map` and `fold` (the last via a derived property); explosion inside a join with a
+view supplying the exploded column; a join keyed on a scalar read out of a document; and every
+binding source form in the table above.
+
+`max` and `min` are asserted and return correct values, but per (2) they get there by flattening
+and aggregating in SQL rather than through `array_max`/`array_min`. The assertion is honest about
+the result and says nothing about the mechanism; treat those two as covered end-to-end and
+**uncovered at the dyna-function layer** until the dispatch guard is added.
 
 ---
 

--- a/docs/engineering/architecture/relational-dynafunctions.md
+++ b/docs/engineering/architecture/relational-dynafunctions.md
@@ -1078,38 +1078,59 @@ every one of these.
    `column "REFERENCE" must appear in the GROUP BY clause`. Either alone is fine — this is
    narrower than (4), which fails even when the aggregate is projected on its own.
 
-**Array functions in the store language — only `array_size` works.** This is the surface that
-matters most for the relational DSL: `array_*` written directly in a `Filter`, a `View` column, a
-`Join` condition or a mapping property, aggregating a JSON array in place with no row expansion.
-Twenty `array_*` names are registered in `DynaFunctionRegistry` and DuckDB renders all twenty, so
-they are all *authorable*. Only one of them executes.
+### 11.9 Array-typed extraction
 
-`array_size` works in all three positions, and is asserted in
-`relational-emit-models/relational-semistructured-store-arrays`. It works because its DuckDB
-renderer casts first — `ifnull(json_array_length(cast(%s as JSON)), 0)`
-(`duckdbExtension.pure:180`). Every other `array_*` renderer is a bare format string over the raw
-operand, so a `SEMISTRUCTURED` column reaches it as JSON where DuckDB wants a LIST:
+The store language can state that an extraction yields an **array**, by suffixing the target type
+with `[]`:
 
 ```
-array_max(TEAM_TABLE.SCORES)
-  -> Binder Error: No function matches ... 'array_aggregate(JSON, STRING_LITERAL)'
+array_max(extractFromSemiStructured(TEAM_TABLE.SCORES, 'values', 'INTEGER[]'))
+tags: Binding TagBinding : extractFromSemiStructured(T.CONTENT, 'payload.tags', 'VARCHAR[]')
 ```
 
-**The obvious fix is worse than the defect.** Casting to a JSON list inside the format string —
-`array_aggregate(cast(%s as JSON[]), 'max')` — parses and runs, and is **silently wrong**,
-because JSON elements compare lexicographically:
+Before this, `extractFromSemiStructured` returned one of ten scalars or nothing. That single
+restriction caused two apparently unrelated failures, because both need a typed list and neither
+could get one:
 
-| Rendering | `[9,100,20]` max |
+- **Every `array_*` function except `array_size` failed.** Twenty are registered with DuckDB
+  renderers, so all twenty are authorable; a `SEMISTRUCTURED` column reached them as JSON where
+  DuckDB wants a LIST — `array_aggregate(JSON, STRING_LITERAL)`. `array_size` was the exception
+  only because its renderer already cast (`json_array_length(cast(%s as JSON))`).
+- **A `[*]` binding needed `parseJson`** to re-type extracted text back into a document;
+  without it the flatten failed with `Cannot mix values of type "NULL"[] and VARCHAR in CASE`.
+
+**Why the element type has to be stated, not inferred.** A `DynaFunction` carries only a name and
+parameters (`HelperRelationalBuilder.java:853-856`) — no return type — and a `ToSql` `transform`
+receives already-rendered strings, so neither layer can recover it. Guessing is not an option
+either: casting blindly to a JSON list parses, runs, and is **silently wrong**, because JSON
+elements compare as text.
+
+| `[9,100,20]` max | |
 |---|---|
 | `cast(x as JSON[])` | **9** — lexicographic |
-| `cast(x as DOUBLE[])` | 100.0 — correct |
+| `cast(x as INTEGER[])` | 100 — correct |
 
-A correct rendering needs the *element type*, which a `ToSql` format string does not have; its
-`transform` hook receives already-rendered strings and cannot inspect the node. The fix therefore
-belongs in a processing function where the type is known — the shape `asListForDuckDB(element,
-sgc, elementType)` (`duckdbExtension.pure:699`) already uses for the flatten path. Note a numeric
-fixture can hide this: `[30,10,20]` yields the right answer lexicographically and only a case like
-`[9,100,20]` exposes it.
+A numeric fixture hides this: `[30,10,20]` gives the right answer lexicographically, and only a
+case like `[9,100,20]` — or `[5,12,7]`, whose text maximum is `"7"` — exposes it. Both are used in
+`relational-semistructured-store-arrays`.
+
+**What changed.** The type gate (`dbExtension.pure:913`) now strips a `[]` suffix and validates
+the element against the same ten scalars, so it stays strict. DuckDB's extraction renderer gained
+an array branch casting to a typed list, and its scalar and array branches now share one type
+mapping so they cannot drift apart.
+
+**What it unlocked, at the source rather than per function:** `array_max`/`array_min`/`array_size`
+are asserted in a mapping property, a filter predicate and a computed view column; and the two
+`[*]` bindings in `relational-semistructured-binding-source` dropped `parseJson` while returning
+byte-identical results.
+
+**Not yet done.** Only DuckDB has the renderer branch — each dialect needs its own, and
+`sqlTextToRelationalDataTypeMap` still maps bare `'ARRAY'` to an element-less `Array()`. An array
+*of objects* is still not expressible: the whitelist admits scalars only, so `Tag[*]` is bound via
+`'VARCHAR[]'` and the elements are re-navigated as JSON text. Admitting a semi-structured element
+type would close that last case. `extractFromSemiStructured` and the `array_*` family also remain
+absent from `getDynaFunctionTypeInferenceMap` (`relationalExtension.pure:189`), so a view column
+built from them carries no inferred datatype — execution is unaffected.
 
 **What a binding can be attached to.** The operation on the right of a `Binding` is not limited to
 a bare column, and the bound property is not limited to `[1]`. All of the following are supported
@@ -1127,6 +1148,12 @@ and now covered:
 The navigation form is what lets one class absorb documents of different shapes: a union whose
 legs bind at different depths — one navigating to a sub-document, the other binding the root —
 resolves onto a single class, and the query cannot tell the legs apart.
+
+**`parseJson` is optional for a `[1]` binding.** Binding a to-one property straight to a
+navigation works — `firm: Binding B : extractFromSemiStructured(COL, 'employment.firm',
+'VARCHAR')` — as the shipped union test does. A `[*]` binding used to require `parseJson` to
+re-type the extracted text into a document; with an array-typed extraction (§11.9) it no longer
+does. `parseJson` remains the right tool for JSON held in an ordinary VARCHAR column.
 
 **Follow-up — the Snowflake `GET` failure is most likely this same cast.**
 `Test_Relational_Snowflake_Semistructured` skips exactly two tests,

--- a/docs/engineering/architecture/relational-dynafunctions.md
+++ b/docs/engineering/architecture/relational-dynafunctions.md
@@ -1037,11 +1037,14 @@ every one of these.
    **Class**. So a primitive collection — `scores: Integer[*]` — fails the guard even once the
    processor sets it, and still flattens.
 
-   | Expression | Before guard | After guard |
+   | Expression | Today | With the guard set |
    |---|---|---|
    | `addresses->map(a\|$a.rank)->sort()` | error `array_sort(VARCHAR)` | **`[3,5,9]`** — array_sort ran |
    | `addresses->map(a\|$a.rank)->removeDuplicates()` | flattened silently | **`[9,3,5]`** — array_distinct ran |
    | `scores->sort()` (`Integer[*]`) | error `array_sort(INTEGER)` | error, unchanged |
+
+   The right-hand column was measured on DuckDB, not inferred: the guard was applied to all ten
+   processors and the results above observed. It is **not** shipped — see below.
 
    An intermediate reading recorded here — that the element type was irrelevant and the missing
    guard was the whole cause — was itself incomplete. Both readings were half right: the guard
@@ -1050,16 +1053,18 @@ every one of these.
    Note also that `distinct` is **not** an array operation: it is the TDS-level distinct that
    de-duplicates result rows. `removeDuplicates` is the one that lowers to `array_distinct`.
 
-   **Fixed** for the ten unconditionally-routed processors (`sort`, `reverse`,
-   `removeDuplicates`, `contains`, `slice`, `take`, `drop`, `last`, `init`, `tail`), which now
-   carry the same `effectiveState` guard `processVariantSize` has. When they engage, the column
-   holds the **whole array** rather than one row per element.
+   **Open, and tracked separately** — [#5114](https://github.com/finos/legend-engine/issues/5114).
+   The remedy is known and was measured: give the ten
+   unconditionally-routed processors (`sort`, `reverse`, `removeDuplicates`, `contains`, `slice`,
+   `take`, `drop`, `last`, `init`, `tail`) the same `effectiveState` guard `processVariantSize`
+   already has, so the column holds the **whole array** rather than one row per element. It is
+   not applied here because it changes the result of an existing Pure query on every relational
+   store, which belongs in its own changeset rather than riding on a store-language change.
 
-   **Still open:** (a) `max`/`min` need an `isSemiStructuredArrayInput` dispatch pair — a
-   behaviour change, deliberately not bundled with the guard fix; (b) primitive collections are
-   excluded by `isClassType`, so no array function reaches them. Since every future `array_*`
-   processor needs both the guard and a dispatch pair, a cross-check test asserting that is worth
-   more than further one-off fixes.
+   Two further gaps travel with it: `max`/`min` also need an `isSemiStructuredArrayInput`
+   dispatch pair, and primitive collections are excluded by `isClassType`, so no array function
+   reaches them at all. Since every `array_*` processor needs both the guard and a dispatch pair,
+   a cross-check test asserting that is worth more than ten one-off fixes.
 
 3. **`first()` and `exists()` do not collapse the flatten** when applied directly to a bound
    to-many property. For a firm with three addresses, `addresses->first().name` returns **three**

--- a/docs/engineering/architecture/relational-dynafunctions.md
+++ b/docs/engineering/architecture/relational-dynafunctions.md
@@ -1143,6 +1143,45 @@ element-less `Array()`, superseded by the `[]` form. `extractFromSemiStructured`
 family remain absent from `getDynaFunctionTypeInferenceMap` (`relationalExtension.pure:189`), so a
 view column built from them carries no inferred datatype — execution is unaffected.
 
+### 11.10 Lambdas in the store language
+
+`array_filter`, `array_transform` and `array_reduce` can be written in a store definition:
+
+```
+array_filter(extractFromSemiStructured(T.DOC, 'divisions', 'SEMISTRUCTURED[]'),
+             d | extractFromSemiStructured($d, 'headcount', 'INTEGER') > 100)
+array_transform(<collection>, d | <body>)
+array_reduce(<collection>, (d, acc | <body>), <seed>)
+```
+
+`$d` refers to the parameter; the sigil is needed because a bare identifier in an operation is
+already a column reference. Parentheses are required for more than one parameter so the names
+cannot read as further arguments, and a single parameter composes back bare. Reduce takes the
+element first and the accumulator second, as `fold` does in Pure.
+
+These build the **existing** `FilterRelationalLambda` / `MapRelationalLambda` /
+`FoldRelationalLambda` (`metamodel.pure:73-102`) that the Pure path already produces, so no SQL
+generation was written — DuckDB, Databricks and Snowflake render them today. Building anything new
+would also have escaped `reAliasQuery` and `milestoning`, which match on `RelationalLambda`.
+
+The parameter is derived entirely from the first argument, which is why no placeholder is needed:
+the renderers take `value` to be the *collection*, not the element, and the collection is that
+argument. Its declared type gives the element type. Consequently the first argument is restricted
+to an extraction or a plain column, both checked at compile time — a column is followed to its
+declaration and refused unless it is `SEMISTRUCTURED`, and an extraction must carry an array type
+or `SEMISTRUCTURED` (allowed unsuffixed, since that type means the shape is unknown and a document
+may be an array).
+
+**Folding documents into a non-string accumulator fails on DuckDB.** `buildFoldLambda` presents the
+elements *as the accumulator's type* — `cast(<collection> as <accumulator>[])` — which suits a fold
+building a string out of documents, the shape the parameterised suite exercises. Summing a number
+out of documents casts the objects whole and fails with `Failed to cast value to numerical`. This
+is pre-existing and reachable from the Pure path too; folding a scalar array is unaffected. A fix
+means keeping the collection at its element type and casting per element in the body.
+
+**Not accepted upstream.** `legend-pure-m2-store-relational-grammar` does not parse this syntax, a
+known gap taken deliberately, as with `TabularFunction`.
+
 **What a binding can be attached to.** The operation on the right of a `Binding` is not limited to
 a bare column, and the bound property is not limited to `[1]`. All of the following are supported
 and now covered:

--- a/docs/engineering/architecture/relational-dynafunctions.md
+++ b/docs/engineering/architecture/relational-dynafunctions.md
@@ -1456,6 +1456,14 @@ unknown dyna name, which already fails, this case *succeeded* — so by §10.4's
 kind of change that would normally warn first. It ships as an error because the alternative is a
 value the modeller never wrote, and because the dialects disagreeing is itself a defect.
 
+### 11.15 The modeller-facing guide
+
+`docs/guides/semi-structured-modelling.md` covers the same surface for people writing models rather
+than changing the engine: the path syntax, the array functions that have been checked, the lambda
+forms, explode, and the shapes that do not work. It is the document to hand someone who asks how to
+model a JSON column, and it should be updated whenever the behaviour here changes — the sections
+above are the reasoning, that guide is the contract a modeller reads.
+
 ### 11.14 Wildcard path segments
 
 `'divisions[*].teams[*].label'` reaches every element at each level. The segment is rewritten

--- a/docs/engineering/architecture/relational-dynafunctions.md
+++ b/docs/engineering/architecture/relational-dynafunctions.md
@@ -1018,13 +1018,53 @@ every one of these.
    Counting elements produced by `explodeSemiStructured` works through a TDS `groupBy` but not
    through a relation projection.
 
+5. **A fan-out column and an aggregate over the same collection cannot share one relation
+   projection.** `~[code: r | $r.tags.code, n: r | $r.tags->size()]` fails with
+   `column "REFERENCE" must appear in the GROUP BY clause`. Either alone is fine — this is
+   narrower than (4), which fails even when the aggregate is projected on its own.
+
+**What a binding can be attached to.** The operation on the right of a `Binding` is not limited to
+a bare column, and the bound property is not limited to `[1]`. All of the following are supported
+and now covered:
+
+| Form | Example |
+|---|---|
+| bare column | `firm: Binding B : [db]T.PROFILE` |
+| navigation to a sub-document | `firm: Binding B : extractFromSemiStructured([db]T.PROFILE, 'employment.firm', 'VARCHAR')` |
+| `parseJson` over a plain VARCHAR column | `firm: Binding B : parseJson([db]T.PROFILE_JSON)` |
+| through a join | `managerFirm: Binding B : [db]@Manager \| [db]T.PROFILE` |
+| **to-many — an array of objects** | `tags: Binding TagB : parseJson(extractFromSemiStructured([db]T.CONTENT, 'payload.tags', 'VARCHAR'))` with `tags: Tag[*]` |
+| sibling arrays off one column | as above, plus `participants: Binding ParticipantB : … 'payload.participants' …` |
+
+The navigation form is what lets one class absorb documents of different shapes: a union whose
+legs bind at different depths — one navigating to a sub-document, the other binding the root —
+resolves onto a single class, and the query cannot tell the legs apart.
+
+**Follow-up — the Snowflake `GET` failure is most likely this same cast.**
+`Test_Relational_Snowflake_Semistructured` skips exactly two tests,
+`union::testSemiStructuredUnionMappingWithBinding` and `…WithBindingAndFilter`, both with:
+
+```
+Invalid argument types for function 'GET': (VARCHAR(134217728), VARCHAR(8))
+```
+
+Databricks skips the same pair. That is precisely the **binding-fed-by-a-navigation** form: the
+navigation is declared `'VARCHAR'`, so the renderer emits a primitive cast, and the property
+access the binding then synthesises calls `GET(<varchar>, 'firmName')` — Snowflake's `GET` needs a
+VARIANT/OBJECT, not a string. DuckDB passes because its arrow operator tolerates JSON text.
+
+If that reading holds, the fix is the shape already used for `processVariantInstanceOf`: stamp
+`avoidCastIfPrimitive = true` on a navigation whose result feeds a binding, so no
+`::varchar` is appended and the value stays a document. Worth confirming against a live Snowflake
+before changing anything — the whole model is asserted on DuckDB here, which cannot reproduce it.
+
 **What does work**, and is now asserted: all 10 whitelist target types; bracket-quoted keys
 containing a space and a dot; index-leading paths against an array-rooted document; four-level
 typed navigation through a binding, including an absent optional branch; primitive, object, and
 nested-inside-nested collections via implicit lateral flatten; `size`, `isEmpty`, `isNotEmpty`,
 `at`, `filter`, `map`, `fold` (via a derived property), and — new ground — **`max` and `min`**;
-explosion inside a join with a view supplying the exploded column; and a join keyed on a scalar
-read out of a document.
+explosion inside a join with a view supplying the exploded column; a join keyed on a scalar read
+out of a document; and every binding source form in the table above.
 
 ---
 

--- a/docs/engineering/architecture/relational-dynafunctions.md
+++ b/docs/engineering/architecture/relational-dynafunctions.md
@@ -1372,3 +1372,46 @@ The suite runs on DuckDB only, as all EMIT models do. What it establishes is tha
 reaches SQL generation and returns a value — the part that was genuinely unknown. Dialect-specific
 rendering of the same calls is the parameterised suite's job, and §11.9 already covers the three
 array renderers there.
+
+### 11.12 `explodeSemiStructured`'s type argument is validated by a different vocabulary
+
+`extractFromSemiStructured` and `explodeSemiStructured` both take a type name as their last
+argument, and they read *different* lists to interpret it.
+
+`extractFromSemiStructured` checks the 11-entry whitelist in §11.9 and fails loudly on anything
+else. `explodeSemiStructured` looks the name up in `sqlTextToRelationalDataTypeMap` — 20 SQL type
+names — and when the lookup misses, treats the flattened element as a document:
+
+```pure
+let func = $map->get($typeName);
+let columnType = if ($func->isEmpty(), | ^SemiStructured(), | $func->toOne()->eval(1000, 1));
+```
+
+The consequence is easier to see once you check what the corpus passes. **Every**
+`explodeSemiStructured` call in this repository passes `'SEMISTRUCTURED'` — and `'SEMISTRUCTURED'`
+is not in that map. The canonical spelling is not recognised; it produces the right answer because
+the miss-path catches it. The function's one real contract is reached by accident, which is why
+`testExplodeReturnTypeAcceptedNames` now pins it.
+
+A typo produces the same right-looking result for the wrong reason, and two names mean different
+things between the sibling functions:
+
+| name | `extractFromSemiStructured` | `explodeSemiStructured` |
+|---|---|---|
+| `'SEMISTRUCTURED'` | document | document, via the miss-path |
+| `'STRING'` | `String` | **silently a document** |
+| `'DATETIME'` | `DateTime` | **silently a document** |
+| `'BIGINT'`, `'DOUBLE'`, … | error | `Integer` / `Float` |
+
+**Not fixed here, deliberately.** Rejecting unrecognised names would turn a working model into a
+broken one on upgrade, which is exactly what §10.4 says must not happen without a warning stage:
+the argument that promoting an unknown *dyna name* is safe — "already a hard failure today … cannot
+break a model that works now" — does not transfer, because an unknown *type argument* succeeds
+today. This belongs in §10's staged rollout, with the severity flag and the escape hatch, not as a
+separate validation path bolted on here.
+
+Two notes for whoever picks it up. Aliasing `'STRING'` and `'DATETIME'` to align the two
+vocabularies is also a silent behaviour change, not a safe subset — those names currently yield
+documents. And `ARRAY`, `BINARY`, `BIT`, `DISTINCT` and `OTHER` are all keys in the map, but
+`ARRAY` and `BINARY` have no case in `dataTypeToCompatiblePureType` and fail with a match error
+further down; any error message that enumerates the map would be advertising a second defect.

--- a/docs/engineering/architecture/relational-dynafunctions.md
+++ b/docs/engineering/architecture/relational-dynafunctions.md
@@ -1415,3 +1415,88 @@ vocabularies is also a silent behaviour change, not a safe subset — those name
 documents. And `ARRAY`, `BINARY`, `BIT`, `DISTINCT` and `OTHER` are all keys in the map, but
 `ARRAY` and `BINARY` have no case in `dataTypeToCompatiblePureType` and fail with a match error
 further down; any error message that enumerates the map would be advertising a second defect.
+
+### 11.13 A declared array type is an assertion, and was not one on Snowflake
+
+The `[]` suffix in `extractFromSemiStructured(col, path, 'SEMISTRUCTURED[]')` is the modeller
+stating that the path holds an array. DuckDB and Databricks enforce that — DuckDB on the cast,
+Databricks with `INVALID_VARIANT_CAST` — but Snowflake's `to_array` **promoted** a scalar or an
+object into a one-element array. Same model, same data, an error on one dialect and a fabricated
+array on another, with nothing to signal it. It also quietly readmitted the irregular JSON that
+§11.9 puts out of scope.
+
+Measured against the integration account rather than reasoned about, which mattered, because the
+obvious fix is not one:
+
+| construct | scalar `9` | object | real `[1,2]` |
+|---|---|---|---|
+| `to_array` | `[9]` — invents | `[{…}]` — invents | ok |
+| `as_array` | `NULL` — drops | `NULL` — drops | ok |
+| `::ARRAY` | `[9]` — invents | `[{…}]` — invents | ok |
+| **`::ARRAY(VARIANT)`** | **raises** | **raises** | ok |
+
+Swapping `to_array` for `::ARRAY` — the change anyone would reach for first — would have altered
+nothing. The structured type raises a real type error: `Typed object schema mismatch in conversion`.
+
+The element type stays `VARIANT` deliberately. Comparison on it is type-aware, so
+`array_max([9,100,20])` still answers 100 rather than ordering as text — the reason `to_array` was
+chosen originally. Missing paths, JSON null, SQL null and empty arrays were each checked and are
+unchanged. Nothing in the suite could have depended on the promotion, since the same tests pass on
+DuckDB where no coercion exists.
+
+**One consequence, one level up.** Typing extractions as `ARRAY(VARIANT)` means a transform whose
+body extracts an array produces `ARRAY(ARRAY(VARIANT))`, and `ARRAY_FLATTEN` refuses that. Widening
+at the flatten — `array_flatten(cast(… as ARRAY))` — is what it accepts, and costs nothing: the
+elements stay VARIANT and the assertion still sits on the extraction cast. This only appeared when
+a two-level `[*]` path ran on Snowflake; DuckDB and Databricks both accept the nested form, so no
+single-dialect run could have found it.
+
+Rejecting a non-array is a behaviour change for any model that relied on the promotion. Unlike an
+unknown dyna name, which already fails, this case *succeeded* — so by §10.4's reasoning it is the
+kind of change that would normally warn first. It ships as an error because the alternative is a
+value the modeller never wrote, and because the dialects disagreeing is itself a defect.
+
+### 11.14 Wildcard path segments
+
+`'divisions[*].teams[*].label'` reaches every element at each level. The segment is rewritten
+during compilation into the transform and flatten it stands for, so no dialect needed wildcard
+support of its own — they already render those nodes, exactly as with the lambdas in §11.10.
+
+The rewrite, per wildcard segment:
+
+```
+array_flatten(array_transform(<prev>, x | extract($x, <segment>, 'SEMISTRUCTURED[]')))
+```
+
+with the last segment carrying the declared type and needing no flatten, since its body produces
+scalars. A path ending in `[*]` has no trailing segment, so the level before it produces the arrays
+and is flattened too.
+
+**The result is flat**, however deep the path went, because Pure has no collection-of-collections
+to return instead — `String[*]` is flat. That is not a choice about JSONPath convention; it is the
+only shape the result can have. It also matches what a property chain over a to-many does.
+
+**The type argument names what the expression returns**, as it does without a wildcard, so a `[*]`
+path carries the array suffix: `'VARCHAR[]'`, not `'VARCHAR'`. Bare scalars are refused at compile
+time with a message naming the correction. The first implementation had this inverted — the leaf
+element type was expected, so the *consistent* spelling failed at runtime inside the dialect,
+reporting a data value rather than the mistake.
+
+`resolveArrayElementType` gained an `array_flatten` case. Beneath a flatten sits a transform whose
+body extraction names its type with a `[]` suffix, and the branch that reads a transform body
+already strips that suffix — which lands on the element type the flattened array has. Only that
+shape is recognised; anything else is still refused rather than guessed.
+
+Empty inner arrays, explicit nulls and absent keys each contribute nothing, so no null filtering is
+needed. Genuinely ragged data — a level that is an array in one row and a scalar in the next —
+fails at the extraction cast, consistently across dialects now that §11.13 has landed.
+
+**Binding a `[*]` path to a to-many property does not give a collection.** It returns the array's
+text as a single value, with no error at compile or run time. Relational multiplicity comes from
+row cardinality: `explodeSemiStructured` produces rows, so `teams: Team[*]` through a join behaves
+normally, while a `[*]` path produces one row with an array in one column and has nothing to range
+over. Tracked as [#5099](https://github.com/finos/legend-engine/issues/5099), with an assessment of
+what a compile-time rejection would take recorded on the issue.
+
+H2 skips wildcard tests: a `[*]` path becomes an `array_transform`, and array lambdas reach H2
+through the `sqlDialectTranslation` path, which has no case for the lambda nodes.

--- a/docs/engineering/architecture/relational-dynafunctions.md
+++ b/docs/engineering/architecture/relational-dynafunctions.md
@@ -969,6 +969,63 @@ so they cannot be written in a `Filter` or `View`. They are also unreachable fro
 `Error mapping not found for class Map`; the working vehicle is a relation-store accessor
 (`#>{DB.TABLE}#`), where the array work happens inside the relation source.
 
+### 11.8 Semi-structured limitations found by building the EMIT models
+
+Six EMIT models under `relational-emit-models/relational-semistructured*` cover modelled
+semi-structured data end to end on DuckDB. Authoring them turned up limitations that no existing
+test records, listed here with the exact symptom. Each was reproduced against a live DuckDB, not
+inferred from source. **None is fixed** — they are recorded so the next person does not rediscover
+them, and the models deliberately do not assert the broken behaviour.
+
+**Authoring surface** (traced to source, all enforced at SQL-generation time — neither
+`extractFromSemiStructured` nor `explodeSemiStructured` is a grammar keyword, so the compiler
+passes name, arity, path and return type through unchecked, `HelperRelationalBuilder.java:853-856`):
+
+| Constraint | Where |
+|---|---|
+| Path must match `(ident\|[N]\|["quoted"])(.ident\|[N]\|["quoted"])*` — no `[*]`, no `[-1]`, no `..`, no `a."k"`, no `$.a` | `dbExtension.pure:918-921`, asserted `:910` |
+| Return type is one of exactly 10 scalars; **no `ARRAY`/`SEMISTRUCTURED`/`VARIANT`/`JSON`** | `dbExtension.pure:912-913` |
+| Neither check runs on the dialect-translation path | `toPostgresModel.pure:1055-1066` |
+| `explodeSemiStructured` is legal **only inside a Join**; elsewhere it compiles then dies with `[unsupported-api] … is not supported yet` | `pureToSQLQuery.pure:9158`; `dbExtension.pure:1040` |
+| At most one *unique* explode per Join; operand must be a plain `TableAliasColumn` of a table or view; source needs ≥1 primary key | `pureToSQLQuery.pure:9236`, `:9239`, `:9245-9248` |
+| Array operations are unavailable across a **join-based** binding (`prop: Binding … : @Join \| …`) | `pureToSQLQuery_variant.pure:179-200`, in-source comment |
+
+**Behavioural gaps, reproduced on DuckDB.** All four appear only in the *relation* query form
+(`->project(~[...])`), which EMIT requires in order to route to a semi-structured-capable target.
+The equivalent TDS forms work, which is why the parameterised suite passes 151/151 and still misses
+every one of these.
+
+1. **`fold` cannot be written in a relation colSpec.** `->fold({a, acc | $acc + $a.name}, '')`
+   fails to parse — `no viable alternative at input '->project(~[…->fold({a, acc | …'`. The
+   two-parameter *block* lambda is the problem, not `fold`; parenthesising does not help.
+   *Workaround, used by the model:* declare the fold as a derived property in `###Pure`, where the
+   ordinary domain grammar applies, and project the derived property.
+
+2. **`sort` and `distinct` on a semi-structured array fail at the database.**
+   `Binder Error: No function matches the given name and argument types 'array_sort(INTEGER)'` —
+   the element is passed as a scalar where DuckDB needs a LIST. Same defect class as the
+   JSON-vs-LIST cast bugs in §11.7. Neither operation is covered anywhere in the repo.
+
+3. **`first()` and `exists()` do not collapse the flatten** when applied directly to a bound
+   to-many property. For a firm with three addresses, `addresses->first().name` returns **three**
+   rows (`A1`, `B2`, `A3`) instead of one, and `addresses->exists(a | $a.rank > 8)` returns three
+   booleans instead of one. Both were isolated in single-column suites, so this is not an artefact
+   of a co-projected column. Note `addresses->filter(…)->first()` behaves correctly — the defect is
+   specific to the un-filtered form. `at(0)` and `filter(…)->size()` are correct.
+
+4. **`->size()` over a join-backed to-many fails in relation form.**
+   `column "ID" must appear in the GROUP BY clause or must be part of an aggregate function`.
+   Counting elements produced by `explodeSemiStructured` works through a TDS `groupBy` but not
+   through a relation projection.
+
+**What does work**, and is now asserted: all 10 whitelist target types; bracket-quoted keys
+containing a space and a dot; index-leading paths against an array-rooted document; four-level
+typed navigation through a binding, including an absent optional branch; primitive, object, and
+nested-inside-nested collections via implicit lateral flatten; `size`, `isEmpty`, `isNotEmpty`,
+`at`, `filter`, `map`, `fold` (via a derived property), and — new ground — **`max` and `min`**;
+explosion inside a join with a view supplying the exploded column; and a join keyed on a scalar
+read out of a document.
+
 ---
 
 ## 12. Phased roadmap

--- a/docs/engineering/architecture/relational-dynafunctions.md
+++ b/docs/engineering/architecture/relational-dynafunctions.md
@@ -1078,6 +1078,39 @@ every one of these.
    `column "REFERENCE" must appear in the GROUP BY clause`. Either alone is fine — this is
    narrower than (4), which fails even when the aggregate is projected on its own.
 
+**Array functions in the store language — only `array_size` works.** This is the surface that
+matters most for the relational DSL: `array_*` written directly in a `Filter`, a `View` column, a
+`Join` condition or a mapping property, aggregating a JSON array in place with no row expansion.
+Twenty `array_*` names are registered in `DynaFunctionRegistry` and DuckDB renders all twenty, so
+they are all *authorable*. Only one of them executes.
+
+`array_size` works in all three positions, and is asserted in
+`relational-emit-models/relational-semistructured-store-arrays`. It works because its DuckDB
+renderer casts first — `ifnull(json_array_length(cast(%s as JSON)), 0)`
+(`duckdbExtension.pure:180`). Every other `array_*` renderer is a bare format string over the raw
+operand, so a `SEMISTRUCTURED` column reaches it as JSON where DuckDB wants a LIST:
+
+```
+array_max(TEAM_TABLE.SCORES)
+  -> Binder Error: No function matches ... 'array_aggregate(JSON, STRING_LITERAL)'
+```
+
+**The obvious fix is worse than the defect.** Casting to a JSON list inside the format string —
+`array_aggregate(cast(%s as JSON[]), 'max')` — parses and runs, and is **silently wrong**,
+because JSON elements compare lexicographically:
+
+| Rendering | `[9,100,20]` max |
+|---|---|
+| `cast(x as JSON[])` | **9** — lexicographic |
+| `cast(x as DOUBLE[])` | 100.0 — correct |
+
+A correct rendering needs the *element type*, which a `ToSql` format string does not have; its
+`transform` hook receives already-rendered strings and cannot inspect the node. The fix therefore
+belongs in a processing function where the type is known — the shape `asListForDuckDB(element,
+sgc, elementType)` (`duckdbExtension.pure:699`) already uses for the flatten path. Note a numeric
+fixture can hide this: `[30,10,20]` yields the right answer lexicographically and only a case like
+`[9,100,20]` exposes it.
+
 **What a binding can be attached to.** The operation on the right of a `Binding` is not limited to
 a bare column, and the bound property is not limited to `[1]`. All of the following are supported
 and now covered:

--- a/docs/engineering/architecture/relational-dynafunctions.md
+++ b/docs/engineering/architecture/relational-dynafunctions.md
@@ -1031,14 +1031,35 @@ every one of these.
    `sort` errors only because `array_sort` rejects a scalar; `distinct`, `max` and `min` are the
    same defect without the safety net. **A passing result is not evidence the array path ran.**
 
-   Note an earlier reading of this — that the split was primitive vs Class element type
-   (`isClassType` in `isSemiStructuredArrayExpression:187`) — was **refuted by experiment**:
-   `sort` fails identically for `Integer[*]` and for a `String` chain rooted at a Class-typed
-   property. The cause is the missing guard, not the element type.
+   **Two conditions must both hold**, which took two experiments to separate. The guard is
+   necessary but not sufficient: `isSemiStructuredArrayInput` delegates to
+   `isSemiStructuredArrayExpression:187`, which requires the property's return type to be a
+   **Class**. So a primitive collection — `scores: Integer[*]` — fails the guard even once the
+   processor sets it, and still flattens.
 
-   Fix shape: give the unguarded processors the same `effectiveState` guard `processVariantSize`
-   has, and add an `isSemiStructuredArrayInput` dispatch pair for `max`/`min`. Any new `array_*`
-   processor needs both, so this is worth a cross-check test rather than a one-off fix.
+   | Expression | Before guard | After guard |
+   |---|---|---|
+   | `addresses->map(a\|$a.rank)->sort()` | error `array_sort(VARCHAR)` | **`[3,5,9]`** — array_sort ran |
+   | `addresses->map(a\|$a.rank)->removeDuplicates()` | flattened silently | **`[9,3,5]`** — array_distinct ran |
+   | `scores->sort()` (`Integer[*]`) | error `array_sort(INTEGER)` | error, unchanged |
+
+   An intermediate reading recorded here — that the element type was irrelevant and the missing
+   guard was the whole cause — was itself incomplete. Both readings were half right: the guard
+   explains the Class-rooted case, `isClassType` explains the primitive case.
+
+   Note also that `distinct` is **not** an array operation: it is the TDS-level distinct that
+   de-duplicates result rows. `removeDuplicates` is the one that lowers to `array_distinct`.
+
+   **Fixed** for the ten unconditionally-routed processors (`sort`, `reverse`,
+   `removeDuplicates`, `contains`, `slice`, `take`, `drop`, `last`, `init`, `tail`), which now
+   carry the same `effectiveState` guard `processVariantSize` has. When they engage, the column
+   holds the **whole array** rather than one row per element.
+
+   **Still open:** (a) `max`/`min` need an `isSemiStructuredArrayInput` dispatch pair — a
+   behaviour change, deliberately not bundled with the guard fix; (b) primitive collections are
+   excluded by `isClassType`, so no array function reaches them. Since every future `array_*`
+   processor needs both the guard and a dispatch pair, a cross-check test asserting that is worth
+   more than further one-off fixes.
 
 3. **`first()` and `exists()` do not collapse the flatten** when applied directly to a bound
    to-many property. For a firm with three addresses, `addresses->first().name` returns **three**

--- a/docs/engineering/architecture/relational-dynafunctions.md
+++ b/docs/engineering/architecture/relational-dynafunctions.md
@@ -866,8 +866,10 @@ dialect remains uncovered.
 
 ### 11.6 Execution layer — EMIT on DuckDB
 
-`legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/duckdb-dyna-semistructured`
-executes dyna functions against a real, in-process DuckDB.
+`legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured`
+executes dyna functions against a real, in-process DuckDB. The model is named and tagged for the
+capability it covers — modelled semi-structured data — not for the engine that happens to run it
+or the IR node that implements it.
 
 **How DuckDB is selected.** EMIT names no database anywhere — not in the `.emit.yaml`, not in
 the runner. `RelationalConnectionFactory:187-189` picks DuckDB when `hints.isRelation()`, and

--- a/docs/engineering/architecture/relational-dynafunctions.md
+++ b/docs/engineering/architecture/relational-dynafunctions.md
@@ -1327,3 +1327,48 @@ reads the warnings and a later phase promotes a wrong rule to an error.
 | [ModelJoin](model-join.md) | `mergeSQLQueryData` and `processDynaFunction` interaction |
 | [`docs/pct/wiring-howto.md`](../../pct/wiring-howto.md) `:47-60`, `:185-202` | Pure function → DynaFunction → SQL wiring, and the Postgres-model translation error |
 | [Coding Standards](../standards/coding-standards.md) | `EngineException` / `SourceInformation` conventions referenced in §8 |
+
+### 11.11 Which `array_*` functions the store language can actually use
+
+Before typed extraction existed, the honest answer was "`array_size`, and by accident". Seven of
+the family render as subscripts or slices, which returned NULL against a JSON document rather than
+failing, so the working set had never been established — only assumed.
+
+`relational-semistructured-array-survey` settles it: one suite per function over an
+`'INTEGER[]'` / `'VARCHAR[]'` extraction, each isolated so a function that fails takes only its own
+suite with it. Source `[3,1,2,1]` — unsorted, with a duplicate, so ordering and de-duplication are
+visible in the result rather than coincidental.
+
+| function | result on `[3,1,2,1]` |
+|---|---|
+| `array_last` | `1` |
+| `array_init` | `3,1,2` |
+| `array_tail` | `1,2,1` |
+| `array_sort` | `1,1,2,3` |
+| `array_reverse` | `1,2,1,3` |
+| `array_append(…, 9)` | `3,1,2,1,9` |
+| `array_position(…, 2)` | `2` |
+| `array_slice(…, 0, 2)` | `3,1` |
+| `array_drop(…, 1)` | `1,2,1` |
+| `array_take(…, 2)` | `3,1` |
+| `array_contains(…, 2)` | `true` |
+| `array_distinct` | `3`, `1`, `2` in unspecified order |
+| `array_concatenate` | `b,a,b,a` |
+| `array_sum` | `7` |
+
+All fourteen work, none returns NULL, and none needed a renderer change — they were blocked
+solely by the scalar-only type whitelist described in §11.9. Together with `array_size`,
+`array_max`, `array_min`, `array_to_string`, `array_first` and the three lambda forms of §11.10,
+the family is fully usable from a `View` column, a `Filter`, a `Join` and a property mapping.
+
+Two behaviours worth knowing rather than discovering:
+
+- **`array_position` is 0-based.** Pure's `indexOf` is 1-based, so the two disagree. The survey
+  asserts `2` for the value `2` in `[3,1,2,1]`.
+- **`array_distinct` does not promise to preserve order.** The survey wraps it in `array_sort`;
+  a test that asserts the raw order is asserting an implementation detail.
+
+The suite runs on DuckDB only, as all EMIT models do. What it establishes is that each function
+reaches SQL generation and returns a value — the part that was genuinely unknown. Dialect-specific
+rendering of the same calls is the parameterised suite's job, and §11.9 already covers the three
+array renderers there.

--- a/docs/engineering/architecture/router-and-pure-to-sql.md
+++ b/docs/engineering/architecture/router-and-pure-to-sql.md
@@ -241,7 +241,7 @@ legend-engine-xts-relationalStore/
           relationalMappingExecution.pure ← StoreContract bridge; SQLExecutionNode creation
           sqlQueryToString/
             dbExtension.pure             ← DbConfig, DbExtension, sqlQueryToString entry
-            dbExtension_default.pure     ← default implementations for all hook points
+            extensionDefaults.pure       ← default implementations for all hook points
 ```
 
 ### 4.3 The SelectSQLQuery AST
@@ -460,9 +460,9 @@ to their dialect-specific SQL equivalents. Each `DynaFunction` has a name (e.g. 
 ```pure
 Class meta::relational::functions::sqlQueryToString::DynaFunctionToSql
 {
-   funcName  : String[1];
-   states    : GenerationState[*];          // SELECT, WHERE, etc.
-   toSql     : ToSql[1];                    // format string + optional transform lambda
+   funcName   : String[1];
+   stateMatch : GenerationState[*];         // SELECT, WHERE, etc.
+   toSql      : ToSql[1];                   // format string + optional transform lambda
 }
 ```
 
@@ -471,7 +471,7 @@ A `ToSql` object combines:
 - `format` — a `%s`-placeholder string like `'date_trunc(\'%s\', %s)'`.
 - `transform` — an optional lambda that pre-processes the parameter strings before substitution.
 
-The default implementations live in `dbExtension_default.pure`. Dialects override only the
+The default implementations live in `extensionDefaults.pure`. Dialects override only the
 functions that differ.
 
 ### 5.5 Dialect Registration
@@ -800,7 +800,7 @@ which adjusts the literal format to match the dialect's timezone handling.
 | SQL AST (SelectSQLQuery) | `meta::relational::metamodel::relation::SelectSQLQuery` |
 | SQL text generation entry | `core_relational/relational/sqlQueryToString/dbExtension.pure` → `sqlQueryToString` |
 | Dialect plug-in | `DbExtension` class in `dbExtension.pure` |
-| Default implementations | `dbExtension_default.pure` |
+| Default implementations | `core_relational/relational/sqlQueryToString/extensionDefaults.pure` |
 | DynaFunction dispatch | `DynaFunctionToSql` + `getDynaFunctionDispatcher` |
 | JDBC adapter | `DatabaseManager` → one subclass per dialect |
 | Dialect discovery (Java) | `DatabaseManager.fromString(dbType)` via `ServiceLoader` |

--- a/docs/guides/semi-structured-modelling.md
+++ b/docs/guides/semi-structured-modelling.md
@@ -1,0 +1,228 @@
+<h1 align="center">MODELLING SEMI-STRUCTURED DATA</h1>
+
+# Overview
+
+A `SEMISTRUCTURED` column holds a JSON document. This guide covers writing expressions over that
+document **inside your store and mapping** — in a property mapping, a `View` column, a `Filter` or
+a `Join` — so that consumers of your model see ordinary typed properties and never have to know the
+data was JSON.
+
+It is written for modellers rather than engine developers. For the engine-side reasoning behind
+these behaviours, see
+[relational-dynafunctions.md](../engineering/architecture/relational-dynafunctions.md) §11.
+
+Every behaviour described here is covered by a test that runs against a live database. The list of
+functions is **not exhaustive** — there are combinations that likely work but have not been
+exercised, and a few that are known not to. If you need something that is not here, ask rather than
+assume.
+
+Your model never mentions `Variant`. JSON is typed either through an ExternalFormat `Binding` or
+read value-by-value with the expressions below; both give you plain Pure classes and primitives.
+
+# Reaching a value
+
+`extractFromSemiStructured` takes the column, a path into the document, and the type you expect to
+find there.
+
+```
+legalName: extractFromSemiStructured(
+             [store::DB]FIRM_SCHEMA.FIRM_TABLE.FIRM_DETAILS,
+             'firm.legalName',
+             'VARCHAR')
+```
+
+## Path syntax
+
+| Form | Example | Reaches |
+|---|---|---|
+| `a.b.c` | `'firm.address.city'` | nested members |
+| `["key"]` | `'firm["legal name"]'` | a key containing spaces or dots |
+| `[0]` | `'divisions[0].name'` | a fixed position in an array |
+| `[*]` | `'divisions[*].name'` | every element at that level |
+
+Not supported: `[-1]`, `..`, and `a."key"`. Use `array_last`, an explicit path, and `a["key"]`.
+
+## Types you can ask for
+
+The third argument tells the database what to produce. Getting it right is what lets the value be
+compared, sorted and joined as the thing it actually is.
+
+`VARCHAR` · `STRING` · `CHAR` · `INTEGER` · `DECIMAL` · `FLOAT` · `BOOLEAN` · `DATE` · `DATETIME` ·
+`TIMESTAMP` · `SEMISTRUCTURED`
+
+`SEMISTRUCTURED` means a nested document. Add `[]` to say the path holds an *array* of that type —
+`'INTEGER[]'`, `'SEMISTRUCTURED[]'` — which is what the array functions need.
+
+> **The `[]` is a promise, not a request.** It states that the value *is* an array. If the document
+> holds a single object or a bare number there instead, the query fails rather than quietly
+> wrapping it. A model that silently invents a one-element array gives you wrong answers rather
+> than an error.
+
+# Every element at a level: `[*]`
+
+A `[*]` segment means "each element here". The result comes back as one flat collection, however
+many levels deep the path went — the same way a property chain over a to-many behaves in Pure.
+
+Because the result is a collection, the type carries the array suffix: `'VARCHAR[]'`, not
+`'VARCHAR'`. That is the same rule as everywhere else — the type names what the expression returns
+— and a bare scalar type on a `[*]` path is refused when the model compiles.
+
+```
+divisionNames: array_to_string(
+                 extractFromSemiStructured(T.FIRM_DETAILS, 'divisions[*].name', 'VARCHAR[]'),
+                 ',')
+```
+→ `Alpha,Beta`
+
+```
+teamLabels: array_to_string(
+              extractFromSemiStructured(T.FIRM_DETAILS, 'divisions[*].teams[*].label', 'VARCHAR[]'),
+              ',')
+```
+→ `Core,Edge,Ops` — flat, not grouped by division
+
+A path ending in `[*]` gives you the elements themselves:
+
+```
+divisionCount: array_size(
+                 extractFromSemiStructured(T.FIRM_DETAILS, 'divisions[*]', 'SEMISTRUCTURED[]'))
+```
+→ `2`
+
+> **Why it flattens.** Pure has no collection-of-collections. `String[*]` is flat, so a two-level
+> wildcard has to produce a flat result — there is no other shape it could return. An empty array,
+> a JSON `null` and a missing key all contribute nothing, which is what you would expect from an
+> optional field.
+
+# Working with arrays
+
+Once an extraction names an array type, the array functions apply to it. Each of these has been run
+and its result checked:
+
+`array_size` · `array_first` · `array_last` · `array_init` · `array_tail` · `array_max` ·
+`array_min` · `array_sum` · `array_sort` · `array_reverse` · `array_distinct` · `array_contains` ·
+`array_position` · `array_append` · `array_concatenate` · `array_slice` · `array_take` ·
+`array_drop` · `array_to_string`
+
+```
+largestDivision: array_max(
+                   extractFromSemiStructured(T.FIRM_DETAILS, 'divisions[*].headcount', 'INTEGER[]'))
+```
+→ `100` — compared as numbers, not as text
+
+Three behaviours worth knowing rather than discovering:
+
+| | |
+|---|---|
+| `array_position` | counts from **0**, where Pure's `indexOf` counts from 1 |
+| `array_distinct` | does not promise to keep the original order — wrap it in `array_sort` if order matters |
+| `array_to_string` | on an empty collection gives null, not an empty string |
+
+# Filter, map and reduce
+
+Three functions take a small expression of their own, written with a parameter name, a `|`, and a
+body that uses `$name`.
+
+```
+array_filter(
+  extractFromSemiStructured(T.FIRM_DETAILS, 'firm.divisions', 'SEMISTRUCTURED[]'),
+  d | extractFromSemiStructured($d, 'headcount', 'INTEGER') > 100)
+```
+
+```
+array_transform(
+  extractFromSemiStructured(T.FIRM_DETAILS, 'firm.divisions', 'SEMISTRUCTURED[]'),
+  d | extractFromSemiStructured($d, 'name', 'VARCHAR'))
+```
+
+```
+array_reduce(
+  extractFromSemiStructured(T.FIRM_DETAILS, 'firm.divisions[*].headcount', 'INTEGER[]'),
+  (h, acc | plus($acc, $h)),
+  0)
+```
+
+Note the starting value comes last, and the lambda takes two parameters — the element first, then
+the accumulator.
+
+They compose, which is the point. This is one property mapping:
+
+```
+firstLargeCity: extractFromSemiStructured(
+                  array_first(
+                    array_filter(
+                      extractFromSemiStructured(T.FIRM_DETAILS, 'firm.divisions', 'SEMISTRUCTURED[]'),
+                      d | extractFromSemiStructured($d, 'headcount', 'INTEGER') > 100)),
+                  'address.city',
+                  'VARCHAR')
+```
+→ `Oslo` — the consumer of your model just sees a `String` property
+
+# One row per element
+
+Everything above produces a **value**. When you want an array to become **rows**, so each element
+can join to another table, that is `explodeSemiStructured`, and it belongs in a `Join`.
+
+```
+Join Block_Trade(
+  extractFromSemiStructured(
+    explodeSemiStructured(Semistructured.Blocks.BLOCKDATA, 'relatedEntities', 'SEMISTRUCTURED'),
+    'tagId', 'VARCHAR') = Semistructured.Trades.ID)
+```
+
+Arrays inside arrays work too — a row per combination:
+
+```
+Join Firm_Team(
+  extractFromSemiStructured(
+    explodeSemiStructured(
+      explodeSemiStructured(FIRM_TABLE.FIRM_DETAILS, 'divisions', 'SEMISTRUCTURED'),
+      'teams', 'SEMISTRUCTURED'),
+    'tid', 'VARCHAR') = TEAM_TABLE.TID)
+```
+
+> **Two things explode needs.** The table you are joining *from* must declare a primary key — the
+> exploded rows are joined back to it, so without one the model will not plan. And the third
+> argument behaves differently here than in `extractFromSemiStructured`: a name it does not
+> recognise is treated as a nested document rather than rejected, so `'STRING'` quietly yields a
+> document instead of text. Pass `'SEMISTRUCTURED'`, which is what nearly every explode wants.
+
+## Choosing between `[*]` and explode
+
+`[*]` gives you a collection you collapse into a property — a name list, a count, a maximum.
+`explodeSemiStructured` gives you rows you can join. Same intuition, different result: pick by
+whether you want a property or a relationship.
+
+This also decides whether a **to-many property** works. A relational mapping gets its multiplicity
+from rows, so `teams: Team[*]` mapped through an exploding join behaves like any other to-many. A
+`[*]` path produces one row with an array in a single column, so there are no rows for a
+`String[*]` to range over — it comes back as one value instead. If you want a real collection
+today, reach for the join.
+
+# What does not work yet
+
+These are known limits, not bugs to report. One of them fails quietly rather than loudly — worth
+reading that row even if you skim the rest.
+
+| Shape | Status | What to do instead |
+|---|---|---|
+| A field that is a single value in some rows and an array in others | not supported | Common in XML-derived JSON. Handle it explicitly for now; a `toArray` helper is being considered. |
+| Mapping `[*]` straight to a `String[*]` property | **compiles, wrong** | You get one value holding the array's text, and no error. Tracked as [#5099](https://github.com/finos/legend-engine/issues/5099). Collapse it with an array function, or get a real collection through a join. |
+| Two independent explodes in one join | not supported | Split into separate joins. |
+| `explodeSemiStructured` outside a `Join` | not supported | Use `[*]` if you want a value rather than rows. |
+| Exploding something other than a plain column | not supported | The innermost explode must read a table or view column directly. |
+| `[-1]`, `..`, `a."key"` | not supported | Use `array_last`, an explicit path, and `a["key"]`. |
+
+# Where this is tested
+
+These expressions run against **DuckDB**, **Snowflake** and **Databricks** as part of the build.
+H2 supports a narrower set and is being retired.
+
+Two caveats. The function list is what has been *checked*, not everything that exists — the
+relational grammar has around 230 functions and this is the semi-structured corner of it. And
+dialects differ in places; if you are modelling against one warehouse and will later point at
+another, it is worth saying so early.
+
+If something you need is not here, ask. Several of the capabilities on this page exist because
+someone described a document they could not model, and the shape of that request is what made the
+gap concrete.

--- a/legend-engine-core/legend-engine-core-emit/legend-engine-emit-report/src/main/java/org/finos/legend/engine/test/emit/report/EMIT_to_HTML.java
+++ b/legend-engine-core/legend-engine-core-emit/legend-engine-emit-report/src/main/java/org/finos/legend/engine/test/emit/report/EMIT_to_HTML.java
@@ -66,6 +66,10 @@ public class EMIT_to_HTML
             "store:relational-inner-join", "store:relational-left-outer-join",
             "store:relational-multi-table", "store:relational-nested-join",
             "store:relational-outer-join", "store:relational-right-outer-join",
+            "store:relational-semistructured", "store:relational-semistructured-array-functions",
+            "store:relational-semistructured-array-index", "store:relational-semistructured-binding",
+            "store:relational-semistructured-explode", "store:relational-semistructured-flatten",
+            "store:relational-semistructured-navigation",
             "store:service-store",
             // milestoning
             "milestoning:all-versions-in-range-query", "milestoning:all-versions-query",

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-databricks/legend-engine-xt-relationalStore-databricks-PCT/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/databricks/semistructured/Test_Relational_Databricks_Semistructured.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-databricks/legend-engine-xt-relationalStore-databricks-PCT/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/databricks/semistructured/Test_Relational_Databricks_Semistructured.java
@@ -56,22 +56,6 @@ public class Test_Relational_Databricks_Semistructured
                 .withKeyValue(
                         "meta::relational::tests::semistructured::explode::testAggregationAggregateExplodedPropertyUsingGroupBy_Connection_1__Boolean_1_",
                         "[AMBIGUOUS_REFERENCE]")
-                // [needsInvestigation] The VARIANT column stores a JSON-string
-                // representation of an array (rather than a parsed VARIANT array); a
-                // straight cast to ARRAY<VARIANT> raises INVALID_VARIANT_CAST. The
-                // explode processors now use `try_cast`, which converts the runtime
-                // error into NULL rows -- so this test may now surface as an assertion
-                // mismatch instead. Root fix requires either forcing parse_json at
-                // ingestion time or emitting try_variant_get with an explicit path.
-                .withKeyValue(
-                        "meta::relational::tests::semistructured::flattening::testMultiArrayOlapWithNestedIfExists_Connection_1__Boolean_1_",
-                        "[INVALID_VARIANT_CAST]")
-                // [needsInvestigation] parse_json based mapping loses join-related
-                // columns -- all Firm-Name projections return null. Not a SQL-syntax
-                // issue but a mapping/join wiring bug specific to parse_json input.
-                .withKeyValue(
-                        "meta::relational::tests::semistructured::parseJson::testParseJsonInMapping_Connection_1__Boolean_1_",
-                        "Anthony,null,null,null,null,null")
                 // [needsInvestigation] Union-mapping-with-binding drops non-Databricks
                 // input rows -- expected 3 firms (A/B/D) but only firm_D returned.
                 // Likely a binding-selection bug in the union router; needs the actual
@@ -108,9 +92,10 @@ public class Test_Relational_Databricks_Semistructured
 
         PureTestBuilder.F2<CoreInstance, MutableList<Object>, Object> executor = (test, params) ->
         {
+            Object result;
             try
             {
-                return PureTestBuilderCompiled.executeFn(test, null, Maps.mutable.empty(), executionSupport, params);
+                result = PureTestBuilderCompiled.executeFn(test, null, Maps.mutable.empty(), executionSupport, params);
             }
             // Throwable rather than Exception: a wrong-result test fails with an AssertionError.
             // Anything not named in pathToReason is still rethrown untouched.
@@ -127,6 +112,14 @@ public class Test_Relational_Databricks_Semistructured
                 }
                 throw e;
             }
+            // Reached only when the test passed. An entry that no longer reproduces is worse
+            // than no entry: it silently suppresses whatever regresses into it next. Raised
+            // outside the try because the catch above takes Throwable and would swallow it.
+            if (failures.containsKey(test))
+            {
+                throw new AssertionError("Expected this test to fail with: " + failures.get(test) + ", but it passed. Remove the entry.");
+            }
+            return result;
         };
 
         TestConnectionIntegration databricks = TestConnectionIntegrationLoader.extensions().select(c -> c.getDatabaseType() == DatabaseType.Databricks).getFirst();

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-databricks/legend-engine-xt-relationalStore-databricks-PCT/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/databricks/semistructured/Test_Relational_Databricks_Semistructured.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-databricks/legend-engine-xt-relationalStore-databricks-PCT/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/databricks/semistructured/Test_Relational_Databricks_Semistructured.java
@@ -56,19 +56,6 @@ public class Test_Relational_Databricks_Semistructured
                 .withKeyValue(
                         "meta::relational::tests::semistructured::explode::testAggregationAggregateExplodedPropertyUsingGroupBy_Connection_1__Boolean_1_",
                         "[AMBIGUOUS_REFERENCE]")
-                // [needsInvestigation] Union-mapping-with-binding drops non-Databricks
-                // input rows -- expected 3 firms (A/B/D) but only firm_D returned.
-                // Likely a binding-selection bug in the union router; needs the actual
-                // generated SQL to diagnose further.
-                .withKeyValue(
-                        "meta::relational::tests::semistructured::union::testSemiStructuredUnionMappingWithBindingAndFilter_Connection_1__Boolean_1_",
-                        "actual:   'Firm/FirmName\\nfirm_D'")
-                // [needsInvestigation] Union-mapping-with-binding: expected 6 firms
-                // (A/B/C/D/E/F) but returned 3 real firms + 3 nulls. Same class of
-                // issue as testSemiStructuredUnionMappingWithBindingAndFilter above.
-                .withKeyValue(
-                        "meta::relational::tests::semistructured::union::testSemiStructuredUnionMappingWithBinding_Connection_1__Boolean_1_",
-                        "actual:   'Firm/FirmName\\nfirm_D\\nfirm_E\\nfirm_F\\nnull\\nnull\\nnull'")
                 // [needsInvestigation] Filtering a semi-structured array then indexing
                 // it: the filtered value stays VARIANT, so the [] extract cannot descend
                 // into it (needs a complex STRUCT/ARRAY/MAP base).

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-databricks/legend-engine-xt-relationalStore-databricks-pure/src/main/resources/core_relational_databricks/relational/sqlQueryToString/databricksExtension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-databricks/legend-engine-xt-relationalStore-databricks-pure/src/main/resources/core_relational_databricks/relational/sqlQueryToString/databricksExtension.pure
@@ -621,6 +621,10 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::datab
   let backTickedPath = $pathSegments->map(s | '`' + $s + '`')->joinStrings('.');
   let elementAccess = $baseRelationalOp + ':' + $backTickedPath;
 
+  // An array extraction casts to a typed ARRAY so the array_* family receives real elements
+  // rather than a variant holding a document.
+  if ($returnType->endsWith('[]'),
+      | $elementAccess + '::ARRAY<' + $returnType->substring(0, $returnType->length() - 2)->databricksSemiStructuredElementType() + '>', |
   if ($returnType->in(['CHAR', 'VARCHAR', 'STRING']), | $elementAccess + '::STRING', |
   if ($returnType->in(['DATETIME', 'TIMESTAMP']), | $elementAccess + '::TIMESTAMP', |
   if ($returnType == 'DATE', | $elementAccess + '::DATE', |
@@ -628,7 +632,16 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::datab
   if ($returnType == 'FLOAT', | $elementAccess + '::DOUBLE', |
   if ($returnType == 'INTEGER', | $elementAccess + '::INT', |
   if ($returnType == 'DECIMAL', | $elementAccess + '::DECIMAL', |
-  $elementAccess)))))));
+  $elementAccess))))))));
+}
+
+function <<access.private>> meta::relational::functions::sqlQueryToString::databricks::databricksSemiStructuredElementType(returnType: String[1]): String[1]
+{
+  if ($returnType->in(['CHAR', 'VARCHAR', 'STRING']), | 'STRING', |
+  if ($returnType->in(['DATETIME', 'TIMESTAMP']), | 'TIMESTAMP', |
+  if ($returnType == 'FLOAT', | 'DOUBLE', |
+  if ($returnType == 'INTEGER', | 'INT', |
+  $returnType))));
 }
 
 function <<access.private>> meta::relational::functions::sqlQueryToString::databricks::processTableFunctionParamPlaceHolder(r:RelationalOperationElement[1], sgc: SqlGenerationContext[1]): String[1]

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-databricks/legend-engine-xt-relationalStore-databricks-pure/src/main/resources/core_relational_databricks/relational/sqlQueryToString/databricksExtension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-databricks/legend-engine-xt-relationalStore-databricks-pure/src/main/resources/core_relational_databricks/relational/sqlQueryToString/databricksExtension.pure
@@ -641,7 +641,8 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::datab
   if ($returnType->in(['DATETIME', 'TIMESTAMP']), | 'TIMESTAMP', |
   if ($returnType == 'FLOAT', | 'DOUBLE', |
   if ($returnType == 'INTEGER', | 'INT', |
-  $returnType))));
+  if ($returnType == 'SEMISTRUCTURED', | 'VARIANT', |
+  $returnType)))));
 }
 
 function <<access.private>> meta::relational::functions::sqlQueryToString::databricks::processTableFunctionParamPlaceHolder(r:RelationalOperationElement[1], sgc: SqlGenerationContext[1]): String[1]

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-duckdb/legend-engine-xt-relationalStore-duckdb-PCT/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-duckdb/legend-engine-xt-relationalStore-duckdb-PCT/pom.xml
@@ -335,6 +335,23 @@
             <artifactId>legend-engine-xt-relationalStore-executionPlan</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- The semi-structured test models declare ###ExternalFormat / Binding sections; without
+             these the section parser is unknown and every test in the suite errors at parse. -->
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-external-format-grammar</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-external-format-compiler</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-json-model</artifactId>
+            <scope>test</scope>
+        </dependency>
         <!-- TEST -->
     </dependencies>
 </project>

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-duckdb/legend-engine-xt-relationalStore-duckdb-PCT/src/main/resources/core_relational_duckdb_pct/testSemistructured.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-duckdb/legend-engine-xt-relationalStore-duckdb-PCT/src/main/resources/core_relational_duckdb_pct/testSemistructured.pure
@@ -1,0 +1,26 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::relational::runtime::*;
+
+// todo move to better module!
+function <<meta::pure::profiles::test.TestCollection>> meta::relational::tests::pct::duckDB::semistructured::testCollection(): meta::pure::test::PureTestCollection[1]
+{
+  meta::relational::tests::semistructured->meta::pure::test::collectParameterizedTests(
+    'duckDB',
+    meta::pure::testConnection::getTestConnection(DatabaseType.DuckDB),
+    [],
+    []
+  );
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-duckdb/legend-engine-xt-relationalStore-duckdb-PCT/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/duckdb/semistructured/Test_Relational_DuckDB_Semistructured.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-duckdb/legend-engine-xt-relationalStore-duckdb-PCT/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/duckdb/semistructured/Test_Relational_DuckDB_Semistructured.java
@@ -1,0 +1,76 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.plan.execution.stores.relational.test.duckdb.semistructured;
+
+import static org.finos.legend.engine.test.shared.framework.PureTestHelperFramework.wrapSuite;
+import java.util.Set;
+import junit.framework.Test;
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.factory.Maps;
+import org.eclipse.collections.api.factory.Sets;
+import org.eclipse.collections.api.list.MutableList;
+import org.finos.legend.engine.plan.execution.stores.relational.connection.tests.api.TestConnectionIntegrationLoader;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.DatabaseType;
+import org.finos.legend.engine.test.shared.framework.TestServerResource;
+import org.finos.legend.pure.m3.execution.test.PureTestBuilder;
+import org.finos.legend.pure.m3.execution.test.TestCollection;
+import org.finos.legend.pure.m4.coreinstance.CoreInstance;
+import org.finos.legend.pure.runtime.java.compiled.execution.CompiledExecutionSupport;
+import org.finos.legend.pure.runtime.java.compiled.testHelper.PureTestBuilderCompiled;
+
+// TODO move to a better module!
+public class Test_Relational_DuckDB_Semistructured
+{
+    private static final Set<String> SKIPPED_TESTS = Sets.mutable.empty();
+
+    public static Test suite()
+    {
+        String testPackage = "meta::relational::tests::pct::duckDB::semistructured";
+        CompiledExecutionSupport executionSupport = PureTestBuilderCompiled.getClassLoaderExecutionSupport();
+
+        Set<CoreInstance> skippedCoreInstances = Sets.mutable.empty();
+        for (String path : SKIPPED_TESTS)
+        {
+            CoreInstance ci = executionSupport.getProcessorSupport().package_getByUserPath(path);
+            if (ci != null)
+            {
+                skippedCoreInstances.add(ci);
+            }
+        }
+
+        PureTestBuilder.F2<CoreInstance, MutableList<Object>, Object> executor = (test, params) ->
+        {
+            if (skippedCoreInstances.contains(test))
+            {
+                return true; // skip
+            }
+            return PureTestBuilderCompiled.executeFn(test, null, Maps.mutable.empty(), executionSupport, params);
+        };
+
+        return wrapSuite(
+                () -> true,
+                () -> PureTestBuilder.buildSuite(
+                        TestCollection.collectTests(testPackage, executionSupport.getProcessorSupport(),
+                                fn -> PureTestBuilderCompiled.generatePureTestCollection(fn, executionSupport),
+                                ci -> PureTestBuilder.satisfiesConditions(ci, executionSupport.getProcessorSupport())
+                        ),
+                        executor,
+                        executionSupport
+                ),
+                () -> false,
+                Lists.mutable.with((TestServerResource) TestConnectionIntegrationLoader.extensions().select(c -> c.getDatabaseType() == DatabaseType.DuckDB).getFirst())
+        );
+    }
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-duckdb/legend-engine-xt-relationalStore-duckdb-pure/src/main/resources/core_relational_duckdb/relational/sqlQueryToString/duckdbExtension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-duckdb/legend-engine-xt-relationalStore-duckdb-pure/src/main/resources/core_relational_duckdb/relational/sqlQueryToString/duckdbExtension.pure
@@ -377,7 +377,8 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::duckD
   if($returnType->in(['CHAR', 'VARCHAR', 'STRING']), | 'VARCHAR', |
   if($returnType->in(['DATETIME', 'TIMESTAMP']), | 'TIMESTAMP', |
   if($returnType == 'FLOAT', | 'DOUBLE', |
-  $returnType)));
+  if($returnType == 'SEMISTRUCTURED', | 'JSON', |
+  $returnType))));
 }
 
 function <<access.private>> meta::relational::functions::sqlQueryToString::duckDB::processTableFunctionParamPlaceHolder(r:RelationalOperationElement[1], sgc: SqlGenerationContext[1]): String[1]

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-duckdb/legend-engine-xt-relationalStore-duckdb-pure/src/main/resources/core_relational_duckdb/relational/sqlQueryToString/duckdbExtension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-duckdb/legend-engine-xt-relationalStore-duckdb-pure/src/main/resources/core_relational_duckdb/relational/sqlQueryToString/duckdbExtension.pure
@@ -361,13 +361,23 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::duckD
 
   let elementAccess = format('json_extract(%s, \'%s\')', [$baseRelationalOp, $jsonPath]);
 
+  // An array extraction casts to a typed list, which is what the array_* family needs -
+  // json_extract on its own yields JSON, and DuckDB compares JSON elements as text.
+  if ($returnType->endsWith('[]'),
+      | 'cast(' + $elementAccess + ' as ' + $returnType->substring(0, $returnType->length() - 2)->duckDBSemiStructuredSqlType() + '[])', |
+  // A string is unquoted rather than cast, so the JSON quotes do not survive into the value.
   if ($returnType->in(['CHAR', 'VARCHAR', 'STRING']), | format('json_extract_string(%s, \'%s\')', [$baseRelationalOp, $jsonPath]), |
-  if ($returnType == 'DATE', | 'cast(' + $elementAccess + ' as DATE)', |
-  if ($returnType->in(['DATETIME', 'TIMESTAMP']), | 'cast(' + $elementAccess + ' as TIMESTAMP)', |
-  if ($returnType == 'BOOLEAN', | 'cast(' + $elementAccess + ' as BOOLEAN)', |
-  if ($returnType == 'FLOAT', | 'cast(' + $elementAccess + ' as DOUBLE)', |
-  if ($returnType == 'INTEGER', | 'cast(' + $elementAccess + ' as INTEGER)', |
-  $elementAccess))))));
+  if ($returnType->in(['DATE', 'DATETIME', 'TIMESTAMP', 'BOOLEAN', 'FLOAT', 'INTEGER']),
+      | 'cast(' + $elementAccess + ' as ' + $returnType->duckDBSemiStructuredSqlType() + ')', |
+  $elementAccess)));
+}
+
+function <<access.private>> meta::relational::functions::sqlQueryToString::duckDB::duckDBSemiStructuredSqlType(returnType: String[1]): String[1]
+{
+  if($returnType->in(['CHAR', 'VARCHAR', 'STRING']), | 'VARCHAR', |
+  if($returnType->in(['DATETIME', 'TIMESTAMP']), | 'TIMESTAMP', |
+  if($returnType == 'FLOAT', | 'DOUBLE', |
+  $returnType)));
 }
 
 function <<access.private>> meta::relational::functions::sqlQueryToString::duckDB::processTableFunctionParamPlaceHolder(r:RelationalOperationElement[1], sgc: SqlGenerationContext[1]): String[1]

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-duckdb/legend-engine-xt-relationalStore-duckdb-pure/src/main/resources/core_relational_duckdb/relational/sqlQueryToString/duckdbExtension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-duckdb/legend-engine-xt-relationalStore-duckdb-pure/src/main/resources/core_relational_duckdb/relational/sqlQueryToString/duckdbExtension.pure
@@ -353,10 +353,14 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::duckD
   let returnType = $params->at(2);
 
   // The authored path uses ["a key"] for quoted members, which DuckDB's JSONPath rejects -
-  // it spells those $."a key". Tokenise and re-emit so every segment form is handled:
-  // a named member becomes ."name", an array subscript stays [n].
+  // it spells those $."a key". Tokenise and re-emit so every segment form is handled: an array
+  // subscript stays [n], and a member is quoted only when it is not a plain identifier, which
+  // leaves the SQL for an ordinary path exactly as it was.
   let jsonPath = '$' + meta::relational::functions::sqlQueryToString::parseSemiStructuredPathNavigation($pathNavigation)
-                          ->map(token | if($token->isDigit(), | '[' + $token + ']', | '.' + $token))
+                          ->map(token | if($token->isDigit(),
+                                          | '[' + $token + ']',
+                                          | let member = $token->substring(1, $token->length() - 1);
+                                            if($member->matches('[a-zA-Z_][a-zA-Z_0-9]*'), | '.' + $member, | '."' + $member + '"');))
                           ->joinStrings('');
 
   let elementAccess = format('json_extract(%s, \'%s\')', [$baseRelationalOp, $jsonPath]);

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-duckdb/legend-engine-xt-relationalStore-duckdb-pure/src/main/resources/core_relational_duckdb/relational/sqlQueryToString/duckdbExtension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-duckdb/legend-engine-xt-relationalStore-duckdb-pure/src/main/resources/core_relational_duckdb/relational/sqlQueryToString/duckdbExtension.pure
@@ -180,7 +180,7 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::duckD
     dynaFnToSql('array_sum',              $allStates,            ^ToSql(format='array_aggregate(%s, \'sum\')')),
     dynaFnToSql('array_sort',             $allStates,            ^ToSql(format='array_sort(%s)')),
     dynaFnToSql('array_reverse',          $allStates,            ^ToSql(format='array_reverse(%s)')),
-    dynaFnToSql('array_size',             $allStates,            ^ToSql(format='ifnull(len(%s), 0)')),
+    dynaFnToSql('array_size',             $allStates,            ^ToSql(format='ifnull(json_array_length(cast(%s as JSON)), 0)')),
     dynaFnToSql('array_append',           $allStates,            ^ToSql(format='array_append(%s, %s)')),
     dynaFnToSql('array_position',         $allStates,            ^ToSql(format='(ifnull(array_position(%s, %s), 0)-1)')),
     dynaFnToSql('array_slice',            $allStates,            ^ToSql(format='(%s[greatest(%s + 1, 1) : greatest(%s, 0)])')),
@@ -352,14 +352,22 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::duckD
   let pathNavigation = $params->at(1);
   let returnType = $params->at(2);
 
-  let elementAccess = format('json_extract(%s, \'$.%s\')', [$baseRelationalOp, $pathNavigation]);
+  // The authored path uses ["a key"] for quoted members, which DuckDB's JSONPath rejects -
+  // it spells those $."a key". Tokenise and re-emit so every segment form is handled:
+  // a named member becomes ."name", an array subscript stays [n].
+  let jsonPath = '$' + meta::relational::functions::sqlQueryToString::parseSemiStructuredPathNavigation($pathNavigation)
+                          ->map(token | if($token->isDigit(), | '[' + $token + ']', | '.' + $token))
+                          ->joinStrings('');
 
-  if ($returnType->in(['CHAR', 'VARCHAR', 'STRING']), | format('json_extract_string(%s, \'$.%s\')', [$baseRelationalOp, $pathNavigation]), |
-  if ($returnType->in(['DATE','DATETIME', 'TIMESTAMP']), | 'cast(' + $elementAccess + ' as TIMESTAMP)', |
+  let elementAccess = format('json_extract(%s, \'%s\')', [$baseRelationalOp, $jsonPath]);
+
+  if ($returnType->in(['CHAR', 'VARCHAR', 'STRING']), | format('json_extract_string(%s, \'%s\')', [$baseRelationalOp, $jsonPath]), |
+  if ($returnType == 'DATE', | 'cast(' + $elementAccess + ' as DATE)', |
+  if ($returnType->in(['DATETIME', 'TIMESTAMP']), | 'cast(' + $elementAccess + ' as TIMESTAMP)', |
   if ($returnType == 'BOOLEAN', | 'cast(' + $elementAccess + ' as BOOLEAN)', |
   if ($returnType == 'FLOAT', | 'cast(' + $elementAccess + ' as DOUBLE)', |
-  if ($returnType == 'INTEGER', | 'cast(' + $elementAccess + 'as INTEGER)', |
-  $elementAccess)))));
+  if ($returnType == 'INTEGER', | 'cast(' + $elementAccess + ' as INTEGER)', |
+  $elementAccess))))));
 }
 
 function <<access.private>> meta::relational::functions::sqlQueryToString::duckDB::processTableFunctionParamPlaceHolder(r:RelationalOperationElement[1], sgc: SqlGenerationContext[1]): String[1]
@@ -658,30 +666,112 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::duckD
    $s->match([
       o:SemiStructuredObjectNavigation[1]     | $o->processSemiStructuredObjectNavigationForDuckDB($sgc),
       f:SemiStructuredArrayFlatten[1]         | $f->processSemiStructuredArrayFlattenForDuckDB($sgc),
-      f:SemiStructuredArrayFlattenRelation[1] | ^SemiStructuredArrayFlatten(navigation = $f.navigation)->processSemiStructuredArrayFlattenForDuckDB($sgc)
+      f:SemiStructuredArrayFlattenRelation[1] | ^SemiStructuredArrayFlatten(navigation = $f.navigation)->processSemiStructuredArrayFlattenForDuckDB($sgc),
+      o:SemiStructuredArrayFlattenOutput[1]   | $o->processSemiStructuredArrayFlattenOutputForDuckDB($sgc)
    ])
+}
+
+function <<access.private>> meta::relational::functions::sqlQueryToString::duckDB::processSemiStructuredArrayFlattenOutputForDuckDB(s:SemiStructuredArrayFlattenOutput[1], sgc:SqlGenerationContext[1]): String[1]
+{
+   // processSemiStructuredArrayFlattenForDuckDB names the unnested column VALUE; reference it
+   // on the flatten alias and cast to the navigated type, as the navigation path does.
+   let doubleQuote = if($sgc.config.useQuotesForTableAliasColumn == false, |'', |'"');
+   let processedIdentifier = $sgc.dbConfig.identifierProcessor($doubleQuote + $s.tableAliasColumn.alias.name->toOne() + $doubleQuote);
+   let elementAccess = $processedIdentifier + '.' + processColumnName('VALUE', $sgc.dbConfig);
+   $elementAccess->castForDuckDBSemiStructuredData($s.returnType);
 }
 
 function <<access.private>> meta::relational::functions::sqlQueryToString::duckDB::processSemiStructuredArrayFlattenForDuckDB(s:SemiStructuredArrayFlatten[1], sgc:SqlGenerationContext[1]): String[1]
 {
    // https://duckdb.org/docs/stable/sql/query_syntax/unnest.html
-   let processedNavigation = $s.navigation->processOperation($sgc);
-   '(select unnest(' + $processedNavigation + ', recursive := false) as VALUE)';
+   // unnest needs a LIST. Semi-structured navigation ('->') yields JSON, which has to be cast
+   // to JSON[] first; anything else reaching here (map_keys, array functions, ...) is already a
+   // LIST and must NOT be cast, or DuckDB tries to re-parse its elements as JSON.
+   // DuckDB has no OUTER unnest and rejects a LEFT JOIN LATERAL on correlated columns, so a row
+   // whose array is empty or absent would simply disappear. Substituting a singleton [NULL]
+   // keeps the row and yields a null flattened value, which is the outer-flatten semantics the
+   // other dialects get from their own flatten operators.
+   let list = $s.navigation->asListForDuckDB($sgc);
+   '(select unnest(if(len(' + $list + ') > 0, ' + $list + ', [NULL]), recursive := false) as VALUE)';
+}
+
+// unnest/filter/apply/reduce all require a LIST. Semi-structured navigation ('->') yields JSON,
+// which must be cast to JSON[] first; anything else reaching here (map_keys, array functions,
+// ...) is already a LIST and must NOT be cast, or DuckDB re-parses its elements as JSON.
+function <<access.private>> meta::relational::functions::sqlQueryToString::duckDB::asListForDuckDB(element: RelationalOperationElement[1], sgc: SqlGenerationContext[1]): String[1]
+{
+   $element->asListForDuckDB($sgc, 'JSON');
+}
+
+function <<access.private>> meta::relational::functions::sqlQueryToString::duckDB::asListForDuckDB(element: RelationalOperationElement[1], sgc: SqlGenerationContext[1], elementType: String[1]): String[1]
+{
+   let processed = $element->processOperation($sgc);
+   if($element->isSemiStructuredValueForDuckDB(),
+      | 'cast(' + $processed + ' as ' + $elementType + '[])',
+      | $processed);
+}
+
+// True when the element renders as a JSON scalar and therefore has to be cast before it can be
+// treated as a list. Navigation ('->') is one source; an explicit cast to SEMISTRUCTURED - which
+// DuckDB spells JSON - is the other. Anything else (keys/values, array functions, a nested
+// filter or apply) is already a LIST and must be left alone.
+function <<access.private>> meta::relational::functions::sqlQueryToString::duckDB::isScalarElementAccessorForDuckDB(element: RelationalOperationElement[1]): Boolean[1]
+{
+   $element->match([
+      d: DynaFunction[1] | $d.name->in(['array_first', 'array_last']),
+      a: Any[1] | false
+   ]);
+}
+
+function <<access.private>> meta::relational::functions::sqlQueryToString::duckDB::isSemiStructuredValueForDuckDB(element: RelationalOperationElement[1]): Boolean[1]
+{
+   $element->match([
+      s: SemiStructuredObjectNavigation[1] | true,
+      d: DynaFunction[1] | ($d.name == 'parseJson')
+                              || (($d.name->in(['cast', 'variantTo']))
+                                   && ($d.parameters->size() > 1)
+                                   && $d.parameters->at(1)->instanceOf(meta::relational::metamodel::DataTypeInfo)
+                                   && ($d.parameters->at(1)->cast(@meta::relational::metamodel::DataTypeInfo).dataType->instanceOf(meta::relational::metamodel::datatype::SemiStructured)
+                                        || $d.parameters->at(1)->cast(@meta::relational::metamodel::DataTypeInfo).dataType->instanceOf(meta::relational::metamodel::datatype::Json))),
+      a: Any[1] | false
+   ]);
 }
 
 function <<access.private>> meta::relational::functions::sqlQueryToString::duckDB::processSemiStructuredObjectNavigationForDuckDB(s:SemiStructuredObjectNavigation[1], sgc:SqlGenerationContext[1]): String[1]
 {
    let processedOperand = $s.operand->processOperation($sgc);
 
-   let elementAccess = $s->match([
-      p: SemiStructuredPropertyAccess[1]     | $p.property,
-      a: SemiStructuredArrayElementAccess[1] | $a.index
+   // A SemiStructuredPropertyAccess carries an OPTIONAL index of its own - 'addresses'->at(0)
+   // is one property access with index 0, not a separate SemiStructuredArrayElementAccess.
+   // Dropping that index makes every element of an array resolve to the same value.
+   // Subscripts are addressed by JSONPath because the index literal may hold an Integer or a
+   // String, and rendering the String form through processOperation would quote it into a key.
+   let navigation = $s->match([
+      p: SemiStructuredPropertyAccess[1] |
+            let propertyAccess = '%s->%s'->format([$processedOperand, $p.property->processOperation($sgc)]);
+            if($p.index->isEmpty(),
+               | $propertyAccess,
+               | '%s->\'$[%s]\''->format([$propertyAccess, $p.index->toOne()->cast(@Literal).value->toString()]));,
+      a: SemiStructuredArrayElementAccess[1] |
+            '%s->\'$[%s]\''->format([$processedOperand, $a.index->cast(@Literal).value->toString()])
    ]);
 
-   '%s->%s'->format([
-      $processedOperand,
-      $elementAccess->processOperation($sgc)
-   ]);
+   // '->' yields JSON, so a navigated string comes back still quoted. Cast to the navigated
+   // type the way Snowflake and Databricks already do.
+   if($s.avoidCastIfPrimitive == true, | $navigation, | $navigation->castForDuckDBSemiStructuredData($s.returnType));
+}
+
+function <<access.private>> meta::relational::functions::sqlQueryToString::duckDB::castForDuckDBSemiStructuredData(elementAccess:String[1], type:Type[0..1]): String[1]
+{
+   // '->>' unquotes a JSON scalar to text; the remaining primitives cast directly from JSON.
+   if($type == String, | '(%s->>\'$\')'->format($elementAccess), |
+   if($type == Integer, | 'cast(%s as INTEGER)'->format($elementAccess), |
+   if($type == Float, | 'cast(%s as DOUBLE)'->format($elementAccess), |
+   if($type == Boolean, | 'cast(%s as BOOLEAN)'->format($elementAccess), |
+   if($type == StrictDate, | 'cast(%s as DATE)'->format($elementAccess), |
+   if($type->isNotEmpty() && $type->toOne()->_subTypeOf(Date), | 'cast(%s as TIMESTAMP)'->format($elementAccess), |
+   if($type->isNotEmpty() && $type->toOne()->instanceOf(Enumeration), | '(%s->>\'$\')'->format($elementAccess), |
+   $elementAccess)))))));
 }
 
 function <<access.private>> meta::relational::functions::sqlQueryToString::duckDB::buildLambdaParameter(param: RelationalLambdaParameter[1], sgc: SqlGenerationContext[1]): String[1]
@@ -700,20 +790,38 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::duckD
 
 function <<access.private>> meta::relational::functions::sqlQueryToString::duckDB::buildFoldLambda(lambda: FoldRelationalLambda[1], sgc: SqlGenerationContext[1]): String[1]
 {
-  'cast(reduce(%s, lambda "%s", "%s" : %s, %s) as %s)'->format([
-    $lambda.parameters->at(0).value->processOperation($sgc),
+  // Cast the seed to the accumulator type. Without it DuckDB unifies the accumulator with the
+  // list element type - JSON, once the collection is a JSON[] - and then fails converting a
+  // seed such as '' into JSON.
+  let accumulatorType = $sgc.dbConfig.dataTypeToSqlText($lambda.parameters->at(1).type);
+  // reduce requires the seed and the list element to share a type, so a JSON element type
+  // would force the seed to JSON and fail on values such as ''. Present the elements as the
+  // accumulator type; the body re-casts each element to JSON where it navigates. The
+  // collection may be a nested filter/apply rather than a bare navigation, so key off the
+  // element type rather than the shape of the expression.
+  let foldCollection = if($lambda.parameters->at(0).type->instanceOf(meta::relational::metamodel::datatype::SemiStructured),
+                          | 'cast(' + $lambda.parameters->at(0).value->processOperation($sgc) + ' as ' + $accumulatorType + '[])',
+                          | $lambda.parameters->at(0).value->asListForDuckDB($sgc, 'VARCHAR'));
+  'cast(reduce(%s, lambda "%s", "%s" : %s, cast(%s as %s)) as %s)'->format([
+    $foldCollection,
     $lambda.parameters->at(1).name,
     $lambda.parameters->at(0).name,
     $lambda.body->processOperation($sgc),
     $lambda.parameters->at(1).value->processOperation($sgc),
-    $sgc.dbConfig.dataTypeToSqlText($lambda.parameters->at(1).type)
+    $accumulatorType,
+    $accumulatorType
   ]);
 }
 
 function <<access.private>> meta::relational::functions::sqlQueryToString::duckDB::buildMapLambda(lambda: MapRelationalLambda[1], sgc: SqlGenerationContext[1]): String[1]
 {
+  // array_first/array_last render as a subscript and yield a single element, but apply needs a
+  // LIST; wrap the element so a map over a [0..1] navigation still binds.
+  let mapCollection = if($lambda.parameters->at(0).value->isScalarElementAccessorForDuckDB(),
+                         | 'list_value(' + $lambda.parameters->at(0).value->processOperation($sgc) + ')',
+                         | $lambda.parameters->at(0).value->asListForDuckDB($sgc));
   'apply(%s, lambda "%s" : %s)'->format([
-      $lambda.parameters->at(0).value->processOperation($sgc),
+      $mapCollection,
       $lambda.parameters->at(0).name,
       $lambda.body->processOperation($sgc)
    ]);
@@ -722,7 +830,7 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::duckD
 function <<access.private>> meta::relational::functions::sqlQueryToString::duckDB::buildFilterLambda(lambda: FilterRelationalLambda[1], sgc: SqlGenerationContext[1]): String[1]
 {
   'filter(%s, lambda "%s" : %s)'->format([
-      $lambda.parameters->at(0).value->processOperation($sgc),
+      $lambda.parameters->at(0).value->asListForDuckDB($sgc),
       $lambda.parameters->at(0).name,
       $lambda.body->processOperation($sgc)
    ]);
@@ -730,10 +838,14 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::duckD
 
 function <<access.private>> meta::relational::functions::sqlQueryToString::duckDB::processJoinTreeNodeWithLateralJoinForDuckDB(j:JoinTreeNode[1], dbConfig : DbConfig[1], format:Format[1], extensions:Extension[*]):String[1]
 {
-   ', lateral '
+   // Use the explicit JOIN form rather than a comma join. Comma binds looser than JOIN, so a
+   // following LEFT OUTER JOIN would attach to the lateral alias while its ON clause still
+   // references the driving table - which DuckDB rejects as a non-inner join on correlated
+   // columns. Snowflake and Databricks emit the explicit form for the same reason.
+   ' inner join lateral '
    + $j.alias
          ->map(a|^$a(name = '"' + $a.name + '"'))
-         ->toOne()->processOperation($dbConfig, ^$format(newLine = '')->indent(), $extensions) + $format.separator();
+         ->toOne()->processOperation($dbConfig, ^$format(newLine = '')->indent(), $extensions) + ' on true' + $format.separator();
 }
 
 function <<access.private>> meta::relational::functions::sqlQueryToString::duckDB::transformRoundForDuckDB(p:String[1..2]):String[1]

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-h2/legend-engine-xt-relationalStore-h2-PCT/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/h2/semistructured/Test_Relational_H2_Semistructured.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-h2/legend-engine-xt-relationalStore-h2-PCT/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/h2/semistructured/Test_Relational_H2_Semistructured.java
@@ -34,6 +34,12 @@ import org.eclipse.collections.api.factory.Maps;
 public class Test_Relational_H2_Semistructured
 {
     private static final Set<String> SKIPPED_TESTS = Sets.mutable.with(
+            // The union of two binding legs casts the shared column to the declared type,
+            // and SEMISTRUCTURED is not an H2 SQL type: "Unknown data type: SEMISTRUCTURED".
+            // Only H2 hits this - it is the sole dialect without a native semi-structured
+            // type, holding the data in a VARCHAR instead. Left failing per H2's retirement.
+            "meta::relational::tests::semistructured::union::testSemiStructuredUnionMappingWithBinding_Connection_1__Boolean_1_",
+            "meta::relational::tests::semistructured::union::testSemiStructuredUnionMappingWithBindingAndFilter_Connection_1__Boolean_1_",
             // H2 is the only dialect on the sqlDialectTranslation path, and toPostgresModel
             // carries no translation for the array_* family: "Couldn't find DynaFunction to
             // Postgres model translation for array_max()" (toPostgresModel.pure:268). This is

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-h2/legend-engine-xt-relationalStore-h2-PCT/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/h2/semistructured/Test_Relational_H2_Semistructured.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-h2/legend-engine-xt-relationalStore-h2-PCT/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/h2/semistructured/Test_Relational_H2_Semistructured.java
@@ -34,6 +34,12 @@ import org.eclipse.collections.api.factory.Maps;
 public class Test_Relational_H2_Semistructured
 {
     private static final Set<String> SKIPPED_TESTS = Sets.mutable.with(
+            // H2 is the only dialect on the sqlDialectTranslation path, and toPostgresModel
+            // carries no translation for the array_* family: "Couldn't find DynaFunction to
+            // Postgres model translation for array_max()" (toPostgresModel.pure:268). This is
+            // independent of semi-structured data - no array function reaches H2 at all.
+            "meta::relational::tests::semistructured::arrayStore::testArrayFunctionsInMapping_Connection_1__Boolean_1_",
+            "meta::relational::tests::semistructured::arrayStore::testArrayFunctionInFilter_Connection_1__Boolean_1_",
             "meta::relational::tests::semistructured::flattening::testSemiStructuredArrayDirectIsEmpty_Connection_1__Boolean_1_",
             "meta::relational::tests::semistructured::flattening::testSemiStructuredArrayDirectIsNotEmpty_Connection_1__Boolean_1_",
             "meta::relational::tests::semistructured::flattening::testSemiStructuredArrayDirectSize_Connection_1__Boolean_1_",

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-h2/legend-engine-xt-relationalStore-h2-PCT/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/h2/semistructured/Test_Relational_H2_Semistructured.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-h2/legend-engine-xt-relationalStore-h2-PCT/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/h2/semistructured/Test_Relational_H2_Semistructured.java
@@ -48,12 +48,6 @@ public class Test_Relational_H2_Semistructured
             // FilterRelationalLambda". Same structural gap as the array_* family - H2 is the only
             // dialect on that path. Left failing per H2's retirement.
             "meta::relational::tests::semistructured::chain::testComplexChainInStoreLanguage_Connection_1__Boolean_1_",
-            // The union of two binding legs casts the shared column to the declared type,
-            // and SEMISTRUCTURED is not an H2 SQL type: "Unknown data type: SEMISTRUCTURED".
-            // Only H2 hits this - it is the sole dialect without a native semi-structured
-            // type, holding the data in a VARCHAR instead. Left failing per H2's retirement.
-            "meta::relational::tests::semistructured::union::testSemiStructuredUnionMappingWithBinding_Connection_1__Boolean_1_",
-            "meta::relational::tests::semistructured::union::testSemiStructuredUnionMappingWithBindingAndFilter_Connection_1__Boolean_1_",
             // H2 is the only dialect on the sqlDialectTranslation path, and toPostgresModel
             // carries no translation for the array_* family: "Couldn't find DynaFunction to
             // Postgres model translation for array_max()" (toPostgresModel.pure:268). This is

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-h2/legend-engine-xt-relationalStore-h2-PCT/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/h2/semistructured/Test_Relational_H2_Semistructured.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-h2/legend-engine-xt-relationalStore-h2-PCT/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/h2/semistructured/Test_Relational_H2_Semistructured.java
@@ -34,6 +34,11 @@ import org.eclipse.collections.api.factory.Maps;
 public class Test_Relational_H2_Semistructured
 {
     private static final Set<String> SKIPPED_TESTS = Sets.mutable.with(
+            // Array lambdas reach H2 through the sqlDialectTranslation path, which has no case for
+            // the lambda nodes: "Match failure: FilterRelationalLambdaObject instanceOf
+            // FilterRelationalLambda". Same structural gap as the array_* family - H2 is the only
+            // dialect on that path. Left failing per H2's retirement.
+            "meta::relational::tests::semistructured::chain::testComplexChainInStoreLanguage_Connection_1__Boolean_1_",
             // The union of two binding legs casts the shared column to the declared type,
             // and SEMISTRUCTURED is not an H2 SQL type: "Unknown data type: SEMISTRUCTURED".
             // Only H2 hits this - it is the sole dialect without a native semi-structured

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-h2/legend-engine-xt-relationalStore-h2-PCT/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/h2/semistructured/Test_Relational_H2_Semistructured.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-h2/legend-engine-xt-relationalStore-h2-PCT/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/h2/semistructured/Test_Relational_H2_Semistructured.java
@@ -34,6 +34,11 @@ import org.eclipse.collections.api.factory.Maps;
 public class Test_Relational_H2_Semistructured
 {
     private static final Set<String> SKIPPED_TESTS = Sets.mutable.with(
+            // A [*] path becomes an array_transform, and array lambdas reach H2 through the
+            // sqlDialectTranslation path, which has no case for the lambda nodes: "Match failure:
+            // MapRelationalLambdaObject instanceOf MapRelationalLambda". Left failing per H2's
+            // retirement.
+            "meta::relational::tests::semistructured::wildcard::testWildcardPathInStoreLanguage_Connection_1__Boolean_1_",
             // H2 renders one lateral flatten correctly - every single-level explode test passes
             // here - but a second lateral over the first one's output yields nulls rather than
             // rows, and does so silently. Left failing per H2's retirement.

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-h2/legend-engine-xt-relationalStore-h2-PCT/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/h2/semistructured/Test_Relational_H2_Semistructured.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-h2/legend-engine-xt-relationalStore-h2-PCT/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/h2/semistructured/Test_Relational_H2_Semistructured.java
@@ -34,6 +34,10 @@ import org.eclipse.collections.api.factory.Maps;
 public class Test_Relational_H2_Semistructured
 {
     private static final Set<String> SKIPPED_TESTS = Sets.mutable.with(
+            // H2 renders one lateral flatten correctly - every single-level explode test passes
+            // here - but a second lateral over the first one's output yields nulls rather than
+            // rows, and does so silently. Left failing per H2's retirement.
+            "meta::relational::tests::semistructured::nested::testNestedExplode_Connection_1__Boolean_1_",
             // Array lambdas reach H2 through the sqlDialectTranslation path, which has no case for
             // the lambda nodes: "Match failure: FilterRelationalLambdaObject instanceOf
             // FilterRelationalLambda". Same structural gap as the array_* family - H2 is the only

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-h2/legend-engine-xt-relationalStore-h2-sqlDialectTranslation-pure/src/main/resources/core_external_store_relational_sql_dialect_translation_h2/h2SqlDialect.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-h2/legend-engine-xt-relationalStore-h2-sqlDialectTranslation-pure/src/main/resources/core_external_store_relational_sql_dialect_translation_h2/h2SqlDialect.pure
@@ -903,7 +903,12 @@ function <<access.private>> meta::external::store::relational::sqlDialectTransla
           pair(| $returnType == 'date',                           | 'date'),
           pair(| $returnType == 'boolean',                        | 'boolean'),
           pair(| $returnType == 'float',                          | 'float'),
-          pair(| $returnType == 'integer',                        | 'integer')
+          pair(| $returnType == 'integer',                        | 'integer'),
+          // H2 has no native semi-structured type - it holds the document in a VARCHAR, which is
+          // what the SemiStructured datatype renders as too - so the cast is a no-op that leaves
+          // the document as the store's own representation. Without an arm here the type name
+          // reaches H2 verbatim and it answers "Unknown data type: SEMISTRUCTURED".
+          pair(| $returnType == 'semistructured',                 | 'varchar')
         ],
         | $returnType
       );

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-PCT/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-PCT/pom.xml
@@ -118,6 +118,11 @@
                             <skip>false</skip>
                             <forkCount>2</forkCount>
                             <reuseForks>false</reuseForks>
+                            <!-- The Snowflake driver decodes results through Arrow, whose
+                                 allocator reflects into java.nio at class-init. JDK 16+ blocks
+                                 that, and every query then fails inside the driver rather than
+                                 in SQL. Harmless on JDK 11, where the flag is simply accepted. -->
+                            <argLine>--add-opens=java.base/java.nio=ALL-UNNAMED</argLine>
                             <systemPropertyVariables>
                                 <AWS_ACCESS_KEY_ID>${env.AWS_ACCESS_KEY_ID}</AWS_ACCESS_KEY_ID>
                                 <AWS_SECRET_ACCESS_KEY>${env.AWS_SECRET_ACCESS_KEY}</AWS_SECRET_ACCESS_KEY>

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-PCT/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/snowflake/semistructured/Test_Relational_Snowflake_Semistructured.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-PCT/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/snowflake/semistructured/Test_Relational_Snowflake_Semistructured.java
@@ -45,9 +45,10 @@ public class Test_Relational_Snowflake_Semistructured
 
         PureTestBuilder.F2<CoreInstance, MutableList<Object>, Object> executor = (test, params) ->
         {
+            Object result;
             try
             {
-                return PureTestBuilderCompiled.executeFn(test, null, Maps.mutable.empty(), executionSupport, params);
+                result = PureTestBuilderCompiled.executeFn(test, null, Maps.mutable.empty(), executionSupport, params);
             }
             catch (Exception e)
             {
@@ -62,6 +63,13 @@ public class Test_Relational_Snowflake_Semistructured
                 }
                 throw e;
             }
+            // Reached only when the test passed. An entry that no longer reproduces is worse
+            // than no entry: it silently suppresses whatever regresses into it next.
+            if (failures.containsKey(test))
+            {
+                throw new AssertionError("Expected this test to fail with: " + failures.get(test) + ", but it passed. Remove the entry.");
+            }
+            return result;
         };
 
         return wrapSuite(

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-PCT/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/snowflake/semistructured/Test_Relational_Snowflake_Semistructured.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-PCT/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/snowflake/semistructured/Test_Relational_Snowflake_Semistructured.java
@@ -38,10 +38,11 @@ public class Test_Relational_Snowflake_Semistructured
         String testPackage = "meta::relational::tests::pct::snowflake::semistructured";
         CompiledExecutionSupport executionSupport = PureTestBuilderCompiled.getClassLoaderExecutionSupport();
 
-        Map<CoreInstance, String> failures = Maps.mutable.with(
-            "meta::relational::tests::semistructured::union::testSemiStructuredUnionMappingWithBindingAndFilter_Connection_1__Boolean_1_", "Invalid argument types for function 'GET': (VARCHAR(134217728), VARCHAR(8))",
-            "meta::relational::tests::semistructured::union::testSemiStructuredUnionMappingWithBinding_Connection_1__Boolean_1_", "Invalid argument types for function 'GET': (VARCHAR(134217728), VARCHAR(8))"
-        ).collect((k, v) -> Tuples.pair(executionSupport.getProcessorSupport().package_getByUserPath(k), v));
+        // Empty: the union-with-binding failures these used to record are fixed by declaring
+        // the extraction SEMISTRUCTURED rather than VARCHAR, so the binding is handed a
+        // document instead of text.
+        Map<CoreInstance, String> failures = Maps.mutable.<String, String>empty()
+            .collect((k, v) -> Tuples.pair(executionSupport.getProcessorSupport().package_getByUserPath(k), v));
 
         PureTestBuilder.F2<CoreInstance, MutableList<Object>, Object> executor = (test, params) ->
         {

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-pure/src/main/resources/core_relational_snowflake/relational/sqlQueryToString/snowflakeExtension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-pure/src/main/resources/core_relational_snowflake/relational/sqlQueryToString/snowflakeExtension.pure
@@ -456,13 +456,17 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::snowf
   // https://docs.snowflake.com/en/sql-reference/functions/get_path
   let elementAccess = format('get_path(%s, \'%s\')', [$baseRelationalOp, $pathNavigation]);
 
+  // An array extraction converts to an ARRAY. The element type is not applied: a Snowflake
+  // ARRAY holds VARIANT, and VARIANT comparison is type-aware, so array_max on numbers
+  // already orders numerically rather than as text.
+  if ($returnType->endsWith('[]'), | 'to_array(' + $elementAccess + ')', |
   if ($returnType->in(['CHAR', 'VARCHAR', 'STRING']), | 'to_varchar(' + $elementAccess + ')', |
   if ($returnType->in(['DATETIME', 'TIMESTAMP']), | 'to_timestamp(' + $elementAccess + ')', |
   if ($returnType == 'DATE', | 'to_date(' + $elementAccess + ')', |
   if ($returnType == 'BOOLEAN', | 'to_boolean(' + $elementAccess + ')', |
   if ($returnType == 'FLOAT', | 'to_double(' + $elementAccess + ')', |
   if ($returnType == 'INTEGER', | 'to_number(' + $elementAccess + ')', |
-  $elementAccess))))));
+  $elementAccess)))))));
 }
 
 function <<access.private>> meta::relational::functions::sqlQueryToString::snowflake::convertToDateSnowflake(params:String[*]):String[1]

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-pure/src/main/resources/core_relational_snowflake/relational/sqlQueryToString/snowflakeExtension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-pure/src/main/resources/core_relational_snowflake/relational/sqlQueryToString/snowflakeExtension.pure
@@ -354,7 +354,10 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::snowf
     dynaFnToSql('toVariantObject',        $allStates,            ^ToSql(format='{%s}', transform={p:String[*] | range(0, $p->size(), 2)->map(i | $p->at($i) + ': ' + $p->at($i + 1))->joinStrings(', ')})),
     dynaFnToSql('keys',                   $allStates,            ^ToSql(format='map_keys(%s)')),
     dynaFnToSql('values',                 $allStates,            ^ToSql(format='transform(map_keys(%s), k -> GET(%s, k))', transform = {p:String[1] | $p->concatenate($p)})),
-    dynaFnToSql('array_flatten',          $allStates,            ^ToSql(format='array_flatten(%s)')),  
+    // Typing an extraction as ARRAY(VARIANT) means a transform whose body extracts an array
+    // produces ARRAY(ARRAY(VARIANT)), which ARRAY_FLATTEN refuses. Widening to a plain ARRAY
+    // first is what it accepts, and the elements stay VARIANT either way.
+    dynaFnToSql('array_flatten',          $allStates,            ^ToSql(format='array_flatten(cast(%s as ARRAY))')),  
     dynaFnToSql('mapConcatenate',         $allStates,            ^ToSql(format='map_cat(%s, %s)')), 
     dynaFnToSql('parseBoolean',           $allStates,            ^ToSql(format='to_boolean(%s)')),
     dynaFnToSql('position',               $allStates,            ^ToSql(format='position(%s in %s)')),

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-pure/src/main/resources/core_relational_snowflake/relational/sqlQueryToString/snowflakeExtension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-pure/src/main/resources/core_relational_snowflake/relational/sqlQueryToString/snowflakeExtension.pure
@@ -456,10 +456,12 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::snowf
   // https://docs.snowflake.com/en/sql-reference/functions/get_path
   let elementAccess = format('get_path(%s, \'%s\')', [$baseRelationalOp, $pathNavigation]);
 
-  // An array extraction converts to an ARRAY. The element type is not applied: a Snowflake
-  // ARRAY holds VARIANT, and VARIANT comparison is type-aware, so array_max on numbers
-  // already orders numerically rather than as text.
-  if ($returnType->endsWith('[]'), | 'to_array(' + $elementAccess + ')', |
+  // A [] suffix is the modeller asserting the path holds an array, so a value that is not one
+  // has to fail rather than be made to fit. to_array promotes a scalar or object into a
+  // one-element array, which invents data and lets a model pass here that fails on DuckDB;
+  // ARRAY(VARIANT) raises instead. The element type stays VARIANT because comparison on it is
+  // type-aware, so array_max over numbers still orders numerically rather than as text.
+  if ($returnType->endsWith('[]'), | 'cast(' + $elementAccess + ' as ARRAY(VARIANT))', |
   if ($returnType->in(['CHAR', 'VARCHAR', 'STRING']), | 'to_varchar(' + $elementAccess + ')', |
   if ($returnType->in(['DATETIME', 'TIMESTAMP']), | 'to_timestamp(' + $elementAccess + ')', |
   if ($returnType == 'DATE', | 'to_date(' + $elementAccess + ')', |

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/pom.xml
@@ -90,6 +90,20 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- DuckDB: driver/DatabaseManager plus the Pure dbExtension. A mapping test whose query
+             returns a Relation is routed to DuckDB rather than H2 (RelationalConnectionFactory),
+             and resolving that connection needs both halves on the classpath. -->
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-relationalStore-duckdb-execution</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-relationalStore-duckdb-pure</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!-- Plan generation + serialisation, in-memory store, json model, java binding —
              same set as the EMIT framework's own tests, kept here to mirror that profile. -->
         <dependency>

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-array-operations.emit.yaml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-array-operations.emit.yaml
@@ -12,22 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: relational-semistructured
-title: "Relational Store — Modelled Semi-structured Data"
+name: relational-semistructured-array-operations
+title: "Relational Store — Operations on JSON Arrays"
 description: |
-  A SEMISTRUCTURED column modelled as ordinary typed properties. One JSON document per
-  row is projected into scalars covering every target type the extraction whitelist
-  accepts, plus the edges of the path grammar: an element of an array of objects, an
-  element of an array of arrays, an array nested inside an object array, bracket-quoted
-  keys containing a space and a dot, and — against a second column whose root is a JSON
-  array — paths that lead with an index.
+  Collection functions applied to to-many properties backed by JSON arrays, grouped by
+  what they do: cardinality (size, isEmpty, isNotEmpty), element access (at, first),
+  and lambda-driven operations (filter, map, fold, exists, joinStrings) which push down
+  to the database rather than materialising the array.
 
-  Navigation is exercised in two positions: property mappings, and a store filter
-  predicate that reads a value out of the document to decide row inclusion.
+  The binding is attached directly to the column. That is a requirement, not a style
+  choice: the auto-flatten gate rejects a binding whose operation carries a join, so
+  array operations are unavailable across a join-based binding.
 
 modelSources:
   model:
-    root: relational-semistructured
+    root: relational-semistructured-array-operations
     files:
       - store/db.pure
       - mapping/mapping.pure
@@ -35,19 +34,21 @@ modelSources:
 
 features:
   - execution:data-element
+  - execution:external-format-binding
   - execution:test-data
   - scaffolding:class
   - scaffolding:relational-mapping
   - scaffolding:relational-store
   - store:relational-semistructured
-  - store:relational-semistructured-navigation
-  - store:relational-semistructured-array-index
-  - store:relational-filter
+  - store:relational-semistructured-array-functions
+  - store:relational-semistructured-binding
+  - store:relational-semistructured-flatten
 stores:
   - relational
 # Distinct non-scaffolding domains: execution, store = 2 -> basic.
 complexity: basic
 tags:
   - semi-structured
-  - variant
+  - binding
+  - array-functions
   - json

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-array-operations/data/testData.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-array-operations/data/testData.pure
@@ -1,0 +1,29 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// RFC-4180: each JSON document is wrapped in " and every internal " is doubled.
+// scores are deliberately unsorted and contain a duplicate, so ordering and
+// de-duplication are distinguishable from the stored order.
+// Alice has 3 addresses (two matching the 'A' prefix), Bob has 1 (non-matching).
+###Data
+Data demo::ssa::data::PersonData
+{
+  Relation
+  #{
+    default.PERSON_TABLE:
+      ID,FIRST_NAME,FIRM_DETAILS
+      1,Alice,"{""legalName"":""Firm X"",""scores"":[30,10,20,10],""addresses"":[{""name"":""A1"",""rank"":5},{""name"":""B2"",""rank"":3},{""name"":""A3"",""rank"":9}]}"
+      2,Bob,"{""legalName"":""Firm A"",""scores"":[7],""addresses"":[{""name"":""Z9"",""rank"":1}]}";
+  }#
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-array-operations/mapping/mapping.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-array-operations/mapping/mapping.pure
@@ -100,8 +100,12 @@ Mapping demo::ssa::PersonMapping
         }
       ];
     },
-    // New ground - max/min over a semi-structured array are exercised nowhere else in
-    // the repo. Kept in their own suite so a failure here isolates from the rest.
+    // max/min over a semi-structured array are exercised nowhere else in the repo. The
+    // values below are correct, but they are reached by flattening and aggregating in
+    // SQL, not through array_max/array_min - max and min carry no semi-structured
+    // dispatch guard, so they never reach their array_* dyna function. This asserts the
+    // result only; it is not evidence the array path ran. See section 11.8 of
+    // docs/engineering/architecture/relational-dynafunctions.md.
     aggregateSuite:
     {
       function: |demo::ssa::Person.all()

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-array-operations/mapping/mapping.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-array-operations/mapping/mapping.pure
@@ -119,40 +119,6 @@ Mapping demo::ssa::PersonMapping
           asserts: [ shouldAggregate: EqualToJson #{ expected: ExternalFormat #{ contentType: 'application/json'; data: '[{"firstName":"Alice","topScore":30,"lowScore":10},{"firstName":"Bob","topScore":7,"lowScore":7}]'; }#; }# ];
         }
       ];
-    },
-    // sort and removeDuplicates act on the array itself, so the column holds the whole
-    // array rather than one row per element. They reach array_sort / array_distinct only
-    // because the processor disables auto-flatten; without that the array is fanned into
-    // rows first and array_sort receives a single element.
-    // Note this is removeDuplicates, not distinct - distinct is a TDS operation that
-    // de-duplicates result rows and never touches the array.
-    orderingSuite:
-    {
-      function: |demo::ssa::Person.all()
-                  ->project(~[firstName: p | $p.firstName, sorted: p | $p.firm.addresses->map(a | $a.rank)->sort()])
-                  ->sort([~firstName->ascending(), ~sorted->ascending()]);
-      tests:
-      [
-        sortElements:
-        {
-          data: [ demo::ssa::store::PersonDB: Reference #{ demo::ssa::data::PersonData }# ];
-          asserts: [ shouldSort: EqualToJson #{ expected: ExternalFormat #{ contentType: 'application/json'; data: '[{"firstName":"Alice","sorted":"[3,5,9]"},{"firstName":"Bob","sorted":"[1]"}]'; }#; }# ];
-        }
-      ];
-    },
-    removeDuplicatesSuite:
-    {
-      function: |demo::ssa::Person.all()
-                  ->project(~[firstName: p | $p.firstName, unique: p | $p.firm.addresses->map(a | $a.rank)->removeDuplicates()])
-                  ->sort([~firstName->ascending(), ~unique->ascending()]);
-      tests:
-      [
-        dedupeElements:
-        {
-          data: [ demo::ssa::store::PersonDB: Reference #{ demo::ssa::data::PersonData }# ];
-          asserts: [ shouldDedupe: EqualToJson #{ expected: ExternalFormat #{ contentType: 'application/json'; data: '[{"firstName":"Alice","unique":"[9,3,5]"},{"firstName":"Bob","unique":"[1]"}]'; }#; }# ];
-        }
-      ];
     }
   ]
 )

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-array-operations/mapping/mapping.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-array-operations/mapping/mapping.pure
@@ -1,0 +1,120 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Mapping
+Mapping demo::ssa::PersonMapping
+(
+  *demo::ssa::Person: Relational
+  {
+    ~primaryKey
+    (
+      [demo::ssa::store::PersonDB]PERSON_TABLE.ID
+    )
+    ~mainTable [demo::ssa::store::PersonDB]PERSON_TABLE
+    firstName: [demo::ssa::store::PersonDB]PERSON_TABLE.FIRST_NAME,
+    // Bound directly to the column, not through a join. Array operations require this:
+    // the auto-flatten gate rejects a binding whose operation carries a join.
+    firm: Binding demo::ssa::FirmBinding : [demo::ssa::store::PersonDB]PERSON_TABLE.FIRM_DETAILS
+  }
+
+  testSuites:
+  [
+    cardinalitySuite:
+    {
+      function: |demo::ssa::Person.all()
+                  ->project(~[firstName: p | $p.firstName, addressCount: p | $p.firm.addresses->size(), noAddresses: p | $p.firm.addresses->isEmpty(), hasAddresses: p | $p.firm.addresses->isNotEmpty()])
+                  ->sort([~firstName->ascending()]);
+      tests:
+      [
+        countElements:
+        {
+          data: [ demo::ssa::store::PersonDB: Reference #{ demo::ssa::data::PersonData }# ];
+          asserts: [ shouldCount: EqualToJson #{ expected: ExternalFormat #{ contentType: 'application/json'; data: '[{"firstName":"Alice","addressCount":3,"noAddresses":false,"hasAddresses":true},{"firstName":"Bob","addressCount":1,"noAddresses":false,"hasAddresses":true}]'; }#; }# ];
+        }
+      ];
+    },
+    elementAccessSuite:
+    {
+      function: |demo::ssa::Person.all()
+                  ->project(~[firstName: p | $p.firstName, firstByIndex: p | $p.firm.addresses->at(0).name])
+                  ->sort([~firstName->ascending()]);
+      tests:
+      [
+        accessElements:
+        {
+          data: [ demo::ssa::store::PersonDB: Reference #{ demo::ssa::data::PersonData }# ];
+          asserts: [ shouldAccess: EqualToJson #{ expected: ExternalFormat #{ contentType: 'application/json'; data: '[{"firstName":"Alice","firstByIndex":"A1"},{"firstName":"Bob","firstByIndex":"Z9"}]'; }#; }# ];
+        }
+      ];
+    },
+    filterSuite:
+    {
+      function: |demo::ssa::Person.all()
+                  ->project(~[firstName: p | $p.firstName, matching: p | $p.firm.addresses->filter(a | $a.name->startsWith('A'))->size()])
+                  ->sort([~firstName->ascending()]);
+      tests:
+      [
+        applyFilter:
+        {
+          data: [ demo::ssa::store::PersonDB: Reference #{ demo::ssa::data::PersonData }# ];
+          asserts: [ shouldFilter: EqualToJson #{ expected: ExternalFormat #{ contentType: 'application/json'; data: '[{"firstName":"Alice","matching":2},{"firstName":"Bob","matching":0}]'; }#; }# ];
+        }
+      ];
+    },
+    mapSuite:
+    {
+      function: |demo::ssa::Person.all()
+                  ->project(~[firstName: p | $p.firstName, name: p | $p.firm.addresses->filter(a | $a.name->startsWith('A'))->map(a | $a.name)])
+                  ->sort([~firstName->ascending(), ~name->ascending()]);
+      tests:
+      [
+        applyMap:
+        {
+          data: [ demo::ssa::store::PersonDB: Reference #{ demo::ssa::data::PersonData }# ];
+          asserts: [ shouldMap: EqualToJson #{ expected: ExternalFormat #{ contentType: 'application/json'; data: '[{"firstName":"Alice","name":"A1"},{"firstName":"Alice","name":"A3"}]'; }#; }# ];
+        }
+      ];
+    },
+    foldSuite:
+    {
+      function: |demo::ssa::Person.all()
+                  ->project(~[firstName: p | $p.firstName, concatenated: p | $p.firm.concatenatedNames()])
+                  ->sort([~firstName->ascending()]);
+      tests:
+      [
+        applyFold:
+        {
+          data: [ demo::ssa::store::PersonDB: Reference #{ demo::ssa::data::PersonData }# ];
+          asserts: [ shouldFold: EqualToJson #{ expected: ExternalFormat #{ contentType: 'application/json'; data: '[{"firstName":"Alice","concatenated":"A1B2A3"},{"firstName":"Bob","concatenated":"Z9"}]'; }#; }# ];
+        }
+      ];
+    },
+    // New ground - max/min over a semi-structured array are exercised nowhere else in
+    // the repo. Kept in their own suite so a failure here isolates from the rest.
+    aggregateSuite:
+    {
+      function: |demo::ssa::Person.all()
+                  ->project(~[firstName: p | $p.firstName, topScore: p | $p.firm.scores->max(), lowScore: p | $p.firm.scores->min()])
+                  ->sort([~firstName->ascending()]);
+      tests:
+      [
+        aggregateElements:
+        {
+          data: [ demo::ssa::store::PersonDB: Reference #{ demo::ssa::data::PersonData }# ];
+          asserts: [ shouldAggregate: EqualToJson #{ expected: ExternalFormat #{ contentType: 'application/json'; data: '[{"firstName":"Alice","topScore":30,"lowScore":10},{"firstName":"Bob","topScore":7,"lowScore":7}]'; }#; }# ];
+        }
+      ];
+    }
+  ]
+)

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-array-operations/mapping/mapping.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-array-operations/mapping/mapping.pure
@@ -119,6 +119,40 @@ Mapping demo::ssa::PersonMapping
           asserts: [ shouldAggregate: EqualToJson #{ expected: ExternalFormat #{ contentType: 'application/json'; data: '[{"firstName":"Alice","topScore":30,"lowScore":10},{"firstName":"Bob","topScore":7,"lowScore":7}]'; }#; }# ];
         }
       ];
+    },
+    // sort and removeDuplicates act on the array itself, so the column holds the whole
+    // array rather than one row per element. They reach array_sort / array_distinct only
+    // because the processor disables auto-flatten; without that the array is fanned into
+    // rows first and array_sort receives a single element.
+    // Note this is removeDuplicates, not distinct - distinct is a TDS operation that
+    // de-duplicates result rows and never touches the array.
+    orderingSuite:
+    {
+      function: |demo::ssa::Person.all()
+                  ->project(~[firstName: p | $p.firstName, sorted: p | $p.firm.addresses->map(a | $a.rank)->sort()])
+                  ->sort([~firstName->ascending(), ~sorted->ascending()]);
+      tests:
+      [
+        sortElements:
+        {
+          data: [ demo::ssa::store::PersonDB: Reference #{ demo::ssa::data::PersonData }# ];
+          asserts: [ shouldSort: EqualToJson #{ expected: ExternalFormat #{ contentType: 'application/json'; data: '[{"firstName":"Alice","sorted":"[3,5,9]"},{"firstName":"Bob","sorted":"[1]"}]'; }#; }# ];
+        }
+      ];
+    },
+    removeDuplicatesSuite:
+    {
+      function: |demo::ssa::Person.all()
+                  ->project(~[firstName: p | $p.firstName, unique: p | $p.firm.addresses->map(a | $a.rank)->removeDuplicates()])
+                  ->sort([~firstName->ascending(), ~unique->ascending()]);
+      tests:
+      [
+        dedupeElements:
+        {
+          data: [ demo::ssa::store::PersonDB: Reference #{ demo::ssa::data::PersonData }# ];
+          asserts: [ shouldDedupe: EqualToJson #{ expected: ExternalFormat #{ contentType: 'application/json'; data: '[{"firstName":"Alice","unique":"[9,3,5]"},{"firstName":"Bob","unique":"[1]"}]'; }#; }# ];
+        }
+      ];
     }
   ]
 )

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-array-operations/store/db.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-array-operations/store/db.pure
@@ -1,0 +1,58 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+Class demo::ssa::Person
+{
+  firstName: String[1];
+  firm: demo::ssa::Firm[1];
+}
+
+Class demo::ssa::Firm
+{
+  legalName: String[1];
+  scores: Integer[*];
+  addresses: demo::ssa::Address[*];
+  // fold needs a two-parameter block lambda, which the relation colSpec grammar cannot
+  // parse. Declaring it here puts it under the ordinary domain grammar, and the query
+  // projects the derived property instead of the fold expression.
+  concatenatedNames() {$this.addresses->fold({a, acc | $acc + $a.name}, '')}: String[1];
+}
+
+Class demo::ssa::Address
+{
+  name: String[1];
+  rank: Integer[1];
+}
+
+###ExternalFormat
+Binding demo::ssa::FirmBinding
+{
+  contentType: 'application/json';
+  modelIncludes: [
+    demo::ssa::Firm,
+    demo::ssa::Address
+  ];
+}
+
+###Relational
+Database demo::ssa::store::PersonDB
+(
+  Table PERSON_TABLE
+  (
+    ID INTEGER PRIMARY KEY,
+    FIRST_NAME VARCHAR(100),
+    FIRM_DETAILS SEMISTRUCTURED
+  )
+)

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-array-survey.emit.yaml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-array-survey.emit.yaml
@@ -1,0 +1,42 @@
+# Copyright 2026 Goldman Sachs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: relational-semistructured-array-survey
+title: "Relational Store — Which Array Functions the Store Language Can Use"
+description: |
+  One suite per array_* function over a typed extraction, so the set that works is visible
+  rather than assumed. Each is isolated: a function that fails takes only its own suite
+  with it.
+modelSources:
+  model:
+    root: relational-semistructured-array-survey
+    files:
+      - store/db.pure
+      - mapping/mapping.pure
+      - data/testData.pure
+features:
+  - execution:data-element
+  - execution:test-data
+  - scaffolding:class
+  - scaffolding:relational-mapping
+  - scaffolding:relational-store
+  - store:relational-semistructured
+  - store:relational-semistructured-array-functions
+stores:
+  - relational
+complexity: basic
+tags:
+  - semi-structured
+  - array-functions
+  - json

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-array-survey/data/testData.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-array-survey/data/testData.pure
@@ -1,0 +1,25 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Unsorted with a duplicate, so ordering and de-duplication are visible.
+###Data
+Data demo::ssv::data::D
+{
+  Relation
+  #{
+    default.T:
+      ID,NUMS,WORDS
+      1,"{""values"":[3,1,2,1]}","{""values"":[""b"",""a""]}";
+  }#
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-array-survey/mapping/mapping.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-array-survey/mapping/mapping.pure
@@ -1,0 +1,210 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Mapping
+Mapping demo::ssv::M
+(
+  *demo::ssv::Row: Relational
+  {
+    ~primaryKey ( [demo::ssv::store::DB]T.ID )
+    ~mainTable [demo::ssv::store::DB]T
+    id: [demo::ssv::store::DB]T.ID,
+    lastVal: array_last(extractFromSemiStructured([demo::ssv::store::DB]T.NUMS, 'values', 'INTEGER[]')),
+    initVals: array_to_string(array_init(extractFromSemiStructured([demo::ssv::store::DB]T.NUMS, 'values', 'INTEGER[]')), ','),
+    tailVals: array_to_string(array_tail(extractFromSemiStructured([demo::ssv::store::DB]T.NUMS, 'values', 'INTEGER[]')), ','),
+    sortedVals: array_to_string(array_sort(extractFromSemiStructured([demo::ssv::store::DB]T.NUMS, 'values', 'INTEGER[]')), ','),
+    reversedVals: array_to_string(array_reverse(extractFromSemiStructured([demo::ssv::store::DB]T.NUMS, 'values', 'INTEGER[]')), ','),
+    appendedVals: array_to_string(array_append(extractFromSemiStructured([demo::ssv::store::DB]T.NUMS, 'values', 'INTEGER[]'), 9), ','),
+    positionOfTwo: array_position(extractFromSemiStructured([demo::ssv::store::DB]T.NUMS, 'values', 'INTEGER[]'), 2),
+    slicedVals: array_to_string(array_slice(extractFromSemiStructured([demo::ssv::store::DB]T.NUMS, 'values', 'INTEGER[]'), 0, 2), ','),
+    droppedVals: array_to_string(array_drop(extractFromSemiStructured([demo::ssv::store::DB]T.NUMS, 'values', 'INTEGER[]'), 1), ','),
+    takenVals: array_to_string(array_take(extractFromSemiStructured([demo::ssv::store::DB]T.NUMS, 'values', 'INTEGER[]'), 2), ','),
+    containsTwo: array_contains(extractFromSemiStructured([demo::ssv::store::DB]T.NUMS, 'values', 'INTEGER[]'), 2),
+    distinctVals: array_to_string(array_sort(array_distinct(extractFromSemiStructured([demo::ssv::store::DB]T.NUMS, 'values', 'INTEGER[]'))), ','),
+    concatenated: array_to_string(array_concatenate(extractFromSemiStructured([demo::ssv::store::DB]T.WORDS, 'values', 'VARCHAR[]'), extractFromSemiStructured([demo::ssv::store::DB]T.WORDS, 'values', 'VARCHAR[]')), ','),
+    sumVals: array_sum(extractFromSemiStructured([demo::ssv::store::DB]T.NUMS, 'values', 'INTEGER[]'))
+  }
+
+  testSuites:
+  [
+    lastValSuite:
+    {
+      function: |demo::ssv::Row.all()->project(~[id: r | $r.id, v: r | $r.lastVal])->sort([~id->ascending()]);
+      tests:
+      [
+        t:
+        {
+          data: [ demo::ssv::store::DB: Reference #{ demo::ssv::data::D }# ];
+          asserts: [ a: EqualToJson #{ expected: ExternalFormat #{ contentType: 'application/json'; data: '[ {\n  "id" : 1,\n  "v" : 1\n} ]'; }#; }# ];
+        }
+      ];
+    },
+    initValsSuite:
+    {
+      function: |demo::ssv::Row.all()->project(~[id: r | $r.id, v: r | $r.initVals])->sort([~id->ascending()]);
+      tests:
+      [
+        t:
+        {
+          data: [ demo::ssv::store::DB: Reference #{ demo::ssv::data::D }# ];
+          asserts: [ a: EqualToJson #{ expected: ExternalFormat #{ contentType: 'application/json'; data: '[ {\n  "id" : 1,\n  "v" : "3,1,2"\n} ]'; }#; }# ];
+        }
+      ];
+    },
+    tailValsSuite:
+    {
+      function: |demo::ssv::Row.all()->project(~[id: r | $r.id, v: r | $r.tailVals])->sort([~id->ascending()]);
+      tests:
+      [
+        t:
+        {
+          data: [ demo::ssv::store::DB: Reference #{ demo::ssv::data::D }# ];
+          asserts: [ a: EqualToJson #{ expected: ExternalFormat #{ contentType: 'application/json'; data: '[ {\n  "id" : 1,\n  "v" : "1,2,1"\n} ]'; }#; }# ];
+        }
+      ];
+    },
+    sortedValsSuite:
+    {
+      function: |demo::ssv::Row.all()->project(~[id: r | $r.id, v: r | $r.sortedVals])->sort([~id->ascending()]);
+      tests:
+      [
+        t:
+        {
+          data: [ demo::ssv::store::DB: Reference #{ demo::ssv::data::D }# ];
+          asserts: [ a: EqualToJson #{ expected: ExternalFormat #{ contentType: 'application/json'; data: '[ {\n  "id" : 1,\n  "v" : "1,1,2,3"\n} ]'; }#; }# ];
+        }
+      ];
+    },
+    reversedValsSuite:
+    {
+      function: |demo::ssv::Row.all()->project(~[id: r | $r.id, v: r | $r.reversedVals])->sort([~id->ascending()]);
+      tests:
+      [
+        t:
+        {
+          data: [ demo::ssv::store::DB: Reference #{ demo::ssv::data::D }# ];
+          asserts: [ a: EqualToJson #{ expected: ExternalFormat #{ contentType: 'application/json'; data: '[ {\n  "id" : 1,\n  "v" : "1,2,1,3"\n} ]'; }#; }# ];
+        }
+      ];
+    },
+    appendedValsSuite:
+    {
+      function: |demo::ssv::Row.all()->project(~[id: r | $r.id, v: r | $r.appendedVals])->sort([~id->ascending()]);
+      tests:
+      [
+        t:
+        {
+          data: [ demo::ssv::store::DB: Reference #{ demo::ssv::data::D }# ];
+          asserts: [ a: EqualToJson #{ expected: ExternalFormat #{ contentType: 'application/json'; data: '[ {\n  "id" : 1,\n  "v" : "3,1,2,1,9"\n} ]'; }#; }# ];
+        }
+      ];
+    },
+    positionOfTwoSuite:
+    {
+      function: |demo::ssv::Row.all()->project(~[id: r | $r.id, v: r | $r.positionOfTwo])->sort([~id->ascending()]);
+      tests:
+      [
+        t:
+        {
+          data: [ demo::ssv::store::DB: Reference #{ demo::ssv::data::D }# ];
+          asserts: [ a: EqualToJson #{ expected: ExternalFormat #{ contentType: 'application/json'; data: '[ {\n  "id" : 1,\n  "v" : 2\n} ]'; }#; }# ];
+        }
+      ];
+    },
+    slicedValsSuite:
+    {
+      function: |demo::ssv::Row.all()->project(~[id: r | $r.id, v: r | $r.slicedVals])->sort([~id->ascending()]);
+      tests:
+      [
+        t:
+        {
+          data: [ demo::ssv::store::DB: Reference #{ demo::ssv::data::D }# ];
+          asserts: [ a: EqualToJson #{ expected: ExternalFormat #{ contentType: 'application/json'; data: '[ {\n  "id" : 1,\n  "v" : "3,1"\n} ]'; }#; }# ];
+        }
+      ];
+    },
+    droppedValsSuite:
+    {
+      function: |demo::ssv::Row.all()->project(~[id: r | $r.id, v: r | $r.droppedVals])->sort([~id->ascending()]);
+      tests:
+      [
+        t:
+        {
+          data: [ demo::ssv::store::DB: Reference #{ demo::ssv::data::D }# ];
+          asserts: [ a: EqualToJson #{ expected: ExternalFormat #{ contentType: 'application/json'; data: '[ {\n  "id" : 1,\n  "v" : "1,2,1"\n} ]'; }#; }# ];
+        }
+      ];
+    },
+    takenValsSuite:
+    {
+      function: |demo::ssv::Row.all()->project(~[id: r | $r.id, v: r | $r.takenVals])->sort([~id->ascending()]);
+      tests:
+      [
+        t:
+        {
+          data: [ demo::ssv::store::DB: Reference #{ demo::ssv::data::D }# ];
+          asserts: [ a: EqualToJson #{ expected: ExternalFormat #{ contentType: 'application/json'; data: '[ {\n  "id" : 1,\n  "v" : "3,1"\n} ]'; }#; }# ];
+        }
+      ];
+    },
+    containsTwoSuite:
+    {
+      function: |demo::ssv::Row.all()->project(~[id: r | $r.id, v: r | $r.containsTwo])->sort([~id->ascending()]);
+      tests:
+      [
+        t:
+        {
+          data: [ demo::ssv::store::DB: Reference #{ demo::ssv::data::D }# ];
+          asserts: [ a: EqualToJson #{ expected: ExternalFormat #{ contentType: 'application/json'; data: '[ {\n  "id" : 1,\n  "v" : true\n} ]'; }#; }# ];
+        }
+      ];
+    },
+    distinctValsSuite:
+    {
+      function: |demo::ssv::Row.all()->project(~[id: r | $r.id, v: r | $r.distinctVals])->sort([~id->ascending()]);
+      tests:
+      [
+        t:
+        {
+          data: [ demo::ssv::store::DB: Reference #{ demo::ssv::data::D }# ];
+          asserts: [ a: EqualToJson #{ expected: ExternalFormat #{ contentType: 'application/json'; data: '[ {\n  "id" : 1,\n  "v" : "1,2,3"\n} ]'; }#; }# ];
+        }
+      ];
+    },
+    concatenatedSuite:
+    {
+      function: |demo::ssv::Row.all()->project(~[id: r | $r.id, v: r | $r.concatenated])->sort([~id->ascending()]);
+      tests:
+      [
+        t:
+        {
+          data: [ demo::ssv::store::DB: Reference #{ demo::ssv::data::D }# ];
+          asserts: [ a: EqualToJson #{ expected: ExternalFormat #{ contentType: 'application/json'; data: '[ {\n  "id" : 1,\n  "v" : "b,a,b,a"\n} ]'; }#; }# ];
+        }
+      ];
+    },
+    sumValsSuite:
+    {
+      function: |demo::ssv::Row.all()->project(~[id: r | $r.id, v: r | $r.sumVals])->sort([~id->ascending()]);
+      tests:
+      [
+        t:
+        {
+          data: [ demo::ssv::store::DB: Reference #{ demo::ssv::data::D }# ];
+          asserts: [ a: EqualToJson #{ expected: ExternalFormat #{ contentType: 'application/json'; data: '[ {\n  "id" : 1,\n  "v" : 7\n} ]'; }#; }# ];
+        }
+      ];
+    }
+  ]
+)

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-array-survey/store/db.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-array-survey/store/db.pure
@@ -1,0 +1,46 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// One property per array_* function, so the survey shows which are usable in the store
+// language now that an extraction can name an array type.
+###Pure
+Class demo::ssv::Row
+{
+  id: Integer[1];
+  lastVal: Integer[0..1];
+  initVals: String[0..1];
+  tailVals: String[0..1];
+  sortedVals: String[0..1];
+  reversedVals: String[0..1];
+  appendedVals: String[0..1];
+  positionOfTwo: Integer[0..1];
+  slicedVals: String[0..1];
+  droppedVals: String[0..1];
+  takenVals: String[0..1];
+  containsTwo: Boolean[0..1];
+  distinctVals: String[0..1];
+  concatenated: String[0..1];
+  sumVals: Integer[0..1];
+}
+
+###Relational
+Database demo::ssv::store::DB
+(
+  Table T
+  (
+    ID INTEGER PRIMARY KEY,
+    NUMS SEMISTRUCTURED,
+    WORDS SEMISTRUCTURED
+  )
+)

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-binding-source.emit.yaml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-binding-source.emit.yaml
@@ -1,0 +1,56 @@
+# Copyright 2026 Goldman Sachs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: relational-semistructured-binding-source
+title: "Relational Store — What a Binding Can Be Attached To"
+description: |
+  A binding does not have to consume a whole column. The same binding and the same Firm
+  class are fed four different ways: the column itself, a navigation to a sub-document,
+  a plain VARCHAR column parsed into a document, and a document reached through a join.
+
+  This is what lets one class absorb documents of different shapes. Two tables holding
+  incompatible layouts — firm nested under "employment" in one, firm as the whole
+  document in the other — are union-mapped onto a single class, and the query cannot
+  tell which leg a row came from.
+
+modelSources:
+  model:
+    root: relational-semistructured-binding-source
+    files:
+      - store/db.pure
+      - mapping/mapping.pure
+      - data/testData.pure
+
+features:
+  - execution:data-element
+  - execution:external-format-binding
+  - execution:test-data
+  - mapping:store-union
+  - scaffolding:class
+  - scaffolding:relational-mapping
+  - scaffolding:relational-store
+  - store:relational-inner-join
+  - store:relational-multi-table
+  - store:relational-semistructured
+  - store:relational-semistructured-binding
+  - store:relational-semistructured-navigation
+stores:
+  - relational
+# Distinct non-scaffolding domains: execution, mapping, store = 3 -> intermediate.
+complexity: intermediate
+tags:
+  - semi-structured
+  - binding
+  - union
+  - json

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-binding-source/data/testData.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-binding-source/data/testData.pure
@@ -1,0 +1,49 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// RFC-4180: each JSON document is wrapped in " and every internal " is doubled.
+// The two Person tables hold deliberately different shapes - Alice's firm is nested
+// under "employment", Bob's is the whole document - and the union reconciles them.
+// Dan reports to Eve, so Dan's managerFirm resolves to Eve's document. Eve has no
+// manager, and still appears, with no value for it.
+// RECORD_TABLE holds two sibling arrays under one "payload" object; each is typed by
+// its own binding attached to a to-many property.
+###Data
+Data demo::ssn::data::PersonData
+{
+  Relation
+  #{
+    PERSON_SCHEMA.PERSON_NESTED:
+      ID,NAME,PROFILE
+      1,Alice,"{""employment"":{""firm"":{""legalName"":""Firm One""}},""grade"":3}";
+
+    PERSON_SCHEMA.PERSON_ROOT:
+      ID,NAME,PROFILE
+      2,Bob,"{""legalName"":""Firm Two""}";
+
+    PERSON_SCHEMA.PERSON_TEXT:
+      ID,NAME,PROFILE_JSON
+      3,Cara,"{""legalName"":""Firm Three""}";
+
+    PERSON_SCHEMA.STAFF:
+      ID,NAME,MANAGER_ID,PROFILE
+      10,Dan,11,"{""legalName"":""Dan Firm""}"
+      11,Eve,,"{""legalName"":""Eve Firm""}";
+
+    PERSON_SCHEMA.RECORD_TABLE:
+      ID,REFERENCE,CONTENT
+      20,R-1,"{""payload"":{""tags"":[{""code"":""T1"",""category"":""Primary""},{""code"":""T2"",""category"":""Secondary""}],""participants"":[{""party"":""P1""}]}}"
+      21,R-2,"{""payload"":{""tags"":[{""code"":""T9"",""category"":""Primary""}],""participants"":[{""party"":""P8""},{""party"":""P9""}]}}";
+  }#
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-binding-source/mapping/mapping.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-binding-source/mapping/mapping.pure
@@ -85,8 +85,8 @@ Mapping demo::ssn::PersonMapping
     )
     ~mainTable [demo::ssn::store::PersonDB]PERSON_SCHEMA.RECORD_TABLE
     reference: [demo::ssn::store::PersonDB]PERSON_SCHEMA.RECORD_TABLE.REFERENCE,
-    tags: Binding demo::ssn::TagBinding : parseJson(extractFromSemiStructured([demo::ssn::store::PersonDB]PERSON_SCHEMA.RECORD_TABLE.CONTENT, 'payload.tags', 'VARCHAR')),
-    participants: Binding demo::ssn::ParticipantBinding : parseJson(extractFromSemiStructured([demo::ssn::store::PersonDB]PERSON_SCHEMA.RECORD_TABLE.CONTENT, 'payload.participants', 'VARCHAR'))
+    tags: Binding demo::ssn::TagBinding : extractFromSemiStructured([demo::ssn::store::PersonDB]PERSON_SCHEMA.RECORD_TABLE.CONTENT, 'payload.tags', 'VARCHAR[]'),
+    participants: Binding demo::ssn::ParticipantBinding : extractFromSemiStructured([demo::ssn::store::PersonDB]PERSON_SCHEMA.RECORD_TABLE.CONTENT, 'payload.participants', 'VARCHAR[]')
   }
 
   testSuites:

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-binding-source/mapping/mapping.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-binding-source/mapping/mapping.pure
@@ -77,6 +77,8 @@ Mapping demo::ssn::PersonMapping
 
   // The bound property is to-many here, so the binding types a JSON array rather than a
   // single object. Two sibling arrays under the same column are typed independently.
+  // SEMISTRUCTURED[] says the extraction yields an array of documents, which is what lets
+  // the elements stay documents rather than being read back as text.
   demo::ssn::Record: Relational
   {
     ~primaryKey
@@ -85,8 +87,8 @@ Mapping demo::ssn::PersonMapping
     )
     ~mainTable [demo::ssn::store::PersonDB]PERSON_SCHEMA.RECORD_TABLE
     reference: [demo::ssn::store::PersonDB]PERSON_SCHEMA.RECORD_TABLE.REFERENCE,
-    tags: Binding demo::ssn::TagBinding : extractFromSemiStructured([demo::ssn::store::PersonDB]PERSON_SCHEMA.RECORD_TABLE.CONTENT, 'payload.tags', 'VARCHAR[]'),
-    participants: Binding demo::ssn::ParticipantBinding : extractFromSemiStructured([demo::ssn::store::PersonDB]PERSON_SCHEMA.RECORD_TABLE.CONTENT, 'payload.participants', 'VARCHAR[]')
+    tags: Binding demo::ssn::TagBinding : extractFromSemiStructured([demo::ssn::store::PersonDB]PERSON_SCHEMA.RECORD_TABLE.CONTENT, 'payload.tags', 'SEMISTRUCTURED[]'),
+    participants: Binding demo::ssn::ParticipantBinding : extractFromSemiStructured([demo::ssn::store::PersonDB]PERSON_SCHEMA.RECORD_TABLE.CONTENT, 'payload.participants', 'SEMISTRUCTURED[]')
   }
 
   testSuites:

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-binding-source/mapping/mapping.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-binding-source/mapping/mapping.pure
@@ -1,0 +1,165 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Mapping
+Mapping demo::ssn::PersonMapping
+(
+  // Two documents with different shapes, reconciled onto one class: one leg navigates
+  // to the sub-document, the other binds the root. Neither the class nor the query
+  // knows which leg a row came from.
+  *demo::ssn::Person: Operation
+  {
+    meta::pure::router::operations::union_OperationSetImplementation_1__SetImplementation_MANY_(Type_Nested, Type_Root)
+  }
+
+  demo::ssn::Person[Type_Nested]: Relational
+  {
+    ~primaryKey
+    (
+      [demo::ssn::store::PersonDB]PERSON_SCHEMA.PERSON_NESTED.ID
+    )
+    ~mainTable [demo::ssn::store::PersonDB]PERSON_SCHEMA.PERSON_NESTED
+    name: [demo::ssn::store::PersonDB]PERSON_SCHEMA.PERSON_NESTED.NAME,
+    profileJson: toJson([demo::ssn::store::PersonDB]PERSON_SCHEMA.PERSON_NESTED.PROFILE),
+    // Binding fed by a navigation rather than by the column itself.
+    firm: Binding demo::ssn::FirmBinding : extractFromSemiStructured([demo::ssn::store::PersonDB]PERSON_SCHEMA.PERSON_NESTED.PROFILE, 'employment.firm', 'VARCHAR')
+  }
+
+  demo::ssn::Person[Type_Root]: Relational
+  {
+    ~primaryKey
+    (
+      [demo::ssn::store::PersonDB]PERSON_SCHEMA.PERSON_ROOT.ID
+    )
+    ~mainTable [demo::ssn::store::PersonDB]PERSON_SCHEMA.PERSON_ROOT
+    name: [demo::ssn::store::PersonDB]PERSON_SCHEMA.PERSON_ROOT.NAME,
+    profileJson: toJson([demo::ssn::store::PersonDB]PERSON_SCHEMA.PERSON_ROOT.PROFILE),
+    firm: Binding demo::ssn::FirmBinding : [demo::ssn::store::PersonDB]PERSON_SCHEMA.PERSON_ROOT.PROFILE
+  }
+
+  // JSON living in a plain VARCHAR column: parseJson turns the text into a document
+  // the binding can type. No SEMISTRUCTURED column is involved.
+  demo::ssn::TextPerson: Relational
+  {
+    ~primaryKey
+    (
+      [demo::ssn::store::PersonDB]PERSON_SCHEMA.PERSON_TEXT.ID
+    )
+    ~mainTable [demo::ssn::store::PersonDB]PERSON_SCHEMA.PERSON_TEXT
+    name: [demo::ssn::store::PersonDB]PERSON_SCHEMA.PERSON_TEXT.NAME,
+    firm: Binding demo::ssn::FirmBinding : parseJson([demo::ssn::store::PersonDB]PERSON_SCHEMA.PERSON_TEXT.PROFILE_JSON)
+  }
+
+  // Binding reached through a join, so the document typed here belongs to another row.
+  // Note this is the one form that cannot carry array operations.
+  demo::ssn::Staff: Relational
+  {
+    ~primaryKey
+    (
+      [demo::ssn::store::PersonDB]PERSON_SCHEMA.STAFF.ID
+    )
+    ~mainTable [demo::ssn::store::PersonDB]PERSON_SCHEMA.STAFF
+    name: [demo::ssn::store::PersonDB]PERSON_SCHEMA.STAFF.NAME,
+    profileJson: toJson([demo::ssn::store::PersonDB]PERSON_SCHEMA.STAFF.PROFILE),
+    managerFirm: Binding demo::ssn::FirmBinding : [demo::ssn::store::PersonDB]@Manager | [demo::ssn::store::PersonDB]PERSON_SCHEMA.STAFF.PROFILE
+  }
+
+  // The bound property is to-many here, so the binding types a JSON array rather than a
+  // single object. Two sibling arrays under the same column are typed independently.
+  demo::ssn::Record: Relational
+  {
+    ~primaryKey
+    (
+      [demo::ssn::store::PersonDB]PERSON_SCHEMA.RECORD_TABLE.ID
+    )
+    ~mainTable [demo::ssn::store::PersonDB]PERSON_SCHEMA.RECORD_TABLE
+    reference: [demo::ssn::store::PersonDB]PERSON_SCHEMA.RECORD_TABLE.REFERENCE,
+    tags: Binding demo::ssn::TagBinding : parseJson(extractFromSemiStructured([demo::ssn::store::PersonDB]PERSON_SCHEMA.RECORD_TABLE.CONTENT, 'payload.tags', 'VARCHAR')),
+    participants: Binding demo::ssn::ParticipantBinding : parseJson(extractFromSemiStructured([demo::ssn::store::PersonDB]PERSON_SCHEMA.RECORD_TABLE.CONTENT, 'payload.participants', 'VARCHAR'))
+  }
+
+  testSuites:
+  [
+    unionSuite:
+    {
+      function: |demo::ssn::Person.all()
+                  ->project(~[name: p | $p.name, legalName: p | $p.firm.legalName, profileJson: p | $p.profileJson])
+                  ->sort([~name->ascending()]);
+      tests:
+      [
+        reconcileShapes:
+        {
+          data: [ demo::ssn::store::PersonDB: Reference #{ demo::ssn::data::PersonData }# ];
+          asserts: [ shouldReconcile: EqualToJson #{ expected: ExternalFormat #{ contentType: 'application/json'; data: '[{"name":"Alice","legalName":"Firm One","profileJson":"{\\"employment\\":{\\"firm\\":{\\"legalName\\":\\"Firm One\\"}},\\"grade\\":3}"},{"name":"Bob","legalName":"Firm Two","profileJson":"{\\"legalName\\":\\"Firm Two\\"}"}]'; }#; }# ];
+        }
+      ];
+    },
+    parseJsonSuite:
+    {
+      function: |demo::ssn::TextPerson.all()
+                  ->project(~[name: p | $p.name, legalName: p | $p.firm.legalName])
+                  ->sort([~name->ascending()]);
+      tests:
+      [
+        typeTextColumn:
+        {
+          data: [ demo::ssn::store::PersonDB: Reference #{ demo::ssn::data::PersonData }# ];
+          asserts: [ shouldTypeText: EqualToJson #{ expected: ExternalFormat #{ contentType: 'application/json'; data: '[{"name":"Cara","legalName":"Firm Three"}]'; }#; }# ];
+        }
+      ];
+    },
+    joinBindingSuite:
+    {
+      function: |demo::ssn::Staff.all()
+                  ->project(~[name: s | $s.name, managerLegalName: s | $s.managerFirm.legalName, profileJson: s | $s.profileJson])
+                  ->sort([~name->ascending()]);
+      tests:
+      [
+        bindThroughJoin:
+        {
+          data: [ demo::ssn::store::PersonDB: Reference #{ demo::ssn::data::PersonData }# ];
+          asserts: [ shouldBindThroughJoin: EqualToJson #{ expected: ExternalFormat #{ contentType: 'application/json'; data: '[{"name":"Dan","managerLegalName":"Eve Firm","profileJson":"{\\"legalName\\":\\"Dan Firm\\"}"},{"name":"Eve","managerLegalName":null,"profileJson":"{\\"legalName\\":\\"Eve Firm\\"}"}]'; }#; }# ];
+        }
+      ];
+    },
+    boundArraySuite:
+    {
+      function: |demo::ssn::Record.all()
+                  ->project(~[reference: r | $r.reference, tagCode: r | $r.tags.code, tagCategory: r | $r.tags.category])
+                  ->sort([~reference->ascending(), ~tagCode->ascending()]);
+      tests:
+      [
+        bindArrayOfObjects:
+        {
+          data: [ demo::ssn::store::PersonDB: Reference #{ demo::ssn::data::PersonData }# ];
+          asserts: [ shouldTypeEachElement: EqualToJson #{ expected: ExternalFormat #{ contentType: 'application/json'; data: '[{"reference":"R-1","tagCode":"T1","tagCategory":"Primary"},{"reference":"R-1","tagCode":"T2","tagCategory":"Secondary"},{"reference":"R-2","tagCode":"T9","tagCategory":"Primary"}]'; }#; }# ];
+        }
+      ];
+    },
+    siblingArraySuite:
+    {
+      function: |demo::ssn::Record.all()
+                  ->project(~[reference: r | $r.reference, party: r | $r.participants.party])
+                  ->sort([~reference->ascending(), ~party->ascending()]);
+      tests:
+      [
+        bindSiblingArray:
+        {
+          data: [ demo::ssn::store::PersonDB: Reference #{ demo::ssn::data::PersonData }# ];
+          asserts: [ shouldTypeSecondArray: EqualToJson #{ expected: ExternalFormat #{ contentType: 'application/json'; data: '[{"reference":"R-1","party":"P1"},{"reference":"R-2","party":"P8"},{"reference":"R-2","party":"P9"}]'; }#; }# ];
+        }
+      ];
+    }
+  ]
+)

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-binding-source/store/db.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-binding-source/store/db.pure
@@ -1,0 +1,132 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// One binding, one Firm class, four different sources feeding it. What varies is the
+// operation on the right of the binding, never the model.
+###Pure
+Class demo::ssn::Firm
+{
+  legalName: String[1];
+}
+
+Class demo::ssn::Person
+{
+  name: String[1];
+  profileJson: String[1];
+  firm: demo::ssn::Firm[1];
+}
+
+Class demo::ssn::TextPerson
+{
+  name: String[1];
+  firm: demo::ssn::Firm[1];
+}
+
+Class demo::ssn::Staff
+{
+  name: String[1];
+  profileJson: String[1];
+  // Staff with no manager still appear, with no value here.
+  managerFirm: demo::ssn::Firm[0..1];
+}
+
+// The bound property is itself to-many: the source yields a JSON array and each
+// element becomes an object. Two sibling arrays under one column are typed by two
+// different bindings.
+Class demo::ssn::Tag
+{
+  code: String[1];
+  category: String[1];
+}
+
+Class demo::ssn::Participant
+{
+  party: String[1];
+}
+
+Class demo::ssn::Record
+{
+  reference: String[1];
+  tags: demo::ssn::Tag[*];
+  participants: demo::ssn::Participant[*];
+}
+
+###ExternalFormat
+Binding demo::ssn::FirmBinding
+{
+  contentType: 'application/json';
+  modelIncludes: [
+    demo::ssn::Firm
+  ];
+}
+
+Binding demo::ssn::TagBinding
+{
+  contentType: 'application/json';
+  modelIncludes: [
+    demo::ssn::Tag
+  ];
+}
+
+Binding demo::ssn::ParticipantBinding
+{
+  contentType: 'application/json';
+  modelIncludes: [
+    demo::ssn::Participant
+  ];
+}
+
+###Relational
+Database demo::ssn::store::PersonDB
+(
+  Schema PERSON_SCHEMA
+  (
+    // Firm sits one level down, under "employment".
+    Table PERSON_NESTED
+    (
+      ID INTEGER PRIMARY KEY,
+      NAME VARCHAR(100),
+      PROFILE SEMISTRUCTURED
+    )
+    // Firm is the whole document.
+    Table PERSON_ROOT
+    (
+      ID INTEGER PRIMARY KEY,
+      NAME VARCHAR(100),
+      PROFILE SEMISTRUCTURED
+    )
+    // JSON held in an ordinary VARCHAR, with no semi-structured column type.
+    Table PERSON_TEXT
+    (
+      ID INTEGER PRIMARY KEY,
+      NAME VARCHAR(100),
+      PROFILE_JSON VARCHAR(1000)
+    )
+    Table STAFF
+    (
+      ID INTEGER PRIMARY KEY,
+      NAME VARCHAR(100),
+      MANAGER_ID INTEGER,
+      PROFILE SEMISTRUCTURED
+    )
+    Table RECORD_TABLE
+    (
+      ID INTEGER PRIMARY KEY,
+      REFERENCE VARCHAR(100),
+      CONTENT SEMISTRUCTURED
+    )
+  )
+
+  Join Manager(PERSON_SCHEMA.STAFF.MANAGER_ID = {target}.ID)
+)

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-binding.emit.yaml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-binding.emit.yaml
@@ -12,22 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: relational-semistructured
-title: "Relational Store — Modelled Semi-structured Data"
+name: relational-semistructured-binding
+title: "Relational Store — JSON Document Typed as a Model"
 description: |
-  A SEMISTRUCTURED column modelled as ordinary typed properties. One JSON document per
-  row is projected into scalars covering every target type the extraction whitelist
-  accepts, plus the edges of the path grammar: an element of an array of objects, an
-  element of an array of arrays, an array nested inside an object array, bracket-quoted
-  keys containing a space and a dot, and — against a second column whose root is a JSON
-  array — paths that lead with an index.
+  A JSON document typed as an ordinary class graph through an ExternalFormat binding,
+  so the modeller works with classes and properties and never with a document-shaped
+  API. A single mapping line binds the column; every property below it — nested
+  objects, their scalars — is resolved during planning without being mapped.
 
-  Navigation is exercised in two positions: property mappings, and a store filter
-  predicate that reads a value out of the document to decide row inclusion.
+  Queries navigate four levels of typed properties. One document omits an optional
+  branch, so a [0..1] property must return no value rather than fail. Navigation is
+  pushed down to the database: the binding contributes a type, not a deserialisation
+  step.
 
 modelSources:
   model:
-    root: relational-semistructured
+    root: relational-semistructured-binding
     files:
       - store/db.pure
       - mapping/mapping.pure
@@ -35,19 +35,19 @@ modelSources:
 
 features:
   - execution:data-element
+  - execution:external-format-binding
   - execution:test-data
   - scaffolding:class
   - scaffolding:relational-mapping
   - scaffolding:relational-store
   - store:relational-semistructured
+  - store:relational-semistructured-binding
   - store:relational-semistructured-navigation
-  - store:relational-semistructured-array-index
-  - store:relational-filter
 stores:
   - relational
 # Distinct non-scaffolding domains: execution, store = 2 -> basic.
 complexity: basic
 tags:
   - semi-structured
-  - variant
+  - binding
   - json

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-binding/data/testData.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-binding/data/testData.pure
@@ -1,0 +1,28 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// RFC-4180: each JSON document is wrapped in " and every internal " is doubled.
+// Alice's address carries "street"; Bob's omits it, so the [0..1] property must come
+// back empty rather than error - the irregular-shape case.
+###Data
+Data demo::ssb::data::PersonData
+{
+  Relation
+  #{
+    default.PERSON_TABLE:
+      ID,FIRST_NAME,FIRM_DETAILS
+      1,Alice,"{""legalName"":""Firm X"",""employeeCount"":4,""address"":{""name"":""HQ"",""street"":""1 Main St"",""geo"":{""lat"":40.7,""lon"":-74.0}}}"
+      2,Bob,"{""legalName"":""Firm A"",""employeeCount"":9,""address"":{""name"":""Annex"",""geo"":{""lat"":51.5,""lon"":-0.1}}}";
+  }#
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-binding/mapping/mapping.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-binding/mapping/mapping.pure
@@ -1,0 +1,71 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Mapping
+Mapping demo::ssb::PersonMapping
+(
+  *demo::ssb::Person: Relational
+  {
+    ~primaryKey
+    (
+      [demo::ssb::store::PersonDB]PERSON_TABLE.ID
+    )
+    ~mainTable [demo::ssb::store::PersonDB]PERSON_TABLE
+    firstName: [demo::ssb::store::PersonDB]PERSON_TABLE.FIRST_NAME,
+    detailsJson: toJson([demo::ssb::store::PersonDB]PERSON_TABLE.FIRM_DETAILS),
+    // One line types the whole document. Nothing below firm is mapped: the property
+    // mappings for address, geo and their scalars are synthesised during planning,
+    // each nesting one more navigation onto the column expression.
+    firm: Binding demo::ssb::FirmBinding : [demo::ssb::store::PersonDB]PERSON_TABLE.FIRM_DETAILS
+  }
+
+  testSuites:
+  [
+    bindingSuite:
+    {
+      // Relation return type selects the execution target; detailsJson is the canary
+      // that fails loudly if this ever routes somewhere without a SEMISTRUCTURED type.
+      function: |demo::ssb::Person.all()
+                  ->project(~[firstName: p | $p.firstName, legalName: p | $p.firm.legalName, employeeCount: p | $p.firm.employeeCount, addressName: p | $p.firm.address.name, street: p | $p.firm.address.street, lat: p | $p.firm.address.geo.lat, lon: p | $p.firm.address.geo.lon])
+                  ->sort([~firstName->ascending()]);
+      tests:
+      [
+        navigateBoundModel:
+        {
+          data:
+          [
+            demo::ssb::store::PersonDB:
+              Reference
+              #{
+                demo::ssb::data::PersonData
+              }#
+          ];
+          asserts:
+          [
+            shouldNavigateNestedTypedProperties:
+              EqualToJson
+              #{
+                expected:
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '[{"firstName":"Alice","legalName":"Firm X","employeeCount":4,"addressName":"HQ","street":"1 Main St","lat":40.7,"lon":-74.0},{"firstName":"Bob","legalName":"Firm A","employeeCount":9,"addressName":"Annex","street":null,"lat":51.5,"lon":-0.1}]';
+                  }#;
+              }#
+          ];
+        }
+      ];
+    }
+  ]
+)

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-binding/store/db.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-binding/store/db.pure
@@ -1,0 +1,68 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Nothing in these classes says "semi-structured" - they are ordinary Pure classes.
+// The JSON document shape is declared once, by the binding, and never restated.
+###Pure
+Class demo::ssb::Person
+{
+  firstName: String[1];
+  detailsJson: String[1];
+  firm: demo::ssb::Firm[1];
+}
+
+Class demo::ssb::Firm
+{
+  legalName: String[1];
+  employeeCount: Integer[1];
+  address: demo::ssb::Address[1];
+}
+
+Class demo::ssb::Address
+{
+  name: String[1];
+  // Absent from the second document: navigation must yield no value rather than fail.
+  street: String[0..1];
+  geo: demo::ssb::Geo[1];
+}
+
+Class demo::ssb::Geo
+{
+  lat: Float[1];
+  lon: Float[1];
+}
+
+###ExternalFormat
+// Every class reachable through the bound property must be listed, or the compiler
+// rejects the mapping ("should be included in modelUnit for binding").
+Binding demo::ssb::FirmBinding
+{
+  contentType: 'application/json';
+  modelIncludes: [
+    demo::ssb::Firm,
+    demo::ssb::Address,
+    demo::ssb::Geo
+  ];
+}
+
+###Relational
+Database demo::ssb::store::PersonDB
+(
+  Table PERSON_TABLE
+  (
+    ID INTEGER PRIMARY KEY,
+    FIRST_NAME VARCHAR(100),
+    FIRM_DETAILS SEMISTRUCTURED
+  )
+)

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-collection.emit.yaml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-collection.emit.yaml
@@ -12,22 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: relational-semistructured
-title: "Relational Store — Modelled Semi-structured Data"
+name: relational-semistructured-collection
+title: "Relational Store — Collections Inside a JSON Document"
 description: |
-  A SEMISTRUCTURED column modelled as ordinary typed properties. One JSON document per
-  row is projected into scalars covering every target type the extraction whitelist
-  accepts, plus the edges of the path grammar: an element of an array of objects, an
-  element of an array of arrays, an array nested inside an object array, bracket-quoted
-  keys containing a space and a dot, and — against a second column whose root is a JSON
-  array — paths that lead with an index.
+  To-many properties backed by JSON arrays: a collection of primitives, a collection of
+  objects, and a collection nested inside another collection. The author writes no
+  flatten call anywhere — declaring the property to-many is what makes the planner emit
+  a lateral flatten, and rows fan out one per element.
 
-  Navigation is exercised in two positions: property mappings, and a store filter
-  predicate that reads a value out of the document to decide row inclusion.
+  The nested case is the discriminating one. Stacking two flattens is reachable through
+  a binding but not through mapping-side explosion, which requires its operand to be a
+  plain column and so cannot explode an already-exploded element.
 
 modelSources:
   model:
-    root: relational-semistructured
+    root: relational-semistructured-collection
     files:
       - store/db.pure
       - mapping/mapping.pure
@@ -35,19 +34,20 @@ modelSources:
 
 features:
   - execution:data-element
+  - execution:external-format-binding
   - execution:test-data
   - scaffolding:class
   - scaffolding:relational-mapping
   - scaffolding:relational-store
   - store:relational-semistructured
-  - store:relational-semistructured-navigation
-  - store:relational-semistructured-array-index
-  - store:relational-filter
+  - store:relational-semistructured-binding
+  - store:relational-semistructured-flatten
 stores:
   - relational
 # Distinct non-scaffolding domains: execution, store = 2 -> basic.
 complexity: basic
 tags:
   - semi-structured
-  - variant
+  - binding
+  - flatten
   - json

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-collection/data/testData.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-collection/data/testData.pure
@@ -1,0 +1,29 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// RFC-4180: each JSON document is wrapped in " and every internal " is doubled.
+// Alice: 2 otherNames, 2 addresses, with 2 and 1 lines respectively.
+// Bob:   1 otherName,  1 address,   with 1 line.
+// The differing cardinalities make the row fan-out visible per level.
+###Data
+Data demo::ssc::data::PersonData
+{
+  Relation
+  #{
+    default.PERSON_TABLE:
+      ID,FIRST_NAME,FIRM_DETAILS
+      1,Alice,"{""legalName"":""Firm X"",""otherNames"":[""FX"",""FirmTen""],""addresses"":[{""name"":""HQ"",""lines"":[{""detail"":""L1""},{""detail"":""L2""}]},{""name"":""Annex"",""lines"":[{""detail"":""L3""}]}]}"
+      2,Bob,"{""legalName"":""Firm A"",""otherNames"":[""FA""],""addresses"":[{""name"":""Main"",""lines"":[{""detail"":""L9""}]}]}";
+  }#
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-collection/mapping/mapping.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-collection/mapping/mapping.pure
@@ -1,0 +1,141 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Mapping
+Mapping demo::ssc::PersonMapping
+(
+  *demo::ssc::Person: Relational
+  {
+    ~primaryKey
+    (
+      [demo::ssc::store::PersonDB]PERSON_TABLE.ID
+    )
+    ~mainTable [demo::ssc::store::PersonDB]PERSON_TABLE
+    firstName: [demo::ssc::store::PersonDB]PERSON_TABLE.FIRST_NAME,
+    firm: Binding demo::ssc::FirmBinding : [demo::ssc::store::PersonDB]PERSON_TABLE.FIRM_DETAILS
+  }
+
+  // No query below writes a flatten call. Navigating a to-many property through a
+  // binding is what makes the planner emit SemiStructuredArrayFlatten and a lateral
+  // join; the rows fan out as a consequence of the model's multiplicity.
+  testSuites:
+  [
+    // These suites carry no toJson canary, and do not need one: every query here
+    // depends on a lateral flatten, which a non-semi-structured target cannot render
+    // at all. A misroute fails outright rather than passing quietly - H2 skips the
+    // whole array-flattening group for exactly this reason.
+    primitiveCollectionSuite:
+    {
+      function: |demo::ssc::Person.all()
+                  ->project(~[firstName: p | $p.firstName, otherName: p | $p.firm.otherNames])
+                  ->sort([~firstName->ascending(), ~otherName->ascending()]);
+      tests:
+      [
+        flattenPrimitiveArray:
+        {
+          data:
+          [
+            demo::ssc::store::PersonDB:
+              Reference
+              #{
+                demo::ssc::data::PersonData
+              }#
+          ];
+          asserts:
+          [
+            shouldFanOutOneRowPerElement:
+              EqualToJson
+              #{
+                expected:
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '[{"firstName":"Alice","otherName":"FX"},{"firstName":"Alice","otherName":"FirmTen"},{"firstName":"Bob","otherName":"FA"}]';
+                  }#;
+              }#
+          ];
+        }
+      ];
+    },
+    complexCollectionSuite:
+    {
+      function: |demo::ssc::Person.all()
+                  ->project(~[firstName: p | $p.firstName, addressName: p | $p.firm.addresses.name])
+                  ->sort([~firstName->ascending(), ~addressName->ascending()]);
+      tests:
+      [
+        flattenObjectArray:
+        {
+          data:
+          [
+            demo::ssc::store::PersonDB:
+              Reference
+              #{
+                demo::ssc::data::PersonData
+              }#
+          ];
+          asserts:
+          [
+            shouldFanOutOneRowPerObject:
+              EqualToJson
+              #{
+                expected:
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '[{"firstName":"Alice","addressName":"Annex"},{"firstName":"Alice","addressName":"HQ"},{"firstName":"Bob","addressName":"Main"}]';
+                  }#;
+              }#
+          ];
+        }
+      ];
+    },
+    // A collection inside a collection - two stacked lateral flattens. This shape is
+    // reachable only through a binding; explodeSemiStructured asserts its operand is a
+    // raw column, so it cannot explode an already-exploded element.
+    nestedCollectionSuite:
+    {
+      function: |demo::ssc::Person.all()
+                  ->project(~[firstName: p | $p.firstName, lineDetail: p | $p.firm.addresses.lines.detail])
+                  ->sort([~firstName->ascending(), ~lineDetail->ascending()]);
+      tests:
+      [
+        flattenNestedArray:
+        {
+          data:
+          [
+            demo::ssc::store::PersonDB:
+              Reference
+              #{
+                demo::ssc::data::PersonData
+              }#
+          ];
+          asserts:
+          [
+            shouldFanOutAcrossBothLevels:
+              EqualToJson
+              #{
+                expected:
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '[{"firstName":"Alice","lineDetail":"L1"},{"firstName":"Alice","lineDetail":"L2"},{"firstName":"Alice","lineDetail":"L3"},{"firstName":"Bob","lineDetail":"L9"}]';
+                  }#;
+              }#
+          ];
+        }
+      ];
+    }
+  ]
+)

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-collection/store/db.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-collection/store/db.pure
@@ -1,0 +1,62 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+Class demo::ssc::Person
+{
+  firstName: String[1];
+  firm: demo::ssc::Firm[1];
+}
+
+Class demo::ssc::Firm
+{
+  legalName: String[1];
+  // Collection of primitives.
+  otherNames: String[*];
+  // Collection of objects, each holding a further collection.
+  addresses: demo::ssc::Address[*];
+}
+
+Class demo::ssc::Address
+{
+  name: String[1];
+  lines: demo::ssc::AddressLine[*];
+}
+
+Class demo::ssc::AddressLine
+{
+  detail: String[1];
+}
+
+###ExternalFormat
+Binding demo::ssc::FirmBinding
+{
+  contentType: 'application/json';
+  modelIncludes: [
+    demo::ssc::Firm,
+    demo::ssc::Address,
+    demo::ssc::AddressLine
+  ];
+}
+
+###Relational
+Database demo::ssc::store::PersonDB
+(
+  Table PERSON_TABLE
+  (
+    ID INTEGER PRIMARY KEY,
+    FIRST_NAME VARCHAR(100),
+    FIRM_DETAILS SEMISTRUCTURED
+  )
+)

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-explode.emit.yaml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-explode.emit.yaml
@@ -12,22 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: relational-semistructured
-title: "Relational Store — Modelled Semi-structured Data"
+name: relational-semistructured-explode
+title: "Relational Store — Exploding a JSON Array into Rows"
 description: |
-  A SEMISTRUCTURED column modelled as ordinary typed properties. One JSON document per
-  row is projected into scalars covering every target type the extraction whitelist
-  accepts, plus the edges of the path grammar: an element of an array of objects, an
-  element of an array of arrays, an array nested inside an object array, bracket-quoted
-  keys containing a space and a dot, and — against a second column whose root is a JSON
-  array — paths that lead with an index.
+  A JSON array fanned out into rows inside a store join, each element's scalar then
+  equi-joined to an ordinary table. The class mapping mentions nothing semi-structured:
+  the to-many property is an ordinary join traversal, and its multiplicity comes from
+  the fan-out.
 
-  Navigation is exercised in two positions: property mappings, and a store filter
-  predicate that reads a value out of the document to decide row inclusion.
+  A view supplies the column being exploded, which is the only way a view participates —
+  explosion is legal solely inside a join operation, and its operand must be a plain
+  column of a table or a view. Elements that fail the join predicate drop out, so the
+  join filters and fans in one step.
 
 modelSources:
   model:
-    root: relational-semistructured
+    root: relational-semistructured-explode
     files:
       - store/db.pure
       - mapping/mapping.pure
@@ -39,15 +39,19 @@ features:
   - scaffolding:class
   - scaffolding:relational-mapping
   - scaffolding:relational-store
+  - store:relational-inline-view
+  - store:relational-inner-join
+  - store:relational-multi-table
   - store:relational-semistructured
+  - store:relational-semistructured-explode
   - store:relational-semistructured-navigation
-  - store:relational-semistructured-array-index
-  - store:relational-filter
 stores:
   - relational
 # Distinct non-scaffolding domains: execution, store = 2 -> basic.
 complexity: basic
 tags:
   - semi-structured
-  - variant
+  - explode
+  - view
+  - join
   - json

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-explode/data/testData.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-explode/data/testData.pure
@@ -1,0 +1,35 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// RFC-4180: each JSON document is wrapped in " and every internal " is doubled.
+// b1 carries two order entries and one trade entry; the trade entry must not join,
+// since the join condition also requires tag = 'order'. b2 carries one order entry.
+###Data
+Data demo::sse::data::TradingData
+{
+  Relation
+  #{
+    TRADING.BLOCKS:
+      ID,ACCOUNT,BLOCKDATA
+      b1,ACC1,"{""relatedEntities"":[{""tag"":""order"",""tagId"":""o1""},{""tag"":""order"",""tagId"":""o2""},{""tag"":""trade"",""tagId"":""t9""}]}"
+      b2,ACC2,"{""relatedEntities"":[{""tag"":""order"",""tagId"":""o3""}]}";
+
+    TRADING.ORDERS:
+      ID,ORDER_NAME
+      o1,Alpha
+      o2,Beta
+      o3,Gamma
+      t9,ShouldNotAppear;
+  }#
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-explode/mapping/mapping.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-explode/mapping/mapping.pure
@@ -1,0 +1,79 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Mapping
+Mapping demo::sse::TradingMapping
+(
+  // Neither class mapping mentions anything semi-structured. The explosion lives
+  // entirely in the store's join definition; the mapping just traverses the join.
+  *demo::sse::Block: Relational
+  {
+    ~primaryKey
+    (
+      [demo::sse::store::TradingDB]TRADING.ACTIVE_BLOCKS.ID
+    )
+    ~mainTable [demo::sse::store::TradingDB]TRADING.ACTIVE_BLOCKS
+    id: [demo::sse::store::TradingDB]TRADING.ACTIVE_BLOCKS.ID,
+    account: [demo::sse::store::TradingDB]TRADING.ACTIVE_BLOCKS.ACCOUNT,
+    orders[demo_sse_Order]: [demo::sse::store::TradingDB]@Block_Order
+  }
+
+  demo::sse::Order: Relational
+  {
+    ~primaryKey
+    (
+      [demo::sse::store::TradingDB]TRADING.ORDERS.ID
+    )
+    ~mainTable [demo::sse::store::TradingDB]TRADING.ORDERS
+    id: [demo::sse::store::TradingDB]TRADING.ORDERS.ID,
+    orderName: [demo::sse::store::TradingDB]TRADING.ORDERS.ORDER_NAME
+  }
+
+  testSuites:
+  [
+    explodeSuite:
+    {
+      function: |demo::sse::Block.all()
+                  ->project(~[blockId: b | $b.id, account: b | $b.account, orderName: b | $b.orders.orderName])
+                  ->sort([~blockId->ascending(), ~orderName->ascending()]);
+      tests:
+      [
+        explodeArrayIntoRows:
+        {
+          data:
+          [
+            demo::sse::store::TradingDB:
+              Reference
+              #{
+                demo::sse::data::TradingData
+              }#
+          ];
+          asserts:
+          [
+            shouldJoinEachExplodedElement:
+              EqualToJson
+              #{
+                expected:
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '[{"blockId":"b1","account":"ACC1","orderName":"Alpha"},{"blockId":"b1","account":"ACC1","orderName":"Beta"},{"blockId":"b2","account":"ACC2","orderName":"Gamma"}]';
+                  }#;
+              }#
+          ];
+        }
+      ];
+    }
+  ]
+)

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-explode/store/db.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-explode/store/db.pure
@@ -1,0 +1,64 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+Class demo::sse::Block
+{
+  id: String[1];
+  account: String[1];
+  // To-many, but backed by a join rather than by a binding: the multiplicity comes
+  // from the row fan-out the explosion produces, not from the model.
+  orders: demo::sse::Order[*];
+}
+
+Class demo::sse::Order
+{
+  id: String[1];
+  orderName: String[1];
+}
+
+###Relational
+Database demo::sse::store::TradingDB
+(
+  Schema TRADING
+  (
+    Table BLOCKS
+    (
+      ID VARCHAR(100) PRIMARY KEY,
+      ACCOUNT VARCHAR(100),
+      BLOCKDATA SEMISTRUCTURED
+    )
+    Table ORDERS
+    (
+      ID VARCHAR(100) PRIMARY KEY,
+      ORDER_NAME VARCHAR(100)
+    )
+
+    // The view exists to supply the column that gets exploded. That is the only way a
+    // view takes part: explodeSemiStructured is legal solely inside a join operation,
+    // and its operand must be a plain column of a table or a view.
+    View ACTIVE_BLOCKS
+    (
+      ID: TRADING.BLOCKS.ID PRIMARY KEY,
+      ACCOUNT: TRADING.BLOCKS.ACCOUNT,
+      BLOCKDATA: TRADING.BLOCKS.BLOCKDATA
+    )
+  )
+
+  // Fans the JSON array into one row per element, then equi-joins each element's
+  // scalar to a real table. The explode expression is repeated, which is allowed:
+  // the one-explode-per-join check runs after duplicates are removed.
+  Join Block_Order(extractFromSemiStructured(explodeSemiStructured(TRADING.ACTIVE_BLOCKS.BLOCKDATA, 'relatedEntities', 'SEMISTRUCTURED'), 'tag', 'VARCHAR') = 'order'
+    and extractFromSemiStructured(explodeSemiStructured(TRADING.ACTIVE_BLOCKS.BLOCKDATA, 'relatedEntities', 'SEMISTRUCTURED'), 'tagId', 'VARCHAR') = TRADING.ORDERS.ID)
+)

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-flatten-probe.emit.yaml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-flatten-probe.emit.yaml
@@ -1,0 +1,28 @@
+name: relational-semistructured-flatten-probe
+title: "Relational Store — What array_flatten Does to Each Array Shape"
+description: |
+  Probes array_flatten against flat, singly-nested, ragged, doubly-nested and empty-inner
+  arrays. A [*] path has to normalise at every step because JSON is irregular, and that
+  normalisation is only sound if flatten collapses one level and leaves a flat array alone.
+modelSources:
+  model:
+    root: relational-semistructured-flatten-probe
+    files:
+      - store/db.pure
+      - mapping/mapping.pure
+      - data/testData.pure
+features:
+  - execution:data-element
+  - execution:test-data
+  - scaffolding:class
+  - scaffolding:relational-mapping
+  - scaffolding:relational-store
+  - store:relational-semistructured
+  - store:relational-semistructured-array-functions
+stores:
+  - relational
+complexity: basic
+tags:
+  - semi-structured
+  - array-functions
+  - json

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-flatten-probe/data/testData.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-flatten-probe/data/testData.pure
@@ -1,0 +1,26 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// a nests uniformly. e holds an empty inner array, n an explicit null, k omits the key, and z
+// is empty throughout - the four ways a document says "nothing here".
+###Data
+Data probe::data::D
+{
+  Relation
+  #{
+    default.T:
+      ID,DOC
+      1,"{""a"":[{""b"":[1,2]},{""b"":[3]}],""e"":[{""b"":[1]},{""b"":[]}],""n"":[{""b"":[1]},{""b"":null}],""k"":[{""b"":[1]},{}],""z"":[{""b"":[]},{""b"":[]}]}";
+  }#
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-flatten-probe/mapping/mapping.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-flatten-probe/mapping/mapping.pure
@@ -1,0 +1,70 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Mapping
+Mapping probe::M
+(
+  *probe::Row: Relational
+  {
+    ~primaryKey ( [probe::store::DB]T.ID )
+    ~mainTable [probe::store::DB]T
+    id: [probe::store::DB]T.ID,
+
+    // A transform whose body yields arrays produces an array of arrays; flattening it is what a
+    // wildcard path needs, since Pure has no nested collection type to represent the former.
+    transformOnly: array_to_string(array_transform(extractFromSemiStructured([probe::store::DB]T.DOC, 'a', 'SEMISTRUCTURED[]'), x | extractFromSemiStructured($x, 'b', 'SEMISTRUCTURED[]')), ';'),
+    transformThenFlatten: array_to_string(array_flatten(array_transform(extractFromSemiStructured([probe::store::DB]T.DOC, 'a', 'SEMISTRUCTURED[]'), x | extractFromSemiStructured($x, 'b', 'SEMISTRUCTURED[]'))), ','),
+
+    // An empty inner array, an explicit null and an absent key are all ordinary optional-field
+    // shapes, and all three have to contribute nothing rather than a null element.
+    emptyInner: array_to_string(array_flatten(array_transform(extractFromSemiStructured([probe::store::DB]T.DOC, 'e', 'SEMISTRUCTURED[]'), x | extractFromSemiStructured($x, 'b', 'SEMISTRUCTURED[]'))), ','),
+    nullInner: array_to_string(array_flatten(array_transform(extractFromSemiStructured([probe::store::DB]T.DOC, 'n', 'SEMISTRUCTURED[]'), x | extractFromSemiStructured($x, 'b', 'SEMISTRUCTURED[]'))), ','),
+    absentInner: array_to_string(array_flatten(array_transform(extractFromSemiStructured([probe::store::DB]T.DOC, 'k', 'SEMISTRUCTURED[]'), x | extractFromSemiStructured($x, 'b', 'SEMISTRUCTURED[]'))), ','),
+    allEmpty: array_to_string(array_flatten(array_transform(extractFromSemiStructured([probe::store::DB]T.DOC, 'z', 'SEMISTRUCTURED[]'), x | extractFromSemiStructured($x, 'b', 'SEMISTRUCTURED[]'))), ',')
+  }
+
+  testSuites:
+  [
+    transformOnlySuite:
+    {
+      function: |probe::Row.all()->project(~[id: r | $r.id, v: r | $r.transformOnly]);
+      tests: [ t: { data: [ probe::store::DB: Reference #{ probe::data::D }# ]; asserts: [ a: EqualToJson #{ expected: ExternalFormat #{ contentType: 'application/json'; data: '[ {\n  "id" : 1,\n  "v" : "[1, 2];[3]"\n} ]'; }#; }# ]; } ];
+    },
+    transformThenFlattenSuite:
+    {
+      function: |probe::Row.all()->project(~[id: r | $r.id, v: r | $r.transformThenFlatten]);
+      tests: [ t: { data: [ probe::store::DB: Reference #{ probe::data::D }# ]; asserts: [ a: EqualToJson #{ expected: ExternalFormat #{ contentType: 'application/json'; data: '[ {\n  "id" : 1,\n  "v" : "1,2,3"\n} ]'; }#; }# ]; } ];
+    },
+    emptyInnerSuite:
+    {
+      function: |probe::Row.all()->project(~[id: r | $r.id, v: r | $r.emptyInner]);
+      tests: [ t: { data: [ probe::store::DB: Reference #{ probe::data::D }# ]; asserts: [ a: EqualToJson #{ expected: ExternalFormat #{ contentType: 'application/json'; data: '[ {\n  "id" : 1,\n  "v" : "1"\n} ]'; }#; }# ]; } ];
+    },
+    nullInnerSuite:
+    {
+      function: |probe::Row.all()->project(~[id: r | $r.id, v: r | $r.nullInner]);
+      tests: [ t: { data: [ probe::store::DB: Reference #{ probe::data::D }# ]; asserts: [ a: EqualToJson #{ expected: ExternalFormat #{ contentType: 'application/json'; data: '[ {\n  "id" : 1,\n  "v" : "1"\n} ]'; }#; }# ]; } ];
+    },
+    absentInnerSuite:
+    {
+      function: |probe::Row.all()->project(~[id: r | $r.id, v: r | $r.absentInner]);
+      tests: [ t: { data: [ probe::store::DB: Reference #{ probe::data::D }# ]; asserts: [ a: EqualToJson #{ expected: ExternalFormat #{ contentType: 'application/json'; data: '[ {\n  "id" : 1,\n  "v" : "1"\n} ]'; }#; }# ]; } ];
+    },
+    allEmptySuite:
+    {
+      function: |probe::Row.all()->project(~[id: r | $r.id, v: r | $r.allEmpty]);
+      tests: [ t: { data: [ probe::store::DB: Reference #{ probe::data::D }# ]; asserts: [ a: EqualToJson #{ expected: ExternalFormat #{ contentType: 'application/json'; data: '[ {\n  "id" : 1,\n  "v" : null\n} ]'; }#; }# ]; } ];
+    }
+  ]
+)

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-flatten-probe/store/db.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-flatten-probe/store/db.pure
@@ -1,0 +1,35 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+Class probe::Row
+{
+  id: Integer[1];
+  transformOnly: String[0..1];
+  transformThenFlatten: String[0..1];
+  emptyInner: String[0..1];
+  nullInner: String[0..1];
+  absentInner: String[0..1];
+  allEmpty: String[0..1];
+}
+
+###Relational
+Database probe::store::DB
+(
+  Table T
+  (
+    ID INTEGER PRIMARY KEY,
+    DOC SEMISTRUCTURED
+  )
+)

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-join.emit.yaml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-join.emit.yaml
@@ -12,22 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: relational-semistructured
-title: "Relational Store — Modelled Semi-structured Data"
+name: relational-semistructured-join
+title: "Relational Store — Joining on a Value Inside a JSON Document"
 description: |
-  A SEMISTRUCTURED column modelled as ordinary typed properties. One JSON document per
-  row is projected into scalars covering every target type the extraction whitelist
-  accepts, plus the edges of the path grammar: an element of an array of objects, an
-  element of an array of arrays, an array nested inside an object array, bracket-quoted
-  keys containing a space and a dot, and — against a second column whose root is a JSON
-  array — paths that lead with an index.
+  A join whose key is not stored in any column. One side reads a nested scalar out of a
+  JSON document and compares it to an ordinary primary key on the other side, so a
+  document-shaped source participates in an ordinary association without being
+  normalised first.
 
-  Navigation is exercised in two positions: property mappings, and a store filter
-  predicate that reads a value out of the document to decide row inclusion.
+  The mapping traverses the join like any other; nothing above the store knows a
+  document is involved.
 
 modelSources:
   model:
-    root: relational-semistructured
+    root: relational-semistructured-join
     files:
       - store/db.pure
       - mapping/mapping.pure
@@ -39,15 +37,15 @@ features:
   - scaffolding:class
   - scaffolding:relational-mapping
   - scaffolding:relational-store
+  - store:relational-inner-join
+  - store:relational-multi-table
   - store:relational-semistructured
   - store:relational-semistructured-navigation
-  - store:relational-semistructured-array-index
-  - store:relational-filter
 stores:
   - relational
 # Distinct non-scaffolding domains: execution, store = 2 -> basic.
 complexity: basic
 tags:
   - semi-structured
-  - variant
+  - join
   - json

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-join/data/testData.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-join/data/testData.pure
@@ -1,0 +1,32 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// RFC-4180: each JSON document is wrapped in " and every internal " is doubled.
+// The firmId that drives the join is nested one level down, under "employment".
+###Data
+Data demo::ssj::data::HrData
+{
+  Relation
+  #{
+    default.EMPLOYEE:
+      ID,NAME,PROFILE
+      1,Alice,"{""employment"":{""firmId"":""f1"",""grade"":3}}"
+      2,Bob,"{""employment"":{""firmId"":""f2"",""grade"":5}}";
+
+    default.FIRM:
+      ID,LEGAL_NAME
+      f1,Firm One
+      f2,Firm Two;
+  }#
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-join/mapping/mapping.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-join/mapping/mapping.pure
@@ -1,0 +1,76 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Mapping
+Mapping demo::ssj::HrMapping
+(
+  *demo::ssj::Employee: Relational
+  {
+    ~primaryKey
+    (
+      [demo::ssj::store::HrDB]EMPLOYEE.ID
+    )
+    ~mainTable [demo::ssj::store::HrDB]EMPLOYEE
+    name: [demo::ssj::store::HrDB]EMPLOYEE.NAME,
+    firm: [demo::ssj::store::HrDB]@Employee_Firm
+  }
+
+  demo::ssj::Firm: Relational
+  {
+    ~primaryKey
+    (
+      [demo::ssj::store::HrDB]FIRM.ID
+    )
+    ~mainTable [demo::ssj::store::HrDB]FIRM
+    id: [demo::ssj::store::HrDB]FIRM.ID,
+    legalName: [demo::ssj::store::HrDB]FIRM.LEGAL_NAME
+  }
+
+  testSuites:
+  [
+    joinOnDocumentValueSuite:
+    {
+      function: |demo::ssj::Employee.all()
+                  ->project(~[name: e | $e.name, firmId: e | $e.firm.id, legalName: e | $e.firm.legalName])
+                  ->sort([~name->ascending()]);
+      tests:
+      [
+        joinAcrossDocumentValue:
+        {
+          data:
+          [
+            demo::ssj::store::HrDB:
+              Reference
+              #{
+                demo::ssj::data::HrData
+              }#
+          ];
+          asserts:
+          [
+            shouldResolveFirmFromDocument:
+              EqualToJson
+              #{
+                expected:
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '[{"name":"Alice","firmId":"f1","legalName":"Firm One"},{"name":"Bob","firmId":"f2","legalName":"Firm Two"}]';
+                  }#;
+              }#
+          ];
+        }
+      ];
+    }
+  ]
+)

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-join/store/db.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-join/store/db.pure
@@ -1,0 +1,47 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+Class demo::ssj::Employee
+{
+  name: String[1];
+  firm: demo::ssj::Firm[1];
+}
+
+Class demo::ssj::Firm
+{
+  id: String[1];
+  legalName: String[1];
+}
+
+###Relational
+Database demo::ssj::store::HrDB
+(
+  Table EMPLOYEE
+  (
+    ID INTEGER PRIMARY KEY,
+    NAME VARCHAR(100),
+    PROFILE SEMISTRUCTURED
+  )
+  Table FIRM
+  (
+    ID VARCHAR(100) PRIMARY KEY,
+    LEGAL_NAME VARCHAR(100)
+  )
+
+  // The join key is not stored in a column - it is read out of the JSON document on
+  // one side and compared to an ordinary column on the other. No explosion is
+  // involved: the document yields a single scalar per row.
+  Join Employee_Firm(extractFromSemiStructured(EMPLOYEE.PROFILE, 'employment.firmId', 'VARCHAR') = FIRM.ID)
+)

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-store-arrays.emit.yaml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-store-arrays.emit.yaml
@@ -1,0 +1,52 @@
+# Copyright 2026 Goldman Sachs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: relational-semistructured-store-arrays
+title: "Relational Store — Array Operations in the Store Language"
+description: |
+  Aggregating a JSON array where it sits, using the store's own expression language
+  rather than a query-side collection function. The array is never fanned into rows:
+  each expression reduces it to a scalar in place.
+
+  The same operations appear in all three positions the store language allows — a
+  property mapping, a filter predicate deciding row inclusion, and computed view
+  columns — so a consumer sees ordinary scalar properties and a normal view.
+
+modelSources:
+  model:
+    root: relational-semistructured-store-arrays
+    files:
+      - store/db.pure
+      - mapping/mapping.pure
+      - data/testData.pure
+
+features:
+  - execution:data-element
+  - execution:test-data
+  - scaffolding:class
+  - scaffolding:relational-mapping
+  - scaffolding:relational-store
+  - store:relational-filter
+  - store:relational-inline-view
+  - store:relational-semistructured
+  - store:relational-semistructured-array-functions
+stores:
+  - relational
+# Distinct non-scaffolding domains: execution, store = 2 -> basic.
+complexity: basic
+tags:
+  - semi-structured
+  - array-functions
+  - view
+  - json

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-store-arrays/data/testData.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-store-arrays/data/testData.pure
@@ -1,0 +1,30 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// RFC-4180: each JSON document is wrapped in " and every internal " is doubled.
+// Owls hold two scores, below the filter's threshold of more than two, so that row is
+// absent from the Team projection while still present in the unfiltered view - which is
+// what shows the filter predicate is doing work rather than passing everything.
+###Data
+Data demo::ssd::data::TeamData
+{
+  Relation
+  #{
+    default.TEAM_TABLE:
+      ID,LABEL,SCORES
+      1,Falcons,"[30,10,20]"
+      2,Ravens,"[5,12,7]"
+      3,Owls,"[40,35]";
+  }#
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-store-arrays/data/testData.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-store-arrays/data/testData.pure
@@ -22,9 +22,9 @@ Data demo::ssd::data::TeamData
   Relation
   #{
     default.TEAM_TABLE:
-      ID,LABEL,SCORES
-      1,Falcons,"{""values"":[9,100,20]}"
-      2,Ravens,"{""values"":[5,12,7]}"
-      3,Owls,"{""values"":[40,35]}";
+      ID,LABEL,SCORES,DIVISIONS
+      1,Falcons,"{""values"":[9,100,20]}","{""divisions"":[{""name"":""Alpha"",""headcount"":150},{""name"":""Beta"",""headcount"":50},{""name"":""Gamma"",""headcount"":300}]}"
+      2,Ravens,"{""values"":[5,12,7]}","{""divisions"":[{""name"":""Delta"",""headcount"":20}]}"
+      3,Owls,"{""values"":[40,35]}","{""divisions"":[{""name"":""Eps"",""headcount"":900}]}";
   }#
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-store-arrays/data/testData.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-store-arrays/data/testData.pure
@@ -23,8 +23,8 @@ Data demo::ssd::data::TeamData
   #{
     default.TEAM_TABLE:
       ID,LABEL,SCORES
-      1,Falcons,"[30,10,20]"
-      2,Ravens,"[5,12,7]"
-      3,Owls,"[40,35]";
+      1,Falcons,"{""values"":[9,100,20]}"
+      2,Ravens,"{""values"":[5,12,7]}"
+      3,Owls,"{""values"":[40,35]}";
   }#
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-store-arrays/mapping/mapping.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-store-arrays/mapping/mapping.pure
@@ -28,6 +28,12 @@ Mapping demo::ssd::TeamMapping
     id: [demo::ssd::store::TeamDB]TEAM_TABLE.ID,
     label: [demo::ssd::store::TeamDB]TEAM_TABLE.LABEL,
     scoreCount: array_size(extractFromSemiStructured([demo::ssd::store::TeamDB]TEAM_TABLE.SCORES, 'values', 'INTEGER[]')),
+    // A lambda in the store language: filter the array, then count what survives. $d binds each
+    // element, and the body navigates into it.
+    largeDivisions: array_size(array_filter(extractFromSemiStructured([demo::ssd::store::TeamDB]TEAM_TABLE.DIVISIONS, 'divisions', 'SEMISTRUCTURED[]'), d | extractFromSemiStructured($d, 'headcount', 'INTEGER') > 100)),
+    // array_transform maps each element, so the result is still a collection - joined here to
+    // land a scalar the projection can carry.
+    divisionNames: array_to_string(array_transform(extractFromSemiStructured([demo::ssd::store::TeamDB]TEAM_TABLE.DIVISIONS, 'divisions', 'SEMISTRUCTURED[]'), d | extractFromSemiStructured($d, 'name', 'VARCHAR')), ','),
     topScore: array_max(extractFromSemiStructured([demo::ssd::store::TeamDB]TEAM_TABLE.SCORES, 'values', 'INTEGER[]')),
     lowScore: array_min(extractFromSemiStructured([demo::ssd::store::TeamDB]TEAM_TABLE.SCORES, 'values', 'INTEGER[]'))
   }
@@ -50,14 +56,14 @@ Mapping demo::ssd::TeamMapping
     mappingArraySuite:
     {
       function: |demo::ssd::Team.all()
-                  ->project(~[label: t | $t.label, scoreCount: t | $t.scoreCount, topScore: t | $t.topScore, lowScore: t | $t.lowScore])
+                  ->project(~[label: t | $t.label, scoreCount: t | $t.scoreCount, topScore: t | $t.topScore, lowScore: t | $t.lowScore, largeDivisions: t | $t.largeDivisions, divisionNames: t | $t.divisionNames])
                   ->sort([~label->ascending()]);
       tests:
       [
         arrayFunctionsInMappingAndFilter:
         {
           data: [ demo::ssd::store::TeamDB: Reference #{ demo::ssd::data::TeamData }# ];
-          asserts: [ shouldAggregateInStore: EqualToJson #{ expected: ExternalFormat #{ contentType: 'application/json'; data: '[{"label":"Falcons","scoreCount":3,"topScore":100,"lowScore":9},{"label":"Ravens","scoreCount":3,"topScore":12,"lowScore":5}]'; }#; }# ];
+          asserts: [ shouldAggregateInStore: EqualToJson #{ expected: ExternalFormat #{ contentType: 'application/json'; data: '[{"label":"Falcons","scoreCount":3,"topScore":100,"lowScore":9,"largeDivisions":2,"divisionNames":"Alpha,Beta,Gamma"},{"label":"Ravens","scoreCount":3,"topScore":12,"lowScore":5,"largeDivisions":0,"divisionNames":"Delta"}]'; }#; }# ];
         }
       ];
     },

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-store-arrays/mapping/mapping.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-store-arrays/mapping/mapping.pure
@@ -1,0 +1,76 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Mapping
+Mapping demo::ssd::TeamMapping
+(
+  // Array functions as property mappings. The query below is an ordinary projection of
+  // scalar properties - all of the array work happens in the store language.
+  *demo::ssd::Team: Relational
+  {
+    ~filter [demo::ssd::store::TeamDB] MultiScoreFilter
+    ~primaryKey
+    (
+      [demo::ssd::store::TeamDB]TEAM_TABLE.ID
+    )
+    ~mainTable [demo::ssd::store::TeamDB]TEAM_TABLE
+    id: [demo::ssd::store::TeamDB]TEAM_TABLE.ID,
+    label: [demo::ssd::store::TeamDB]TEAM_TABLE.LABEL,
+    scoreCount: array_size([demo::ssd::store::TeamDB]TEAM_TABLE.SCORES)
+  }
+
+  // Same functions again, this time reached through a view that computes them.
+  demo::ssd::TeamStats: Relational
+  {
+    ~primaryKey
+    (
+      [demo::ssd::store::TeamDB]TEAM_STATS.ID
+    )
+    ~mainTable [demo::ssd::store::TeamDB]TEAM_STATS
+    id: [demo::ssd::store::TeamDB]TEAM_STATS.ID,
+    total: [demo::ssd::store::TeamDB]TEAM_STATS.TOTAL
+  }
+
+  testSuites:
+  [
+    mappingArraySuite:
+    {
+      function: |demo::ssd::Team.all()
+                  ->project(~[label: t | $t.label, scoreCount: t | $t.scoreCount])
+                  ->sort([~label->ascending()]);
+      tests:
+      [
+        arrayFunctionsInMappingAndFilter:
+        {
+          data: [ demo::ssd::store::TeamDB: Reference #{ demo::ssd::data::TeamData }# ];
+          asserts: [ shouldAggregateInStore: EqualToJson #{ expected: ExternalFormat #{ contentType: 'application/json'; data: '[{"label":"Falcons","scoreCount":3},{"label":"Ravens","scoreCount":3}]'; }#; }# ];
+        }
+      ];
+    },
+    viewArraySuite:
+    {
+      function: |demo::ssd::TeamStats.all()
+                  ->project(~[id: s | $s.id, total: s | $s.total])
+                  ->sort([~id->ascending()]);
+      tests:
+      [
+        arrayFunctionsInViewColumns:
+        {
+          data: [ demo::ssd::store::TeamDB: Reference #{ demo::ssd::data::TeamData }# ];
+          asserts: [ shouldComputeViewColumns: EqualToJson #{ expected: ExternalFormat #{ contentType: 'application/json'; data: '[{"id":1,"total":3},{"id":2,"total":3},{"id":3,"total":2}]'; }#; }# ];
+        }
+      ];
+    }
+  ]
+)

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-store-arrays/mapping/mapping.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-store-arrays/mapping/mapping.pure
@@ -27,7 +27,9 @@ Mapping demo::ssd::TeamMapping
     ~mainTable [demo::ssd::store::TeamDB]TEAM_TABLE
     id: [demo::ssd::store::TeamDB]TEAM_TABLE.ID,
     label: [demo::ssd::store::TeamDB]TEAM_TABLE.LABEL,
-    scoreCount: array_size([demo::ssd::store::TeamDB]TEAM_TABLE.SCORES)
+    scoreCount: array_size(extractFromSemiStructured([demo::ssd::store::TeamDB]TEAM_TABLE.SCORES, 'values', 'INTEGER[]')),
+    topScore: array_max(extractFromSemiStructured([demo::ssd::store::TeamDB]TEAM_TABLE.SCORES, 'values', 'INTEGER[]')),
+    lowScore: array_min(extractFromSemiStructured([demo::ssd::store::TeamDB]TEAM_TABLE.SCORES, 'values', 'INTEGER[]'))
   }
 
   // Same functions again, this time reached through a view that computes them.
@@ -39,7 +41,8 @@ Mapping demo::ssd::TeamMapping
     )
     ~mainTable [demo::ssd::store::TeamDB]TEAM_STATS
     id: [demo::ssd::store::TeamDB]TEAM_STATS.ID,
-    total: [demo::ssd::store::TeamDB]TEAM_STATS.TOTAL
+    total: [demo::ssd::store::TeamDB]TEAM_STATS.TOTAL,
+    top: [demo::ssd::store::TeamDB]TEAM_STATS.TOP
   }
 
   testSuites:
@@ -47,28 +50,28 @@ Mapping demo::ssd::TeamMapping
     mappingArraySuite:
     {
       function: |demo::ssd::Team.all()
-                  ->project(~[label: t | $t.label, scoreCount: t | $t.scoreCount])
+                  ->project(~[label: t | $t.label, scoreCount: t | $t.scoreCount, topScore: t | $t.topScore, lowScore: t | $t.lowScore])
                   ->sort([~label->ascending()]);
       tests:
       [
         arrayFunctionsInMappingAndFilter:
         {
           data: [ demo::ssd::store::TeamDB: Reference #{ demo::ssd::data::TeamData }# ];
-          asserts: [ shouldAggregateInStore: EqualToJson #{ expected: ExternalFormat #{ contentType: 'application/json'; data: '[{"label":"Falcons","scoreCount":3},{"label":"Ravens","scoreCount":3}]'; }#; }# ];
+          asserts: [ shouldAggregateInStore: EqualToJson #{ expected: ExternalFormat #{ contentType: 'application/json'; data: '[{"label":"Falcons","scoreCount":3,"topScore":100,"lowScore":9},{"label":"Ravens","scoreCount":3,"topScore":12,"lowScore":5}]'; }#; }# ];
         }
       ];
     },
     viewArraySuite:
     {
       function: |demo::ssd::TeamStats.all()
-                  ->project(~[id: s | $s.id, total: s | $s.total])
+                  ->project(~[id: s | $s.id, total: s | $s.total, top: s | $s.top])
                   ->sort([~id->ascending()]);
       tests:
       [
         arrayFunctionsInViewColumns:
         {
           data: [ demo::ssd::store::TeamDB: Reference #{ demo::ssd::data::TeamData }# ];
-          asserts: [ shouldComputeViewColumns: EqualToJson #{ expected: ExternalFormat #{ contentType: 'application/json'; data: '[{"id":1,"total":3},{"id":2,"total":3},{"id":3,"total":2}]'; }#; }# ];
+          asserts: [ shouldComputeViewColumns: EqualToJson #{ expected: ExternalFormat #{ contentType: 'application/json'; data: '[{"id":1,"total":3,"top":100},{"id":2,"total":3,"top":12},{"id":3,"total":2,"top":40}]'; }#; }# ];
         }
       ];
     }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-store-arrays/mapping/mapping.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-store-arrays/mapping/mapping.pure
@@ -34,6 +34,8 @@ Mapping demo::ssd::TeamMapping
     // array_transform maps each element, so the result is still a collection - joined here to
     // land a scalar the projection can carry.
     divisionNames: array_to_string(array_transform(extractFromSemiStructured([demo::ssd::store::TeamDB]TEAM_TABLE.DIVISIONS, 'divisions', 'SEMISTRUCTURED[]'), d | extractFromSemiStructured($d, 'name', 'VARCHAR')), ','),
+    // Element first, then accumulator, as fold is written in Pure.
+    totalScore: array_reduce(extractFromSemiStructured([demo::ssd::store::TeamDB]TEAM_TABLE.SCORES, 'values', 'INTEGER[]'), (d, acc | plus($acc, $d)), 0),
     topScore: array_max(extractFromSemiStructured([demo::ssd::store::TeamDB]TEAM_TABLE.SCORES, 'values', 'INTEGER[]')),
     lowScore: array_min(extractFromSemiStructured([demo::ssd::store::TeamDB]TEAM_TABLE.SCORES, 'values', 'INTEGER[]'))
   }
@@ -56,14 +58,14 @@ Mapping demo::ssd::TeamMapping
     mappingArraySuite:
     {
       function: |demo::ssd::Team.all()
-                  ->project(~[label: t | $t.label, scoreCount: t | $t.scoreCount, topScore: t | $t.topScore, lowScore: t | $t.lowScore, largeDivisions: t | $t.largeDivisions, divisionNames: t | $t.divisionNames])
+                  ->project(~[label: t | $t.label, scoreCount: t | $t.scoreCount, topScore: t | $t.topScore, lowScore: t | $t.lowScore, largeDivisions: t | $t.largeDivisions, divisionNames: t | $t.divisionNames, totalScore: t | $t.totalScore])
                   ->sort([~label->ascending()]);
       tests:
       [
         arrayFunctionsInMappingAndFilter:
         {
           data: [ demo::ssd::store::TeamDB: Reference #{ demo::ssd::data::TeamData }# ];
-          asserts: [ shouldAggregateInStore: EqualToJson #{ expected: ExternalFormat #{ contentType: 'application/json'; data: '[{"label":"Falcons","scoreCount":3,"topScore":100,"lowScore":9,"largeDivisions":2,"divisionNames":"Alpha,Beta,Gamma"},{"label":"Ravens","scoreCount":3,"topScore":12,"lowScore":5,"largeDivisions":0,"divisionNames":"Delta"}]'; }#; }# ];
+          asserts: [ shouldAggregateInStore: EqualToJson #{ expected: ExternalFormat #{ contentType: 'application/json'; data: '[{"label":"Falcons","scoreCount":3,"topScore":100,"lowScore":9,"largeDivisions":2,"divisionNames":"Alpha,Beta,Gamma","totalScore":129},{"label":"Ravens","scoreCount":3,"topScore":12,"lowScore":5,"largeDivisions":0,"divisionNames":"Delta","totalScore":24}]'; }#; }# ];
         }
       ];
     },

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-store-arrays/store/db.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-store-arrays/store/db.pure
@@ -1,0 +1,50 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+Class demo::ssd::Team
+{
+  id: Integer[1];
+  label: String[1];
+  scoreCount: Integer[1];
+}
+
+Class demo::ssd::TeamStats
+{
+  id: Integer[1];
+  total: Integer[1];
+}
+
+###Relational
+Database demo::ssd::store::TeamDB
+(
+  Table TEAM_TABLE
+  (
+    ID INTEGER PRIMARY KEY,
+    LABEL VARCHAR(100),
+    // A JSON array of numbers, aggregated where it sits rather than fanned into rows.
+    SCORES SEMISTRUCTURED
+  )
+
+  // Array function in a filter predicate: row inclusion decided by an aggregate of the
+  // array, with no row expansion. Ravens hold two scores and drop out.
+  Filter MultiScoreFilter(array_size(TEAM_TABLE.SCORES) > 2)
+
+  // Array function as a computed view column.
+  View TEAM_STATS
+  (
+    ID: TEAM_TABLE.ID PRIMARY KEY,
+    TOTAL: array_size(TEAM_TABLE.SCORES)
+  )
+)

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-store-arrays/store/db.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-store-arrays/store/db.pure
@@ -18,12 +18,15 @@ Class demo::ssd::Team
   id: Integer[1];
   label: String[1];
   scoreCount: Integer[1];
+  topScore: Integer[1];
+  lowScore: Integer[1];
 }
 
 Class demo::ssd::TeamStats
 {
   id: Integer[1];
   total: Integer[1];
+  top: Integer[1];
 }
 
 ###Relational
@@ -38,13 +41,14 @@ Database demo::ssd::store::TeamDB
   )
 
   // Array function in a filter predicate: row inclusion decided by an aggregate of the
-  // array, with no row expansion. Ravens hold two scores and drop out.
-  Filter MultiScoreFilter(array_size(TEAM_TABLE.SCORES) > 2)
+  // array, with no row expansion.
+  Filter MultiScoreFilter(array_size(extractFromSemiStructured(TEAM_TABLE.SCORES, 'values', 'INTEGER[]')) > 2)
 
   // Array function as a computed view column.
   View TEAM_STATS
   (
     ID: TEAM_TABLE.ID PRIMARY KEY,
-    TOTAL: array_size(TEAM_TABLE.SCORES)
+    TOTAL: array_size(extractFromSemiStructured(TEAM_TABLE.SCORES, 'values', 'INTEGER[]')),
+    TOP: array_max(extractFromSemiStructured(TEAM_TABLE.SCORES, 'values', 'INTEGER[]'))
   )
 )

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-store-arrays/store/db.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-store-arrays/store/db.pure
@@ -20,6 +20,7 @@ Class demo::ssd::Team
   scoreCount: Integer[1];
   largeDivisions: Integer[1];
   divisionNames: String[1];
+  totalScore: Integer[1];
   topScore: Integer[1];
   lowScore: Integer[1];
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-store-arrays/store/db.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-store-arrays/store/db.pure
@@ -18,6 +18,8 @@ Class demo::ssd::Team
   id: Integer[1];
   label: String[1];
   scoreCount: Integer[1];
+  largeDivisions: Integer[1];
+  divisionNames: String[1];
   topScore: Integer[1];
   lowScore: Integer[1];
 }
@@ -37,7 +39,9 @@ Database demo::ssd::store::TeamDB
     ID INTEGER PRIMARY KEY,
     LABEL VARCHAR(100),
     // A JSON array of numbers, aggregated where it sits rather than fanned into rows.
-    SCORES SEMISTRUCTURED
+    SCORES SEMISTRUCTURED,
+    // Array of objects, so the lambda body has to navigate into each element.
+    DIVISIONS SEMISTRUCTURED
   )
 
   // Array function in a filter predicate: row inclusion decided by an aggregate of the

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-wildcard.emit.yaml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-wildcard.emit.yaml
@@ -1,0 +1,29 @@
+name: relational-semistructured-wildcard
+title: "Relational Store — Wildcard Paths in the Store Language"
+description: |
+  A [*] segment maps over every element at that level and flattens the result, so a path can
+  reach through several arrays and still yield the flat collection Pure's type system requires.
+  The resulting array is collapsed by the array_* family, as a relational property mapping
+  produces one value per column.
+modelSources:
+  model:
+    root: relational-semistructured-wildcard
+    files:
+      - store/db.pure
+      - mapping/mapping.pure
+      - data/testData.pure
+features:
+  - execution:data-element
+  - execution:test-data
+  - scaffolding:class
+  - scaffolding:relational-mapping
+  - scaffolding:relational-store
+  - store:relational-semistructured
+  - store:relational-semistructured-wildcard-path
+stores:
+  - relational
+complexity: intermediate
+tags:
+  - semi-structured
+  - json
+  - wildcard

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-wildcard/data/testData.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-wildcard/data/testData.pure
@@ -1,0 +1,26 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Two divisions, each holding teams, so a two-level wildcard has to flatten across both. The
+// headcounts are ordered so a lexicographic max would answer 9 rather than 100.
+###Data
+Data wild::data::D
+{
+  Relation
+  #{
+    default.T:
+      ID,DOC
+      1,"{""divisions"":[{""name"":""Alpha"",""headcount"":9,""teams"":[{""label"":""Core""},{""label"":""Edge""}]},{""name"":""Beta"",""headcount"":100,""teams"":[{""label"":""Ops""}]}]}";
+  }#
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-wildcard/mapping/mapping.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-wildcard/mapping/mapping.pure
@@ -1,0 +1,83 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Mapping
+Mapping wild::M
+(
+  *wild::Row: Relational
+  {
+    ~primaryKey ( [wild::store::DB]T.ID )
+    ~mainTable [wild::store::DB]T
+    id: [wild::store::DB]T.ID,
+
+    // One wildcard: map each division to its name. No flattening is needed because the body
+    // produces scalars.
+    oneLevel: array_to_string(extractFromSemiStructured([wild::store::DB]T.DOC, 'divisions[*].name', 'VARCHAR[]'), ','),
+
+    // Two wildcards. Alpha holds two teams and Beta one, so a result that keeps the levels
+    // nested would read [Core,Edge],[Ops] rather than the flat sequence Pure requires.
+    twoLevels: array_to_string(extractFromSemiStructured([wild::store::DB]T.DOC, 'divisions[*].teams[*].label', 'VARCHAR[]'), ','),
+
+    // The same path counted rather than joined: without the flatten this is 2, one per
+    // division, which looks like a plausible answer.
+    countLeaves: array_size(extractFromSemiStructured([wild::store::DB]T.DOC, 'divisions[*].teams[*].label', 'VARCHAR[]')),
+
+    // Headcounts are 9 then 100, so a lexicographic comparison answers 9.
+    maxLeaf: array_max(extractFromSemiStructured([wild::store::DB]T.DOC, 'divisions[*].headcount', 'INTEGER[]')),
+
+    // A path ending in [*] has no trailing segment, so the level before it produces the arrays.
+    countDivisions: array_size(extractFromSemiStructured([wild::store::DB]T.DOC, 'divisions[*]', 'SEMISTRUCTURED[]')),
+
+    // The desugaring names its own lambda parameters wc1, wc2 and so on. A hand-written lambda
+    // using the same name has to keep its own binding: if the two share a scope the inner path
+    // resolves against the wrong element and returns a wrong answer rather than failing.
+
+
+    shadowed: array_to_string(array_transform(extractFromSemiStructured([wild::store::DB]T.DOC, 'divisions', 'SEMISTRUCTURED[]'), wc1 | array_to_string(extractFromSemiStructured($wc1, 'teams[*].label', 'VARCHAR[]'), '|')), ',')
+  }
+
+  testSuites:
+  [
+    oneLevelSuite:
+    {
+      function: |wild::Row.all()->project(~[id: r | $r.id, v: r | $r.oneLevel]);
+      tests: [ t: { data: [ wild::store::DB: Reference #{ wild::data::D }# ]; asserts: [ a: EqualToJson #{ expected: ExternalFormat #{ contentType: 'application/json'; data: '[ {\n  "id" : 1,\n  "v" : "Alpha,Beta"\n} ]'; }#; }# ]; } ];
+    },
+    twoLevelsSuite:
+    {
+      function: |wild::Row.all()->project(~[id: r | $r.id, v: r | $r.twoLevels]);
+      tests: [ t: { data: [ wild::store::DB: Reference #{ wild::data::D }# ]; asserts: [ a: EqualToJson #{ expected: ExternalFormat #{ contentType: 'application/json'; data: '[ {\n  "id" : 1,\n  "v" : "Core,Edge,Ops"\n} ]'; }#; }# ]; } ];
+    },
+    countLeavesSuite:
+    {
+      function: |wild::Row.all()->project(~[id: r | $r.id, v: r | $r.countLeaves]);
+      tests: [ t: { data: [ wild::store::DB: Reference #{ wild::data::D }# ]; asserts: [ a: EqualToJson #{ expected: ExternalFormat #{ contentType: 'application/json'; data: '[ {\n  "id" : 1,\n  "v" : 3\n} ]'; }#; }# ]; } ];
+    },
+    maxLeafSuite:
+    {
+      function: |wild::Row.all()->project(~[id: r | $r.id, v: r | $r.maxLeaf]);
+      tests: [ t: { data: [ wild::store::DB: Reference #{ wild::data::D }# ]; asserts: [ a: EqualToJson #{ expected: ExternalFormat #{ contentType: 'application/json'; data: '[ {\n  "id" : 1,\n  "v" : 100\n} ]'; }#; }# ]; } ];
+    },
+    shadowedSuite:
+    {
+      function: |wild::Row.all()->project(~[id: r | $r.id, v: r | $r.shadowed]);
+      tests: [ t: { data: [ wild::store::DB: Reference #{ wild::data::D }# ]; asserts: [ a: EqualToJson #{ expected: ExternalFormat #{ contentType: 'application/json'; data: '[ {\n  "id" : 1,\n  "v" : "Core|Edge,Ops"\n} ]'; }#; }# ]; } ];
+    },
+    countDivisionsSuite:
+    {
+      function: |wild::Row.all()->project(~[id: r | $r.id, v: r | $r.countDivisions]);
+      tests: [ t: { data: [ wild::store::DB: Reference #{ wild::data::D }# ]; asserts: [ a: EqualToJson #{ expected: ExternalFormat #{ contentType: 'application/json'; data: '[ {\n  "id" : 1,\n  "v" : 2\n} ]'; }#; }# ]; } ];
+    }
+  ]
+)

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-wildcard/store/db.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured-wildcard/store/db.pure
@@ -1,0 +1,36 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+Class wild::Row
+{
+  id: Integer[1];
+  // [*] yields an array, which the array_* family collapses to a scalar property.
+  oneLevel: String[0..1];
+  twoLevels: String[0..1];
+  countLeaves: Integer[0..1];
+  maxLeaf: Integer[0..1];
+  countDivisions: Integer[0..1];
+  shadowed: String[0..1];
+}
+
+###Relational
+Database wild::store::DB
+(
+  Table T
+  (
+    ID INTEGER PRIMARY KEY,
+    DOC SEMISTRUCTURED
+  )
+)

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured.emit.yaml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured.emit.yaml
@@ -1,0 +1,50 @@
+# Copyright 2026 Goldman Sachs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: relational-semistructured
+title: "Relational Store — Modelled Semi-structured Data"
+description: |
+  A SEMISTRUCTURED column modelled as ordinary typed properties. One JSON document per
+  row is projected into scalars, an element of an array of objects, an element of an
+  array of arrays, and an array nested inside an object array — so the model surface is
+  a normal class, with the document shape confined to the mapping.
+
+  Navigation is exercised in two positions: property mappings, and a store filter
+  predicate that reads a value out of the document to decide row inclusion.
+
+modelSources:
+  model:
+    root: relational-semistructured
+    files:
+      - store/db.pure
+      - mapping/mapping.pure
+      - data/testData.pure
+
+features:
+  - execution:data-element
+  - execution:test-data
+  - scaffolding:class
+  - scaffolding:relational-mapping
+  - scaffolding:relational-store
+  - store:relational-semistructured
+  - store:relational-semistructured-navigation
+  - store:relational-semistructured-array-index
+  - store:relational-filter
+stores:
+  - relational
+complexity: intermediate
+tags:
+  - semi-structured
+  - variant
+  - json

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured/data/testData.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured/data/testData.pure
@@ -12,18 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// JSON payloads are CSV-quoted with doubled double-quotes.
-//   orders  - array of objects, navigated as orders[0].price
-//   matrix  - array of arrays, navigated as matrix[0][1] (consecutive indices)
-//   items   - object array whose element holds an array, navigated as items[0].tags[1]
+// RFC-4180: each JSON document is wrapped in " and every internal " is doubled.
+//   orders     - array of objects, navigated as orders[0].price
+//   matrix     - array of arrays, navigated as matrix[0][1] (consecutive indices)
+//   items      - object array whose element holds an array, navigated as items[0].tags[1]
+//   "odd keys" - key holding a space, whose child key holds a dot; reachable only
+//                through bracket-quoted segments
+//   FIRM_TAGS  - root is an array, so paths may lead with an index
 ###Data
 Data demo::ss::data::FirmData
 {
   Relation
   #{
     default.FIRM_TABLE:
-      ID,FIRM_DETAILS
-      1,"{""legalName"":""Firm X"",""employeeCount"":4,""orders"":[{""price"":100},{""price"":250}],""matrix"":[[1,2],[3,4]],""items"":[{""tags"":[""a"",""b""]}],""nums"":[3,1,2]}"
-      2,"{""legalName"":""Firm A"",""employeeCount"":1,""orders"":[{""price"":50}],""matrix"":[[9,8],[7,6]],""items"":[{""tags"":[""x"",""y""]}],""nums"":[9,7,8]}";
+      ID,FIRM_DETAILS,FIRM_TAGS
+      1,"{""legalName"":""Firm X"",""employeeCount"":4,""isMnc"":true,""ticker"":""FX"",""sector"":""Tech"",""revenue"":1234.5,""marketCap"":9876.54,""dates"":{""estDate"":""2020-01-15"",""lastUpdate"":""2024-03-02T10:15:30"",""auditStamp"":""2024-03-02T10:15:30""},""odd keys"":{""a.b c"":""quoted-hit""},""orders"":[{""price"":100},{""price"":250}],""matrix"":[[1,2],[3,4]],""items"":[{""tags"":[""a"",""b""]}]}","[""alpha"",{""label"":""beta""}]"
+      2,"{""legalName"":""Firm A"",""employeeCount"":1,""isMnc"":false,""ticker"":""FA"",""sector"":""Retail"",""revenue"":50.25,""marketCap"":100.75,""dates"":{""estDate"":""2021-06-30"",""lastUpdate"":""2023-01-05T08:00:00"",""auditStamp"":""2023-01-05T08:00:00""},""odd keys"":{""a.b c"":""quoted-miss""},""orders"":[{""price"":50}],""matrix"":[[9,8],[7,6]],""items"":[{""tags"":[""x"",""y""]}]}","[""gamma"",{""label"":""delta""}]";
   }#
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured/data/testData.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured/data/testData.pure
@@ -1,0 +1,29 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// JSON payloads are CSV-quoted with doubled double-quotes.
+//   orders  - array of objects, navigated as orders[0].price
+//   matrix  - array of arrays, navigated as matrix[0][1] (consecutive indices)
+//   items   - object array whose element holds an array, navigated as items[0].tags[1]
+###Data
+Data demo::ss::data::FirmData
+{
+  Relation
+  #{
+    default.FIRM_TABLE:
+      ID,FIRM_DETAILS
+      1,"{""legalName"":""Firm X"",""employeeCount"":4,""orders"":[{""price"":100},{""price"":250}],""matrix"":[[1,2],[3,4]],""items"":[{""tags"":[""a"",""b""]}],""nums"":[3,1,2]}"
+      2,"{""legalName"":""Firm A"",""employeeCount"":1,""orders"":[{""price"":50}],""matrix"":[[9,8],[7,6]],""items"":[{""tags"":[""x"",""y""]}],""nums"":[9,7,8]}";
+  }#
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured/mapping/mapping.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured/mapping/mapping.pure
@@ -24,15 +24,33 @@ Mapping demo::ss::FirmMapping
     )
     ~mainTable [demo::ss::store::FirmDB]FIRM_TABLE
     id: [demo::ss::store::FirmDB]FIRM_TABLE.ID,
+
+    // One property per entry of the target-type whitelist, which is scalar-only and
+    // matched case-insensitively.
     legalName: extractFromSemiStructured([demo::ss::store::FirmDB]FIRM_TABLE.FIRM_DETAILS, 'legalName', 'VARCHAR'),
+    ticker: extractFromSemiStructured([demo::ss::store::FirmDB]FIRM_TABLE.FIRM_DETAILS, 'ticker', 'CHAR'),
+    sector: extractFromSemiStructured([demo::ss::store::FirmDB]FIRM_TABLE.FIRM_DETAILS, 'sector', 'STRING'),
     employeeCount: extractFromSemiStructured([demo::ss::store::FirmDB]FIRM_TABLE.FIRM_DETAILS, 'employeeCount', 'INTEGER'),
+    isMnc: extractFromSemiStructured([demo::ss::store::FirmDB]FIRM_TABLE.FIRM_DETAILS, 'isMnc', 'BOOLEAN'),
+    revenue: extractFromSemiStructured([demo::ss::store::FirmDB]FIRM_TABLE.FIRM_DETAILS, 'revenue', 'FLOAT'),
+    marketCap: extractFromSemiStructured([demo::ss::store::FirmDB]FIRM_TABLE.FIRM_DETAILS, 'marketCap', 'DECIMAL'),
+    estDate: extractFromSemiStructured([demo::ss::store::FirmDB]FIRM_TABLE.FIRM_DETAILS, 'dates.estDate', 'DATE'),
+    lastUpdate: extractFromSemiStructured([demo::ss::store::FirmDB]FIRM_TABLE.FIRM_DETAILS, 'dates.lastUpdate', 'DATETIME'),
+    auditStamp: extractFromSemiStructured([demo::ss::store::FirmDB]FIRM_TABLE.FIRM_DETAILS, 'dates.auditStamp', 'TIMESTAMP'),
+
+    // Path-grammar edges.
     firstOrderPrice: extractFromSemiStructured([demo::ss::store::FirmDB]FIRM_TABLE.FIRM_DETAILS, 'orders[0].price', 'INTEGER'),
-    detailsJson: toJson([demo::ss::store::FirmDB]FIRM_TABLE.FIRM_DETAILS),
     // Consecutive indices into an array of arrays.
     nestedCell: extractFromSemiStructured([demo::ss::store::FirmDB]FIRM_TABLE.FIRM_DETAILS, 'matrix[0][1]', 'INTEGER'),
     // Index, then property, then index again.
     nestedTag: extractFromSemiStructured([demo::ss::store::FirmDB]FIRM_TABLE.FIRM_DETAILS, 'items[0].tags[1]', 'VARCHAR'),
-    details: [demo::ss::store::FirmDB]FIRM_TABLE.FIRM_DETAILS
+    // Bracket-quoted keys, holding a space and a dot - unreachable with dot notation.
+    quotedKey: extractFromSemiStructured([demo::ss::store::FirmDB]FIRM_TABLE.FIRM_DETAILS, '["odd keys"]["a.b c"]', 'VARCHAR'),
+    // Index-leading paths, against a document whose root is an array.
+    firstTag: extractFromSemiStructured([demo::ss::store::FirmDB]FIRM_TABLE.FIRM_TAGS, '[0]', 'VARCHAR'),
+    secondTagLabel: extractFromSemiStructured([demo::ss::store::FirmDB]FIRM_TABLE.FIRM_TAGS, '[1].label', 'VARCHAR'),
+
+    detailsJson: toJson([demo::ss::store::FirmDB]FIRM_TABLE.FIRM_DETAILS)
   }
 
   testSuites:
@@ -44,7 +62,7 @@ Mapping demo::ss::FirmMapping
       // SEMISTRUCTURED type and stop testing anything here. detailsJson keeps that
       // honest - it has no rendering outside a semi-structured-capable target.
       function: |demo::ss::Firm.all()
-                  ->project(~[legalName: f | $f.legalName, employeeCount: f | $f.employeeCount, firstOrderPrice: f | $f.firstOrderPrice, nestedCell: f | $f.nestedCell, nestedTag: f | $f.nestedTag, detailsJson: f | $f.detailsJson])
+                  ->project(~[legalName: f | $f.legalName, ticker: f | $f.ticker, sector: f | $f.sector, employeeCount: f | $f.employeeCount, isMnc: f | $f.isMnc, revenue: f | $f.revenue, marketCap: f | $f.marketCap, estDate: f | $f.estDate, lastUpdate: f | $f.lastUpdate, auditStamp: f | $f.auditStamp, firstOrderPrice: f | $f.firstOrderPrice, nestedCell: f | $f.nestedCell, nestedTag: f | $f.nestedTag, quotedKey: f | $f.quotedKey, firstTag: f | $f.firstTag, secondTagLabel: f | $f.secondTagLabel, detailsJson: f | $f.detailsJson])
                   ->sort([~legalName->ascending()]);
       tests:
       [
@@ -67,7 +85,7 @@ Mapping demo::ss::FirmMapping
                   ExternalFormat
                   #{
                     contentType: 'application/json';
-                    data: '[{"legalName":"Firm X","employeeCount":4,"firstOrderPrice":100,"nestedCell":2,"nestedTag":"b","detailsJson":"{\\"legalName\\":\\"Firm X\\",\\"employeeCount\\":4,\\"orders\\":[{\\"price\\":100},{\\"price\\":250}],\\"matrix\\":[[1,2],[3,4]],\\"items\\":[{\\"tags\\":[\\"a\\",\\"b\\"]}],\\"nums\\":[3,1,2]}"}]';
+                    data: '[{"legalName":"Firm X","ticker":"FX","sector":"Tech","employeeCount":4,"isMnc":true,"revenue":1234.5,"marketCap":"9876.54","estDate":"2020-01-15","lastUpdate":"2024-03-02T10:15:30.000000000+0000","auditStamp":"2024-03-02T10:15:30.000000000+0000","firstOrderPrice":100,"nestedCell":2,"nestedTag":"b","quotedKey":"quoted-hit","firstTag":"alpha","secondTagLabel":"beta","detailsJson":"{\\"legalName\\":\\"Firm X\\",\\"employeeCount\\":4,\\"isMnc\\":true,\\"ticker\\":\\"FX\\",\\"sector\\":\\"Tech\\",\\"revenue\\":1234.5,\\"marketCap\\":9876.54,\\"dates\\":{\\"estDate\\":\\"2020-01-15\\",\\"lastUpdate\\":\\"2024-03-02T10:15:30\\",\\"auditStamp\\":\\"2024-03-02T10:15:30\\"},\\"odd keys\\":{\\"a.b c\\":\\"quoted-hit\\"},\\"orders\\":[{\\"price\\":100},{\\"price\\":250}],\\"matrix\\":[[1,2],[3,4]],\\"items\\":[{\\"tags\\":[\\"a\\",\\"b\\"]}]}"}]';
                   }#;
               }#
           ];

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured/mapping/mapping.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured/mapping/mapping.pure
@@ -1,0 +1,78 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Mapping
+Mapping demo::ss::FirmMapping
+(
+  *demo::ss::Firm: Relational
+  {
+    ~filter [demo::ss::store::FirmDB] LargeFirmFilter
+    ~primaryKey
+    (
+      [demo::ss::store::FirmDB]FIRM_TABLE.ID
+    )
+    ~mainTable [demo::ss::store::FirmDB]FIRM_TABLE
+    id: [demo::ss::store::FirmDB]FIRM_TABLE.ID,
+    legalName: extractFromSemiStructured([demo::ss::store::FirmDB]FIRM_TABLE.FIRM_DETAILS, 'legalName', 'VARCHAR'),
+    employeeCount: extractFromSemiStructured([demo::ss::store::FirmDB]FIRM_TABLE.FIRM_DETAILS, 'employeeCount', 'INTEGER'),
+    firstOrderPrice: extractFromSemiStructured([demo::ss::store::FirmDB]FIRM_TABLE.FIRM_DETAILS, 'orders[0].price', 'INTEGER'),
+    detailsJson: toJson([demo::ss::store::FirmDB]FIRM_TABLE.FIRM_DETAILS),
+    // Consecutive indices into an array of arrays.
+    nestedCell: extractFromSemiStructured([demo::ss::store::FirmDB]FIRM_TABLE.FIRM_DETAILS, 'matrix[0][1]', 'INTEGER'),
+    // Index, then property, then index again.
+    nestedTag: extractFromSemiStructured([demo::ss::store::FirmDB]FIRM_TABLE.FIRM_DETAILS, 'items[0].tags[1]', 'VARCHAR'),
+    details: [demo::ss::store::FirmDB]FIRM_TABLE.FIRM_DETAILS
+  }
+
+  testSuites:
+  [
+    semiStructuredSuite:
+    {
+      // Returning a Relation is what selects the execution target; the TDS form
+      // (->project([...], ['names'])) would silently run somewhere without a
+      // SEMISTRUCTURED type and stop testing anything here. detailsJson keeps that
+      // honest - it has no rendering outside a semi-structured-capable target.
+      function: |demo::ss::Firm.all()
+                  ->project(~[legalName: f | $f.legalName, employeeCount: f | $f.employeeCount, firstOrderPrice: f | $f.firstOrderPrice, nestedCell: f | $f.nestedCell, nestedTag: f | $f.nestedTag, detailsJson: f | $f.detailsJson])
+                  ->sort([~legalName->ascending()]);
+      tests:
+      [
+        extractAndNavigate:
+        {
+          data:
+          [
+            demo::ss::store::FirmDB:
+              Reference
+              #{
+                demo::ss::data::FirmData
+              }#
+          ];
+          asserts:
+          [
+            shouldExtractScalarsAndIndexedArrayElement:
+              EqualToJson
+              #{
+                expected:
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '[{"legalName":"Firm X","employeeCount":4,"firstOrderPrice":100,"nestedCell":2,"nestedTag":"b","detailsJson":"{\\"legalName\\":\\"Firm X\\",\\"employeeCount\\":4,\\"orders\\":[{\\"price\\":100},{\\"price\\":250}],\\"matrix\\":[[1,2],[3,4]],\\"items\\":[{\\"tags\\":[\\"a\\",\\"b\\"]}],\\"nums\\":[3,1,2]}"}]';
+                  }#;
+              }#
+          ];
+        }
+      ];
+    }
+  ]
+)

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured/store/db.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured/store/db.pure
@@ -1,0 +1,41 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+import meta::pure::metamodel::variant::*;
+
+Class demo::ss::Firm
+{
+  id: Integer[1];
+  legalName: String[1];
+  employeeCount: Integer[1];
+  firstOrderPrice: Integer[1];
+  detailsJson: String[1];
+  nestedCell: Integer[1];
+  nestedTag: String[1];
+  details: meta::pure::metamodel::variant::Variant[1];
+}
+
+###Relational
+Database demo::ss::store::FirmDB
+(
+  Table FIRM_TABLE
+  (
+    ID INTEGER PRIMARY KEY,
+    FIRM_DETAILS SEMISTRUCTURED
+  )
+
+  // Row inclusion decided by a value read out of the document, not by a stored column.
+  Filter LargeFirmFilter(extractFromSemiStructured(FIRM_TABLE.FIRM_DETAILS, 'employeeCount', 'INTEGER') > 2)
+)

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured/store/db.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-semistructured/store/db.pure
@@ -13,18 +13,26 @@
 // limitations under the License.
 
 ###Pure
-import meta::pure::metamodel::variant::*;
-
 Class demo::ss::Firm
 {
   id: Integer[1];
   legalName: String[1];
   employeeCount: Integer[1];
+  isMnc: Boolean[1];
+  ticker: String[1];
+  sector: String[1];
+  revenue: Float[1];
+  marketCap: Decimal[1];
+  estDate: StrictDate[1];
+  lastUpdate: DateTime[1];
+  auditStamp: DateTime[1];
   firstOrderPrice: Integer[1];
-  detailsJson: String[1];
   nestedCell: Integer[1];
   nestedTag: String[1];
-  details: meta::pure::metamodel::variant::Variant[1];
+  quotedKey: String[1];
+  firstTag: String[1];
+  secondTagLabel: String[1];
+  detailsJson: String[1];
 }
 
 ###Relational
@@ -33,7 +41,10 @@ Database demo::ss::store::FirmDB
   Table FIRM_TABLE
   (
     ID INTEGER PRIMARY KEY,
-    FIRM_DETAILS SEMISTRUCTURED
+    FIRM_DETAILS SEMISTRUCTURED,
+    // Root of this document is a JSON *array*, which is what makes an
+    // index-leading path such as '[1].label' expressible.
+    FIRM_TAGS SEMISTRUCTURED
   )
 
   // Row inclusion decided by a value read out of the document, not by a stored column.

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/RelationalParserGrammar.g4
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/RelationalParserGrammar.g4
@@ -219,9 +219,11 @@ functionOperation:                          identifier PAREN_OPEN (functionOpera
 ;
 functionOperationArgument:                  operation | functionOperationArgumentArray | functionOperationLambda
 ;
-// A single-parameter lambda, as filter/map/fold over an array take. The body is an ordinary
-// operation, so it may navigate, compare, or call another function.
+// A lambda, as filter/map/fold over an array take. The body is an ordinary operation, so it may
+// navigate, compare, or call another function. Parentheses are required for more than one
+// parameter, so that the names cannot be read as further arguments to the enclosing function.
 functionOperationLambda:                    identifier PIPE operation
+                                            | PAREN_OPEN identifier (COMMA identifier)* PIPE operation PAREN_CLOSE
 ;
 functionOperationArgumentArray:             BRACKET_OPEN (functionOperationArgument (COMMA functionOperationArgument)*)? BRACKET_CLOSE
 ;

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/RelationalParserGrammar.g4
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/RelationalParserGrammar.g4
@@ -194,11 +194,16 @@ booleanOperator:                            AND | OR
 atomicOperation:                            (
                                                 groupOperation
                                                 | ( databasePointer? functionOperation )
+                                                | lambdaParameter
                                                 | columnOperation
                                                 | joinOperation
                                                 | constant
                                             )
                                             atomicOperationRight?
+;
+// $x inside a lambda body. Ahead of columnOperation because a bare identifier is a column
+// reference, so the parameter needs its own sigil to stay unambiguous.
+lambdaParameter:                            DOLLAR identifier
 ;
 atomicOperationRight:                       (atomicOperator atomicOperation) | atomicSelfOperator
 ;
@@ -212,7 +217,11 @@ constant:                                   STRING | INTEGER | FLOAT
 ;
 functionOperation:                          identifier PAREN_OPEN (functionOperationArgument (COMMA functionOperationArgument)*)? PAREN_CLOSE
 ;
-functionOperationArgument:                  operation | functionOperationArgumentArray
+functionOperationArgument:                  operation | functionOperationArgumentArray | functionOperationLambda
+;
+// A single-parameter lambda, as filter/map/fold over an array take. The body is an ordinary
+// operation, so it may navigate, compare, or call another function.
+functionOperationLambda:                    identifier PIPE operation
 ;
 functionOperationArgumentArray:             BRACKET_OPEN (functionOperationArgument (COMMA functionOperationArgument)*)? BRACKET_CLOSE
 ;

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/HelperRelationalBuilder.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/HelperRelationalBuilder.java
@@ -816,7 +816,141 @@ public class HelperRelationalBuilder
         throw new UnsupportedOperationException();
     }
 
+    // filter/transform/reduce over an array. The Pure path already lowers these to
+    // Filter/Map/FoldRelationalLambda and every dialect that supports semi-structured data renders
+    // them, so authoring one in a store definition builds the same node rather than a parallel one.
+    private static final MutableSet<String> ARRAY_LAMBDA_FUNCTIONS = Sets.mutable.with("array_filter", "array_transform");
+
+    // Works on the compiled collection rather than the protocol node, so a column can be followed
+    // to its declaration and checked: pointing an array lambda at an ordinary VARCHAR column is a
+    // modelling error worth catching here, not a puzzle to decode from a dialect message later.
+    private static org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.datatype.DataType resolveArrayElementType(RelationalOperationElement collection, CompileContext context, SourceInformation sourceInformation)
+    {
+        if (collection instanceof org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.DynaFunction)
+        {
+            org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.DynaFunction extract = (org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.DynaFunction) collection;
+            if ("extractFromSemiStructured".equals(extract._name()))
+            {
+                MutableList<RelationalOperationElement> params = Lists.mutable.withAll(extract._parameters());
+                if (params.size() == 3 && params.get(2) instanceof org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.Literal)
+                {
+                    Object declared = ((org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.Literal) params.get(2))._value();
+                    if (declared instanceof String)
+                    {
+                        String type = ((String) declared).toUpperCase();
+                        if (type.endsWith("[]"))
+                        {
+                            return buildDataType(type.substring(0, type.length() - 2), context, sourceInformation);
+                        }
+                        // SEMISTRUCTURED without the suffix is allowed on purpose: it says the shape
+                        // is unknown, and a document may well be an array, so refusing it here would
+                        // reject a legitimate model on a guess. A named scalar is different - an
+                        // INTEGER is not an array - so those are still refused now.
+                        if ("SEMISTRUCTURED".equals(type))
+                        {
+                            return buildDataType(type, context, sourceInformation);
+                        }
+                        throw new EngineException("An array lambda needs a collection: extract it with an array type such as 'INTEGER[]', or as 'SEMISTRUCTURED' when the shape is not known; found '" + declared + "'", sourceInformation, EngineErrorType.COMPILATION);
+                    }
+                }
+            }
+        }
+        if (collection instanceof org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.TableAliasColumn)
+        {
+            org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.Column column = ((org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.TableAliasColumn) collection)._column();
+            org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.datatype.DataType columnType = column == null ? null : column._type();
+            if (!(columnType instanceof org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.datatype.SemiStructured))
+            {
+                throw new EngineException("An array lambda operates on semi-structured data, but column '" + (column == null ? "?" : column._name()) + "' is not declared SEMISTRUCTURED", sourceInformation, EngineErrorType.COMPILATION);
+            }
+            // The column holds documents, so that is the element type.
+            return columnType;
+        }
+        throw new EngineException("An array lambda operates on a semi-structured column or an extractFromSemiStructured of one; the element type cannot be determined otherwise", sourceInformation, EngineErrorType.COMPILATION);
+    }
+
+    // meta::relational::functions::database::sqlTextToRelationalDataTypeMap is the canonical list of
+    // these names; this mirrors the subset extractFromSemiStructured admits. Unknown names fail
+    // rather than falling back to a string type, which would hand the dialect a plausible-looking
+    // cast and turn a modelling mistake into a wrong answer.
+    private static org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.datatype.DataType buildDataType(String elementType, CompileContext context, SourceInformation sourceInformation)
+    {
+        switch (elementType)
+        {
+            case "INTEGER":
+                return new Root_meta_relational_metamodel_datatype_Integer_Impl("", null, context.pureModel.getClass("meta::relational::metamodel::datatype::Integer"));
+            case "FLOAT":
+                return new Root_meta_relational_metamodel_datatype_Float_Impl("", null, context.pureModel.getClass("meta::relational::metamodel::datatype::Float"));
+            case "DECIMAL":
+                return new Root_meta_relational_metamodel_datatype_Decimal_Impl("", null, context.pureModel.getClass("meta::relational::metamodel::datatype::Decimal"));
+            case "BOOLEAN":
+                return new Root_meta_relational_metamodel_datatype_Bit_Impl("", null, context.pureModel.getClass("meta::relational::metamodel::datatype::Bit"));
+            case "DATE":
+                return new Root_meta_relational_metamodel_datatype_Date_Impl("", null, context.pureModel.getClass("meta::relational::metamodel::datatype::Date"));
+            case "DATETIME":
+            case "TIMESTAMP":
+                return new Root_meta_relational_metamodel_datatype_Timestamp_Impl("", null, context.pureModel.getClass("meta::relational::metamodel::datatype::Timestamp"));
+            case "CHAR":
+            case "VARCHAR":
+            case "STRING":
+                return new Root_meta_relational_metamodel_datatype_Varchar_Impl("", null, context.pureModel.getClass("meta::relational::metamodel::datatype::Varchar"))._size(4000L);
+            case "SEMISTRUCTURED":
+                return new Root_meta_relational_metamodel_datatype_SemiStructured_Impl("", null, context.pureModel.getClass("meta::relational::metamodel::datatype::SemiStructured"));
+            default:
+                throw new EngineException("'" + elementType + "' is not a type an array lambda can bind its parameter to", sourceInformation, EngineErrorType.COMPILATION);
+        }
+    }
+
+    private static boolean isArrayLambdaFunction(DynaFunc dynaFunc)
+    {
+        return ARRAY_LAMBDA_FUNCTIONS.contains(dynaFunc.funcName)
+                && dynaFunc.parameters != null
+                && dynaFunc.parameters.size() == 2
+                && dynaFunc.parameters.get(1) instanceof org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model.operation.RelationalLambda;
+    }
+
+    private static RelationalOperationElement buildRelationalLambda(DynaFunc dynaFunc, CompileContext context, MutableMap<String, org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.TableAlias> aliasMap, MutableList<org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.TableAliasColumn> selfJoinTargets, MutableMap<String, Root_meta_relational_metamodel_RelationalLambdaParameter> lambdaScope, org.finos.legend.pure.m4.coreinstance.SourceInformation m3SourceInformation)
+    {
+        org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model.operation.RelationalLambda lambda = (org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model.operation.RelationalLambda) dynaFunc.parameters.get(1);
+        // The array being operated on is the first argument, so it supplies both halves the
+        // parameter needs: the value the dialect renders the collection from, and the element type.
+        RelationalOperationElement collection = processRelationalOperationElement(dynaFunc.parameters.get(0), context, aliasMap, selfJoinTargets, lambdaScope);
+        org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.datatype.DataType elementType = resolveArrayElementType(collection, context, dynaFunc.sourceInformation);
+
+        Root_meta_relational_metamodel_RelationalLambdaParameter parameter = new Root_meta_relational_metamodel_RelationalLambdaParameter_Impl("", m3SourceInformation, context.pureModel.getClass("meta::relational::metamodel::RelationalLambdaParameter"))
+                ._name(lambda.parameterName)
+                ._value(collection)
+                ._type(elementType);
+
+        MutableMap<String, Root_meta_relational_metamodel_RelationalLambdaParameter> bodyScope = Maps.mutable.withMap(lambdaScope);
+        bodyScope.put(lambda.parameterName, parameter);
+        RelationalOperationElement body = processRelationalOperationElement(lambda.body, context, aliasMap, selfJoinTargets, bodyScope);
+
+        // Named explicitly rather than defaulted: falling through to one of these would build a
+        // filter where a caller asked for something else, and the difference only shows up as a
+        // wrong answer at execution.
+        switch (dynaFunc.funcName)
+        {
+            case "array_filter":
+                return new Root_meta_relational_metamodel_FilterRelationalLambda_Impl("", m3SourceInformation, context.pureModel.getClass("meta::relational::metamodel::FilterRelationalLambda"))
+                        ._parameters(Lists.mutable.with(parameter))._body(body);
+            case "array_transform":
+                return new Root_meta_relational_metamodel_MapRelationalLambda_Impl("", m3SourceInformation, context.pureModel.getClass("meta::relational::metamodel::MapRelationalLambda"))
+                        ._parameters(Lists.mutable.with(parameter))._body(body);
+            default:
+                throw new EngineException("'" + dynaFunc.funcName + "' is listed as an array lambda but has no case here", dynaFunc.sourceInformation, EngineErrorType.COMPILATION);
+        }
+    }
+
     public static RelationalOperationElement processRelationalOperationElement(org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model.operation.RelationalOperationElement operationElement, CompileContext context, MutableMap<String, org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.TableAlias> aliasMap, MutableList<org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.TableAliasColumn> selfJoinTargets)
+    {
+        return processRelationalOperationElement(operationElement, context, aliasMap, selfJoinTargets, Maps.mutable.empty());
+    }
+
+    // lambdaScope binds a lambda's parameter name while its body is compiled, so a $x in the body
+    // resolves to the very RelationalLambdaParameter the enclosing lambda declares - which is how
+    // the Pure path represents such a reference too.
+    public static RelationalOperationElement processRelationalOperationElement(org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model.operation.RelationalOperationElement operationElement, CompileContext context, MutableMap<String, org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.TableAlias> aliasMap, MutableList<org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.TableAliasColumn> selfJoinTargets, MutableMap<String, Root_meta_relational_metamodel_RelationalLambdaParameter> lambdaScope)
     {
         org.finos.legend.pure.m4.coreinstance.SourceInformation m3SourceInformation = SourceInformationHelper.toM3SourceInformation(operationElement.sourceInformation);
         if (operationElement instanceof org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model.operation.TableAliasColumn)
@@ -846,15 +980,29 @@ public class HelperRelationalBuilder
             ElementWithJoins elementWithJoins = (ElementWithJoins) operationElement;
             RelationalOperationElementWithJoin res = new Root_meta_relational_metamodel_RelationalOperationElementWithJoin_Impl("", m3SourceInformation, context.pureModel.getClass("meta::relational::metamodel::RelationalOperationElementWithJoin"))
                     ._joinTreeNode(buildElementWithJoinsJoinTreeNode(elementWithJoins.joins, context));
-            return elementWithJoins.relationalElement == null ? res : res._relationalOperationElement(processRelationalOperationElement(elementWithJoins.relationalElement, context, Maps.mutable.empty(), selfJoinTargets));
+            return elementWithJoins.relationalElement == null ? res : res._relationalOperationElement(processRelationalOperationElement(elementWithJoins.relationalElement, context, Maps.mutable.empty(), selfJoinTargets, lambdaScope));
         }
         else if (operationElement instanceof DynaFunc)
         {
             DynaFunc dynaFunc = (DynaFunc) operationElement;
-            MutableList<RelationalOperationElement> ps = ListIterate.collect(dynaFunc.parameters, relationalOperationElement -> processRelationalOperationElement(relationalOperationElement, context, aliasMap, selfJoinTargets));
+            if (isArrayLambdaFunction(dynaFunc))
+            {
+                return buildRelationalLambda(dynaFunc, context, aliasMap, selfJoinTargets, lambdaScope, m3SourceInformation);
+            }
+            MutableList<RelationalOperationElement> ps = ListIterate.collect(dynaFunc.parameters, relationalOperationElement -> processRelationalOperationElement(relationalOperationElement, context, aliasMap, selfJoinTargets, lambdaScope));
             return new Root_meta_relational_metamodel_DynaFunction_Impl("", m3SourceInformation, context.pureModel.getClass("meta::relational::metamodel::DynaFunction"))
                     ._name(dynaFunc.funcName)
                     ._parameters(ps);
+        }
+        else if (operationElement instanceof org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model.operation.LambdaParameter)
+        {
+            org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model.operation.LambdaParameter parameter = (org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model.operation.LambdaParameter) operationElement;
+            Root_meta_relational_metamodel_RelationalLambdaParameter bound = lambdaScope.get(parameter.name);
+            if (bound == null)
+            {
+                throw new EngineException("The lambda parameter '" + parameter.name + "' is not in scope", parameter.sourceInformation, EngineErrorType.COMPILATION);
+            }
+            return bound;
         }
         else if (operationElement instanceof org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model.operation.Literal)
         {

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/HelperRelationalBuilder.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/HelperRelationalBuilder.java
@@ -819,7 +819,7 @@ public class HelperRelationalBuilder
     // filter/transform/reduce over an array. The Pure path already lowers these to
     // Filter/Map/FoldRelationalLambda and every dialect that supports semi-structured data renders
     // them, so authoring one in a store definition builds the same node rather than a parallel one.
-    private static final MutableSet<String> ARRAY_LAMBDA_FUNCTIONS = Sets.mutable.with("array_filter", "array_transform");
+    private static final MutableSet<String> ARRAY_LAMBDA_FUNCTIONS = Sets.mutable.with("array_filter", "array_transform", "array_reduce");
 
     // Works on the compiled collection rather than the protocol node, so a column can be followed
     // to its declaration and checked: pointing an array lambda at an ordinary VARCHAR column is a
@@ -901,11 +901,44 @@ public class HelperRelationalBuilder
         }
     }
 
+    private static Root_meta_relational_metamodel_RelationalLambdaParameter newLambdaParameter(String name, RelationalOperationElement value, org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.datatype.DataType type, CompileContext context, org.finos.legend.pure.m4.coreinstance.SourceInformation m3SourceInformation)
+    {
+        return new Root_meta_relational_metamodel_RelationalLambdaParameter_Impl("", m3SourceInformation, context.pureModel.getClass("meta::relational::metamodel::RelationalLambdaParameter"))
+                ._name(name)._value(value)._type(type);
+    }
+
+    // The accumulator is typed from the starting value, since that is what it holds before the
+    // first element is folded in. Only a literal is read, because anything else would be a guess.
+    private static org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.datatype.DataType resolveAccumulatorType(org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model.operation.RelationalOperationElement seed, CompileContext context, SourceInformation sourceInformation)
+    {
+        if (seed instanceof org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model.operation.Literal)
+        {
+            Object value = ((org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model.operation.Literal) seed).value;
+            if (value instanceof Integer || value instanceof Long)
+            {
+                return buildDataType("INTEGER", context, sourceInformation);
+            }
+            if (value instanceof Double || value instanceof Float)
+            {
+                return buildDataType("FLOAT", context, sourceInformation);
+            }
+            if (value instanceof String)
+            {
+                return buildDataType("VARCHAR", context, sourceInformation);
+            }
+            if (value instanceof Boolean)
+            {
+                return buildDataType("BOOLEAN", context, sourceInformation);
+            }
+        }
+        throw new EngineException("The starting value of 'array_reduce' must be a literal, so the accumulator can be typed from it", sourceInformation, EngineErrorType.COMPILATION);
+    }
+
     private static boolean isArrayLambdaFunction(DynaFunc dynaFunc)
     {
         return ARRAY_LAMBDA_FUNCTIONS.contains(dynaFunc.funcName)
                 && dynaFunc.parameters != null
-                && dynaFunc.parameters.size() == 2
+                && dynaFunc.parameters.size() >= 2
                 && dynaFunc.parameters.get(1) instanceof org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model.operation.RelationalLambda;
     }
 
@@ -917,13 +950,31 @@ public class HelperRelationalBuilder
         RelationalOperationElement collection = processRelationalOperationElement(dynaFunc.parameters.get(0), context, aliasMap, selfJoinTargets, lambdaScope);
         org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.datatype.DataType elementType = resolveArrayElementType(collection, context, dynaFunc.sourceInformation);
 
-        Root_meta_relational_metamodel_RelationalLambdaParameter parameter = new Root_meta_relational_metamodel_RelationalLambdaParameter_Impl("", m3SourceInformation, context.pureModel.getClass("meta::relational::metamodel::RelationalLambdaParameter"))
-                ._name(lambda.parameterName)
-                ._value(collection)
-                ._type(elementType);
+        boolean isFold = "array_reduce".equals(dynaFunc.funcName);
+        int expected = isFold ? 2 : 1;
+        if (lambda.parameterNames.size() != expected)
+        {
+            throw new EngineException("'" + dynaFunc.funcName + "' takes a lambda of " + expected + " parameter(s), found " + lambda.parameterNames.size(), dynaFunc.sourceInformation, EngineErrorType.COMPILATION);
+        }
+        if (isFold && dynaFunc.parameters.size() != 3)
+        {
+            throw new EngineException("'array_reduce' takes a collection, a lambda and a starting value", dynaFunc.sourceInformation, EngineErrorType.COMPILATION);
+        }
 
+        // The two parameters are not interchangeable. The renderers read the collection from the
+        // first and the starting value from the second, so the element is described by the
+        // collection and its element type, and the accumulator by the starting value and its own
+        // type. Written element-first, as fold is in Pure.
+        MutableList<Root_meta_relational_metamodel_RelationalLambdaParameter> parameters = Lists.mutable.empty();
         MutableMap<String, Root_meta_relational_metamodel_RelationalLambdaParameter> bodyScope = Maps.mutable.withMap(lambdaScope);
-        bodyScope.put(lambda.parameterName, parameter);
+
+        parameters.add(newLambdaParameter(lambda.parameterNames.get(0), collection, elementType, context, m3SourceInformation));
+        if (isFold)
+        {
+            RelationalOperationElement seed = processRelationalOperationElement(dynaFunc.parameters.get(2), context, aliasMap, selfJoinTargets, lambdaScope);
+            parameters.add(newLambdaParameter(lambda.parameterNames.get(1), seed, resolveAccumulatorType(dynaFunc.parameters.get(2), context, dynaFunc.sourceInformation), context, m3SourceInformation));
+        }
+        parameters.forEach(parameter -> bodyScope.put(parameter._name(), parameter));
         RelationalOperationElement body = processRelationalOperationElement(lambda.body, context, aliasMap, selfJoinTargets, bodyScope);
 
         // Named explicitly rather than defaulted: falling through to one of these would build a
@@ -933,10 +984,13 @@ public class HelperRelationalBuilder
         {
             case "array_filter":
                 return new Root_meta_relational_metamodel_FilterRelationalLambda_Impl("", m3SourceInformation, context.pureModel.getClass("meta::relational::metamodel::FilterRelationalLambda"))
-                        ._parameters(Lists.mutable.with(parameter))._body(body);
+                        ._parameters(parameters)._body(body);
             case "array_transform":
                 return new Root_meta_relational_metamodel_MapRelationalLambda_Impl("", m3SourceInformation, context.pureModel.getClass("meta::relational::metamodel::MapRelationalLambda"))
-                        ._parameters(Lists.mutable.with(parameter))._body(body);
+                        ._parameters(parameters)._body(body);
+            case "array_reduce":
+                return new Root_meta_relational_metamodel_FoldRelationalLambda_Impl("", m3SourceInformation, context.pureModel.getClass("meta::relational::metamodel::FoldRelationalLambda"))
+                        ._parameters(parameters)._body(body);
             default:
                 throw new EngineException("'" + dynaFunc.funcName + "' is listed as an array lambda but has no case here", dynaFunc.sourceInformation, EngineErrorType.COMPILATION);
         }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/HelperRelationalBuilder.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/HelperRelationalBuilder.java
@@ -826,6 +826,11 @@ public class HelperRelationalBuilder
     // modelling error worth catching here, not a puzzle to decode from a dialect message later.
     private static org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.datatype.DataType resolveArrayElementType(RelationalOperationElement collection, CompileContext context, SourceInformation sourceInformation)
     {
+        return resolveArrayElementType(collection, context, sourceInformation, false);
+    }
+
+    private static org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.datatype.DataType resolveArrayElementType(RelationalOperationElement collection, CompileContext context, SourceInformation sourceInformation, boolean fromTransformBody)
+    {
         if (collection instanceof org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.DynaFunction)
         {
             org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.DynaFunction extract = (org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.DynaFunction) collection;
@@ -850,6 +855,12 @@ public class HelperRelationalBuilder
                         {
                             return buildDataType(type, context, sourceInformation);
                         }
+                        // Reached when a transform body is the extraction: it names the type of
+                        // each produced element directly, so there is no suffix to strip.
+                        if (fromTransformBody)
+                        {
+                            return buildDataType(type, context, sourceInformation);
+                        }
                         throw new EngineException("An array lambda needs a collection: extract it with an array type such as 'INTEGER[]', or as 'SEMISTRUCTURED' when the shape is not known; found '" + declared + "'", sourceInformation, EngineErrorType.COMPILATION);
                     }
                 }
@@ -866,7 +877,23 @@ public class HelperRelationalBuilder
             // The column holds documents, so that is the element type.
             return columnType;
         }
-        throw new EngineException("An array lambda operates on a semi-structured column or an extractFromSemiStructured of one; the element type cannot be determined otherwise", sourceInformation, EngineErrorType.COMPILATION);
+        // Array operations compose, so the collection may itself be one. A filter yields what it
+        // was given, so its element type carries over. A transform yields whatever its body
+        // produces, which is knowable when that body is an extraction naming its type.
+        if (collection instanceof Root_meta_relational_metamodel_FilterRelationalLambda)
+        {
+            return ((Root_meta_relational_metamodel_FilterRelationalLambda) collection)._parameters().getFirst()._type();
+        }
+        if (collection instanceof Root_meta_relational_metamodel_MapRelationalLambda)
+        {
+            org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.RelationalOperationElement body = ((Root_meta_relational_metamodel_MapRelationalLambda) collection)._body();
+            if (body instanceof org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.DynaFunction && "extractFromSemiStructured".equals(((org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.DynaFunction) body)._name()))
+            {
+                return resolveArrayElementType(body, context, sourceInformation, true);
+            }
+            throw new EngineException("The element type of an array_transform used as a collection is only known when its body is an extractFromSemiStructured naming a type", sourceInformation, EngineErrorType.COMPILATION);
+        }
+        throw new EngineException("An array lambda operates on a semi-structured column, an extractFromSemiStructured of one, or another array operation; the element type cannot be determined otherwise", sourceInformation, EngineErrorType.COMPILATION);
     }
 
     // meta::relational::functions::database::sqlTextToRelationalDataTypeMap is the canonical list of

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/HelperRelationalBuilder.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/HelperRelationalBuilder.java
@@ -834,6 +834,14 @@ public class HelperRelationalBuilder
         if (collection instanceof org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.DynaFunction)
         {
             org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.DynaFunction extract = (org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.DynaFunction) collection;
+            // array_flatten removes one level of nesting. Beneath it sits a transform whose body
+            // extraction names its type with a [] suffix, and the branch below strips that suffix
+            // when reading a transform body - which lands on the element type the flattened array
+            // has. Only that shape is recognised; anything else falls through and is refused.
+            if ("array_flatten".equals(extract._name()) && extract._parameters().size() == 1)
+            {
+                return resolveArrayElementType(Lists.mutable.withAll(extract._parameters()).get(0), context, sourceInformation, fromTransformBody);
+            }
             if ("extractFromSemiStructured".equals(extract._name()))
             {
                 MutableList<RelationalOperationElement> params = Lists.mutable.withAll(extract._parameters());
@@ -961,6 +969,120 @@ public class HelperRelationalBuilder
         throw new EngineException("The starting value of 'array_reduce' must be a literal, so the accumulator can be typed from it", sourceInformation, EngineErrorType.COMPILATION);
     }
 
+    private static final String PATH_WILDCARD = "[*]";
+
+    // A [*] segment means "every element at this level". Pure has no nested collection type, so
+    // the result has to come back flat - which is also what a Pure property chain over a to-many
+    // yields. Rewriting to array_transform/array_flatten here means the dialects need no wildcard
+    // support of their own: they already render these.
+    private static boolean isWildcardExtraction(DynaFunc dynaFunc)
+    {
+        return "extractFromSemiStructured".equals(dynaFunc.funcName)
+                && dynaFunc.parameters != null
+                && dynaFunc.parameters.size() == 3
+                && wildcardPathOf(dynaFunc) != null;
+    }
+
+    private static String wildcardPathOf(DynaFunc dynaFunc)
+    {
+        Object path = literalValue(dynaFunc.parameters.get(1));
+        return (path instanceof String && ((String) path).contains(PATH_WILDCARD)) ? (String) path : null;
+    }
+
+    private static Object literalValue(org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model.operation.RelationalOperationElement e)
+    {
+        return e instanceof org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model.operation.Literal
+                ? ((org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model.operation.Literal) e).value
+                : null;
+    }
+
+    private static org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model.operation.Literal protocolLiteral(Object value, org.finos.legend.engine.protocol.pure.m3.SourceInformation si)
+    {
+        org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model.operation.Literal l =
+                new org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model.operation.Literal();
+        l.value = value;
+        l.sourceInformation = si;
+        return l;
+    }
+
+    private static DynaFunc protocolDyna(String name, org.finos.legend.engine.protocol.pure.m3.SourceInformation si, org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model.operation.RelationalOperationElement... params)
+    {
+        DynaFunc d = new DynaFunc();
+        d.funcName = name;
+        d.sourceInformation = si;
+        d.parameters = Lists.mutable.of(params);
+        return d;
+    }
+
+    // 'a.b[*].c[*].d' becomes a base extraction of a.b, then one transform per wildcard. Every
+    // level but the last yields documents, so it is annotated SEMISTRUCTURED[] and flattened; the
+    // last carries the type the modeller declared. A path ending in [*] has no trailing segment,
+    // so the level before it produces the arrays and is flattened too.
+    private static org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model.operation.RelationalOperationElement desugarWildcardExtraction(DynaFunc dynaFunc)
+    {
+        org.finos.legend.engine.protocol.pure.m3.SourceInformation si = dynaFunc.sourceInformation;
+        String path = wildcardPathOf(dynaFunc);
+        Object declaredType = literalValue(dynaFunc.parameters.get(2));
+        if (!(declaredType instanceof String))
+        {
+            throw new EngineException("The type of an extractFromSemiStructured with a " + PATH_WILDCARD + " segment must be a literal", si, EngineErrorType.COMPILATION);
+        }
+        // The type argument names what the expression returns, exactly as it does without a
+        // wildcard. A [*] path always returns a collection, so it has to carry the [] suffix -
+        // and the leaf extraction is then given the element type inside it.
+        String declared = (String) declaredType;
+        if (!declared.toUpperCase().endsWith("[]"))
+        {
+            throw new EngineException("A path containing " + PATH_WILDCARD + " returns a collection, so its type must carry the array suffix: '" + declared + "[]' rather than '" + declared + "'", si, EngineErrorType.COMPILATION);
+        }
+        String leaf = declared.substring(0, declared.length() - 2);
+
+        MutableList<String> parts = Lists.mutable.empty();
+        for (String raw : path.split(java.util.regex.Pattern.quote(PATH_WILDCARD), -1))
+        {
+            parts.add(raw.startsWith(".") ? raw.substring(1) : raw);
+        }
+        boolean trailing = parts.getLast().isEmpty();
+        if (trailing)
+        {
+            parts.remove(parts.size() - 1);
+        }
+        if (parts.isEmpty() || parts.anySatisfy(String::isEmpty))
+        {
+            throw new EngineException("'" + path + "' has an empty segment around a " + PATH_WILDCARD, si, EngineErrorType.COMPILATION);
+        }
+
+        int last = parts.size() - 1;
+        String baseType = (last == 0) ? (trailing ? leaf + "[]" : leaf) : "SEMISTRUCTURED[]";
+        org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model.operation.RelationalOperationElement current =
+                protocolDyna("extractFromSemiStructured", si, dynaFunc.parameters.get(0), protocolLiteral(parts.get(0), si), protocolLiteral(baseType, si));
+
+        for (int i = 1; i <= last; i++)
+        {
+            boolean isLast = i == last;
+            String bodyType = isLast ? (trailing ? leaf + "[]" : leaf) : "SEMISTRUCTURED[]";
+            String param = "wc" + i;
+
+            org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model.operation.LambdaParameter ref =
+                    new org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model.operation.LambdaParameter();
+            ref.name = param;
+            ref.sourceInformation = si;
+
+            org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model.operation.RelationalLambda lambda =
+                    new org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model.operation.RelationalLambda();
+            lambda.parameterNames = Lists.mutable.of(param);
+            lambda.sourceInformation = si;
+            lambda.body = protocolDyna("extractFromSemiStructured", si, ref, protocolLiteral(parts.get(i), si), protocolLiteral(bodyType, si));
+
+            current = protocolDyna("array_transform", si, current, lambda);
+            if (!isLast || trailing)
+            {
+                current = protocolDyna("array_flatten", si, current);
+            }
+        }
+        return current;
+    }
+
     private static boolean isArrayLambdaFunction(DynaFunc dynaFunc)
     {
         return ARRAY_LAMBDA_FUNCTIONS.contains(dynaFunc.funcName)
@@ -1066,6 +1188,10 @@ public class HelperRelationalBuilder
         else if (operationElement instanceof DynaFunc)
         {
             DynaFunc dynaFunc = (DynaFunc) operationElement;
+            if (isWildcardExtraction(dynaFunc))
+            {
+                return processRelationalOperationElement(desugarWildcardExtraction(dynaFunc), context, aliasMap, selfJoinTargets, lambdaScope);
+            }
             if (isArrayLambdaFunction(dynaFunc))
             {
                 return buildRelationalLambda(dynaFunc, context, aliasMap, selfJoinTargets, lambdaScope, m3SourceInformation);

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/RelationalParseTreeWalker.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/RelationalParseTreeWalker.java
@@ -864,7 +864,7 @@ public class RelationalParseTreeWalker
             RelationalParserGrammar.FunctionOperationLambdaContext lambdaCtx = ctx.functionOperationLambda();
             RelationalLambda lambda = new RelationalLambda();
             lambda.sourceInformation = this.walkerSourceInformation.getSourceInformation(lambdaCtx);
-            lambda.parameterName = PureGrammarParserUtility.fromIdentifier(lambdaCtx.identifier());
+            lambda.parameterNames = ListIterate.collect(lambdaCtx.identifier(), PureGrammarParserUtility::fromIdentifier);
             lambda.body = this.visitOperation(lambdaCtx.operation(), scopeInfo);
             return lambda;
         }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/RelationalParseTreeWalker.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/RelationalParseTreeWalker.java
@@ -82,6 +82,8 @@ import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.r
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model.operation.JoinPointer;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model.operation.Literal;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model.operation.LiteralList;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model.operation.RelationalLambda;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model.operation.LambdaParameter;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model.operation.RelationalOperationElement;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model.operation.TableAliasColumn;
 import org.finos.legend.engine.shared.core.operational.errorManagement.EngineException;
@@ -701,6 +703,12 @@ public class RelationalParseTreeWalker
             String database = ctx.databasePointer() != null ? this.visitDatabasePointer(ctx.databasePointer()) : null;
             operationElement = this.visitFunctionOperation(ctx.functionOperation(), database != null ? ScopeInfo.Builder.newInstance(scopeInfo).withDatabase(database).build() : scopeInfo);
         }
+        else if (ctx.lambdaParameter() != null)
+        {
+            LambdaParameter parameter = new LambdaParameter();
+            parameter.name = PureGrammarParserUtility.fromIdentifier(ctx.lambdaParameter().identifier());
+            operationElement = parameter;
+        }
         else if (ctx.constant() != null)
         {
             operationElement = this.visitConstant(ctx.constant());
@@ -850,6 +858,15 @@ public class RelationalParseTreeWalker
         if (ctx.operation() != null)
         {
             return this.visitOperation(ctx.operation(), scopeInfo);
+        }
+        if (ctx.functionOperationLambda() != null)
+        {
+            RelationalParserGrammar.FunctionOperationLambdaContext lambdaCtx = ctx.functionOperationLambda();
+            RelationalLambda lambda = new RelationalLambda();
+            lambda.sourceInformation = this.walkerSourceInformation.getSourceInformation(lambdaCtx);
+            lambda.parameterName = PureGrammarParserUtility.fromIdentifier(lambdaCtx.identifier());
+            lambda.body = this.visitOperation(lambdaCtx.operation(), scopeInfo);
+            return lambda;
         }
         LiteralList literalList = new LiteralList();
         literalList.sourceInformation = this.walkerSourceInformation.getSourceInformation(ctx);

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/HelperRelationalGrammarComposer.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/HelperRelationalGrammarComposer.java
@@ -71,6 +71,15 @@ public class HelperRelationalGrammarComposer
         {
             return renderLiteral((Literal) op, context);
         }
+        else if (op instanceof RelationalLambda)
+        {
+            RelationalLambda lambda = (RelationalLambda) op;
+            return lambda.parameterName + " | " + renderRelationalOperationElement(lambda.body, context, nested, numTabs);
+        }
+        else if (op instanceof LambdaParameter)
+        {
+            return "$" + ((LambdaParameter) op).name;
+        }
         return PureGrammarComposerUtility.unsupported(op.getClass(), "relational operation element type");
     }
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/HelperRelationalGrammarComposer.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/HelperRelationalGrammarComposer.java
@@ -74,7 +74,12 @@ public class HelperRelationalGrammarComposer
         else if (op instanceof RelationalLambda)
         {
             RelationalLambda lambda = (RelationalLambda) op;
-            return lambda.parameterName + " | " + renderRelationalOperationElement(lambda.body, context, nested, numTabs);
+            String body = renderRelationalOperationElement(lambda.body, context, nested, numTabs);
+            // Parentheses are required for more than one parameter, so compose them back the same
+            // way; a single parameter keeps the barer form it was written in.
+            return lambda.parameterNames.size() == 1
+                    ? lambda.parameterNames.get(0) + " | " + body
+                    : "(" + String.join(", ", lambda.parameterNames) + " | " + body + ")";
         }
         else if (op instanceof LambdaParameter)
         {

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/test/java/org/finos/legend/engine/language/pure/compiler/test/TestRelationalCompilationFromGrammar.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/test/java/org/finos/legend/engine/language/pure/compiler/test/TestRelationalCompilationFromGrammar.java
@@ -4866,4 +4866,78 @@ public class TestRelationalCompilationFromGrammar extends TestCompilationFromGra
                 "  ]\n" +
                 "}\n");
     }
+
+    private static final String ARRAY_LAMBDA_STORE =
+            "###Relational\n" +
+            "Database my::DB\n" +
+            "(\n" +
+            "  Table T\n" +
+            "  (\n" +
+            "    ID INTEGER PRIMARY KEY,\n" +
+            "    DOC SEMISTRUCTURED,\n" +
+            "    NAME VARCHAR(100)\n" +
+            "  )\n";
+
+    @Test
+    public void testArrayFilterLambdaOverExtractedArray()
+    {
+        test(ARRAY_LAMBDA_STORE +
+                "  View V\n" +
+                "  (\n" +
+                "    ID: T.ID PRIMARY KEY,\n" +
+                "    N: array_size(array_filter(extractFromSemiStructured(T.DOC, 'divisions', 'SEMISTRUCTURED[]'), d | extractFromSemiStructured($d, 'headcount', 'INTEGER')))\n" +
+                "  )\n" +
+                ")\n");
+    }
+
+    // The shape is unknown, so this is allowed rather than guessed at - a document may be an array.
+    @Test
+    public void testArrayFilterLambdaOverSemiStructuredWithoutArraySuffix()
+    {
+        test(ARRAY_LAMBDA_STORE +
+                "  View V\n" +
+                "  (\n" +
+                "    ID: T.ID PRIMARY KEY,\n" +
+                "    N: array_size(array_filter(extractFromSemiStructured(T.DOC, 'divisions', 'SEMISTRUCTURED'), d | extractFromSemiStructured($d, 'headcount', 'INTEGER')))\n" +
+                "  )\n" +
+                ")\n");
+    }
+
+    @Test
+    public void testArrayFilterLambdaOverSemiStructuredColumn()
+    {
+        test(ARRAY_LAMBDA_STORE +
+                "  View V\n" +
+                "  (\n" +
+                "    ID: T.ID PRIMARY KEY,\n" +
+                "    N: array_size(array_filter(T.DOC, d | extractFromSemiStructured($d, 'headcount', 'INTEGER')))\n" +
+                "  )\n" +
+                ")\n");
+    }
+
+    // An INTEGER is not a collection, so this is a modelling mistake worth naming now.
+    @Test
+    public void testArrayFilterLambdaRejectsScalarExtraction()
+    {
+        test(ARRAY_LAMBDA_STORE +
+                "  View V\n" +
+                "  (\n" +
+                "    ID: T.ID PRIMARY KEY,\n" +
+                "    N: array_size(array_filter(extractFromSemiStructured(T.DOC, 'divisions', 'INTEGER'), d | extractFromSemiStructured($d, 'headcount', 'INTEGER')))\n" +
+                "  )\n" +
+                ")\n", "COMPILATION error at [13:19-147]: An array lambda needs a collection: extract it with an array type such as 'INTEGER[]', or as 'SEMISTRUCTURED' when the shape is not known; found 'INTEGER'");
+    }
+
+    // Pointing at an ordinary column used to compile and fail later as a dialect error.
+    @Test
+    public void testArrayFilterLambdaRejectsNonSemiStructuredColumn()
+    {
+        test(ARRAY_LAMBDA_STORE +
+                "  View V\n" +
+                "  (\n" +
+                "    ID: T.ID PRIMARY KEY,\n" +
+                "    N: array_size(array_filter(T.NAME, d | extractFromSemiStructured($d, 'headcount', 'INTEGER')))\n" +
+                "  )\n" +
+                ")\n", "COMPILATION error at [13:19-97]: An array lambda operates on semi-structured data, but column 'NAME' is not declared SEMISTRUCTURED");
+    }
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestRelationalOperationElementGrammarRoundtrip.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestRelationalOperationElementGrammarRoundtrip.java
@@ -59,6 +59,16 @@ public class TestRelationalOperationElementGrammarRoundtrip
         Assert.assertEquals(null, val, renderedOperation);
     }
 
+    // Round-trips through the protocol like test() above, but allows the composed form to differ
+    // from the source, for syntax the composer canonicalises.
+    protected static void testWithSourceAndExpected(String source, String expectedComposed) throws Exception
+    {
+        RelationalOperationElement op = RelationalGrammarParserExtension.parseRelationalOperationElement(source, "", 0, 0, true);
+        String json = objectMapper.writeValueAsString(op);
+        RelationalOperationElement operation = objectMapper.readValue(json, RelationalOperationElement.class);
+        Assert.assertEquals(expectedComposed, RelationalGrammarComposerExtension.renderRelationalOperationElement(operation));
+    }
+
     @Test
     public void testSimplePropertyMapping()
     {
@@ -89,5 +99,22 @@ public class TestRelationalOperationElementGrammarRoundtrip
     public void testLambdaParameterIsDistinctFromAColumn()
     {
         test("array_filter([store::TESTDB]SCHEMA.TABLE.DOC, d | equal($d, [store::TESTDB]SCHEMA.TABLE.COL))", null);
+    }
+
+    @Test
+    public void testArrayReduceLambdaWithTwoParameters()
+    {
+        test("array_reduce(extractFromSemiStructured([store::TESTDB]SCHEMA.TABLE.DOC, 'divisions', 'SEMISTRUCTURED[]'), (d, acc | plus($acc, extractFromSemiStructured($d, 'headcount', 'INTEGER'))), 0)", null);
+    }
+
+    // A single parameter may be written parenthesised, but composes back bare: parentheses are
+    // only required to keep several names from reading as further arguments, so one name has a
+    // single canonical form. This asserts the normalised output rather than the input.
+    @Test
+    public void testSingleParameterLambdaInParenthesesNormalises() throws Exception
+    {
+        testWithSourceAndExpected(
+                "array_filter([store::TESTDB]SCHEMA.TABLE.DOC, (d | extractFromSemiStructured($d, 'name', 'VARCHAR')))",
+                "array_filter([store::TESTDB]SCHEMA.TABLE.DOC, d | extractFromSemiStructured($d, 'name', 'VARCHAR'))");
     }
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestRelationalOperationElementGrammarRoundtrip.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestRelationalOperationElementGrammarRoundtrip.java
@@ -64,4 +64,30 @@ public class TestRelationalOperationElementGrammarRoundtrip
     {
         test("[store::TESTDB]SCHEMA.TABLE.COL", null);
     }
+
+    @Test
+    public void testArrayFilterLambda()
+    {
+        test("array_filter(extractFromSemiStructured([store::TESTDB]SCHEMA.TABLE.DOC, 'divisions', 'SEMISTRUCTURED[]'), d | extractFromSemiStructured($d, 'headcount', 'INTEGER'))", null);
+    }
+
+    @Test
+    public void testArrayFilterLambdaOverColumn()
+    {
+        test("array_filter([store::TESTDB]SCHEMA.TABLE.DOC, d | extractFromSemiStructured($d, 'name', 'VARCHAR'))", null);
+    }
+
+    @Test
+    public void testArrayTransformLambda()
+    {
+        test("array_transform(extractFromSemiStructured([store::TESTDB]SCHEMA.TABLE.DOC, 'tags', 'SEMISTRUCTURED[]'), t | extractFromSemiStructured($t, 'label', 'VARCHAR'))", null);
+    }
+
+    // The parameter is referenced with a sigil because a bare identifier is already a column
+    // reference; this pins that the two stay distinguishable.
+    @Test
+    public void testLambdaParameterIsDistinctFromAColumn()
+    {
+        test("array_filter([store::TESTDB]SCHEMA.TABLE.DOC, d | equal($d, [store::TESTDB]SCHEMA.TABLE.COL))", null);
+    }
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-http-api/src/test/java/org.finos.legend.engine.language.pure.grammar.api.relationalOperationElement.test/TestRelationalOperationElementApi.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-http-api/src/test/java/org.finos.legend.engine.language.pure.grammar.api.relationalOperationElement.test/TestRelationalOperationElementApi.java
@@ -42,7 +42,7 @@ public class TestRelationalOperationElementApi extends TestGrammar<RelationalOpe
     @Test
     public void testSimpleError()
     {
-        testError("add(1,", "Unexpected token '<EOF>'. Valid alternatives: ['Database', 'include', 'Table', 'Schema', 'View', 'TabularFunction', 'Filter', 'MultiGrainFilter', 'Join', '{target}', 'and', 'or', 'milestoning', 'business', 'BUS_FROM', 'BUS_THRU', 'THRU_IS_INCLUSIVE', 'BUS_SNAPSHOT_DATE', 'processing', 'PROCESSING_IN', 'PROCESSING_OUT', 'OUT_IS_INCLUSIVE', 'INFINITY_DATE', 'PROCESSING_SNAPSHOT_DATE', 'AssociationMapping', 'EnumerationMapping', 'Otherwise', 'Inline', 'Binding', 'scope', '[', '(', '@']", new SourceInformation("", 1, 7, 1, 11));
+        testError("add(1,", "Unexpected token '<EOF>'. Valid alternatives: ['Database', 'include', 'Table', 'Schema', 'View', 'TabularFunction', 'Filter', 'MultiGrainFilter', 'Join', '{target}', 'and', 'or', 'milestoning', 'business', 'BUS_FROM', 'BUS_THRU', 'THRU_IS_INCLUSIVE', 'BUS_SNAPSHOT_DATE', 'processing', 'PROCESSING_IN', 'PROCESSING_OUT', 'OUT_IS_INCLUSIVE', 'INFINITY_DATE', 'PROCESSING_SNAPSHOT_DATE', 'AssociationMapping', 'EnumerationMapping', 'Otherwise', 'Inline', 'Binding', 'scope', '[', '(', '$', '@']", new SourceInformation("", 1, 7, 1, 11));
     }
 
     @Test

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-protocol/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/store/relational/model/operation/LambdaParameter.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-protocol/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/store/relational/model/operation/LambdaParameter.java
@@ -1,0 +1,20 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model.operation;
+
+public class LambdaParameter extends RelationalOperationElement
+{
+    public String name;
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-protocol/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/store/relational/model/operation/RelationalLambda.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-protocol/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/store/relational/model/operation/RelationalLambda.java
@@ -16,6 +16,6 @@ package org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.
 
 public class RelationalLambda extends RelationalOperationElement
 {
-    public String parameterName;
+    public java.util.List<String> parameterNames;
     public RelationalOperationElement body;
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-protocol/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/store/relational/model/operation/RelationalLambda.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-protocol/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/store/relational/model/operation/RelationalLambda.java
@@ -1,0 +1,21 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model.operation;
+
+public class RelationalLambda extends RelationalOperationElement
+{
+    public String parameterName;
+    public RelationalOperationElement body;
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-protocol/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/store/relational/model/operation/RelationalOperationElement.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-protocol/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/store/relational/model/operation/RelationalOperationElement.java
@@ -24,7 +24,9 @@ import org.finos.legend.engine.protocol.pure.m3.SourceInformation;
         @JsonSubTypes.Type(value = ElementWithJoins.class, name = "elemtWithJoins"),
         @JsonSubTypes.Type(value = DynaFunc.class, name = "dynaFunc"),
         @JsonSubTypes.Type(value = Literal.class, name = "literal"),
-        @JsonSubTypes.Type(value = LiteralList.class, name = "literalList")
+        @JsonSubTypes.Type(value = LiteralList.class, name = "literalList"),
+        @JsonSubTypes.Type(value = RelationalLambda.class, name = "relationalLambda"),
+        @JsonSubTypes.Type(value = LambdaParameter.class, name = "lambdaParameter")
 })
 public abstract class RelationalOperationElement
 {

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery.pure
@@ -9291,12 +9291,15 @@ function meta::relational::functions::pureToSqlQuery::applyJoinWithExplodeInCond
   let sourceAliasInJoin = $join->otherTableFromAlias($targetAliasInJoin)->toOne();
 
   let allExplodeCalls = $join.operation->extractExplodeSemiStructured()->removeDuplicates();
-  assert($allExplodeCalls->size() == 1, 'only one unique explode allowed in operation in join: ' + $join.name); // This condition needs to be relaxed to support many-to-many
-  let explodeOp = $allExplodeCalls->at(0)->cast(@DynaFunction);
-  assert($explodeOp.parameters->size() == 3, 'explodeSemiStructured takes exactly 3 arguments, passed: ', $explodeOp.parameters->size());
-  assert($explodeOp.parameters->at(0)->instanceOf(TableAliasColumn), 'Input to explodeSemiStructured must be defined as a column in table/view in join: ' + $join.name); // This condition needs to be relaxed to support nested explosion
-  let columnToExplode = $explodeOp.parameters->at(0)->cast(@TableAliasColumn);
-  let pathToExplode   = $explodeOp.parameters->at(1)->cast(@Literal).value->cast(@String);
+  // An explode nested inside another is one chain producing a row per combination, not two
+  // independent explodes. Only chain roots are counted here, so many-to-many stays unsupported.
+  let rootExplodeCalls = $allExplodeCalls->filter(e | !$allExplodeCalls->exists(other | !$other->is($e) && $other->cast(@DynaFunction).parameters->map(prm | $prm->extractExplodeSemiStructured())->exists(d | $d->is($e))));
+  assert($rootExplodeCalls->size() == 1, 'only one unique explode allowed in operation in join: ' + $join.name); // This condition needs to be relaxed to support many-to-many
+  let explodeOp = $rootExplodeCalls->at(0)->cast(@DynaFunction);
+  let explodeChain = $explodeOp->explodeSemiStructuredChain();
+  $explodeChain->forAll(e | assert($e.parameters->size() == 3, 'explodeSemiStructured takes exactly 3 arguments, passed: ', $e.parameters->size()));
+  assert($explodeChain->at(0).parameters->at(0)->instanceOf(TableAliasColumn), 'Input to explodeSemiStructured must be defined as a column in table/view in join: ' + $join.name);
+  let columnToExplode = $explodeChain->at(0).parameters->at(0)->cast(@TableAliasColumn);
   let pureReturnType  = $explodeOp.parameters->at(2)->cast(@Literal).value->cast(@String)->explodeReturnType();
   let tableToExplodeAlias = $columnToExplode.alias;
 
@@ -9307,29 +9310,37 @@ function meta::relational::functions::pureToSqlQuery::applyJoinWithExplodeInCond
 
   // 1. create a subquery(exploded) for the flattened relation by doing a lateral join between tableToFlatten and the flattened array.
   let toExplodeRootTreeNode = ^RootJoinTreeNode(alias=^TableAlias(name='root',relationalElement=$tableToExplodeAlias.relationalElement->processRelation([], $joinType, $nodeId, true, -1, true, $milestoningContext, $state, $context, $extensions)));
-  let pathNavigation = meta::relational::functions::sqlQueryToString::parseSemiStructuredPathNavigation($pathToExplode);
-  let initialNavigation = if($pathNavigation->at(0)->isDigit(), | ^SemiStructuredArrayElementAccess(operand=^$columnToExplode(alias = $toExplodeRootTreeNode.alias),index=^Literal(value = $pathNavigation->at(0))), |  ^SemiStructuredPropertyAccess(property=^Literal(value = $pathNavigation->at(0)->substring(1, $pathNavigation->at(0)->length()-1)), operand=^$columnToExplode(alias = $toExplodeRootTreeNode.alias)));
-  let semiStructuredNavigation = $pathNavigation->slice(1, $pathNavigation->size())->fold({property, navigation | if($property->isDigit(), | ^SemiStructuredArrayElementAccess(operand=$navigation,index=^Literal(value = $property)), |  ^SemiStructuredPropertyAccess(property=^Literal(value = $property->substring(1, $property->length()-1)), operand=$navigation)) }, $initialNavigation );
-  let arrayFlattening = ^SemiStructuredArrayFlatten(navigation = $semiStructuredNavigation);
-  let leftAlias = $toExplodeRootTreeNode.alias;
-  let rightAlias = ^TableAlias(relationalElement = $arrayFlattening, name = 'arrayFlatten_0');
-  let joinName = 'join_arrayFlatten_' + $arrayFlattening->buildUniqueName(false, true, $extensions);
-  let lateralJoin = ^Join(
-    name      = $joinName,
-    target    = $rightAlias,
-    aliases   = [pair($leftAlias, $rightAlias), pair($rightAlias, $leftAlias)],
-    operation = ^DynaFunction(name = 'equal', parameters = [^Literal(value = 1), ^Literal(value = 1)])
-  );
-  let lateralJoinNode = ^JoinTreeNode(
-    database = $joinTree.database,
-    joinName = $joinName,
-    alias    = $rightAlias,
-    join     = $lateralJoin,
-    joinType = JoinType.INNER,
-    lateral  = true
-  );
-  let explodedRootTreeNode = ^$toExplodeRootTreeNode(childrenData = $lateralJoinNode);
-  let flattenOutputAlias            = ^Alias(name = 'flattened_prop', relationalElement = ^SemiStructuredArrayFlattenOutput(tableAliasColumn = ^TableAliasColumn(alias = $lateralJoinNode.alias->toOne(), column = ^Column(name = 'VALUE', type = ^meta::relational::metamodel::datatype::SemiStructured())), returnType = $pureReturnType));
+  // One lateral per level. Level 0 navigates from the re-rooted base column; each level above it
+  // navigates from the VALUE the level below produced, which is what fans out an array held
+  // inside each element of the array beneath it.
+  let lateralAliases = $explodeChain->fold({e, aliasesSoFar |
+      let level = $aliasesSoFar->size();
+      let operand = if($level == 0,
+                      | ^$columnToExplode(alias = $toExplodeRootTreeNode.alias),
+                      | ^TableAliasColumn(alias = $aliasesSoFar->at($level - 1)->cast(@TableAlias), column = ^Column(name = 'VALUE', type = ^meta::relational::metamodel::datatype::SemiStructured())));
+      let navigation = buildSemiStructuredNavigationForExplode($e.parameters->at(1)->cast(@Literal).value->cast(@String), $operand);
+      $aliasesSoFar->concatenate(^TableAlias(relationalElement = ^SemiStructuredArrayFlatten(navigation = $navigation), name = 'arrayFlatten_' + $level->toString()));
+    }, [])->cast(@TableAlias);
+  let lateralJoinNodes = range(0, $lateralAliases->size())->map(level |
+      let rightAlias = $lateralAliases->at($level);
+      let leftAlias = if($level == 0, | $toExplodeRootTreeNode.alias, | $lateralAliases->at($level - 1));
+      let joinName = 'join_arrayFlatten_' + $rightAlias.relationalElement->cast(@SemiStructuredArrayFlatten)->buildUniqueName(false, true, $extensions);
+      ^JoinTreeNode(
+        database = $joinTree.database,
+        joinName = $joinName,
+        alias    = $rightAlias,
+        join     = ^Join(
+          name      = $joinName,
+          target    = $rightAlias,
+          aliases   = [pair($leftAlias, $rightAlias), pair($rightAlias, $leftAlias)],
+          operation = ^DynaFunction(name = 'equal', parameters = [^Literal(value = 1), ^Literal(value = 1)])
+        ),
+        joinType = JoinType.INNER,
+        lateral  = true
+      );
+    );
+  let explodedRootTreeNode = ^$toExplodeRootTreeNode(childrenData = $lateralJoinNodes);
+  let flattenOutputAlias            = ^Alias(name = 'flattened_prop', relationalElement = ^SemiStructuredArrayFlattenOutput(tableAliasColumn = ^TableAliasColumn(alias = $lateralAliases->last()->toOne(), column = ^Column(name = 'VALUE', type = ^meta::relational::metamodel::datatype::SemiStructured())), returnType = $pureReturnType));
   let columnsForInnerJoin           = $join.operation->extractTableAliasColumns()->filter(tac|$tac.alias == $tableToExplodeAlias )->map(c|^TableAliasColumn(column = $c.column, alias = $toExplodeRootTreeNode.alias))->removeDuplicates();
   let additionalColumnsToFetch      = if($tableToExplodeAlias == $sourceAliasInJoin,
                                         | $srcPrimaryKeys->map(c|^Alias(name = 'leftJoinKey_' + $srcPrimaryKeys->indexOf($c)->toString(), relationalElement = ^TableAliasColumn(column=$c, alias=$toExplodeRootTreeNode.alias))),  // fetch only pks from source
@@ -9354,7 +9365,7 @@ function meta::relational::functions::pureToSqlQuery::applyJoinWithExplodeInCond
   let reprocessedJoin = reprocessJoin(^$join(operation=$updatedOperation), [^OldAliasToNewAlias(first = $tableToExplodeAlias.name->toOne(), second = $explodedSubQuery), ^OldAliasToNewAlias(first = $otherTableInJoin.name, second = $otherTableInJoinUpdated)], []);
   let innerJoinTreeNode = ^JoinTreeNode(
     database = $joinTree.database,
-    joinName = 'inner_join_flattened_' + $targetAliasInJoin->buildUniqueName(true, true, $extensions) + '__' + $joinName,
+    joinName = 'inner_join_flattened_' + $targetAliasInJoin->buildUniqueName(true, true, $extensions) + '__' + $lateralJoinNodes->at(0).joinName,
     alias    = if($targetAliasInJoin == $tableToExplodeAlias, | $explodedSubQuery, | $otherTableInJoinUpdated),
     join     = $reprocessedJoin,
     joinType = JoinType.INNER

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery_variant.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery_variant.pure
@@ -463,7 +463,10 @@ function meta::relational::functions::pureToSqlQuery::processVariantInstanceOf(f
   let keyProp = $variantToMetadata.typeName->orElse('_type');
   let className = $variantToMetadata.typeLookup->filter(p | $p.second == $class)->head().first->orElse($class.name->toOne());
 
-  let typeProp = ^SemiStructuredPropertyAccess(operand = $variant, property = ^Literal(value = $keyProp), returnType = String);
+  // avoidCastIfPrimitive: the navigation is immediately wrapped in its own variantTo conversion
+  // below, so the renderer must not also cast. Dialects whose unquote is not idempotent (DuckDB
+  // renders variantTo on VARCHAR as ->>'$', which requires JSON input) fail on the double cast.
+  let typeProp = ^SemiStructuredPropertyAccess(operand = $variant, property = ^Literal(value = $keyProp), returnType = String, avoidCastIfPrimitive = true);
   let typePropCasted = newDynaFunction('variantTo', [$typeProp, ^DataTypeInfo(dataType = ^meta::relational::metamodel::datatype::Varchar(size=100))]);
   let instanceOf = newDynaFunction('equal', [$typePropCasted, ^Literal(value = $className)]);
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery_variant.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery_variant.pure
@@ -1048,6 +1048,23 @@ function meta::relational::functions::pureToSqlQuery::extractExplodeSemiStructur
     ]);
 }
 
+// Innermost first, so index 0 is the explode whose input must be a column and each later entry
+// fans out an array held inside the elements the previous one produced.
+function meta::relational::functions::pureToSqlQuery::explodeSemiStructuredChain(op: DynaFunction[1]):DynaFunction[*]
+{
+  let inner = $op.parameters->at(0);
+  if($inner->instanceOf(DynaFunction) && $inner->cast(@DynaFunction).name == meta::relational::functions::sqlQueryToString::DynaFunctionRegistry.explodeSemiStructured.name,
+     | $inner->cast(@DynaFunction)->explodeSemiStructuredChain()->concatenate($op),
+     | $op);
+}
+
+function meta::relational::functions::pureToSqlQuery::buildSemiStructuredNavigationForExplode(path: String[1], operand: RelationalOperationElement[1]):RelationalOperationElement[1]
+{
+  let pathNavigation = meta::relational::functions::sqlQueryToString::parseSemiStructuredPathNavigation($path);
+  let initialNavigation = if($pathNavigation->at(0)->isDigit(), | ^SemiStructuredArrayElementAccess(operand=$operand,index=^Literal(value = $pathNavigation->at(0))), |  ^SemiStructuredPropertyAccess(property=^Literal(value = $pathNavigation->at(0)->substring(1, $pathNavigation->at(0)->length()-1)), operand=$operand));
+  $pathNavigation->slice(1, $pathNavigation->size())->fold({property, navigation | if($property->isDigit(), | ^SemiStructuredArrayElementAccess(operand=$navigation,index=^Literal(value = $property)), |  ^SemiStructuredPropertyAccess(property=^Literal(value = $property->substring(1, $property->length()-1)), operand=$navigation)) }, $initialNavigation);
+}
+
 function meta::relational::functions::pureToSqlQuery::explodeReturnType(typeName:String[1]):Type[0..1]
 {
     let map = meta::relational::functions::database::sqlTextToRelationalDataTypeMap();

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery_variant.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery_variant.pure
@@ -298,17 +298,23 @@ function meta::relational::functions::pureToSqlQuery::processVariantConcatenate(
 
 function meta::relational::functions::pureToSqlQuery::processVariantDrop(f:FunctionExpression[1], currentPropertyMapping:PropertyMapping[*], operation:SelectWithCursor[1], vars:Map<VariableExpression, ValueSpecification>[1], state:State[1], joinType:JoinType[1], nodeId:String[1], aggFromMap:List<ColumnGroup>[1], context:DebugContext[1], extensions:Extension[*]):RelationalOperationElement[1]
 {
-  processDynaFunction('array_drop', {reo | $reo->init()->toVariantFriendlyValue($f.parametersValues->at(0).genericType->genericTypeToDataType($f.parametersValues->at(0).multiplicity))->concatenate($reo->last())}, $f, $currentPropertyMapping, $operation, $vars, $state, $joinType, $nodeId, $aggFromMap, $context, $extensions);
+  // Semi-structured guard: disable auto-flatten so the array stays as a scalar column
+  let effectiveState = if($f->isSemiStructuredArrayInput($vars, $state), |^$state(disableAutoFlatten = true), |$state);
+  processDynaFunction('array_drop', {reo | $reo->init()->toVariantFriendlyValue($f.parametersValues->at(0).genericType->genericTypeToDataType($f.parametersValues->at(0).multiplicity))->concatenate($reo->last())}, $f, $currentPropertyMapping, $operation, $vars, $effectiveState, $joinType, $nodeId, $aggFromMap, $context, $extensions);
 }
 
 function meta::relational::functions::pureToSqlQuery::processVariantTake(f:FunctionExpression[1], currentPropertyMapping:PropertyMapping[*], operation:SelectWithCursor[1], vars:Map<VariableExpression, ValueSpecification>[1], state:State[1], joinType:JoinType[1], nodeId:String[1], aggFromMap:List<ColumnGroup>[1], context:DebugContext[1], extensions:Extension[*]):RelationalOperationElement[1]
 {
-  processDynaFunction('array_take', {reo | $reo->init()->toVariantFriendlyValue($f.parametersValues->at(0).genericType->genericTypeToDataType($f.parametersValues->at(0).multiplicity))->concatenate($reo->last())}, $f, $currentPropertyMapping, $operation, $vars, $state, $joinType, $nodeId, $aggFromMap, $context, $extensions);
+  // Semi-structured guard: disable auto-flatten so the array stays as a scalar column
+  let effectiveState = if($f->isSemiStructuredArrayInput($vars, $state), |^$state(disableAutoFlatten = true), |$state);
+  processDynaFunction('array_take', {reo | $reo->init()->toVariantFriendlyValue($f.parametersValues->at(0).genericType->genericTypeToDataType($f.parametersValues->at(0).multiplicity))->concatenate($reo->last())}, $f, $currentPropertyMapping, $operation, $vars, $effectiveState, $joinType, $nodeId, $aggFromMap, $context, $extensions);
 }
 
 function meta::relational::functions::pureToSqlQuery::processVariantLast(f:FunctionExpression[1], currentPropertyMapping:PropertyMapping[*], operation:SelectWithCursor[1], vars:Map<VariableExpression, ValueSpecification>[1], state:State[1], joinType:JoinType[1], nodeId:String[1], aggFromMap:List<ColumnGroup>[1], context:DebugContext[1], extensions:Extension[*]):RelationalOperationElement[1]
 {
-  processDynaFunction('array_last', {reo | $reo->toVariantFriendlyValue($f.parametersValues->at(0).genericType->genericTypeToDataType($f.parametersValues->at(0).multiplicity))}, $f, $currentPropertyMapping, $operation, $vars, $state, $joinType, $nodeId, $aggFromMap, $context, $extensions);
+  // Semi-structured guard: disable auto-flatten so the array stays as a scalar column
+  let effectiveState = if($f->isSemiStructuredArrayInput($vars, $state), |^$state(disableAutoFlatten = true), |$state);
+  processDynaFunction('array_last', {reo | $reo->toVariantFriendlyValue($f.parametersValues->at(0).genericType->genericTypeToDataType($f.parametersValues->at(0).multiplicity))}, $f, $currentPropertyMapping, $operation, $vars, $effectiveState, $joinType, $nodeId, $aggFromMap, $context, $extensions);
 }
 
 function meta::relational::functions::pureToSqlQuery::processVariantFirst(f:FunctionExpression[1], currentPropertyMapping:PropertyMapping[*], operation:SelectWithCursor[1], vars:Map<VariableExpression, ValueSpecification>[1], state:State[1], joinType:JoinType[1], nodeId:String[1], aggFromMap:List<ColumnGroup>[1], context:DebugContext[1], extensions:Extension[*]):RelationalOperationElement[1]
@@ -318,12 +324,16 @@ function meta::relational::functions::pureToSqlQuery::processVariantFirst(f:Func
 
 function meta::relational::functions::pureToSqlQuery::processVariantInit(f:FunctionExpression[1], currentPropertyMapping:PropertyMapping[*], operation:SelectWithCursor[1], vars:Map<VariableExpression, ValueSpecification>[1], state:State[1], joinType:JoinType[1], nodeId:String[1], aggFromMap:List<ColumnGroup>[1], context:DebugContext[1], extensions:Extension[*]):RelationalOperationElement[1]
 {
-  processDynaFunction('array_init', {reo | $reo->toVariantFriendlyValue($f.parametersValues->at(0).genericType->genericTypeToDataType($f.parametersValues->at(0).multiplicity))}, $f, $currentPropertyMapping, $operation, $vars, $state, $joinType, $nodeId, $aggFromMap, $context, $extensions);
+  // Semi-structured guard: disable auto-flatten so the array stays as a scalar column
+  let effectiveState = if($f->isSemiStructuredArrayInput($vars, $state), |^$state(disableAutoFlatten = true), |$state);
+  processDynaFunction('array_init', {reo | $reo->toVariantFriendlyValue($f.parametersValues->at(0).genericType->genericTypeToDataType($f.parametersValues->at(0).multiplicity))}, $f, $currentPropertyMapping, $operation, $vars, $effectiveState, $joinType, $nodeId, $aggFromMap, $context, $extensions);
 }
 
 function meta::relational::functions::pureToSqlQuery::processVariantTail(f:FunctionExpression[1], currentPropertyMapping:PropertyMapping[*], operation:SelectWithCursor[1], vars:Map<VariableExpression, ValueSpecification>[1], state:State[1], joinType:JoinType[1], nodeId:String[1], aggFromMap:List<ColumnGroup>[1], context:DebugContext[1], extensions:Extension[*]):RelationalOperationElement[1]
 {
-  processDynaFunction('array_tail', {reo | $reo->toVariantFriendlyValue($f.parametersValues->at(0).genericType->genericTypeToDataType($f.parametersValues->at(0).multiplicity))}, $f, $currentPropertyMapping, $operation, $vars, $state, $joinType, $nodeId, $aggFromMap, $context, $extensions);
+  // Semi-structured guard: disable auto-flatten so the array stays as a scalar column
+  let effectiveState = if($f->isSemiStructuredArrayInput($vars, $state), |^$state(disableAutoFlatten = true), |$state);
+  processDynaFunction('array_tail', {reo | $reo->toVariantFriendlyValue($f.parametersValues->at(0).genericType->genericTypeToDataType($f.parametersValues->at(0).multiplicity))}, $f, $currentPropertyMapping, $operation, $vars, $effectiveState, $joinType, $nodeId, $aggFromMap, $context, $extensions);
 }
 
 function meta::relational::functions::pureToSqlQuery::processVariantPlus(f:FunctionExpression[1], currentPropertyMapping:PropertyMapping[*], operation:SelectWithCursor[1], vars:Map<VariableExpression, ValueSpecification>[1], state:State[1], joinType:JoinType[1], nodeId:String[1], aggFromMap:List<ColumnGroup>[1], context:DebugContext[1], extensions:Extension[*]):RelationalOperationElement[1]
@@ -343,12 +353,16 @@ function meta::relational::functions::pureToSqlQuery::processVariantMin(f:Functi
 
 function meta::relational::functions::pureToSqlQuery::processVariantSort(f:FunctionExpression[1], currentPropertyMapping:PropertyMapping[*], operation:SelectWithCursor[1], vars:Map<VariableExpression, ValueSpecification>[1], state:State[1], joinType:JoinType[1], nodeId:String[1], aggFromMap:List<ColumnGroup>[1], context:DebugContext[1], extensions:Extension[*]):RelationalOperationElement[1]
 {
-  processDynaFunction('array_sort', {reo | $reo->toVariantFriendlyValue($f.parametersValues->at(0).genericType->genericTypeToDataType($f.parametersValues->at(0).multiplicity))}, $f, $currentPropertyMapping, $operation, $vars, $state, $joinType, $nodeId, $aggFromMap, $context, $extensions);
+  // Semi-structured guard: disable auto-flatten so the array stays as a scalar column
+  let effectiveState = if($f->isSemiStructuredArrayInput($vars, $state), |^$state(disableAutoFlatten = true), |$state);
+  processDynaFunction('array_sort', {reo | $reo->toVariantFriendlyValue($f.parametersValues->at(0).genericType->genericTypeToDataType($f.parametersValues->at(0).multiplicity))}, $f, $currentPropertyMapping, $operation, $vars, $effectiveState, $joinType, $nodeId, $aggFromMap, $context, $extensions);
 }
 
 function meta::relational::functions::pureToSqlQuery::processVariantReverse(f:FunctionExpression[1], currentPropertyMapping:PropertyMapping[*], operation:SelectWithCursor[1], vars:Map<VariableExpression, ValueSpecification>[1], state:State[1], joinType:JoinType[1], nodeId:String[1], aggFromMap:List<ColumnGroup>[1], context:DebugContext[1], extensions:Extension[*]):RelationalOperationElement[1]
 {
-  processDynaFunction('array_reverse', {reo | $reo->toVariantFriendlyValue($f.parametersValues->at(0).genericType->genericTypeToDataType($f.parametersValues->at(0).multiplicity))}, $f, $currentPropertyMapping, $operation, $vars, $state, $joinType, $nodeId, $aggFromMap, $context, $extensions);
+  // Semi-structured guard: disable auto-flatten so the array stays as a scalar column
+  let effectiveState = if($f->isSemiStructuredArrayInput($vars, $state), |^$state(disableAutoFlatten = true), |$state);
+  processDynaFunction('array_reverse', {reo | $reo->toVariantFriendlyValue($f.parametersValues->at(0).genericType->genericTypeToDataType($f.parametersValues->at(0).multiplicity))}, $f, $currentPropertyMapping, $operation, $vars, $effectiveState, $joinType, $nodeId, $aggFromMap, $context, $extensions);
 }
 
 function meta::relational::functions::pureToSqlQuery::processVariantSize(f:FunctionExpression[1], currentPropertyMapping:PropertyMapping[*], operation:SelectWithCursor[1], vars:Map<VariableExpression, ValueSpecification>[1], state:State[1], joinType:JoinType[1], nodeId:String[1], aggFromMap:List<ColumnGroup>[1], context:DebugContext[1], extensions:Extension[*]):RelationalOperationElement[1]
@@ -405,7 +419,9 @@ function meta::relational::functions::pureToSqlQuery::processVariant_notSupporte
 
 function meta::relational::functions::pureToSqlQuery::processVariantSlice(f:FunctionExpression[1], currentPropertyMapping:PropertyMapping[*], operation:SelectWithCursor[1], vars:Map<VariableExpression, ValueSpecification>[1], state:State[1], joinType:JoinType[1], nodeId:String[1], aggFromMap:List<ColumnGroup>[1], context:DebugContext[1], extensions:Extension[*]):RelationalOperationElement[1]
 {
-  processDynaFunction('array_slice', {reo | $reo->take($reo->size() - 2)->toVariantFriendlyValue($f.parametersValues->at(0).genericType->genericTypeToDataType($f.parametersValues->at(0).multiplicity))->concatenate($reo->drop($reo->size() - 2))}, $f, $currentPropertyMapping, $operation, $vars, $state, $joinType, $nodeId, $aggFromMap, $context, $extensions);
+  // Semi-structured guard: disable auto-flatten so the array stays as a scalar column
+  let effectiveState = if($f->isSemiStructuredArrayInput($vars, $state), |^$state(disableAutoFlatten = true), |$state);
+  processDynaFunction('array_slice', {reo | $reo->take($reo->size() - 2)->toVariantFriendlyValue($f.parametersValues->at(0).genericType->genericTypeToDataType($f.parametersValues->at(0).multiplicity))->concatenate($reo->drop($reo->size() - 2))}, $f, $currentPropertyMapping, $operation, $vars, $effectiveState, $joinType, $nodeId, $aggFromMap, $context, $extensions);
 }
 
 function meta::relational::functions::pureToSqlQuery::processVariantKeys(f:FunctionExpression[1], currentPropertyMapping:PropertyMapping[*], operation:SelectWithCursor[1], vars:Map<VariableExpression, ValueSpecification>[1], state:State[1], joinType:JoinType[1], nodeId:String[1], aggFromMap:List<ColumnGroup>[1], context:DebugContext[1], extensions:Extension[*]):RelationalOperationElement[1]
@@ -420,12 +436,16 @@ function meta::relational::functions::pureToSqlQuery::processVariantValues(f:Fun
 
 function meta::relational::functions::pureToSqlQuery::processVariantContains(f:FunctionExpression[1], currentPropertyMapping:PropertyMapping[*], operation:SelectWithCursor[1], vars:Map<VariableExpression, ValueSpecification>[1], state:State[1], joinType:JoinType[1], nodeId:String[1], aggFromMap:List<ColumnGroup>[1], context:DebugContext[1], extensions:Extension[*]):RelationalOperationElement[1]
 {
-  processDynaFunction('array_contains', {reo | $reo->init()->toVariantFriendlyValue($f.parametersValues->at(0).genericType->genericTypeToDataType($f.parametersValues->at(0).multiplicity))->concatenate($reo->last())}, $f, $currentPropertyMapping, $operation, $vars, $state, $joinType, $nodeId, $aggFromMap, $context, $extensions);
+  // Semi-structured guard: disable auto-flatten so the array stays as a scalar column
+  let effectiveState = if($f->isSemiStructuredArrayInput($vars, $state), |^$state(disableAutoFlatten = true), |$state);
+  processDynaFunction('array_contains', {reo | $reo->init()->toVariantFriendlyValue($f.parametersValues->at(0).genericType->genericTypeToDataType($f.parametersValues->at(0).multiplicity))->concatenate($reo->last())}, $f, $currentPropertyMapping, $operation, $vars, $effectiveState, $joinType, $nodeId, $aggFromMap, $context, $extensions);
 }
 
 function meta::relational::functions::pureToSqlQuery::processVariantRemoveDuplicates(f:FunctionExpression[1], currentPropertyMapping:PropertyMapping[*], operation:SelectWithCursor[1], vars:Map<VariableExpression, ValueSpecification>[1], state:State[1], joinType:JoinType[1], nodeId:String[1], aggFromMap:List<ColumnGroup>[1], context:DebugContext[1], extensions:Extension[*]):RelationalOperationElement[1]
 {
-  processDynaFunction('array_distinct', {reo | $reo->toVariantFriendlyValue($f.parametersValues->at(0).genericType->genericTypeToDataType($f.parametersValues->at(0).multiplicity))}, $f, $currentPropertyMapping, $operation, $vars, $state, $joinType, $nodeId, $aggFromMap, $context, $extensions);
+  // Semi-structured guard: disable auto-flatten so the array stays as a scalar column
+  let effectiveState = if($f->isSemiStructuredArrayInput($vars, $state), |^$state(disableAutoFlatten = true), |$state);
+  processDynaFunction('array_distinct', {reo | $reo->toVariantFriendlyValue($f.parametersValues->at(0).genericType->genericTypeToDataType($f.parametersValues->at(0).multiplicity))}, $f, $currentPropertyMapping, $operation, $vars, $effectiveState, $joinType, $nodeId, $aggFromMap, $context, $extensions);
 }
 
 function meta::relational::functions::pureToSqlQuery::findVariantType(value: RelationalOperationElement[1]):meta::relational::metamodel::datatype::TypedSemiStructured[0..1]

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery_variant.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery_variant.pure
@@ -298,23 +298,17 @@ function meta::relational::functions::pureToSqlQuery::processVariantConcatenate(
 
 function meta::relational::functions::pureToSqlQuery::processVariantDrop(f:FunctionExpression[1], currentPropertyMapping:PropertyMapping[*], operation:SelectWithCursor[1], vars:Map<VariableExpression, ValueSpecification>[1], state:State[1], joinType:JoinType[1], nodeId:String[1], aggFromMap:List<ColumnGroup>[1], context:DebugContext[1], extensions:Extension[*]):RelationalOperationElement[1]
 {
-  // Semi-structured guard: disable auto-flatten so the array stays as a scalar column
-  let effectiveState = if($f->isSemiStructuredArrayInput($vars, $state), |^$state(disableAutoFlatten = true), |$state);
-  processDynaFunction('array_drop', {reo | $reo->init()->toVariantFriendlyValue($f.parametersValues->at(0).genericType->genericTypeToDataType($f.parametersValues->at(0).multiplicity))->concatenate($reo->last())}, $f, $currentPropertyMapping, $operation, $vars, $effectiveState, $joinType, $nodeId, $aggFromMap, $context, $extensions);
+  processDynaFunction('array_drop', {reo | $reo->init()->toVariantFriendlyValue($f.parametersValues->at(0).genericType->genericTypeToDataType($f.parametersValues->at(0).multiplicity))->concatenate($reo->last())}, $f, $currentPropertyMapping, $operation, $vars, $state, $joinType, $nodeId, $aggFromMap, $context, $extensions);
 }
 
 function meta::relational::functions::pureToSqlQuery::processVariantTake(f:FunctionExpression[1], currentPropertyMapping:PropertyMapping[*], operation:SelectWithCursor[1], vars:Map<VariableExpression, ValueSpecification>[1], state:State[1], joinType:JoinType[1], nodeId:String[1], aggFromMap:List<ColumnGroup>[1], context:DebugContext[1], extensions:Extension[*]):RelationalOperationElement[1]
 {
-  // Semi-structured guard: disable auto-flatten so the array stays as a scalar column
-  let effectiveState = if($f->isSemiStructuredArrayInput($vars, $state), |^$state(disableAutoFlatten = true), |$state);
-  processDynaFunction('array_take', {reo | $reo->init()->toVariantFriendlyValue($f.parametersValues->at(0).genericType->genericTypeToDataType($f.parametersValues->at(0).multiplicity))->concatenate($reo->last())}, $f, $currentPropertyMapping, $operation, $vars, $effectiveState, $joinType, $nodeId, $aggFromMap, $context, $extensions);
+  processDynaFunction('array_take', {reo | $reo->init()->toVariantFriendlyValue($f.parametersValues->at(0).genericType->genericTypeToDataType($f.parametersValues->at(0).multiplicity))->concatenate($reo->last())}, $f, $currentPropertyMapping, $operation, $vars, $state, $joinType, $nodeId, $aggFromMap, $context, $extensions);
 }
 
 function meta::relational::functions::pureToSqlQuery::processVariantLast(f:FunctionExpression[1], currentPropertyMapping:PropertyMapping[*], operation:SelectWithCursor[1], vars:Map<VariableExpression, ValueSpecification>[1], state:State[1], joinType:JoinType[1], nodeId:String[1], aggFromMap:List<ColumnGroup>[1], context:DebugContext[1], extensions:Extension[*]):RelationalOperationElement[1]
 {
-  // Semi-structured guard: disable auto-flatten so the array stays as a scalar column
-  let effectiveState = if($f->isSemiStructuredArrayInput($vars, $state), |^$state(disableAutoFlatten = true), |$state);
-  processDynaFunction('array_last', {reo | $reo->toVariantFriendlyValue($f.parametersValues->at(0).genericType->genericTypeToDataType($f.parametersValues->at(0).multiplicity))}, $f, $currentPropertyMapping, $operation, $vars, $effectiveState, $joinType, $nodeId, $aggFromMap, $context, $extensions);
+  processDynaFunction('array_last', {reo | $reo->toVariantFriendlyValue($f.parametersValues->at(0).genericType->genericTypeToDataType($f.parametersValues->at(0).multiplicity))}, $f, $currentPropertyMapping, $operation, $vars, $state, $joinType, $nodeId, $aggFromMap, $context, $extensions);
 }
 
 function meta::relational::functions::pureToSqlQuery::processVariantFirst(f:FunctionExpression[1], currentPropertyMapping:PropertyMapping[*], operation:SelectWithCursor[1], vars:Map<VariableExpression, ValueSpecification>[1], state:State[1], joinType:JoinType[1], nodeId:String[1], aggFromMap:List<ColumnGroup>[1], context:DebugContext[1], extensions:Extension[*]):RelationalOperationElement[1]
@@ -324,16 +318,12 @@ function meta::relational::functions::pureToSqlQuery::processVariantFirst(f:Func
 
 function meta::relational::functions::pureToSqlQuery::processVariantInit(f:FunctionExpression[1], currentPropertyMapping:PropertyMapping[*], operation:SelectWithCursor[1], vars:Map<VariableExpression, ValueSpecification>[1], state:State[1], joinType:JoinType[1], nodeId:String[1], aggFromMap:List<ColumnGroup>[1], context:DebugContext[1], extensions:Extension[*]):RelationalOperationElement[1]
 {
-  // Semi-structured guard: disable auto-flatten so the array stays as a scalar column
-  let effectiveState = if($f->isSemiStructuredArrayInput($vars, $state), |^$state(disableAutoFlatten = true), |$state);
-  processDynaFunction('array_init', {reo | $reo->toVariantFriendlyValue($f.parametersValues->at(0).genericType->genericTypeToDataType($f.parametersValues->at(0).multiplicity))}, $f, $currentPropertyMapping, $operation, $vars, $effectiveState, $joinType, $nodeId, $aggFromMap, $context, $extensions);
+  processDynaFunction('array_init', {reo | $reo->toVariantFriendlyValue($f.parametersValues->at(0).genericType->genericTypeToDataType($f.parametersValues->at(0).multiplicity))}, $f, $currentPropertyMapping, $operation, $vars, $state, $joinType, $nodeId, $aggFromMap, $context, $extensions);
 }
 
 function meta::relational::functions::pureToSqlQuery::processVariantTail(f:FunctionExpression[1], currentPropertyMapping:PropertyMapping[*], operation:SelectWithCursor[1], vars:Map<VariableExpression, ValueSpecification>[1], state:State[1], joinType:JoinType[1], nodeId:String[1], aggFromMap:List<ColumnGroup>[1], context:DebugContext[1], extensions:Extension[*]):RelationalOperationElement[1]
 {
-  // Semi-structured guard: disable auto-flatten so the array stays as a scalar column
-  let effectiveState = if($f->isSemiStructuredArrayInput($vars, $state), |^$state(disableAutoFlatten = true), |$state);
-  processDynaFunction('array_tail', {reo | $reo->toVariantFriendlyValue($f.parametersValues->at(0).genericType->genericTypeToDataType($f.parametersValues->at(0).multiplicity))}, $f, $currentPropertyMapping, $operation, $vars, $effectiveState, $joinType, $nodeId, $aggFromMap, $context, $extensions);
+  processDynaFunction('array_tail', {reo | $reo->toVariantFriendlyValue($f.parametersValues->at(0).genericType->genericTypeToDataType($f.parametersValues->at(0).multiplicity))}, $f, $currentPropertyMapping, $operation, $vars, $state, $joinType, $nodeId, $aggFromMap, $context, $extensions);
 }
 
 function meta::relational::functions::pureToSqlQuery::processVariantPlus(f:FunctionExpression[1], currentPropertyMapping:PropertyMapping[*], operation:SelectWithCursor[1], vars:Map<VariableExpression, ValueSpecification>[1], state:State[1], joinType:JoinType[1], nodeId:String[1], aggFromMap:List<ColumnGroup>[1], context:DebugContext[1], extensions:Extension[*]):RelationalOperationElement[1]
@@ -353,16 +343,12 @@ function meta::relational::functions::pureToSqlQuery::processVariantMin(f:Functi
 
 function meta::relational::functions::pureToSqlQuery::processVariantSort(f:FunctionExpression[1], currentPropertyMapping:PropertyMapping[*], operation:SelectWithCursor[1], vars:Map<VariableExpression, ValueSpecification>[1], state:State[1], joinType:JoinType[1], nodeId:String[1], aggFromMap:List<ColumnGroup>[1], context:DebugContext[1], extensions:Extension[*]):RelationalOperationElement[1]
 {
-  // Semi-structured guard: disable auto-flatten so the array stays as a scalar column
-  let effectiveState = if($f->isSemiStructuredArrayInput($vars, $state), |^$state(disableAutoFlatten = true), |$state);
-  processDynaFunction('array_sort', {reo | $reo->toVariantFriendlyValue($f.parametersValues->at(0).genericType->genericTypeToDataType($f.parametersValues->at(0).multiplicity))}, $f, $currentPropertyMapping, $operation, $vars, $effectiveState, $joinType, $nodeId, $aggFromMap, $context, $extensions);
+  processDynaFunction('array_sort', {reo | $reo->toVariantFriendlyValue($f.parametersValues->at(0).genericType->genericTypeToDataType($f.parametersValues->at(0).multiplicity))}, $f, $currentPropertyMapping, $operation, $vars, $state, $joinType, $nodeId, $aggFromMap, $context, $extensions);
 }
 
 function meta::relational::functions::pureToSqlQuery::processVariantReverse(f:FunctionExpression[1], currentPropertyMapping:PropertyMapping[*], operation:SelectWithCursor[1], vars:Map<VariableExpression, ValueSpecification>[1], state:State[1], joinType:JoinType[1], nodeId:String[1], aggFromMap:List<ColumnGroup>[1], context:DebugContext[1], extensions:Extension[*]):RelationalOperationElement[1]
 {
-  // Semi-structured guard: disable auto-flatten so the array stays as a scalar column
-  let effectiveState = if($f->isSemiStructuredArrayInput($vars, $state), |^$state(disableAutoFlatten = true), |$state);
-  processDynaFunction('array_reverse', {reo | $reo->toVariantFriendlyValue($f.parametersValues->at(0).genericType->genericTypeToDataType($f.parametersValues->at(0).multiplicity))}, $f, $currentPropertyMapping, $operation, $vars, $effectiveState, $joinType, $nodeId, $aggFromMap, $context, $extensions);
+  processDynaFunction('array_reverse', {reo | $reo->toVariantFriendlyValue($f.parametersValues->at(0).genericType->genericTypeToDataType($f.parametersValues->at(0).multiplicity))}, $f, $currentPropertyMapping, $operation, $vars, $state, $joinType, $nodeId, $aggFromMap, $context, $extensions);
 }
 
 function meta::relational::functions::pureToSqlQuery::processVariantSize(f:FunctionExpression[1], currentPropertyMapping:PropertyMapping[*], operation:SelectWithCursor[1], vars:Map<VariableExpression, ValueSpecification>[1], state:State[1], joinType:JoinType[1], nodeId:String[1], aggFromMap:List<ColumnGroup>[1], context:DebugContext[1], extensions:Extension[*]):RelationalOperationElement[1]
@@ -419,9 +405,7 @@ function meta::relational::functions::pureToSqlQuery::processVariant_notSupporte
 
 function meta::relational::functions::pureToSqlQuery::processVariantSlice(f:FunctionExpression[1], currentPropertyMapping:PropertyMapping[*], operation:SelectWithCursor[1], vars:Map<VariableExpression, ValueSpecification>[1], state:State[1], joinType:JoinType[1], nodeId:String[1], aggFromMap:List<ColumnGroup>[1], context:DebugContext[1], extensions:Extension[*]):RelationalOperationElement[1]
 {
-  // Semi-structured guard: disable auto-flatten so the array stays as a scalar column
-  let effectiveState = if($f->isSemiStructuredArrayInput($vars, $state), |^$state(disableAutoFlatten = true), |$state);
-  processDynaFunction('array_slice', {reo | $reo->take($reo->size() - 2)->toVariantFriendlyValue($f.parametersValues->at(0).genericType->genericTypeToDataType($f.parametersValues->at(0).multiplicity))->concatenate($reo->drop($reo->size() - 2))}, $f, $currentPropertyMapping, $operation, $vars, $effectiveState, $joinType, $nodeId, $aggFromMap, $context, $extensions);
+  processDynaFunction('array_slice', {reo | $reo->take($reo->size() - 2)->toVariantFriendlyValue($f.parametersValues->at(0).genericType->genericTypeToDataType($f.parametersValues->at(0).multiplicity))->concatenate($reo->drop($reo->size() - 2))}, $f, $currentPropertyMapping, $operation, $vars, $state, $joinType, $nodeId, $aggFromMap, $context, $extensions);
 }
 
 function meta::relational::functions::pureToSqlQuery::processVariantKeys(f:FunctionExpression[1], currentPropertyMapping:PropertyMapping[*], operation:SelectWithCursor[1], vars:Map<VariableExpression, ValueSpecification>[1], state:State[1], joinType:JoinType[1], nodeId:String[1], aggFromMap:List<ColumnGroup>[1], context:DebugContext[1], extensions:Extension[*]):RelationalOperationElement[1]
@@ -436,16 +420,12 @@ function meta::relational::functions::pureToSqlQuery::processVariantValues(f:Fun
 
 function meta::relational::functions::pureToSqlQuery::processVariantContains(f:FunctionExpression[1], currentPropertyMapping:PropertyMapping[*], operation:SelectWithCursor[1], vars:Map<VariableExpression, ValueSpecification>[1], state:State[1], joinType:JoinType[1], nodeId:String[1], aggFromMap:List<ColumnGroup>[1], context:DebugContext[1], extensions:Extension[*]):RelationalOperationElement[1]
 {
-  // Semi-structured guard: disable auto-flatten so the array stays as a scalar column
-  let effectiveState = if($f->isSemiStructuredArrayInput($vars, $state), |^$state(disableAutoFlatten = true), |$state);
-  processDynaFunction('array_contains', {reo | $reo->init()->toVariantFriendlyValue($f.parametersValues->at(0).genericType->genericTypeToDataType($f.parametersValues->at(0).multiplicity))->concatenate($reo->last())}, $f, $currentPropertyMapping, $operation, $vars, $effectiveState, $joinType, $nodeId, $aggFromMap, $context, $extensions);
+  processDynaFunction('array_contains', {reo | $reo->init()->toVariantFriendlyValue($f.parametersValues->at(0).genericType->genericTypeToDataType($f.parametersValues->at(0).multiplicity))->concatenate($reo->last())}, $f, $currentPropertyMapping, $operation, $vars, $state, $joinType, $nodeId, $aggFromMap, $context, $extensions);
 }
 
 function meta::relational::functions::pureToSqlQuery::processVariantRemoveDuplicates(f:FunctionExpression[1], currentPropertyMapping:PropertyMapping[*], operation:SelectWithCursor[1], vars:Map<VariableExpression, ValueSpecification>[1], state:State[1], joinType:JoinType[1], nodeId:String[1], aggFromMap:List<ColumnGroup>[1], context:DebugContext[1], extensions:Extension[*]):RelationalOperationElement[1]
 {
-  // Semi-structured guard: disable auto-flatten so the array stays as a scalar column
-  let effectiveState = if($f->isSemiStructuredArrayInput($vars, $state), |^$state(disableAutoFlatten = true), |$state);
-  processDynaFunction('array_distinct', {reo | $reo->toVariantFriendlyValue($f.parametersValues->at(0).genericType->genericTypeToDataType($f.parametersValues->at(0).multiplicity))}, $f, $currentPropertyMapping, $operation, $vars, $effectiveState, $joinType, $nodeId, $aggFromMap, $context, $extensions);
+  processDynaFunction('array_distinct', {reo | $reo->toVariantFriendlyValue($f.parametersValues->at(0).genericType->genericTypeToDataType($f.parametersValues->at(0).multiplicity))}, $f, $currentPropertyMapping, $operation, $vars, $state, $joinType, $nodeId, $aggFromMap, $context, $extensions);
 }
 
 function meta::relational::functions::pureToSqlQuery::findVariantType(value: RelationalOperationElement[1]):meta::relational::metamodel::datatype::TypedSemiStructured[0..1]

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/sqlQueryToString/dbExtension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/sqlQueryToString/dbExtension.pure
@@ -925,7 +925,11 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::proce
   assert($p1->matches(extractFromSemiStructuredPathRegex()), 'path specfication must follow regex: ' + extractFromSemiStructuredPathRegex());
   let p2 = $params->at(2)->cast(@Literal).value->cast(@String)->toUpper();
   let supportedTypes = ['BOOLEAN', 'CHAR', 'VARCHAR', 'STRING', 'INTEGER', 'DECIMAL', 'FLOAT', 'DATE', 'DATETIME', 'TIMESTAMP'];
-  assertContains($supportedTypes, $p2, $p2 + ' must be one of ' + $supportedTypes->joinStrings(', '));
+  // A trailing [] denotes an array of the named type. The element type has to be stated:
+  // it is what lets a dialect cast the extraction to a typed list rather than leave it as
+  // an untyped document, and it is not recoverable from anywhere else.
+  let elementType = if($p2->endsWith('[]'), | $p2->substring(0, $p2->length() - 2), | $p2);
+  assertContains($supportedTypes, $elementType, $p2 + ' must be one of ' + $supportedTypes->joinStrings(', ') + ', each optionally suffixed with [] for an array');
   let processedParams = $result.toSql.transform->toOne()->eval([$p0, $p1, $p2]);
   format($result.toSql.format, $processedParams);
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/sqlQueryToString/dbExtension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/sqlQueryToString/dbExtension.pure
@@ -924,7 +924,11 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::proce
   let p1 = $params->at(1)->cast(@Literal).value->cast(@String);
   assert($p1->matches(extractFromSemiStructuredPathRegex()), 'path specfication must follow regex: ' + extractFromSemiStructuredPathRegex());
   let p2 = $params->at(2)->cast(@Literal).value->cast(@String)->toUpper();
-  let supportedTypes = ['BOOLEAN', 'CHAR', 'VARCHAR', 'STRING', 'INTEGER', 'DECIMAL', 'FLOAT', 'DATE', 'DATETIME', 'TIMESTAMP'];
+  // SEMISTRUCTURED says the extraction yields a document rather than a scalar, so the
+  // dialect leaves it as the store's own semi-structured type instead of unquoting it to
+  // text. That is what a binding over a sub-document needs: rendered as text, the property
+  // accesses the binding synthesises are handed a string where a document is required.
+  let supportedTypes = ['BOOLEAN', 'CHAR', 'VARCHAR', 'STRING', 'INTEGER', 'DECIMAL', 'FLOAT', 'DATE', 'DATETIME', 'TIMESTAMP', 'SEMISTRUCTURED'];
   // A trailing [] denotes an array of the named type. The element type has to be stated:
   // it is what lets a dialect cast the extraction to a typed list rather than leave it as
   // an untyped document, and it is not recoverable from anywhere else.

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/sqlQueryToString/dbExtension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/sqlQueryToString/dbExtension.pure
@@ -922,7 +922,7 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::proce
   let result = $sgc.dbConfig.dynaFuncDispatch($func, $sgc)->toOne();
   let p0 = $params->at(0)->processOperation($newSgc);
   let p1 = $params->at(1)->cast(@Literal).value->cast(@String);
-  assert($p1->matches(extractFromSemiStructuredPathRegex()), 'path specfication must follow regex: ' + extractFromSemiStructuredPathRegex());
+  assert($p1->matches(extractFromSemiStructuredPathRegex()), 'path specification must follow regex: ' + extractFromSemiStructuredPathRegex());
   let p2 = $params->at(2)->cast(@Literal).value->cast(@String)->toUpper();
   // SEMISTRUCTURED says the extraction yields a document rather than a scalar, so the
   // dialect leaves it as the store's own semi-structured type instead of unquoting it to

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/sqlQueryToString/dbSpecific/h2/h2Extension1_4_200.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/sqlQueryToString/dbSpecific/h2/h2Extension1_4_200.pure
@@ -227,7 +227,12 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::h2::v
   if ($returnType == 'BOOLEAN', | 'boolean', |
   if ($returnType == 'FLOAT', | 'float', |
   if ($returnType == 'INTEGER', | 'integer', |
-  $returnType))))));
+  // H2 has no native semi-structured type - it holds the document in a VARCHAR, which is what
+  // the datatype match for SemiStructured renders too - so the cast is a no-op that leaves the
+  // document as the store's own representation. Without this the type name reaches H2 verbatim
+  // and it answers "Unknown data type: SEMISTRUCTURED".
+  if ($returnType == 'SEMISTRUCTURED', | 'varchar', |
+  $returnType)))))));
 
   format('cast(%s as %s)', [$relationalPropertyAccess, $castTo]);
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/sqlQueryToString/dbSpecific/h2/h2Extension2_1_214.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/sqlQueryToString/dbSpecific/h2/h2Extension2_1_214.pure
@@ -349,7 +349,12 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::h2::v
   if ($returnType == 'BOOLEAN', | 'boolean', |
   if ($returnType == 'FLOAT', | 'float', |
   if ($returnType == 'INTEGER', | 'integer', |
-  $returnType))))));
+  // H2 has no native semi-structured type - it holds the document in a VARCHAR, which is what
+  // the datatype match for SemiStructured renders too - so the cast is a no-op that leaves the
+  // document as the store's own representation. Without this the type name reaches H2 verbatim
+  // and it answers "Unknown data type: SEMISTRUCTURED".
+  if ($returnType == 'SEMISTRUCTURED', | 'varchar', |
+  $returnType)))))));
 
   format('cast(%s as %s)', [$relationalPropertyAccess, $castTo]);
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/tests/semistructured/model/arrayFunctionsInStoreLanguage.legend
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/tests/semistructured/model/arrayFunctionsInStoreLanguage.legend
@@ -1,0 +1,64 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the 'License');
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+Class arrayStore::model::Team
+{
+  id: Integer[1];
+  topScore: Integer[1];
+  lowScore: Integer[1];
+  scoreCount: Integer[1];
+}
+
+function arrayStore::arrayFunctionsInMapping():TabularDataSet[1]
+{
+    arrayStore::model::Team.all()->project([x|$x.id, x|$x.topScore, x|$x.lowScore, x|$x.scoreCount], ['Id', 'Top', 'Low', 'Count']);
+}
+
+function arrayStore::arrayFunctionInFilter():TabularDataSet[1]
+{
+    arrayStore::model::Team.all()->filter(x|$x.topScore > 20)->project([x|$x.id, x|$x.topScore], ['Id', 'Top']);
+}
+
+###Relational
+Database arrayStore::store::DB
+(
+  Schema TEAM_SCHEMA
+  (
+    Table TEAM_TABLE
+    (
+      ID INTEGER PRIMARY KEY,
+      SCORES SEMISTRUCTURED
+    )
+  )
+)
+
+###Mapping
+Mapping arrayStore::mapping::Mapping
+(
+  arrayStore::model::Team: Relational
+  {
+    ~primaryKey
+    (
+      [arrayStore::store::DB]TEAM_SCHEMA.TEAM_TABLE.ID
+    )
+    ~mainTable [arrayStore::store::DB]TEAM_SCHEMA.TEAM_TABLE
+    id: [arrayStore::store::DB]TEAM_SCHEMA.TEAM_TABLE.ID,
+    // The [] suffix states the element type, which is what lets the dialect cast the
+    // extraction to a typed list. Without it the array_* family receives a document.
+    topScore: array_max(extractFromSemiStructured([arrayStore::store::DB]TEAM_SCHEMA.TEAM_TABLE.SCORES, 'values', 'INTEGER[]')),
+    lowScore: array_min(extractFromSemiStructured([arrayStore::store::DB]TEAM_SCHEMA.TEAM_TABLE.SCORES, 'values', 'INTEGER[]')),
+    scoreCount: array_size(extractFromSemiStructured([arrayStore::store::DB]TEAM_SCHEMA.TEAM_TABLE.SCORES, 'values', 'INTEGER[]'))
+  }
+)

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/tests/semistructured/model/complexChainInStoreLanguage.legend
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/tests/semistructured/model/complexChainInStoreLanguage.legend
@@ -1,0 +1,66 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the 'License');
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+Class chain::model::Firm
+{
+  id: Integer[1];
+  // Every property below is an ordinary scalar. The whole chain - navigate, filter, take the
+  // first survivor, navigate again - happens in the store definition.
+  firstLargeCity: String[1];
+  firstLargeName: String[1];
+  largeCount: Integer[1];
+  allLargeNames: String[1];
+  totalLargeHeadcount: Integer[1];
+}
+
+function chain::complexChainInStoreLanguage():TabularDataSet[1]
+{
+    chain::model::Firm.all()->project([x|$x.id, x|$x.firstLargeName, x|$x.firstLargeCity, x|$x.largeCount, x|$x.allLargeNames, x|$x.totalLargeHeadcount],
+                                      ['Id', 'First Large Name', 'First Large City', 'Large Count', 'All Large Names', 'Total Large Headcount']);
+}
+
+###Relational
+Database chain::store::DB
+(
+  Schema FIRM_SCHEMA
+  (
+    Table FIRM_TABLE
+    (
+      ID INTEGER PRIMARY KEY,
+      FIRM_DETAILS SEMISTRUCTURED
+    )
+  )
+)
+
+###Mapping
+Mapping chain::mapping::Mapping
+(
+  chain::model::Firm: Relational
+  {
+    ~primaryKey
+    (
+      [chain::store::DB]FIRM_SCHEMA.FIRM_TABLE.ID
+    )
+    ~mainTable [chain::store::DB]FIRM_SCHEMA.FIRM_TABLE
+    id: [chain::store::DB]FIRM_SCHEMA.FIRM_TABLE.ID,
+
+    // navigate -> filter -> first -> navigate again, two levels down on the far side.
+    firstLargeCity: extractFromSemiStructured(array_first(array_filter(extractFromSemiStructured([chain::store::DB]FIRM_SCHEMA.FIRM_TABLE.FIRM_DETAILS, 'firm.divisions', 'SEMISTRUCTURED[]'), d | extractFromSemiStructured($d, 'headcount', 'INTEGER') > 100)), 'address.city', 'VARCHAR'),
+    firstLargeName: extractFromSemiStructured(array_first(array_filter(extractFromSemiStructured([chain::store::DB]FIRM_SCHEMA.FIRM_TABLE.FIRM_DETAILS, 'firm.divisions', 'SEMISTRUCTURED[]'), d | extractFromSemiStructured($d, 'headcount', 'INTEGER') > 100)), 'name', 'VARCHAR'),
+    largeCount: array_size(array_filter(extractFromSemiStructured([chain::store::DB]FIRM_SCHEMA.FIRM_TABLE.FIRM_DETAILS, 'firm.divisions', 'SEMISTRUCTURED[]'), d | extractFromSemiStructured($d, 'headcount', 'INTEGER') > 100)),
+    allLargeNames: array_to_string(array_transform(array_filter(extractFromSemiStructured([chain::store::DB]FIRM_SCHEMA.FIRM_TABLE.FIRM_DETAILS, 'firm.divisions', 'SEMISTRUCTURED[]'), d | extractFromSemiStructured($d, 'headcount', 'INTEGER') > 100), d | extractFromSemiStructured($d, 'name', 'VARCHAR')), '|'),
+    totalLargeHeadcount: array_reduce(array_transform(array_filter(extractFromSemiStructured([chain::store::DB]FIRM_SCHEMA.FIRM_TABLE.FIRM_DETAILS, 'firm.divisions', 'SEMISTRUCTURED[]'), d | extractFromSemiStructured($d, 'headcount', 'INTEGER') > 100), d | extractFromSemiStructured($d, 'headcount', 'INTEGER')), (h, acc | plus($acc, $h)), 0)
+  }
+)

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/tests/semistructured/model/nestedExplodeSemiStructured.legend
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/tests/semistructured/model/nestedExplodeSemiStructured.legend
@@ -1,0 +1,84 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the 'License');
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+Class nested::model::Firm
+{
+  id: Integer[1];
+  teams: nested::model::Team[*];
+}
+
+Class nested::model::Team
+{
+  tid: String[1];
+  label: String[1];
+}
+
+function nested::nestedExplode():TabularDataSet[1]
+{
+    nested::model::Firm.all()->project([x|$x.id, x|$x.teams.tid, x|$x.teams.label],
+                                       ['Id', 'Team Id', 'Label']);
+}
+
+###Relational
+Database nested::store::DB
+(
+  Schema NESTED_SCHEMA
+  (
+    Table FIRM_TABLE
+    (
+      ID INTEGER PRIMARY KEY,
+      FIRM_DETAILS SEMISTRUCTURED
+    )
+    Table TEAM_TABLE
+    (
+      TID VARCHAR(100) PRIMARY KEY,
+      LABEL VARCHAR(100)
+    )
+  )
+
+  // One row per (division, team): the outer explode fans out divisions, the inner one fans out
+  // the teams held inside each division.
+  Join Firm_Team(extractFromSemiStructured(
+                   explodeSemiStructured(
+                     explodeSemiStructured(NESTED_SCHEMA.FIRM_TABLE.FIRM_DETAILS, 'divisions', 'SEMISTRUCTURED'),
+                     'teams', 'SEMISTRUCTURED'),
+                   'tid', 'VARCHAR') = NESTED_SCHEMA.TEAM_TABLE.TID)
+)
+
+###Mapping
+Mapping nested::mapping::Mapping
+(
+  nested::model::Firm: Relational
+  {
+    ~primaryKey
+    (
+      [nested::store::DB]NESTED_SCHEMA.FIRM_TABLE.ID
+    )
+    ~mainTable [nested::store::DB]NESTED_SCHEMA.FIRM_TABLE
+    id: [nested::store::DB]NESTED_SCHEMA.FIRM_TABLE.ID,
+    teams: [nested::store::DB]@Firm_Team
+  }
+
+  nested::model::Team: Relational
+  {
+    ~primaryKey
+    (
+      [nested::store::DB]NESTED_SCHEMA.TEAM_TABLE.TID
+    )
+    ~mainTable [nested::store::DB]NESTED_SCHEMA.TEAM_TABLE
+    tid: [nested::store::DB]NESTED_SCHEMA.TEAM_TABLE.TID,
+    label: [nested::store::DB]NESTED_SCHEMA.TEAM_TABLE.LABEL
+  }
+)

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/tests/semistructured/model/semiStructuredUnionMapping.legend
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/tests/semistructured/model/semiStructuredUnionMapping.legend
@@ -83,7 +83,7 @@ Mapping test::mapping::testMapping
       [test::store::testDB]PERSON_SCHEMA.PERSON_TABLE_1.ID
     )
     ~mainTable [test::store::testDB]PERSON_SCHEMA.PERSON_TABLE_1
-    firm: Binding test::binding::FirmBinding : extractFromSemiStructured([test::store::testDB]PERSON_SCHEMA.PERSON_TABLE_1.FIRM_DETAILS, 'firm', 'VARCHAR')
+    firm: Binding test::binding::FirmBinding : extractFromSemiStructured([test::store::testDB]PERSON_SCHEMA.PERSON_TABLE_1.FIRM_DETAILS, 'firm', 'SEMISTRUCTURED')
   }
   test::model::Person[Type_B]: Relational
   {

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/tests/semistructured/model/wildcardPathInStoreLanguage.legend
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/tests/semistructured/model/wildcardPathInStoreLanguage.legend
@@ -1,0 +1,68 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the 'License');
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+Class wildcard::model::Firm
+{
+  id: Integer[1];
+  divisionNames: String[0..1];
+  teamLabels: String[0..1];
+  teamCount: Integer[0..1];
+  maxHeadcount: Integer[0..1];
+}
+
+function wildcard::wildcardPathInStoreLanguage():TabularDataSet[1]
+{
+    wildcard::model::Firm.all()->project([x|$x.id, x|$x.divisionNames, x|$x.teamLabels, x|$x.teamCount, x|$x.maxHeadcount],
+                                         ['Id', 'Division Names', 'Team Labels', 'Team Count', 'Max Headcount']);
+}
+
+###Relational
+Database wildcard::store::DB
+(
+  Schema FIRM_SCHEMA
+  (
+    Table FIRM_TABLE
+    (
+      ID INTEGER PRIMARY KEY,
+      FIRM_DETAILS SEMISTRUCTURED
+    )
+  )
+)
+
+###Mapping
+Mapping wildcard::mapping::Mapping
+(
+  wildcard::model::Firm: Relational
+  {
+    ~primaryKey
+    (
+      [wildcard::store::DB]FIRM_SCHEMA.FIRM_TABLE.ID
+    )
+    ~mainTable [wildcard::store::DB]FIRM_SCHEMA.FIRM_TABLE
+    id: [wildcard::store::DB]FIRM_SCHEMA.FIRM_TABLE.ID,
+
+    // One wildcard: the body yields scalars, so no flattening is required.
+    divisionNames: array_to_string(extractFromSemiStructured([wildcard::store::DB]FIRM_SCHEMA.FIRM_TABLE.FIRM_DETAILS, 'divisions[*].name', 'VARCHAR[]'), '|'),
+
+    // Two wildcards. Pure has no nested collection type, so this has to come back flat.
+    teamLabels: array_to_string(extractFromSemiStructured([wildcard::store::DB]FIRM_SCHEMA.FIRM_TABLE.FIRM_DETAILS, 'divisions[*].teams[*].label', 'VARCHAR[]'), '|'),
+
+    // Counted rather than joined: without the flatten this counts divisions, not teams.
+    teamCount: array_size(extractFromSemiStructured([wildcard::store::DB]FIRM_SCHEMA.FIRM_TABLE.FIRM_DETAILS, 'divisions[*].teams[*].label', 'VARCHAR[]')),
+
+    // Headcounts are ordered so a text comparison answers 9 rather than 100.
+    maxHeadcount: array_max(extractFromSemiStructured([wildcard::store::DB]FIRM_SCHEMA.FIRM_TABLE.FIRM_DETAILS, 'divisions[*].headcount', 'INTEGER[]'))
+  }
+)

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/tests/semistructured/testArrayFunctionsInStoreLanguage.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/tests/semistructured/testArrayFunctionsInStoreLanguage.pure
@@ -1,0 +1,63 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the 'License');
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::relational::tests::semistructured::arrayStore::*;
+import meta::pure::test::*;
+import meta::relational::metamodel::*;
+import meta::core::runtime::*;
+import meta::pure::mapping::*;
+
+// The scores are deliberately awkward. A maximum of [9,100,20] is 9 if the elements are
+// compared as text and 100 if the element type reached the database, and [5,12,7] has a
+// text maximum of "7". A tidier array such as [30,10,20] returns the right answer either
+// way and would hide a broken cast.
+function meta::relational::tests::semistructured::arrayStore::arrayExecute(conn: Connection[1], func: String[1], expected: String[1]):Boolean[1]
+{
+  let csv =
+        'TEAM_SCHEMA\n' +
+        'TEAM_TABLE\n' +
+        'ID,SCORES\n' +
+        '1,"{""values"": [9, 100, 20]}"\n' +
+        '2,"{""values"": [5, 12, 7]}"\n' +
+        '3,"{""values"": [40, 35]}"\n'
+        ;
+
+  let model = '/core_relational/relational/tests/semistructured/model/arrayFunctionsInStoreLanguage.legend';
+
+  let m = 'arrayStore::mapping::Mapping';
+  let s = 'arrayStore::store::DB';
+
+   meta::relational::metamodel::execute::tests::executeLegendFunction($conn, $csv, $model, $func, $m, $s, $expected);
+}
+
+function <<paramTest.Test>> meta::relational::tests::semistructured::arrayStore::testArrayFunctionsInMapping(conn: Connection[1]):Boolean[1]
+{
+  arrayExecute($conn,
+    'arrayStore::arrayFunctionsInMapping__TabularDataSet_1_',
+    'Id,Top,Low,Count\n' +
+    '1,100,9,3\n' +
+    '2,12,5,3\n' +
+    '3,40,35,2\n'
+  );
+}
+
+function <<paramTest.Test>> meta::relational::tests::semistructured::arrayStore::testArrayFunctionInFilter(conn: Connection[1]):Boolean[1]
+{
+  arrayExecute($conn,
+    'arrayStore::arrayFunctionInFilter__TabularDataSet_1_',
+    'Id,Top\n' +
+    '1,100\n' +
+    '3,40\n'
+  );
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/tests/semistructured/testComplexChainInStoreLanguage.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/tests/semistructured/testComplexChainInStoreLanguage.pure
@@ -1,0 +1,50 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the 'License');
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::relational::tests::semistructured::chain::*;
+import meta::pure::test::*;
+import meta::relational::metamodel::*;
+import meta::core::runtime::*;
+import meta::pure::mapping::*;
+
+// The divisions are ordered so that a chain which loses its filter, or takes the wrong survivor,
+// returns a different city rather than an error. Firm 1's first division is small and its first
+// large one is second in the array; firm 2's only large division is last; firm 3 has none, so the
+// chain has to survive an empty result.
+function meta::relational::tests::semistructured::chain::chainExecute(conn: Connection[1], func: String[1], expected: String[1]):Boolean[1]
+{
+  let csv =
+        'FIRM_SCHEMA\n' +
+        'FIRM_TABLE\n' +
+        'ID,FIRM_DETAILS\n' +
+        '1,"{""firm"": {""divisions"": [{""name"": ""Small"", ""headcount"": 10, ""address"": {""city"": ""Lisbon""}}, {""name"": ""Alpha"", ""headcount"": 150, ""address"": {""city"": ""Oslo""}}, {""name"": ""Beta"", ""headcount"": 300, ""address"": {""city"": ""Kyoto""}}]}}"\n' +
+        '2,"{""firm"": {""divisions"": [{""name"": ""Tiny"", ""headcount"": 5, ""address"": {""city"": ""Cairo""}}, {""name"": ""Gamma"", ""headcount"": 400, ""address"": {""city"": ""Lima""}}]}}"\n' +
+        '3,"{""firm"": {""divisions"": [{""name"": ""Mini"", ""headcount"": 2, ""address"": {""city"": ""Perth""}}]}}"\n'
+        ;
+
+  let model = '/core_relational/relational/tests/semistructured/model/complexChainInStoreLanguage.legend';
+
+  meta::relational::metamodel::execute::tests::executeLegendFunction($conn, $csv, $model, $func, 'chain::mapping::Mapping', 'chain::store::DB', $expected);
+}
+
+function <<paramTest.Test>> meta::relational::tests::semistructured::chain::testComplexChainInStoreLanguage(conn: Connection[1]):Boolean[1]
+{
+  chainExecute($conn,
+    'chain::complexChainInStoreLanguage__TabularDataSet_1_',
+    'Id,First Large Name,First Large City,Large Count,All Large Names,Total Large Headcount\n' +
+    '1,Alpha,Oslo,2,Alpha|Beta,450\n' +
+    '2,Gamma,Lima,1,Gamma,400\n' +
+    '3,,,0,,0\n'
+  );
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/tests/semistructured/testExplodeSemiStructuredMapping.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/tests/semistructured/testExplodeSemiStructuredMapping.pure
@@ -435,3 +435,15 @@ function <<paramTest.Test>> meta::relational::tests::semistructured::explode::te
     'o6,t7\n'
   );
 }
+
+// Pins what explodeReturnType promises today. 'SEMISTRUCTURED' is the only spelling any mapping
+// passes and it is not in the lookup map - it reaches the document case by falling through, so
+// nothing else records that this is the contract. See section 11.12 for the gaps left open.
+function <<test.Test>> meta::relational::tests::semistructured::explode::testExplodeReturnTypeAcceptedNames():Boolean[1]
+{
+  assertEmpty('SEMISTRUCTURED'->meta::relational::functions::pureToSqlQuery::explodeReturnType(), 'SEMISTRUCTURED describes a nested document, so it has no scalar Pure type');
+  assertEquals(String, 'VARCHAR'->meta::relational::functions::pureToSqlQuery::explodeReturnType());
+  assertEquals(Integer, 'INTEGER'->meta::relational::functions::pureToSqlQuery::explodeReturnType());
+  assertEquals(DateTime, 'TIMESTAMP'->meta::relational::functions::pureToSqlQuery::explodeReturnType());
+  assertEquals(StrictDate, 'DATE'->meta::relational::functions::pureToSqlQuery::explodeReturnType());
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/tests/semistructured/testNestedExplodeSemiStructured.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/tests/semistructured/testNestedExplodeSemiStructured.pure
@@ -1,0 +1,65 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the 'License');
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::relational::tests::semistructured::nested::*;
+import meta::pure::test::*;
+import meta::relational::metamodel::*;
+import meta::core::runtime::*;
+import meta::pure::mapping::*;
+
+// Firm 1's teams are spread across two divisions, so an implementation that fans out only the
+// outer array loses t3 rather than erroring. Firm 2 holds two teams in a single division, and
+// firm 3 has a division with no teams at all.
+function meta::relational::tests::semistructured::nested::nestedExecute(conn: Connection[1], func: String[1], expected: String[1]):Boolean[1]
+{
+  let firms =
+        'NESTED_SCHEMA\n' +
+        'FIRM_TABLE\n' +
+        'ID,FIRM_DETAILS\n' +
+        '1,"{""divisions"": [{""name"": ""Alpha"", ""teams"": [{""tid"": ""t1""}, {""tid"": ""t2""}]}, {""name"": ""Beta"", ""teams"": [{""tid"": ""t3""}]}]}"\n' +
+        '2,"{""divisions"": [{""name"": ""Gamma"", ""teams"": [{""tid"": ""t4""}, {""tid"": ""t5""}]}]}"\n' +
+        '3,"{""divisions"": [{""name"": ""Delta"", ""teams"": []}]}"\n'
+        ;
+
+  let teams =
+        'NESTED_SCHEMA\n' +
+        'TEAM_TABLE\n' +
+        'TID,LABEL\n' +
+        't1,Core\n' +
+        't2,Edge\n' +
+        't3,Ops\n' +
+        't4,Risk\n' +
+        't5,Data\n'
+        ;
+
+  let model = '/core_relational/relational/tests/semistructured/model/nestedExplodeSemiStructured.legend';
+
+  meta::relational::metamodel::execute::tests::executeLegendFunction($conn, [$firms, $teams], $model, $func, 'nested::mapping::Mapping', 'nested::store::DB', $expected);
+}
+
+function <<paramTest.Test>> meta::relational::tests::semistructured::nested::testNestedExplode(conn: Connection[1]):Boolean[1]
+{
+  nestedExecute($conn,
+    'nested::nestedExplode__TabularDataSet_1_',
+    'Id,Team Id,Label\n' +
+    '1,t1,Core\n' +
+    '1,t2,Edge\n' +
+    '1,t3,Ops\n' +
+    '2,t4,Risk\n' +
+    '2,t5,Data\n' +
+    // Firm 3's only division holds an empty team list, so the inner lateral yields nothing and
+    // the left join back to the source keeps the firm with nulls rather than dropping it.
+    '3,null,null\n'
+  );
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/tests/semistructured/testWildcardPathInStoreLanguage.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/tests/semistructured/testWildcardPathInStoreLanguage.pure
@@ -1,0 +1,48 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the 'License');
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::relational::tests::semistructured::wildcard::*;
+import meta::pure::test::*;
+import meta::relational::metamodel::*;
+import meta::core::runtime::*;
+import meta::pure::mapping::*;
+
+// Firm 1 spreads teams across two divisions, so a wildcard that fails to flatten loses rows
+// rather than erroring. Firm 2 has a division holding no teams, and firm 3 no divisions at all.
+function meta::relational::tests::semistructured::wildcard::wildcardExecute(conn: Connection[1], func: String[1], expected: String[1]):Boolean[1]
+{
+  let csv =
+        'FIRM_SCHEMA\n' +
+        'FIRM_TABLE\n' +
+        'ID,FIRM_DETAILS\n' +
+        '1,"{""divisions"": [{""name"": ""Alpha"", ""headcount"": 9, ""teams"": [{""label"": ""Core""}, {""label"": ""Edge""}]}, {""name"": ""Beta"", ""headcount"": 100, ""teams"": [{""label"": ""Ops""}]}]}"\n' +
+        '2,"{""divisions"": [{""name"": ""Gamma"", ""headcount"": 50, ""teams"": []}]}"\n' +
+        '3,"{""divisions"": []}"\n'
+        ;
+
+  let model = '/core_relational/relational/tests/semistructured/model/wildcardPathInStoreLanguage.legend';
+
+  meta::relational::metamodel::execute::tests::executeLegendFunction($conn, $csv, $model, $func, 'wildcard::mapping::Mapping', 'wildcard::store::DB', $expected);
+}
+
+function <<paramTest.Test>> meta::relational::tests::semistructured::wildcard::testWildcardPathInStoreLanguage(conn: Connection[1]):Boolean[1]
+{
+  wildcardExecute($conn,
+    'wildcard::wildcardPathInStoreLanguage__TabularDataSet_1_',
+    'Id,Division Names,Team Labels,Team Count,Max Headcount\n' +
+    '1,Alpha|Beta,Core|Edge|Ops,3,100\n' +
+    '2,Gamma,null,0,50\n' +
+    '3,null,null,0,null\n'
+  );
+}


### PR DESCRIPTION
## What this enables

A modeller can express a multi-step JSON navigation **in the relational store language** — inside a `View` column, a `Filter`, a `Join` or a property mapping — and consumers see an ordinary typed property. The acceptance test is one property mapping:

```
firstLargeCity: extractFromSemiStructured(
    array_first(array_filter(
        extractFromSemiStructured(T.FIRM_DETAILS, 'firm.divisions', 'SEMISTRUCTURED[]'),
        d | extractFromSemiStructured($d, 'headcount', 'INTEGER') > 100)),
    'address.city', 'VARCHAR')
```

Navigate, filter a collection, take the first survivor, navigate further into it. `Variant` appears nowhere in the models or mappings — JSON is typed through an ExternalFormat `Binding`.

## Root cause worth highlighting

One 10-entry scalar whitelist in `dbExtension.pure` was blocking three separately-recorded failures at once: the whole `array_*` family (only `array_size` worked), `[*]` bindings that needed `parseJson` to recover array-ness, and a Snowflake `GET(VARCHAR…)` error whose recorded reason had misdiagnosed it as a union-router bug. Letting an extraction name an array element type (`'INTEGER[]'`) and a document (`'SEMISTRUCTURED'`) fixed all three and retired four expected-failure records.

## Lambdas reuse what already existed

`array_filter` / `array_transform` / `array_reduce` in the store language compile to the **existing** `FilterRelationalLambda` / `MapRelationalLambda` / `FoldRelationalLambda` nodes that the Pure path already produced. **No SQL-generation code was written** and no dyna-registry entries were added — only the authoring path (grammar, walker, protocol, compiler, composer). A parallel node class would also have been silently skipped by `reAliasQuery` and milestoning.

Syntax: `array_filter(<collection>, d | <body>)` with `$d` in the body; `array_reduce(<collection>, <seed>, (acc, x | <body>))`.

## Verification

| suite | result |
|---|---|
| DuckDB semi-structured | 154 / 154, **0 exclusions** |
| Snowflake semi-structured | 154 / 154, **0 exclusions** (was 2) † |
| Databricks semi-structured | 154 / 154, exclusions 8 → 4 † |
| H2 semi-structured | 154 / 154 (skips; H2 is on a demise path) |
| DuckDB PCT | 1469 |
| Relational EMIT | 389 |
| `Test_Pure_Relational` | 2734 |

† The two cloud figures were measured before the rebase onto 4.140.1-SNAPSHOT. Both suites are expected to be unchanged, but they have not been re-measured locally since; the cloud CI run is the confirmation.

Expected-failure entries now **fail when they stop reproducing**, which immediately caught two stale Databricks records — one of which was masking a wrong *answer* rather than an error.

## Known gaps, deliberately not addressed here

- **`explodeSemiStructured`**: Join-only reachability; at most one unique explode per join; the operand must be a bare `TableAliasColumn`, so nested explosion is impossible. Documented in the architecture doc; next piece of work.
- **No compile-time validation** of dyna name, arity, path or return type — all still fail at SQL generation. Section 10 of the doc proposes the seam and its warn-first rollout.
- **Explode's type argument** reads a different vocabulary than `extractFromSemiStructured`, and an unrecognised name silently yields a document. Left alone on purpose: unlike an unknown dyna name, an unknown type argument *succeeds* today, so rejecting it would break working models on upgrade. Belongs in the staged rollout.
- **Postgres / MemSQL / ClickHouse** have no array branch — they sit outside the parameterised suite, so the code would be unverifiable.
- **Engine-first**: the upstream `legend-pure-m2-store-relational-grammar` parser does not accept the lambda syntax, following the `TabularFunction` precedent.

## Docs

`docs/engineering/architecture/relational-dynafunctions.md` gains sections 11.8–11.12: the limitations found by building the models, array-typed extraction, store-language lambdas, which `array_*` functions actually work, and the explode type-argument divergence.
