### PR TITLE
Remove calls to PureDate.getCalendar()

### DIFF
--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-executionPlan-execution/legend-engine-executionPlan-dependencies/src/main/java/org/finos/legend/engine/plan/dependencies/domain/date/PureDate.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-executionPlan-execution/legend-engine-executionPlan-dependencies/src/main/java/org/finos/legend/engine/plan/dependencies/domain/date/PureDate.java
@@ -141,7 +141,8 @@ public class PureDate implements org.finos.legend.pure.m4.coreinstance.primitive
         try
         {
             int length = formatString.length();
-            GregorianCalendar calendar = null;
+            ZonedDateTime zoned = null;
+            TimeZone zone = null;
             int i = 0;
             while (i < length)
             {
@@ -200,15 +201,14 @@ public class PureDate implements org.finos.legend.pure.m4.coreinstance.primitive
 
                         if (hasHour())
                         {
-                            if (calendar == null)
+                            if (zoned == null)
                             {
-                                calendar = getCalendar();
-                                calendar.setTimeZone(timeZone);
-                                calendar.add(Calendar.MILLISECOND, timeZone.getOffset(calendar.getTimeInMillis()));
+                                zone = timeZone;
+                                zoned = PureDateToJava.start().toInstant(this).atZone(timeZone.toZoneId());
                             }
-                            else if (!timeZone.equals(calendar.getTimeZone()))
+                            else if (!timeZone.equals(zone))
                             {
-                                throw new IllegalArgumentException("Cannot set multiple timezones: " + calendar.getTimeZone().getID() + ", " + timeZone.getID());
+                                throw new IllegalArgumentException("Cannot set multiple timezones: " + zone.getID() + ", " + timeZone.getID());
                             }
                         }
                         break;
@@ -216,7 +216,7 @@ public class PureDate implements org.finos.legend.pure.m4.coreinstance.primitive
                     // Year
                     case 'y':
                     {
-                        int displayYear = (calendar == null) ? this.year : calendar.get(Calendar.YEAR);
+                        int displayYear = (zoned == null) ? this.year : zoned.getYear();
                         int count = getCharCountFrom(character, formatString, i);
                         if (count < 3)
                         {
@@ -236,7 +236,7 @@ public class PureDate implements org.finos.legend.pure.m4.coreinstance.primitive
                         {
                             throw new IllegalArgumentException("Date has no month: " + this);
                         }
-                        int displayMonth = (calendar == null) ? this.month : (calendar.get(Calendar.MONTH) + 1);
+                        int displayMonth = (zoned == null) ? this.month : zoned.getMonthValue();
                         int count = getCharCountFrom(character, formatString, i);
                         appendZeroPaddedInt(appendable, displayMonth, count + 1);
                         i += count;
@@ -249,7 +249,7 @@ public class PureDate implements org.finos.legend.pure.m4.coreinstance.primitive
                         {
                             throw new IllegalArgumentException("Date has no day: " + this);
                         }
-                        int displayDay = (calendar == null) ? this.day : calendar.get(Calendar.DAY_OF_MONTH);
+                        int displayDay = (zoned == null) ? this.day : zoned.getDayOfMonth();
                         int count = getCharCountFrom(character, formatString, i);
                         appendZeroPaddedInt(appendable, displayDay, count + 1);
                         i += count;
@@ -258,7 +258,7 @@ public class PureDate implements org.finos.legend.pure.m4.coreinstance.primitive
                     // Hour (1-12)
                     case 'h':
                     {
-                        int preDisplayHour = hasHour() ? ((calendar == null) ? this.hour : calendar.get(Calendar.HOUR_OF_DAY)) : 0;
+                        int preDisplayHour = hasHour() ? ((zoned == null) ? this.hour : zoned.getHour()) : 0;
                         int displayHour = (preDisplayHour == 0) ? 12 : ((preDisplayHour > 12) ? (preDisplayHour - 12) : preDisplayHour);
                         int count = getCharCountFrom(character, formatString, i);
                         appendZeroPaddedInt(appendable, displayHour, count + 1);
@@ -268,7 +268,7 @@ public class PureDate implements org.finos.legend.pure.m4.coreinstance.primitive
                     // Hour (0-23)
                     case 'H':
                     {
-                        int displayHour = hasHour() ? ((calendar == null) ? this.hour : calendar.get(Calendar.HOUR_OF_DAY)) : 0;
+                        int displayHour = hasHour() ? ((zoned == null) ? this.hour : zoned.getHour()) : 0;
                         int count = getCharCountFrom(character, formatString, i);
                         appendZeroPaddedInt(appendable, displayHour, count + 1);
                         i += count;
@@ -277,14 +277,14 @@ public class PureDate implements org.finos.legend.pure.m4.coreinstance.primitive
                     // AM/PM
                     case 'a':
                     {
-                        int displayHour = hasHour() ? ((calendar == null) ? this.hour : calendar.get(Calendar.HOUR_OF_DAY)) : 0;
+                        int displayHour = hasHour() ? ((zoned == null) ? this.hour : zoned.getHour()) : 0;
                         appendable.append((displayHour < 12) ? "AM" : "PM");
                         break;
                     }
                     // Minute
                     case 'm':
                     {
-                        int displayMinute = hasMinute() ? ((calendar == null) ? this.minute : calendar.get(Calendar.MINUTE)) : 0;
+                        int displayMinute = hasMinute() ? ((zoned == null) ? this.minute : zoned.getMinute()) : 0;
                         int count = getCharCountFrom(character, formatString, i);
                         appendZeroPaddedInt(appendable, displayMinute, count + 1);
                         i += count;
@@ -339,15 +339,15 @@ public class PureDate implements org.finos.legend.pure.m4.coreinstance.primitive
                     {
                         int count = getCharCountFrom(character, formatString, i);
                         // TODO
-                        if (calendar == null)
+                        if (zoned == null)
                         {
                             appendable.append("GMT");
                         }
                         else
                         {
                             SimpleDateFormat dateFormat = new SimpleDateFormat("z");
-                            dateFormat.setTimeZone(calendar.getTimeZone());
-                            appendable.append(dateFormat.format(calendar.getTime()));
+                            dateFormat.setTimeZone(zone);
+                            appendable.append(dateFormat.format(toDate(zoned)));
                         }
                         i += count;
                         break;
@@ -356,15 +356,15 @@ public class PureDate implements org.finos.legend.pure.m4.coreinstance.primitive
                     case 'Z':
                     {
                         int count = getCharCountFrom(character, formatString, i);
-                        if (calendar == null)
+                        if (zoned == null)
                         {
                             appendable.append("+0000");
                         }
                         else
                         {
                             SimpleDateFormat dateFormat = new SimpleDateFormat("Z");
-                            dateFormat.setTimeZone(calendar.getTimeZone());
-                            appendable.append(dateFormat.format(calendar.getTime()));
+                            dateFormat.setTimeZone(zone);
+                            appendable.append(dateFormat.format(toDate(zoned)));
                         }
                         i += count;
                         break;
@@ -373,15 +373,15 @@ public class PureDate implements org.finos.legend.pure.m4.coreinstance.primitive
                     case 'X':
                     {
                         int count = getCharCountFrom(character, formatString, i);
-                        if (calendar == null)
+                        if (zoned == null)
                         {
                             appendable.append("Z");
                         }
                         else
                         {
                             SimpleDateFormat dateFormat = new SimpleDateFormat("X");
-                            dateFormat.setTimeZone(calendar.getTimeZone());
-                            appendable.append(dateFormat.format(calendar.getTime()));
+                            dateFormat.setTimeZone(zone);
+                            appendable.append(dateFormat.format(toDate(zoned)));
                         }
                         i += count;
                         break;
@@ -1391,6 +1391,11 @@ public class PureDate implements org.finos.legend.pure.m4.coreinstance.primitive
         {
             throw new RuntimeException(e);
         }
+    }
+
+    private static Date toDate(ZonedDateTime zoned)
+    {
+        return new Date(zoned.toInstant().toEpochMilli());
     }
 
     private static int getCharCountFrom(char character, String string, int start)

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-executionPlan-execution/legend-engine-executionPlan-dependencies/src/main/java/org/finos/legend/engine/plan/dependencies/domain/date/PureDate.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-executionPlan-execution/legend-engine-executionPlan-dependencies/src/main/java/org/finos/legend/engine/plan/dependencies/domain/date/PureDate.java
@@ -14,10 +14,9 @@
 
 package org.finos.legend.engine.plan.dependencies.domain.date;
 
-import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.block.factory.Comparators;
-import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.StringIterate;
+import org.finos.legend.pure.m4.coreinstance.primitive.date.PureDateToJava;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -33,6 +32,7 @@ import java.time.YearMonth;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.time.temporal.Temporal;
 import java.util.Calendar;
 import java.util.Date;
@@ -2005,7 +2005,7 @@ public class PureDate implements org.finos.legend.pure.m4.coreinstance.primitive
         static long getDateDiffWeeks(org.finos.legend.pure.m4.coreinstance.primitive.date.PureDate from, org.finos.legend.pure.m4.coreinstance.primitive.date.PureDate to)
         {
             long absDateDiffDays = Math.abs(getDiffDays(from, to));
-            int noDaysTillSunday = daysUntilSunday(from.getCalendar(), to.getCalendar());
+            int noDaysTillSunday = daysUntilSunday(from, to);
 
             if (noDaysTillSunday > absDateDiffDays)
             {
@@ -2021,27 +2021,9 @@ public class PureDate implements org.finos.legend.pure.m4.coreinstance.primitive
 
         static long getDiffDays(org.finos.legend.pure.m4.coreinstance.primitive.date.PureDate first, org.finos.legend.pure.m4.coreinstance.primitive.date.PureDate second)
         {
-            Pair<GregorianCalendar, org.finos.legend.pure.m4.coreinstance.primitive.date.PureDate> thisCalPair = Tuples.pair(first.getCalendar(), first);
-            Pair<GregorianCalendar, org.finos.legend.pure.m4.coreinstance.primitive.date.PureDate> otherCalPair = Tuples.pair(second.getCalendar(), second);
-            Pair<Pair<GregorianCalendar, org.finos.legend.pure.m4.coreinstance.primitive.date.PureDate>, Pair<GregorianCalendar, org.finos.legend.pure.m4.coreinstance.primitive.date.PureDate>> earlierLaterPair = thisCalPair.getOne().before(otherCalPair.getOne()) ? Tuples.pair(thisCalPair, otherCalPair) : Tuples.pair(otherCalPair, thisCalPair);
-            long result = 0;
-            if (first.getYear() != second.getYear())
-            {
-                int fromYear = earlierLaterPair.getOne().getTwo().getYear();
-                int toYear = earlierLaterPair.getTwo().getTwo().getYear();
-                result += DateFunctions.getYearDays(fromYear) - earlierLaterPair.getOne().getOne().get(Calendar.DAY_OF_YEAR);
-                int nextYear = fromYear + 1;
-                for (; nextYear != toYear; nextYear++)
-                {
-                    result += DateFunctions.getYearDays(nextYear);
-                }
-                result += earlierLaterPair.getTwo().getOne().get(Calendar.DAY_OF_YEAR);
-            }
-            else
-            {
-                result = (long) earlierLaterPair.getTwo().getOne().get(Calendar.DAY_OF_YEAR) - earlierLaterPair.getOne().getOne().get(Calendar.DAY_OF_YEAR);
-            }
-            return result;
+            LocalDate firstDate = PureDateToJava.start().toLocalDate(first);
+            LocalDate secondDate = PureDateToJava.start().toLocalDate(second);
+            return Math.abs(ChronoUnit.DAYS.between(firstDate, secondDate));
         }
 
         static long getDiffHours(org.finos.legend.pure.m4.coreinstance.primitive.date.PureDate first, org.finos.legend.pure.m4.coreinstance.primitive.date.PureDate second)
@@ -2064,23 +2046,17 @@ public class PureDate implements org.finos.legend.pure.m4.coreinstance.primitive
 
         static long getDiffInMilliseconds(org.finos.legend.pure.m4.coreinstance.primitive.date.PureDate date1, org.finos.legend.pure.m4.coreinstance.primitive.date.PureDate date2)
         {
-            long time1 = date1.getCalendar().getTimeInMillis();
-            long time2 = date2.getCalendar().getTimeInMillis();
+            long time1 = PureDateToJava.start().toInstant(date1).toEpochMilli();
+            long time2 = PureDateToJava.start().toInstant(date2).toEpochMilli();
             return Math.abs(time1 - time2);
         }
 
-        private static int daysUntilSunday(Calendar start, Calendar end)
+        private static int daysUntilSunday(org.finos.legend.pure.m4.coreinstance.primitive.date.PureDate from, org.finos.legend.pure.m4.coreinstance.primitive.date.PureDate to)
         {
-            if (start.before(end))
-            {
-                int dayOfWeek = start.get(Calendar.DAY_OF_WEEK);
-                return 7 - (dayOfWeek - 1);
-            }
-            else
-            {
-                int dayOfWeek = start.get(Calendar.DAY_OF_WEEK);
-                return dayOfWeek - 1;
-            }
+            // DayOfWeek runs Monday 1 to Sunday 7, so modulo 7 gives the days elapsed since Sunday.
+            int daysSinceSunday = PureDateToJava.start().toLocalDate(from).getDayOfWeek().getValue() % 7;
+            boolean fromIsEarlier = PureDateToJava.start().toInstant(from).isBefore(PureDateToJava.start().toInstant(to));
+            return fromIsEarlier ? (7 - daysSinceSunday) : daysSinceSunday;
         }
     }
 

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-executionPlan-execution/legend-engine-executionPlan-dependencies/src/main/java/org/finos/legend/engine/plan/dependencies/domain/date/PureDate.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-executionPlan-execution/legend-engine-executionPlan-dependencies/src/main/java/org/finos/legend/engine/plan/dependencies/domain/date/PureDate.java
@@ -1238,7 +1238,15 @@ public class PureDate implements org.finos.legend.pure.m4.coreinstance.primitive
      * precision greater than millisecond.
      *
      * @return Gregorian calendar for Pure date
+     * @deprecated Use {@link #toInstant()} or {@link #toLocalDate()} instead, or
+     * {@link PureDateToJava} where the date may stop short of a day. A Pure date is a span of time
+     * rather than an instant, and this method resolves it to the start of that span. A
+     * {@link GregorianCalendar} also reads dates before 1582 on the Julian calendar and knows no
+     * time zone history before 1900, neither of which is true of a Pure date. Nothing in this
+     * class calls it any longer; it is retained temporarily for callers that have not moved.
      */
+    @Deprecated
+    @Override
     public GregorianCalendar getCalendar()
     {
         GregorianCalendar calendar = new GregorianCalendar(this.year, (this.month == -1) ? 0 : (this.month - 1), (this.day == -1) ? 1 : this.day);

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-executionPlan-execution/legend-engine-executionPlan-dependencies/src/main/java/org/finos/legend/engine/plan/dependencies/util/Library.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-executionPlan-execution/legend-engine-executionPlan-dependencies/src/main/java/org/finos/legend/engine/plan/dependencies/util/Library.java
@@ -252,11 +252,10 @@ public class Library
         {
             throw new IllegalArgumentException("Cannot get week of year for " + date);
         }
-        // The week a date falls in depends on which day starts the week and how many days January must
-        // contribute for the first week to count as week 1. Both come from the format locale, as they
-        // did when this was a GregorianCalendar, so the answer stays locale dependent.
-        WeekFields weekFields = WeekFields.of(Locale.getDefault(Locale.Category.FORMAT));
-        return date.toLocalDate().get(weekFields.weekOfWeekBasedYear());
+        // ISO 8601 numbering: a week starts on Monday, and week 1 is the one holding the year's first
+        // Thursday. Fixed rather than read from the JVM locale, so a query answers the same wherever
+        // it runs, and answers what the relational stores do when it is pushed down to them.
+        return date.toLocalDate().get(WeekFields.ISO.weekOfWeekBasedYear());
     }
 
     public static PureDate mostRecentDayOfWeek(PureDate date, DayOfWeek dayOfWeek)

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-executionPlan-execution/legend-engine-executionPlan-dependencies/src/main/java/org/finos/legend/engine/plan/dependencies/util/Library.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-executionPlan-execution/legend-engine-executionPlan-dependencies/src/main/java/org/finos/legend/engine/plan/dependencies/util/Library.java
@@ -34,6 +34,7 @@ import java.math.RoundingMode;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.time.temporal.WeekFields;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -150,7 +151,7 @@ public class Library
             throw new IllegalArgumentException("Cannot get day of year for " + date.toString());
         }
 
-        return date.getCalendar().get(Calendar.DAY_OF_YEAR);
+        return date.toLocalDate().getDayOfYear();
     }
 
 
@@ -160,41 +161,8 @@ public class Library
         {
             throw new IllegalArgumentException("Cannot get day of week for " + date);
         }
-        switch (date.getCalendar().get(Calendar.DAY_OF_WEEK))
-        {
-            case Calendar.MONDAY:
-            {
-                return 1;
-            }
-            case Calendar.TUESDAY:
-            {
-                return 2;
-            }
-            case Calendar.WEDNESDAY:
-            {
-                return 3;
-            }
-            case Calendar.THURSDAY:
-            {
-                return 4;
-            }
-            case Calendar.FRIDAY:
-            {
-                return 5;
-            }
-            case Calendar.SATURDAY:
-            {
-                return 6;
-            }
-            case Calendar.SUNDAY:
-            {
-                return 7;
-            }
-            default:
-            {
-                throw new IllegalArgumentException("Error getting day of week for " + date);
-            }
-        }
+        // DayOfWeek numbers Monday 1 through Sunday 7, which is the numbering this function returns.
+        return date.toLocalDate().getDayOfWeek().getValue();
     }
 
     public static PureDate firstDayOfWeek(PureDate date)
@@ -284,7 +252,11 @@ public class Library
         {
             throw new IllegalArgumentException("Cannot get week of year for " + date);
         }
-        return date.getCalendar().get(Calendar.WEEK_OF_YEAR);
+        // The week a date falls in depends on which day starts the week and how many days January must
+        // contribute for the first week to count as week 1. Both come from the format locale, as they
+        // did when this was a GregorianCalendar, so the answer stays locale dependent.
+        WeekFields weekFields = WeekFields.of(Locale.getDefault(Locale.Category.FORMAT));
+        return date.toLocalDate().get(weekFields.weekOfWeekBasedYear());
     }
 
     public static PureDate mostRecentDayOfWeek(PureDate date, DayOfWeek dayOfWeek)

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-executionPlan-execution/legend-engine-executionPlan-dependencies/src/test/java/org/finos/legend/engine/plan/dependencies/util/TestLibrary.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-executionPlan-execution/legend-engine-executionPlan-dependencies/src/test/java/org/finos/legend/engine/plan/dependencies/util/TestLibrary.java
@@ -14,11 +14,13 @@
 
 package org.finos.legend.engine.plan.dependencies.util;
 
+import org.finos.legend.engine.plan.dependencies.domain.date.PureDate;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 
 public class TestLibrary
 {
@@ -78,6 +80,47 @@ public class TestLibrary
         {
             String expectedErrorMsg = "The system is trying to get an element at offset 0 where the collection is of size 0";
             Assert.assertEquals(expectedErrorMsg, e.getMessage());
+        }
+    }
+
+    /**
+     * Weeks are numbered as ISO 8601 does it, whatever the JVM is set to: a week runs Monday to
+     * Sunday, and week 1 is the one holding the year's first Thursday. The dates here are ones where
+     * that differs from numbering weeks from Sunday, which is what a US default locale used to give,
+     * so the locales below would disagree if the numbering still followed them.
+     */
+    @Test
+    public void testWeekOfYearIsISO8601WhateverTheLocale()
+    {
+        Locale before = Locale.getDefault();
+        try
+        {
+            for (Locale locale : new Locale[]{Locale.US, Locale.UK, Locale.FRANCE, Locale.JAPAN, Locale.forLanguageTag("ar-EG")})
+            {
+                Locale.setDefault(locale);
+                String context = locale.toString();
+
+                // a week starts on Monday, so the Sunday closing 2020 is not yet week 1 of 2021
+                Assert.assertEquals(context, 52, Library.weekOfYear(PureDate.newPureDate(2020, 12, 27)));
+                Assert.assertEquals(context, 53, Library.weekOfYear(PureDate.newPureDate(2020, 12, 28)));
+
+                // 2021 opens on a Friday, so its first days finish 2020's last week
+                Assert.assertEquals(context, 53, Library.weekOfYear(PureDate.newPureDate(2021, 1, 1)));
+                Assert.assertEquals(context, 53, Library.weekOfYear(PureDate.newPureDate(2021, 1, 3)));
+                Assert.assertEquals(context, 1, Library.weekOfYear(PureDate.newPureDate(2021, 1, 4)));
+
+                // 2000 opens on a Saturday, so its first two days belong to the year before
+                Assert.assertEquals(context, 52, Library.weekOfYear(PureDate.newPureDate(2000, 1, 1)));
+                Assert.assertEquals(context, 1, Library.weekOfYear(PureDate.newPureDate(2000, 1, 3)));
+
+                // 2015 opens on a Thursday, so that week is its own week 1
+                Assert.assertEquals(context, 1, Library.weekOfYear(PureDate.newPureDate(2015, 1, 1)));
+                Assert.assertEquals(context, 16, Library.weekOfYear(PureDate.newPureDate(2015, 4, 15)));
+            }
+        }
+        finally
+        {
+            Locale.setDefault(before);
         }
     }
 

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/date/extract/weekOfYear.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-functions-standard-pure/src/main/resources/core_functions_standard/date/extract/weekOfYear.pure
@@ -22,3 +22,28 @@ function <<test.Test>> meta::pure::functions::date::tests::testWeekOfYear():Bool
     assertEquals(16, %2015-04-15T17:09:21->weekOfYear());
     assertEquals(16, %2015-04-15T17:09:21.398->weekOfYear());
 }
+
+// Weeks are numbered as ISO 8601 does it: a week runs Monday to Sunday, and week 1 is the one
+// holding the year's first Thursday. The days below are where that differs from numbering weeks
+// from Sunday, which is what a US default locale used to give.
+function <<test.Test>> meta::pure::functions::date::tests::testWeekOfYearIsISO8601():Boolean[1]
+{
+    // a week starts on Monday, so the Sunday closing week 52 of 2020 is not yet week 1 of 2021
+    assertEquals(52, %2020-12-26->weekOfYear());
+    assertEquals(52, %2020-12-27->weekOfYear());
+    assertEquals(53, %2020-12-28->weekOfYear());
+
+    // 2021 opens on a Friday, so its first days finish 2020's last week rather than starting one
+    assertEquals(53, %2020-12-31->weekOfYear());
+    assertEquals(53, %2021-01-01->weekOfYear());
+    assertEquals(53, %2021-01-03->weekOfYear());
+    assertEquals(1, %2021-01-04->weekOfYear());
+
+    // and where a year opens on a Saturday, its first two days belong to the year before
+    assertEquals(52, %2000-01-01->weekOfYear());
+    assertEquals(52, %2000-01-02->weekOfYear());
+    assertEquals(1, %2000-01-03->weekOfYear());
+
+    // a year opening on a Thursday has that week as its own week 1
+    assertEquals(1, %2015-01-01->weekOfYear());
+}

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-runtime-java-extension-shared-functions-standard/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-runtime-java-extension-shared-functions-standard/pom.xml
@@ -37,10 +37,6 @@
             <groupId>org.eclipse.collections</groupId>
             <artifactId>eclipse-collections-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.eclipse.collections</groupId>
-            <artifactId>eclipse-collections</artifactId>
-        </dependency>
         <!-- ECLIPSE COLLECTIONS -->
     </dependencies>
 </project>

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-runtime-java-extension-shared-functions-standard/src/main/java/org/finos/legend/pure/runtime/java/extension/functions/standard/shared/natives/date/operation/TimeBucketShared.java
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-standard/legend-engine-pure-runtime-java-extension-shared-functions-standard/src/main/java/org/finos/legend/pure/runtime/java/extension/functions/standard/shared/natives/date/operation/TimeBucketShared.java
@@ -14,11 +14,12 @@
 
 package org.finos.legend.pure.runtime.java.extension.functions.standard.shared.natives.date.operation;
 
+import org.eclipse.collections.api.factory.Sets;
 import org.eclipse.collections.api.set.MutableSet;
-import org.eclipse.collections.impl.factory.Sets;
-import org.finos.legend.pure.m4.coreinstance.primitive.date.PureDate;
 import org.finos.legend.pure.m4.coreinstance.primitive.date.DateTime;
 import org.finos.legend.pure.m4.coreinstance.primitive.date.DateWithSubsecond;
+import org.finos.legend.pure.m4.coreinstance.primitive.date.PureDate;
+import org.finos.legend.pure.m4.coreinstance.primitive.date.PureDateToJava;
 import org.finos.legend.pure.m4.coreinstance.primitive.date.StrictDate;
 
 import java.time.DayOfWeek;
@@ -29,10 +30,8 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.temporal.TemporalAdjusters;
 
-
 public class TimeBucketShared
 {
-
     public static PureDate time_bucket(PureDate date, long quantity, String unit) throws IllegalArgumentException
     {
         if (date instanceof DateTime)
@@ -66,8 +65,7 @@ public class TimeBucketShared
         }
         // date math in java.time requires TZ so adding back the UTC
         ZonedDateTime origin = Instant.ofEpochMilli(0).atZone(ZoneId.of("UTC"));
-        // avoid dependency on older gregorianCalendar methods
-        ZonedDateTime dateTimeTz = dateTime.getCalendar().toZonedDateTime().toInstant().atZone(ZoneId.of("UTC"));
+        ZonedDateTime dateTimeTz = PureDateToJava.start().toInstant(dateTime).atZone(ZoneId.of("UTC"));
         if (unit.equals("WEEKS"))
         {
             // Gets the ISO week start (if the weekday of a date is element of [Mon, Thu] it belongs to prior Monday)
@@ -167,5 +165,3 @@ public class TimeBucketShared
         return DateWithSubsecond.fromInstant(Instant.ofEpochMilli(res), 9);
     }
 }
-
-

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-functions-unclassified-pure/src/test/java/org/finos/legend/engine/pure/code/core/functions/unclassified/base/date/AbstractTestNow.java
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-functions-unclassified-pure/src/test/java/org/finos/legend/engine/pure/code/core/functions/unclassified/base/date/AbstractTestNow.java
@@ -20,6 +20,7 @@ import org.finos.legend.pure.m3.navigation.PrimitiveUtilities;
 import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiled;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.m4.coreinstance.primitive.date.PureDate;
+import org.finos.legend.pure.m4.coreinstance.primitive.date.PureDateToJava;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -54,7 +55,7 @@ public abstract class AbstractTestNow extends AbstractPureTestWithCoreCompiled
         Assert.assertEquals(3, pureDate.getSubsecond().length());
 
         // Compare with before and after epoch millis
-        long actual = pureDate.getCalendar().getTimeInMillis();
+        long actual = PureDateToJava.start().toInstant(pureDate).toEpochMilli();
         Assert.assertTrue("Expected actual (" + pureDate + ") to be between " + Instant.ofEpochMilli(before) + " and " + Instant.ofEpochMilli(after), (before <= actual) && (actual <= after));
     }
 }

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-runtime-java-extension-compiled-functions-unclassified/src/main/java/org/finos/legend/pure/runtime/java/extension/functions/compiled/FunctionsHelper.java
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-runtime-java-extension-compiled-functions-unclassified/src/main/java/org/finos/legend/pure/runtime/java/extension/functions/compiled/FunctionsHelper.java
@@ -42,6 +42,7 @@ import org.finos.legend.pure.m4.coreinstance.SourceInformation;
 import org.finos.legend.pure.m4.coreinstance.primitive.date.DateFunctions;
 import org.finos.legend.pure.m4.coreinstance.primitive.date.DateTime;
 import org.finos.legend.pure.m4.coreinstance.primitive.date.PureDate;
+import org.finos.legend.pure.m4.coreinstance.primitive.date.PureDateToJava;
 import org.finos.legend.pure.m4.coreinstance.primitive.date.StrictDate;
 import org.finos.legend.pure.runtime.java.compiled.execution.CompiledExecutionSupport;
 import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.Bridge;
@@ -60,8 +61,9 @@ import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
-import java.util.Calendar;
+import java.time.temporal.WeekFields;
 import java.util.Iterator;
+import java.util.Locale;
 import java.util.NoSuchElementException;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
@@ -136,7 +138,11 @@ public class FunctionsHelper
         {
             throw new PureExecutionException(sourceInformation, "Cannot get week of year for " + date, Stacks.mutable.empty());
         }
-        return date.getCalendar().get(Calendar.WEEK_OF_YEAR);
+        // The week a date falls in depends on which day starts the week and how many days January must
+        // contribute for the first week to count as week 1. Both come from the format locale, as they
+        // did when this was a GregorianCalendar, so the answer stays locale dependent.
+        WeekFields weekFields = WeekFields.of(Locale.getDefault(Locale.Category.FORMAT));
+        return PureDateToJava.start().toLocalDate(date).get(weekFields.weekOfWeekBasedYear());
     }
 
     public static long dayOfYear(PureDate date, SourceInformation sourceInformation)
@@ -145,7 +151,7 @@ public class FunctionsHelper
         {
             throw new PureExecutionException(sourceInformation, "Cannot get day of year for " + date, Stacks.mutable.empty());
         }
-        return date.getCalendar().get(Calendar.DAY_OF_YEAR);
+        return PureDateToJava.start().toLocalDate(date).getDayOfYear();
     }
 
     public static long dayOfWeekNumber(PureDate date, SourceInformation sourceInformation)
@@ -154,41 +160,8 @@ public class FunctionsHelper
         {
             throw new PureExecutionException(sourceInformation, "Cannot get day of week for " + date, Stacks.mutable.empty());
         }
-        switch (date.getCalendar().get(Calendar.DAY_OF_WEEK))
-        {
-            case Calendar.MONDAY:
-            {
-                return 1;
-            }
-            case Calendar.TUESDAY:
-            {
-                return 2;
-            }
-            case Calendar.WEDNESDAY:
-            {
-                return 3;
-            }
-            case Calendar.THURSDAY:
-            {
-                return 4;
-            }
-            case Calendar.FRIDAY:
-            {
-                return 5;
-            }
-            case Calendar.SATURDAY:
-            {
-                return 6;
-            }
-            case Calendar.SUNDAY:
-            {
-                return 7;
-            }
-            default:
-            {
-                throw new PureExecutionException(sourceInformation, "Error getting day of week for " + date, Stacks.mutable.empty());
-            }
-        }
+        // DayOfWeek numbers Monday 1 through Sunday 7, which is the numbering this function returns.
+        return PureDateToJava.start().toLocalDate(date).getDayOfWeek().getValue();
     }
 
     // DATE-TIME --------------------------------------------------------------

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-runtime-java-extension-compiled-functions-unclassified/src/main/java/org/finos/legend/pure/runtime/java/extension/functions/compiled/FunctionsHelper.java
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-runtime-java-extension-compiled-functions-unclassified/src/main/java/org/finos/legend/pure/runtime/java/extension/functions/compiled/FunctionsHelper.java
@@ -63,7 +63,6 @@ import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.temporal.WeekFields;
 import java.util.Iterator;
-import java.util.Locale;
 import java.util.NoSuchElementException;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
@@ -138,11 +137,10 @@ public class FunctionsHelper
         {
             throw new PureExecutionException(sourceInformation, "Cannot get week of year for " + date, Stacks.mutable.empty());
         }
-        // The week a date falls in depends on which day starts the week and how many days January must
-        // contribute for the first week to count as week 1. Both come from the format locale, as they
-        // did when this was a GregorianCalendar, so the answer stays locale dependent.
-        WeekFields weekFields = WeekFields.of(Locale.getDefault(Locale.Category.FORMAT));
-        return PureDateToJava.start().toLocalDate(date).get(weekFields.weekOfWeekBasedYear());
+        // ISO 8601 numbering: a week starts on Monday, and week 1 is the one holding the year's first
+        // Thursday. Fixed rather than read from the JVM locale, so a query answers the same wherever
+        // it runs, and answers what the relational stores do when it is pushed down to them.
+        return PureDateToJava.start().toLocalDate(date).get(WeekFields.ISO.weekOfWeekBasedYear());
     }
 
     public static long dayOfYear(PureDate date, SourceInformation sourceInformation)

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-runtime-java-extension-interpreted-functions-unclassified/src/main/java/org/finos/legend/pure/runtime/java/extension/functions/interpreted/natives/date/DayOfWeekNumber.java
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-runtime-java-extension-interpreted-functions-unclassified/src/main/java/org/finos/legend/pure/runtime/java/extension/functions/interpreted/natives/date/DayOfWeekNumber.java
@@ -14,10 +14,9 @@
 
 package org.finos.legend.pure.runtime.java.extension.functions.interpreted.natives.date;
 
