### PR TITLE
Explode an array held inside each element of another array

### DIFF
--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-h2/legend-engine-xt-relationalStore-h2-PCT/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/h2/semistructured/Test_Relational_H2_Semistructured.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-h2/legend-engine-xt-relationalStore-h2-PCT/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/test/h2/semistructured/Test_Relational_H2_Semistructured.java
@@ -34,6 +34,10 @@ import org.eclipse.collections.api.factory.Maps;
 public class Test_Relational_H2_Semistructured
 {
     private static final Set<String> SKIPPED_TESTS = Sets.mutable.with(
+            // H2 renders one lateral flatten correctly - every single-level explode test passes
+            // here - but a second lateral over the first one's output yields nulls rather than
+            // rows, and does so silently. Left failing per H2's retirement.
+            "meta::relational::tests::semistructured::nested::testNestedExplode_Connection_1__Boolean_1_",
             // Array lambdas reach H2 through the sqlDialectTranslation path, which has no case for
             // the lambda nodes: "Match failure: FilterRelationalLambdaObject instanceOf
             // FilterRelationalLambda". Same structural gap as the array_* family - H2 is the only

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery.pure
@@ -9291,12 +9291,15 @@ function meta::relational::functions::pureToSqlQuery::applyJoinWithExplodeInCond
   let sourceAliasInJoin = $join->otherTableFromAlias($targetAliasInJoin)->toOne();
 
   let allExplodeCalls = $join.operation->extractExplodeSemiStructured()->removeDuplicates();
-  assert($allExplodeCalls->size() == 1, 'only one unique explode allowed in operation in join: ' + $join.name); // This condition needs to be relaxed to support many-to-many
-  let explodeOp = $allExplodeCalls->at(0)->cast(@DynaFunction);
-  assert($explodeOp.parameters->size() == 3, 'explodeSemiStructured takes exactly 3 arguments, passed: ', $explodeOp.parameters->size());
-  assert($explodeOp.parameters->at(0)->instanceOf(TableAliasColumn), 'Input to explodeSemiStructured must be defined as a column in table/view in join: ' + $join.name); // This condition needs to be relaxed to support nested explosion
-  let columnToExplode = $explodeOp.parameters->at(0)->cast(@TableAliasColumn);
-  let pathToExplode   = $explodeOp.parameters->at(1)->cast(@Literal).value->cast(@String);
+  // An explode nested inside another is one chain producing a row per combination, not two
+  // independent explodes. Only chain roots are counted here, so many-to-many stays unsupported.
+  let rootExplodeCalls = $allExplodeCalls->filter(e | !$allExplodeCalls->exists(other | !$other->is($e) && $other->cast(@DynaFunction).parameters->map(prm | $prm->extractExplodeSemiStructured())->exists(d | $d->is($e))));
+  assert($rootExplodeCalls->size() == 1, 'only one unique explode allowed in operation in join: ' + $join.name); // This condition needs to be relaxed to support many-to-many
+  let explodeOp = $rootExplodeCalls->at(0)->cast(@DynaFunction);
+  let explodeChain = $explodeOp->explodeSemiStructuredChain();
+  $explodeChain->forAll(e | assert($e.parameters->size() == 3, 'explodeSemiStructured takes exactly 3 arguments, passed: ', $e.parameters->size()));
+  assert($explodeChain->at(0).parameters->at(0)->instanceOf(TableAliasColumn), 'Input to explodeSemiStructured must be defined as a column in table/view in join: ' + $join.name);
+  let columnToExplode = $explodeChain->at(0).parameters->at(0)->cast(@TableAliasColumn);
   let pureReturnType  = $explodeOp.parameters->at(2)->cast(@Literal).value->cast(@String)->explodeReturnType();
   let tableToExplodeAlias = $columnToExplode.alias;
 
@@ -9307,29 +9310,37 @@ function meta::relational::functions::pureToSqlQuery::applyJoinWithExplodeInCond
 
   // 1. create a subquery(exploded) for the flattened relation by doing a lateral join between tableToFlatten and the flattened array.
   let toExplodeRootTreeNode = ^RootJoinTreeNode(alias=^TableAlias(name='root',relationalElement=$tableToExplodeAlias.relationalElement->processRelation([], $joinType, $nodeId, true, -1, true, $milestoningContext, $state, $context, $extensions)));
-  let pathNavigation = meta::relational::functions::sqlQueryToString::parseSemiStructuredPathNavigation($pathToExplode);
-  let initialNavigation = if($pathNavigation->at(0)->isDigit(), | ^SemiStructuredArrayElementAccess(operand=^$columnToExplode(alias = $toExplodeRootTreeNode.alias),index=^Literal(value = $pathNavigation->at(0))), |  ^SemiStructuredPropertyAccess(property=^Literal(value = $pathNavigation->at(0)->substring(1, $pathNavigation->at(0)->length()-1)), operand=^$columnToExplode(alias = $toExplodeRootTreeNode.alias)));
-  let semiStructuredNavigation = $pathNavigation->slice(1, $pathNavigation->size())->fold({property, navigation | if($property->isDigit(), | ^SemiStructuredArrayElementAccess(operand=$navigation,index=^Literal(value = $property)), |  ^SemiStructuredPropertyAccess(property=^Literal(value = $property->substring(1, $property->length()-1)), operand=$navigation)) }, $initialNavigation );
-  let arrayFlattening = ^SemiStructuredArrayFlatten(navigation = $semiStructuredNavigation);
-  let leftAlias = $toExplodeRootTreeNode.alias;
-  let rightAlias = ^TableAlias(relationalElement = $arrayFlattening, name = 'arrayFlatten_0');
-  let joinName = 'join_arrayFlatten_' + $arrayFlattening->buildUniqueName(false, true, $extensions);
-  let lateralJoin = ^Join(
-    name      = $joinName,
-    target    = $rightAlias,
-    aliases   = [pair($leftAlias, $rightAlias), pair($rightAlias, $leftAlias)],
-    operation = ^DynaFunction(name = 'equal', parameters = [^Literal(value = 1), ^Literal(value = 1)])
-  );
-  let lateralJoinNode = ^JoinTreeNode(
-    database = $joinTree.database,
-    joinName = $joinName,
-    alias    = $rightAlias,
-    join     = $lateralJoin,
-    joinType = JoinType.INNER,
-    lateral  = true
-  );
-  let explodedRootTreeNode = ^$toExplodeRootTreeNode(childrenData = $lateralJoinNode);
-  let flattenOutputAlias            = ^Alias(name = 'flattened_prop', relationalElement = ^SemiStructuredArrayFlattenOutput(tableAliasColumn = ^TableAliasColumn(alias = $lateralJoinNode.alias->toOne(), column = ^Column(name = 'VALUE', type = ^meta::relational::metamodel::datatype::SemiStructured())), returnType = $pureReturnType));
+  // One lateral per level. Level 0 navigates from the re-rooted base column; each level above it
+  // navigates from the VALUE the level below produced, which is what fans out an array held
+  // inside each element of the array beneath it.
+  let lateralAliases = $explodeChain->fold({e, aliasesSoFar |
+      let level = $aliasesSoFar->size();
+      let operand = if($level == 0,
+                      | ^$columnToExplode(alias = $toExplodeRootTreeNode.alias),
+                      | ^TableAliasColumn(alias = $aliasesSoFar->at($level - 1)->cast(@TableAlias), column = ^Column(name = 'VALUE', type = ^meta::relational::metamodel::datatype::SemiStructured())));
+      let navigation = buildSemiStructuredNavigationForExplode($e.parameters->at(1)->cast(@Literal).value->cast(@String), $operand);
+      $aliasesSoFar->concatenate(^TableAlias(relationalElement = ^SemiStructuredArrayFlatten(navigation = $navigation), name = 'arrayFlatten_' + $level->toString()));
+    }, [])->cast(@TableAlias);
+  let lateralJoinNodes = range(0, $lateralAliases->size())->map(level |
+      let rightAlias = $lateralAliases->at($level);
+      let leftAlias = if($level == 0, | $toExplodeRootTreeNode.alias, | $lateralAliases->at($level - 1));
+      let joinName = 'join_arrayFlatten_' + $rightAlias.relationalElement->cast(@SemiStructuredArrayFlatten)->buildUniqueName(false, true, $extensions);
+      ^JoinTreeNode(
+        database = $joinTree.database,
+        joinName = $joinName,
+        alias    = $rightAlias,
+        join     = ^Join(
+          name      = $joinName,
+          target    = $rightAlias,
+          aliases   = [pair($leftAlias, $rightAlias), pair($rightAlias, $leftAlias)],
+          operation = ^DynaFunction(name = 'equal', parameters = [^Literal(value = 1), ^Literal(value = 1)])
+        ),
+        joinType = JoinType.INNER,
+        lateral  = true
+      );
+    );
+  let explodedRootTreeNode = ^$toExplodeRootTreeNode(childrenData = $lateralJoinNodes);
+  let flattenOutputAlias            = ^Alias(name = 'flattened_prop', relationalElement = ^SemiStructuredArrayFlattenOutput(tableAliasColumn = ^TableAliasColumn(alias = $lateralAliases->last()->toOne(), column = ^Column(name = 'VALUE', type = ^meta::relational::metamodel::datatype::SemiStructured())), returnType = $pureReturnType));
   let columnsForInnerJoin           = $join.operation->extractTableAliasColumns()->filter(tac|$tac.alias == $tableToExplodeAlias )->map(c|^TableAliasColumn(column = $c.column, alias = $toExplodeRootTreeNode.alias))->removeDuplicates();
   let additionalColumnsToFetch      = if($tableToExplodeAlias == $sourceAliasInJoin,
                                         | $srcPrimaryKeys->map(c|^Alias(name = 'leftJoinKey_' + $srcPrimaryKeys->indexOf($c)->toString(), relationalElement = ^TableAliasColumn(column=$c, alias=$toExplodeRootTreeNode.alias))),  // fetch only pks from source
@@ -9354,7 +9365,7 @@ function meta::relational::functions::pureToSqlQuery::applyJoinWithExplodeInCond
   let reprocessedJoin = reprocessJoin(^$join(operation=$updatedOperation), [^OldAliasToNewAlias(first = $tableToExplodeAlias.name->toOne(), second = $explodedSubQuery), ^OldAliasToNewAlias(first = $otherTableInJoin.name, second = $otherTableInJoinUpdated)], []);
   let innerJoinTreeNode = ^JoinTreeNode(
     database = $joinTree.database,
-    joinName = 'inner_join_flattened_' + $targetAliasInJoin->buildUniqueName(true, true, $extensions) + '__' + $joinName,
+    joinName = 'inner_join_flattened_' + $targetAliasInJoin->buildUniqueName(true, true, $extensions) + '__' + $lateralJoinNodes->at(0).joinName,
     alias    = if($targetAliasInJoin == $tableToExplodeAlias, | $explodedSubQuery, | $otherTableInJoinUpdated),
     join     = $reprocessedJoin,
     joinType = JoinType.INNER

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery_variant.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery_variant.pure
@@ -1048,6 +1048,23 @@ function meta::relational::functions::pureToSqlQuery::extractExplodeSemiStructur
     ]);
 }
 
+// Innermost first, so index 0 is the explode whose input must be a column and each later entry
+// fans out an array held inside the elements the previous one produced.
+function meta::relational::functions::pureToSqlQuery::explodeSemiStructuredChain(op: DynaFunction[1]):DynaFunction[*]
+{
+  let inner = $op.parameters->at(0);
+  if($inner->instanceOf(DynaFunction) && $inner->cast(@DynaFunction).name == meta::relational::functions::sqlQueryToString::DynaFunctionRegistry.explodeSemiStructured.name,
+     | $inner->cast(@DynaFunction)->explodeSemiStructuredChain()->concatenate($op),
+     | $op);
+}
+
+function meta::relational::functions::pureToSqlQuery::buildSemiStructuredNavigationForExplode(path: String[1], operand: RelationalOperationElement[1]):RelationalOperationElement[1]
+{
+  let pathNavigation = meta::relational::functions::sqlQueryToString::parseSemiStructuredPathNavigation($path);
+  let initialNavigation = if($pathNavigation->at(0)->isDigit(), | ^SemiStructuredArrayElementAccess(operand=$operand,index=^Literal(value = $pathNavigation->at(0))), |  ^SemiStructuredPropertyAccess(property=^Literal(value = $pathNavigation->at(0)->substring(1, $pathNavigation->at(0)->length()-1)), operand=$operand));
+  $pathNavigation->slice(1, $pathNavigation->size())->fold({property, navigation | if($property->isDigit(), | ^SemiStructuredArrayElementAccess(operand=$navigation,index=^Literal(value = $property)), |  ^SemiStructuredPropertyAccess(property=^Literal(value = $property->substring(1, $property->length()-1)), operand=$navigation)) }, $initialNavigation);
+}
+
 function meta::relational::functions::pureToSqlQuery::explodeReturnType(typeName:String[1]):Type[0..1]
 {
     let map = meta::relational::functions::database::sqlTextToRelationalDataTypeMap();

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/tests/semistructured/model/nestedExplodeSemiStructured.legend
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/tests/semistructured/model/nestedExplodeSemiStructured.legend
@@ -1,0 +1,84 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the 'License');
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+Class nested::model::Firm
+{
+  id: Integer[1];
+  teams: nested::model::Team[*];
+}
+
+Class nested::model::Team
+{
+  tid: String[1];
+  label: String[1];
+}
+
+function nested::nestedExplode():TabularDataSet[1]
+{
+    nested::model::Firm.all()->project([x|$x.id, x|$x.teams.tid, x|$x.teams.label],
+                                       ['Id', 'Team Id', 'Label']);
+}
+
+###Relational
+Database nested::store::DB
+(
+  Schema NESTED_SCHEMA
+  (
+    Table FIRM_TABLE
+    (
+      ID INTEGER PRIMARY KEY,
+      FIRM_DETAILS SEMISTRUCTURED
+    )
+    Table TEAM_TABLE
+    (
+      TID VARCHAR(100) PRIMARY KEY,
+      LABEL VARCHAR(100)
+    )
+  )
+
+  // One row per (division, team): the outer explode fans out divisions, the inner one fans out
+  // the teams held inside each division.
+  Join Firm_Team(extractFromSemiStructured(
+                   explodeSemiStructured(
+                     explodeSemiStructured(NESTED_SCHEMA.FIRM_TABLE.FIRM_DETAILS, 'divisions', 'SEMISTRUCTURED'),
+                     'teams', 'SEMISTRUCTURED'),
+                   'tid', 'VARCHAR') = NESTED_SCHEMA.TEAM_TABLE.TID)
+)
+
+###Mapping
+Mapping nested::mapping::Mapping
+(
+  nested::model::Firm: Relational
+  {
+    ~primaryKey
+    (
+      [nested::store::DB]NESTED_SCHEMA.FIRM_TABLE.ID
+    )
+    ~mainTable [nested::store::DB]NESTED_SCHEMA.FIRM_TABLE
+    id: [nested::store::DB]NESTED_SCHEMA.FIRM_TABLE.ID,
+    teams: [nested::store::DB]@Firm_Team
+  }
+
+  nested::model::Team: Relational
+  {
+    ~primaryKey
+    (
+      [nested::store::DB]NESTED_SCHEMA.TEAM_TABLE.TID
+    )
+    ~mainTable [nested::store::DB]NESTED_SCHEMA.TEAM_TABLE
+    tid: [nested::store::DB]NESTED_SCHEMA.TEAM_TABLE.TID,
+    label: [nested::store::DB]NESTED_SCHEMA.TEAM_TABLE.LABEL
+  }
+)

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/tests/semistructured/testNestedExplodeSemiStructured.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/tests/semistructured/testNestedExplodeSemiStructured.pure
@@ -1,0 +1,65 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the 'License');
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::relational::tests::semistructured::nested::*;
+import meta::pure::test::*;
+import meta::relational::metamodel::*;
+import meta::core::runtime::*;
+import meta::pure::mapping::*;
+
+// Firm 1's teams are spread across two divisions, so an implementation that fans out only the
+// outer array loses t3 rather than erroring. Firm 2 holds two teams in a single division, and
+// firm 3 has a division with no teams at all.
+function meta::relational::tests::semistructured::nested::nestedExecute(conn: Connection[1], func: String[1], expected: String[1]):Boolean[1]
+{
+  let firms =
+        'NESTED_SCHEMA\n' +
+        'FIRM_TABLE\n' +
+        'ID,FIRM_DETAILS\n' +
+        '1,"{""divisions"": [{""name"": ""Alpha"", ""teams"": [{""tid"": ""t1""}, {""tid"": ""t2""}]}, {""name"": ""Beta"", ""teams"": [{""tid"": ""t3""}]}]}"\n' +
+        '2,"{""divisions"": [{""name"": ""Gamma"", ""teams"": [{""tid"": ""t4""}, {""tid"": ""t5""}]}]}"\n' +
+        '3,"{""divisions"": [{""name"": ""Delta"", ""teams"": []}]}"\n'
+        ;
+
+  let teams =
+        'NESTED_SCHEMA\n' +
+        'TEAM_TABLE\n' +
+        'TID,LABEL\n' +
+        't1,Core\n' +
+        't2,Edge\n' +
+        't3,Ops\n' +
+        't4,Risk\n' +
+        't5,Data\n'
+        ;
+
+  let model = '/core_relational/relational/tests/semistructured/model/nestedExplodeSemiStructured.legend';
+
+  meta::relational::metamodel::execute::tests::executeLegendFunction($conn, [$firms, $teams], $model, $func, 'nested::mapping::Mapping', 'nested::store::DB', $expected);
+}
+
+function <<paramTest.Test>> meta::relational::tests::semistructured::nested::testNestedExplode(conn: Connection[1]):Boolean[1]
+{
+  nestedExecute($conn,
+    'nested::nestedExplode__TabularDataSet_1_',
+    'Id,Team Id,Label\n' +
+    '1,t1,Core\n' +
+    '1,t2,Edge\n' +
+    '1,t3,Ops\n' +
+    '2,t4,Risk\n' +
+    '2,t5,Data\n' +
+    // Firm 3's only division holds an empty team list, so the inner lateral yields nothing and
+    // the left join back to the source keeps the firm with nulls rather than dropping it.
+    '3,null,null\n'
+  );
+}