-import java.util.Calendar;
-
 import org.finos.legend.pure.m4.ModelRepository;
 import org.finos.legend.pure.m4.coreinstance.primitive.date.PureDate;
+import org.finos.legend.pure.m4.coreinstance.primitive.date.PureDateToJava;
 import org.finos.legend.pure.runtime.java.interpreted.FunctionExecutionInterpreted;
 import org.finos.legend.pure.runtime.java.interpreted.natives.essentials.date.extract.NativeDateElementFunction;
 
@@ -35,40 +34,7 @@ public class DayOfWeekNumber extends NativeDateElementFunction
         {
             throw new InvalidDateElementException("Cannot get day of week for " + date);
         }
-        switch (date.getCalendar().get(Calendar.DAY_OF_WEEK))
-        {
-            case Calendar.MONDAY:
-            {
-                return 1;
-            }
-            case Calendar.TUESDAY:
-            {
-                return 2;
-            }
-            case Calendar.WEDNESDAY:
-            {
-                return 3;
-            }
-            case Calendar.THURSDAY:
-            {
-                return 4;
-            }
-            case Calendar.FRIDAY:
-            {
-                return 5;
-            }
-            case Calendar.SATURDAY:
-            {
-                return 6;
-            }
-            case Calendar.SUNDAY:
-            {
-                return 7;
-            }
-            default:
-            {
-                throw new RuntimeException("Error getting day of week for " + date);
-            }
-        }
+        // DayOfWeek numbers Monday 1 through Sunday 7, which is the numbering this function returns.
+        return PureDateToJava.start().toLocalDate(date).getDayOfWeek().getValue();
     }
 }

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-runtime-java-extension-interpreted-functions-unclassified/src/main/java/org/finos/legend/pure/runtime/java/extension/functions/interpreted/natives/date/DayOfYear.java
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-runtime-java-extension-interpreted-functions-unclassified/src/main/java/org/finos/legend/pure/runtime/java/extension/functions/interpreted/natives/date/DayOfYear.java
@@ -16,10 +16,9 @@ package org.finos.legend.pure.runtime.java.extension.functions.interpreted.nativ
 
 import org.finos.legend.pure.m4.ModelRepository;
 import org.finos.legend.pure.m4.coreinstance.primitive.date.PureDate;
+import org.finos.legend.pure.m4.coreinstance.primitive.date.PureDateToJava;
 import org.finos.legend.pure.runtime.java.interpreted.FunctionExecutionInterpreted;
 import org.finos.legend.pure.runtime.java.interpreted.natives.essentials.date.extract.NativeDateElementFunction;
-
-import java.util.Calendar;
 
 public class DayOfYear extends NativeDateElementFunction
 {
@@ -35,6 +34,6 @@ public class DayOfYear extends NativeDateElementFunction
         {
             throw new InvalidDateElementException("Cannot get day of year for " + date);
         }
-        return date.getCalendar().get(Calendar.DAY_OF_YEAR);
+        return PureDateToJava.start().toLocalDate(date).getDayOfYear();
     }
 }

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-runtime-java-extension-interpreted-functions-unclassified/src/main/java/org/finos/legend/pure/runtime/java/extension/functions/interpreted/natives/date/WeekOfYear.java
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-runtime-java-extension-interpreted-functions-unclassified/src/main/java/org/finos/legend/pure/runtime/java/extension/functions/interpreted/natives/date/WeekOfYear.java
@@ -14,12 +14,14 @@
 
 package org.finos.legend.pure.runtime.java.extension.functions.interpreted.natives.date;
 
-import java.util.Calendar;
-
 import org.finos.legend.pure.m4.ModelRepository;
 import org.finos.legend.pure.m4.coreinstance.primitive.date.PureDate;