### PR DESCRIPTION
Stacked on #5097 — base is `duckdb-semistructured-support`, so this diff shows only the nested-explode change. It will retarget to `master` automatically when #5097 merges.

## What this enables

A document that holds an array inside each element of another array can now produce a row per combination:

```
Join Firm_Team(extractFromSemiStructured(
                 explodeSemiStructured(
                   explodeSemiStructured(FIRM_TABLE.FIRM_DETAILS, 'divisions', 'SEMISTRUCTURED'),
                   'teams', 'SEMISTRUCTURED'),
                 'tid', 'VARCHAR') = TEAM_TABLE.TID)
```

The path argument already walked several levels, so the gap was never deeper *navigation* — it was a second *fan-out*.

## Why it was blocked, and by which guard

Two guards prevented this, for different reasons, and the wrong one fired first. `extractExplodeSemiStructured` recurses into parameters, so a nested pair counted as two calls and tripped the `only one unique explode allowed` assert — the **many-to-many** message — for a case the *other* guard's comment actually describes.

Nested calls are now recognised as one chain: only explodes not contained inside another are counted, so two genuinely independent explodes still raise exactly as before. The chain is then unwound to its base, which is where the plain-column requirement genuinely belongs.

## One lateral per level

Level 0 navigates from the re-rooted base column as before; each level above navigates from the `VALUE` the level below produced. They sit as **siblings under the root** rather than nested inside one another — chained laterals are sequential `FROM` items, and the correlation is carried by each join naming the previous alias.

No dialect code was needed: `SemiStructuredArrayFlatten` and lateral joins are already rendered by every target.

## The fixture is built to fail loudly

One firm's teams are spread across two divisions, so an implementation that fans out only the outer array **loses a row rather than erroring** — the failure a green count would otherwise hide. Another firm has a division with no teams: the inner lateral yields nothing and the left join back to the source keeps the firm with nulls, which is what a to-many with no values should do.

## Verification

| suite | result |
|---|---|
| DuckDB semi-structured | 155 / 155 |
| Snowflake semi-structured | 155 / 155 |
| Databricks semi-structured | 155 / 155 |
| H2 semi-structured | 155 / 155 (one skip) |
| `Test_Pure_Relational` | 2734 |

**H2 is skipped, and the reason is specific**: every single-level explode test passes there, but a second lateral over the first one's output returns nulls — silently, not as an error. Left failing per H2's retirement.

## Not addressed here

Two explodes over *different* columns in one join (many-to-many) still raise, and the operand of the innermost explode must still be a plain column in a table or view.