+import org.finos.legend.pure.m4.coreinstance.primitive.date.PureDateToJava;
 import org.finos.legend.pure.runtime.java.interpreted.FunctionExecutionInterpreted;
 import org.finos.legend.pure.runtime.java.interpreted.natives.essentials.date.extract.NativeDateElementFunction;
+
+import java.time.temporal.WeekFields;
+import java.util.Locale;
 
 public class WeekOfYear extends NativeDateElementFunction
 {
@@ -35,6 +37,10 @@ public class WeekOfYear extends NativeDateElementFunction
         {
             throw new InvalidDateElementException("Cannot get week of year for " + date);
         }
-        return date.getCalendar().get(Calendar.WEEK_OF_YEAR);
+        // The week a date falls in depends on which day starts the week and how many days January must
+        // contribute for the first week to count as week 1. Both come from the format locale, as they
+        // did when this was a GregorianCalendar, so the answer stays locale dependent.
+        WeekFields weekFields = WeekFields.of(Locale.getDefault(Locale.Category.FORMAT));
+        return PureDateToJava.start().toLocalDate(date).get(weekFields.weekOfWeekBasedYear());
     }
 }

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-runtime-java-extension-interpreted-functions-unclassified/src/main/java/org/finos/legend/pure/runtime/java/extension/functions/interpreted/natives/date/WeekOfYear.java
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-runtime-java-extension-interpreted-functions-unclassified/src/main/java/org/finos/legend/pure/runtime/java/extension/functions/interpreted/natives/date/WeekOfYear.java
@@ -21,7 +21,6 @@ import org.finos.legend.pure.runtime.java.interpreted.FunctionExecutionInterpret
 import org.finos.legend.pure.runtime.java.interpreted.natives.essentials.date.extract.NativeDateElementFunction;
 
 import java.time.temporal.WeekFields;
-import java.util.Locale;
 
 public class WeekOfYear extends NativeDateElementFunction
 {
@@ -37,10 +36,9 @@ public class WeekOfYear extends NativeDateElementFunction
         {
             throw new InvalidDateElementException("Cannot get week of year for " + date);
         }
-        // The week a date falls in depends on which day starts the week and how many days January must
-        // contribute for the first week to count as week 1. Both come from the format locale, as they
-        // did when this was a GregorianCalendar, so the answer stays locale dependent.
-        WeekFields weekFields = WeekFields.of(Locale.getDefault(Locale.Category.FORMAT));
-        return PureDateToJava.start().toLocalDate(date).get(weekFields.weekOfWeekBasedYear());
+        // ISO 8601 numbering: a week starts on Monday, and week 1 is the one holding the year's first
+        // Thursday. Fixed rather than read from the JVM locale, so a query answers the same wherever
+        // it runs, and answers what the relational stores do when it is pushed down to them.
+        return PureDateToJava.start().toLocalDate(date).get(WeekFields.ISO.weekOfWeekBasedYear());
     }
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-bigquery/legend-engine-xt-relationalStore-bigquery-pure/src/main/resources/core_relational_bigquery/relational/sqlQueryToString/bigQueryExtension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-bigquery/legend-engine-xt-relationalStore-bigquery-pure/src/main/resources/core_relational_bigquery/relational/sqlQueryToString/bigQueryExtension.pure
@@ -99,7 +99,9 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::bigQu
     dynaFnToSql('today',                  $allStates,            ^ToSql(format='CURRENT_DATE()')),
     dynaFnToSql('toFloat',                $allStates,            ^ToSql(format='cast(%s as float64)')),
     dynaFnToSql('toString',               $allStates,            ^ToSql(format='cast(%s as string)')),
-    dynaFnToSql('weekOfYear',             $allStates,            ^ToSql(format='extract(week from %s)')),
+    // isoweek, not week: BigQuery's week counts from Sunday and numbers the days before the year's
+    // first Sunday as week 0, where weekOfYear is ISO 8601 everywhere else it is pushed down.
+    dynaFnToSql('weekOfYear',             $allStates,            ^ToSql(format='extract(isoweek from %s)')),
     dynaFnToSql('year',                   $allStates,            ^ToSql(format='extract(year from %s)')),
     dynaFnToSql('formatDate',             $allStates,            ^ToSql(format='%s', transform={p:String[2] | $p->transformFormatDateBigQuery()}))
   ];

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-spanner/legend-engine-xt-relationalStore-spanner-pure/src/main/resources/core_relational_spanner/relational/sqlQueryToString/spannerExtension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-spanner/legend-engine-xt-relationalStore-spanner-pure/src/main/resources/core_relational_spanner/relational/sqlQueryToString/spannerExtension.pure
@@ -152,7 +152,9 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::spann
     // dynaFnToSql('stdDevPopulation',       $allStates,            ^ToSql(format='stddev_pop(%s)')),
     dynaFnToSql('stdDevSample',           $allStates,            ^ToSql(format='stddev_samp(%s)')),
     dynaFnToSql('today',                  $allStates,            ^ToSql(format='current_date')),
-    dynaFnToSql('weekOfYear',             $allStates,            ^ToSql(format='extract(week from %s)')),
+    // isoweek, not week: GoogleSQL's week counts from Sunday and numbers the days before the year's
+    // first Sunday as week 0, where weekOfYear is ISO 8601 everywhere else it is pushed down.
+    dynaFnToSql('weekOfYear',             $allStates,            ^ToSql(format='extract(isoweek from %s)')),
     dynaFnToSql('year',                   $allStates,            ^ToSql(format='extract(year from %s)')),
     // dynaFnToSql('toString',               $allStates,            ^ToSql(format='cast(%s as varchar)')),
     dynaFnToSql('formatDate',             $allStates,            ^ToSql(format='%s', transform={p:String[2] | $p->transformFormatDateSpanner()}))

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-sqlserver/legend-engine-xt-relationalStore-sqlserver-pure/src/main/resources/core_relational_sqlserver/relational/sqlQueryToString/sqlServerExtension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-sqlserver/legend-engine-xt-relationalStore-sqlserver-pure/src/main/resources/core_relational_sqlserver/relational/sqlQueryToString/sqlServerExtension.pure
@@ -166,7 +166,9 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::sqlSe
     dynaFnToSql('toString',               $allStates,            ^ToSql(format='cast(%s as varchar)')),
     dynaFnToSql('variancePopulation',     $allStates,            ^ToSql(format='varp(%s)')),
     dynaFnToSql('varianceSample',         $allStates,            ^ToSql(format='var(%s)')),
-    dynaFnToSql('weekOfYear',             $allStates,            ^ToSql(format='datepart(wk, %s)')),
+    // iso_week, not wk: the wk part counts weeks from whichever day SET DATEFIRST names, which the
+    // session can change, where weekOfYear is ISO 8601.
+    dynaFnToSql('weekOfYear',             $allStates,            ^ToSql(format='datepart(iso_week, %s)')),
     dynaFnToSql('year',                   $allStates,            ^ToSql(format='year(%s)')),
     dynaFnToSql('formatDate',             $allStates,            ^ToSql(format='%s', transform={p:String[2] | $p->transformFormatDateSqlServer()}))
   ];

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/sqlQueryToString/dbSpecific/h2/h2Extension1_4_200.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/sqlQueryToString/dbSpecific/h2/h2Extension1_4_200.pure
@@ -157,7 +157,9 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::h2::v
     dynaFnToSql('toFloat',                $allStates,            ^ToSql(format='cast(%s as double precision)')),
     dynaFnToSql('toString',               $allStates,            ^ToSql(format='cast(%s as varchar)')),
     dynaFnToSql('toTimestamp',            $allStates,            ^ToSql(format='%s', transform={p:String[2] | $p->transformToTimestampH2()})),
-    dynaFnToSql('weekOfYear',             $allStates,            ^ToSql(format='week(%s)')),
+    // iso_week, not week: H2's week counts from Sunday, so 2020-12-27 is week 1 of 2021 there and
+    // week 52 of 2020 under ISO 8601, which is what weekOfYear means.
+    dynaFnToSql('weekOfYear',             $allStates,            ^ToSql(format='iso_week(%s)')),
     dynaFnToSql('year',                   $allStates,            ^ToSql(format='year(%s)')),
     dynaFnToSql('convertTimeZone',        $allStates,         ^ToSql(format='%s', transform={p:String[3] | $p->transformConvertTimeZone()})),
     dynaFnToSql('formatDate',             $allStates,         ^ToSql(format='%s', transform={p:String[2] | $p->transformFormatDate()}))

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/sqlQueryToString/dbSpecific/h2/h2Extension2_1_214.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/sqlQueryToString/dbSpecific/h2/h2Extension2_1_214.pure
@@ -266,7 +266,9 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::h2::v
     dynaFnToSql('toDecimal',              $allStates,            ^ToSql(format='cast(%s as decimal)')),
     dynaFnToSql('toFloat',                $allStates,            ^ToSql(format='cast(%s as double precision)')),
     dynaFnToSql('toTimestamp',            $allStates,            ^ToSql(format='%s', transform={p:String[2] | $p->transformToTimestampH2()})),
-    dynaFnToSql('weekOfYear',             $allStates,            ^ToSql(format='week(%s)')),
+    // iso_week, not week: H2's week counts from Sunday, so 2020-12-27 is week 1 of 2021 there and
+    // week 52 of 2020 under ISO 8601, which is what weekOfYear means.
+    dynaFnToSql('weekOfYear',             $allStates,            ^ToSql(format='iso_week(%s)')),
     dynaFnToSql('year',                   $allStates,            ^ToSql(format='year(%s)')),
     dynaFnToSql('convertTimeZone',        $allStates,         ^ToSql(format='%s', transform={p:String[3] | $p->transformConvertTimeZone()})),
     dynaFnToSql('formatDate',             $allStates,         ^ToSql(format='%s', transform={p:String[2] | $p->transformFormatDate()}))


### PR DESCRIPTION
## Summary

Removes every call to `PureDate.getCalendar()` in legend-engine, and settles `weekOfYear` on ISO 8601 so it no longer depends on the JVM's default locale.

`PureDate.getCalendar()` was deprecated upstream in legend-pure 5.95.0. Each caller here built a `GregorianCalendar` only to read a single field back out of it; they now go through `java.time` instead. The plan-dependencies copy of `PureDate` carries its own `getCalendar()`, which is deprecated to match — it is no longer called from anywhere, but stays because `enginePlatformDependencies.pure` declares it on the generated Java view of that class, so plans built by older servers may still reference it.

## Behaviour changes

Most of this is a refactor: for dates from 1900 onward, with the exception noted below, output is byte-identical to before. The differences are all cases where a `GregorianCalendar` was answering for a Pure date in terms the Pure date does not use.

| Area | Before | After | Applies to |
|---|---|---|---|
| `dayOfYear`, `dayOfWeekNumber`, `weekOfYear`, `dateDiff` | Julian calendar | proleptic Gregorian | dates before 1583 |
| `format` with a `[zone]` | today's standard offset applied to every earlier instant | real zone history | dates before 1900 |
| `format` with a `[zone]` | wall-clock reinterpretation, off by an hour | the instant the date stands for | instants in a DST gap |
| `weekOfYear` | first day of week and minimal-days from the JVM locale | ISO 8601 | 39.4% of days, 2000–2030 |

Concretely:

- `%1500-03-01` had day of year 61, because the calendar counted a Julian leap day that the proleptic Gregorian calendar does not have. It is now 60. `dateDiff` was internally inconsistent here, taking day-of-year from a Julian-reading calendar but the length of each intervening year from the proleptic Gregorian leap rule; both sides now agree.
- `%1899-12-31T23:59:59` in `[Asia/Kolkata]` rendered `+0530`; the offset there was really `+0521`. `[Africa/Monrovia]` rendered `+0000` where it was `-0043`. `java.util.TimeZone` carries no zone history before 1900 and applies the modern standard offset to everything earlier.
- `%2024-03-10T02:30` in `[America/New_York]` rendered `22:30`. The instant is `21:30` there. `Calendar.setTimeZone` reinterprets already-set fields as *local* wall time, so this was read as a New York wall time that does not exist, nudged forward an hour by lenient resolution, and adding the zone offset back did not undo it.

**Deliberately unchanged:** the plan-dependencies `format()` still renders `z` as a short zone name and still truncates `X` to whole hours (`+05` for India). Those are defects, but fixing this fork is not what this change is for — the goal was to remove the calendar, and `z`, `Z` and `X` still go through `SimpleDateFormat`, which only ever needed an instant rather than a calendar.

## weekOfYear

`weekOfYear` took both the first day of the week and the number of days January must contribute to week 1 from the JVM default locale, so the same query answered differently depending on where it ran. legend-pure's ADR-004 names this as a defect to fix independently of everything else.

ISO 8601 is not an arbitrary choice among locale-free options — it is what most of the stores this function is pushed down to already compute. Eleven of the eighteen relational adapters asked for an ISO week before this change: `toISOWeek` in ClickHouse, `week_iso` in DB2, `weekofyear` in Databricks and MemSQL, `week` in DuckDB, Presto and Trino, `date_part('week',…)` in Postgres, `extract(week …)` in Redshift, `datepart(WEEK,…)` in Spark, and `WEEKOFYEAR` in Snowflake. Seven did not, and five of those are fixed here:

| adapter | was | now |
|---|---|---|
| H2 (1.4.200 and 2.1.214) | `week(x)` | `iso_week(x)` |
| BigQuery | `extract(week from x)` | `extract(isoweek from x)` |
| Spanner | `extract(week from x)` | `extract(isoweek from x)` |
| SQL Server | `datepart(wk, x)` | `datepart(iso_week, x)` |

**H2 is the one that mattered.** Its `week()` counts weeks from Sunday, so `2020-12-27` came back as week 1 of 2021 where ISO has it as week 52 of 2020. H2 is a default-profile PCT store, which means in-memory and pushed-down answers were already parting company on those dates for anyone running the default suite. Checked against the driver: `week()` and
`extract(week from x)` disagree with ISO on the year boundaries, `iso_week()` and `extract(iso_week from x)` agree, and DuckDB's `week()` was ISO all along and needed nothing.

BigQuery and Spanner share GoogleSQL, where `WEEK` starts on Sunday and numbers the days before the year's first Sunday as week 0, which ISO never produces. `WEEK(MONDAY)` would fix the start day and keep week 0, so `ISOWEEK` is the variant that matches. SQL Server's `wk` follows whichever day `SET DATEFIRST` names, which a session can change; `iso_week` does not move.

Four adapters are deliberately left alone. Oracle asks for `extract(week from x)`, which Oracle does not accept at all, so its week numbering is not the first thing wrong with it. Snowflake is ISO until a session sets `WEEK_START` or `WEEK_OF_YEAR_POLICY`. Neither Sybase has an ISO week part to ask for, so those need emulating rather than renaming.

Nothing caught any of this because `weekOfYear` is marked `<<test.Test>>` rather than `<<PCT.test>>`, so no cross-store comparison runs on it. Promoting it is the change that would stop this recurring, and is not attempted here.

This is the most visible change in the PR: ISO and the previous US-default numbering disagree on 39.4% of days between 2000 and 2030. The single assertion that existed before (`%2015-04-15 -> 16`) holds under both conventions and so proved nothing; the new tests are at the year boundaries where the two part.

## Verification

- 2,595 tests pass across the five affected modules, 0 checkstyle violations.
- `testWeekOfYearIsISO8601` runs in both the compiled and interpreted engines.
- `TestLibrary.testWeekOfYearIsISO8601WhateverTheLocale` runs the discriminating dates under US, UK, France, Japan and ar-EG defaults and asserts they agree. Against the previous implementation it fails with `en_US expected:<52> but was:<1>`.
- Differential harnesses against the original implementations, beyond the suites:
  - date elements: 189,196 consecutive days (1583-01-01 to 2100-12-31), zero differences, and the compiled and generated-plan implementations agree with each other on all 219,511 days from 1500;
  - date differences: 200,000 random date pairs from 1583, zero differences in days, weeks and milliseconds;
  - `format`: 6,210 combinations of 23 dates x 14 zones x 18 format strings, identical for every date from 1900 outside a DST gap.

## Out of scope

- **Oracle, Snowflake, Sybase and Sybase IQ** keep their current `weekOfYear` translations, for the reasons given above. Oracle's is invalid SQL independently of week numbering and predates this PR.
- Two further locale dependencies found while auditing, to be handled separately: subsecond strings built with `String.format("%0Nd", ...)`, which emit non-ASCII digits under a locale whose default numbering system is not Latin; and `z` in the plan-dependencies `format()`, which renders zone short names in the format locale.
- **Eliminating the fork.** `org.finos.legend.engine.plan.dependencies.domain.date.PureDate` is a stale copy of legend-pure's, and the two have diverged in how they handle partial dates, `z`, and sub-hour offsets. Converging them is the real fix and a separate change.