### PR TITLE
Compare in()/quantified comparison operands at their common type

### DIFF
--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/handlers/Handlers.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/handlers/Handlers.java
@@ -234,7 +234,8 @@ public class Handlers
                     throw new EngineException(functionName + "(..., Relation) expects a relation with a single column, got " + _RelationType.print(type, processorSupport), parameters.get(1).sourceInformation, EngineErrorType.COMPILATION);
                 }
                 GenericType columnType = _Column.getColumnType(type._columns().getOnly());
-                if (!org.finos.legend.pure.m3.navigation.generictype.GenericType.isGenericCompatibleWith(processed.get(0)._genericType(), columnType, processorSupport))
+                if (comparableCommonType(processed.get(0)._genericType(), columnType, valueSpecificationBuilder.getContext().pureModel) == null
+                        && !org.finos.legend.pure.m3.navigation.generictype.GenericType.isGenericCompatibleWith(processed.get(0)._genericType(), columnType, processorSupport))
                 {
                     throw new EngineException(functionName + "(..., Relation) expects the value and the relation column to be of the same type, got " +
                             org.finos.legend.pure.m3.navigation.generictype.GenericType.print(processed.get(0)._genericType(), processorSupport) + " and " +
@@ -246,6 +247,43 @@ public class Handlers
     };
 
     public static final ParametersInference InInference = SingleColumnRelationInference.apply("in");
+
+    // Engine literals and parameters carry the coarse primitives (Integer, String) where a relational column carries
+    // the precise ones (Int, Varchar(n)), so the value and the column routinely differ while still being comparable.
+    // Their common supertype carries no typeVariableValues, and ExtendedPrimitiveType.testTypeVariableValuesCompatible
+    // zips, so an empty list matches any width -- which is what makes it a valid U for the value and the column alike.
+    // That shape (a Varchar carrying no size) would not pass GenericTypeValidator, which the engine never runs over
+    // handler-built value specifications. Null means nothing more specific than Any in common, or nothing concrete.
+    private static GenericType comparableCommonType(GenericType valueType, GenericType columnType, PureModel pureModel)
+    {
+        GenericType common = MostCommonType.mostCommon(Lists.mutable.with(valueType, columnType), pureModel);
+        return common == null || common._rawType() == null || common._rawType() == pureModel.getType(M3Paths.Any) ? null : common;
+    }
+
+    private static GenericType singleRelationColumnType(ValueSpecification relation, PureModel pureModel)
+    {
+        GenericType gt = relation._genericType();
+        if (!pureModel.taxonomyTypes("cov_relation_Relation").contains(gt._rawType().getName()))
+        {
+            return null;
+        }
+        GenericType relationType = gt._typeArguments().getOnly();
+        if (!(relationType._rawType() instanceof RelationType))
+        {
+            return null;
+        }
+        RelationType<?> type = (RelationType<?>) relationType._rawType();
+        return type._columns().size() == 1 ? _Column.getColumnType(type._columns().getOnly()) : null;
+    }
+
+    // U and Z cannot be inferred from the arguments -- Z is constrained as Relation<Z=(?:U)> -- so resolve them
+    // explicitly, in declaration order, the way eval and flatten do for their wildcard-column ColSpecs.
+    private static RichIterable<? extends GenericType> singleColumnRelationTypeArguments(List<ValueSpecification> ps, PureModel pureModel)
+    {
+        GenericType columnType = singleRelationColumnType(ps.get(1), pureModel);
+        GenericType common = columnType == null ? null : comparableCommonType(ps.get(0)._genericType(), columnType, pureModel);
+        return Lists.fixedSize.of(common == null ? ps.get(0)._genericType() : common, ps.get(1)._genericType()._typeArguments().getOnly());
+    }
 
     // There is no notEqualAny / notEqualAll: !equalAll is the one and !equalAny is the other, by De Morgan.
     public static final ImmutableList<String> QUANTIFIED_COMPARISONS = Lists.immutable.of(
@@ -1673,12 +1711,10 @@ public class Handlers
         register("meta::pure::functions::collection::objectReferenceIn_Any_1__String_MANY__Boolean_1_", "objectReferenceIn", false, ps -> res("Boolean", "one"));
 
         // The Relation overload must be tried first: a Relation[1] also satisfies the collection overloads' Any[*] parameter.
-        // U and Z cannot be inferred from the arguments -- Z is constrained as Relation<Z=(?:U)> -- so resolve them
-        // explicitly, in declaration order, the way eval and flatten do for their wildcard-column ColSpecs.
         register(grp(InInference,
                 h("meta::pure::functions::relation::in_U_$0_1$__Relation_1__Boolean_1_", "in", false,
                         ps -> res("Boolean", "one"),
-                        ps -> Lists.fixedSize.of(ps.get(0)._genericType(), ps.get(1)._genericType()._typeArguments().getOnly()),
+                        ps -> singleColumnRelationTypeArguments(ps, pureModel),
                         ps -> ps.size() == 2 && typeOne(ps.get(1), pureModel.taxonomyTypes("cov_relation_Relation"))),
                 h("meta::pure::functions::collection::in_Any_1__Any_MANY__Boolean_1_", "in", false, ps -> res("Boolean", "one"), ps -> isOne(ps.get(0)._multiplicity())),
                 h("meta::pure::functions::collection::in_Any_$0_1$__Any_MANY__Boolean_1_", "in", false, ps -> res("Boolean", "one"), ps -> isZeroOne(ps.get(0)._multiplicity()))));
@@ -1690,7 +1726,7 @@ public class Handlers
             register(grp(SingleColumnRelationInference.apply(quantified),
                     h("meta::pure::functions::relation::" + quantified + "_U_$0_1$__Relation_1__Boolean_1_", quantified, false,
                             ps -> res("Boolean", "one"),
-                            ps -> Lists.fixedSize.of(ps.get(0)._genericType(), ps.get(1)._genericType()._typeArguments().getOnly()),
+                            ps -> singleColumnRelationTypeArguments(ps, pureModel),
                             ps -> ps.size() == 2 && typeOne(ps.get(1), pureModel.taxonomyTypes("cov_relation_Relation")))));
         }
 

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/test/java/org/finos/legend/engine/language/pure/compiler/test/fromGrammar/TestRelationNotUsingDatabaseAccessor.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/test/java/org/finos/legend/engine/language/pure/compiler/test/fromGrammar/TestRelationNotUsingDatabaseAccessor.java
@@ -174,6 +174,34 @@ public class TestRelationNotUsingDatabaseAccessor extends TestCompilationFromGra
     }
 
     @Test
+    public void testInAcrossPrecisePrimitivesOfDifferentWidth()
+    {
+        Pair<PureModelContextData, PureModel> data = test(
+                "###Pure\n" +
+                        "function test::f():Any[*]\n" +
+                        "{\n" +
+                        "   'ab'->cast(@meta::pure::precisePrimitives::Varchar(32))->in(1->cast(@meta::pure::metamodel::relation::Relation<(c:meta::pure::precisePrimitives::Varchar(64))>))\n" +
+                        "}"
+        );
+
+        SimpleFunctionExpression in = (SimpleFunctionExpression) data.getTwo().getConcreteFunctionDefinition_safe("test::f__Any_MANY_")._expressionSequence().getOnly();
+        Assert.assertEquals("in_U_$0_1$__Relation_1__Boolean_1_", in._func()._name());
+        Assert.assertEquals("Varchar", GenericType.print(in._resolvedTypeParameters().getFirst(), data.getTwo().getExecutionSupport().getProcessorSupport()));
+    }
+
+    @Test
+    public void testInAcrossUnrelatedPrimitivesStillFails()
+    {
+        test(
+                "###Pure\n" +
+                        "function test::f():Any[*]\n" +
+                        "{\n" +
+                        "   1->in(1->cast(@meta::pure::metamodel::relation::Relation<(c:meta::pure::precisePrimitives::Varchar(64))>))\n" +
+                        "}", "COMPILATION error at [4:13-16]: in(..., Relation) expects the value and the relation column to be of the same type, got Integer and (c:Varchar(64))"
+        );
+    }
+
+    @Test
     public void testMerge()
     {
         PureModel pureModel = test(

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/test/java/org/finos/legend/engine/language/pure/compiler/test/TestRelationFunctions.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/test/java/org/finos/legend/engine/language/pure/compiler/test/TestRelationFunctions.java
@@ -1522,6 +1522,138 @@ public class TestRelationFunctions extends TestCompilationFromGrammar.TestCompil
         );
     }
 
+    @Test
+    public void testInAcrossDifferentVarcharWidths()
+    {
+        test(
+                "###Relational\n" +
+                        "Database a::A\n" +
+                        "(\n" +
+                        "   Table tb(id Integer, name VARCHAR(32))\n" +
+                        "   Table other(oid BIGINT, oname VARCHAR(64))\n" +
+                        ")\n" +
+                        "\n" +
+                        "###Pure\n" +
+                        "function test::f():Any[*]\n" +
+                        "{\n" +
+                        "   #>{a::A.tb}#->filter(x|$x.name->in(#>{a::A.other}#->select(~oname)))\n" +
+                        "}");
+    }
+
+    @Test
+    public void testInAcrossDifferentIntegerWidths()
+    {
+        test(
+                "###Relational\n" +
+                        "Database a::A\n" +
+                        "(\n" +
+                        "   Table tb(id Integer, name VARCHAR(32))\n" +
+                        "   Table other(oid BIGINT, oname VARCHAR(64))\n" +
+                        ")\n" +
+                        "\n" +
+                        "###Pure\n" +
+                        "function test::f():Any[*]\n" +
+                        "{\n" +
+                        "   #>{a::A.tb}#->filter(x|$x.id->in(#>{a::A.other}#->select(~oid)))\n" +
+                        "}");
+    }
+
+    @Test
+    public void testInAcrossDifferentDecimalPrecisions()
+    {
+        test(
+                "###Relational\n" +
+                        "Database a::A\n" +
+                        "(\n" +
+                        "   Table tb(amount DECIMAL(18,6))\n" +
+                        "   Table other(oamount DECIMAL(20,2))\n" +
+                        ")\n" +
+                        "\n" +
+                        "###Pure\n" +
+                        "function test::f():Any[*]\n" +
+                        "{\n" +
+                        "   #>{a::A.tb}#->filter(x|$x.amount->in(#>{a::A.other}#->select(~oamount)))\n" +
+                        "}");
+    }
+
+    @Test
+    public void testInWithStringLiteralAgainstVarcharColumn()
+    {
+        test(
+                "###Relational\n" +
+                        "Database a::A (Table tb(id Integer, name VARCHAR(32)))\n" +
+                        "\n" +
+                        "###Pure\n" +
+                        "function test::f():Any[*]\n" +
+                        "{\n" +
+                        "   #>{a::A.tb}#->filter(x|'abc'->in(#>{a::A.tb}#->select(~name)))\n" +
+                        "}");
+    }
+
+    @Test
+    public void testInWithIntegerLiteralAgainstIntColumn()
+    {
+        test(
+                "###Relational\n" +
+                        "Database a::A (Table tb(id Integer, name VARCHAR(32)))\n" +
+                        "\n" +
+                        "###Pure\n" +
+                        "function test::f():Any[*]\n" +
+                        "{\n" +
+                        "   #>{a::A.tb}#->filter(x|1->in(#>{a::A.tb}#->select(~id)))\n" +
+                        "}");
+    }
+
+    @Test
+    public void testInWithEmptyValueAgainstVarcharColumn()
+    {
+        test(
+                "###Relational\n" +
+                        "Database a::A (Table tb(id Integer, name VARCHAR(32)))\n" +
+                        "\n" +
+                        "###Pure\n" +
+                        "function test::f():Any[*]\n" +
+                        "{\n" +
+                        "   #>{a::A.tb}#->filter(x|[]->in(#>{a::A.tb}#->select(~name)))\n" +
+                        "}");
+    }
+
+    @Test
+    public void testQuantifiedComparisonAcrossDifferentVarcharWidths()
+    {
+        test(
+                "###Relational\n" +
+                        "Database a::A\n" +
+                        "(\n" +
+                        "   Table tb(id Integer, name VARCHAR(32))\n" +
+                        "   Table other(oid BIGINT, oname VARCHAR(64))\n" +
+                        ")\n" +
+                        "\n" +
+                        "###Pure\n" +
+                        "function test::f():Any[*]\n" +
+                        "{\n" +
+                        "   #>{a::A.tb}#->filter(x|$x.name->greaterThanAny(#>{a::A.other}#->select(~oname)))\n" +
+                        "}");
+    }
+
+    @Test
+    public void testExistsAcrossDifferentVarcharWidths()
+    {
+        test(
+                "###Relational\n" +
+                        "Database a::A\n" +
+                        "(\n" +
+                        "   Table tb(id Integer, name VARCHAR(32))\n" +
+                        "   Table other(oid BIGINT, oname VARCHAR(64))\n" +
+                        ")\n" +
+                        "\n" +
+                        "###Pure\n" +
+                        "function test::f():Any[*]\n" +
+                        "{\n" +
+                        "   #>{a::A.tb}#->filter(x|#>{a::A.other}#->exists(o|$o.oname == $x.name))\n" +
+                        "}");
+    }
+
     @Override
     public String getDuplicatedElementTestCode()
     {


### PR DESCRIPTION
## Problem

`meta::pure::functions::relation::in` and the ten quantified comparisons (`equalAny`, `greaterThanAll`, …) declare `(value:U[0..1], rel:Relation<Z=(?:U)>[1])`. That constraint is not expressible to the engine compiler, so `Handlers.SingleColumnRelationInference` checks it by hand with `GenericType.isGenericCompatibleWith`, which opens with `ExtendedPrimitiveType.testTypeVariableValuesCompatible` — an **exact equality** comparison on `typeVariableValues`.

So a perfectly well-defined comparison across two tables fails to compile:

```
COMPILATION error: in(..., Relation) expects the value and the relation column
to be of the same type, got Varchar(32) and (oname:Varchar(64))
```

The wider problem is not width. Engine literals and parameters carry the *coarse* primitives (`Integer`, `String`) while relational columns carry the *precise* ones (`Int`, `Varchar(n)`), so only column-to-column comparisons of identical type compiled at all:

| value | column | before |
|---|---|---|
| `Varchar(32)` | `Varchar(64)` | rejected — type-variable values differ |
| `Int` | `BigInt` | rejected — neither raw type subtypes the other |
| `String` (`'abc'`) | `Varchar(200)` | rejected — `String` is not a subtype of `Varchar` |
| `Integer` (`1`) | `Int` | rejected — same, other direction |

## Change

Resolve the two operands to their best common covariant supertype, reusing `MostCommonType.mostCommon` — already the engine's answer for `coalesce` — and accept when that type is concrete and not `Any`.

The common type of `Varchar(32)` and `Varchar(64)` is a bare `Varchar` carrying no `typeVariableValues`, and `testTypeVariableValuesCompatible` zips, so an empty list matches any width. That is what makes it a valid `U` for the value and the column alike, including for the body's `cast(@Column<Nil,U|0..1>)`.

One helper serves both the gate and the type-argument lambda, so the check and `U` cannot drift apart. The previous check stays as a fallback, so nothing that compiled before stops compiling.

`Int` against `Varchar(200)` still has nothing but `Any` in common and is still rejected, **with the message unchanged**. Widening `U` also retires the empty-value case, where `U` was previously `Nil`.

`exists` is unaffected — it constrains nothing between the relation and the predicate, and `==` is registered only as `equal_Any_MANY__Any_MANY__Boolean_1_`. A test records that.

## Tests

`TestRelationNotUsingDatabaseAccessor` (core): the minimal repro, asserting the resolved type parameter prints as bare `Varchar`, plus a negative test for unrelated primitives.

`TestRelationFunctions` (relational grammar): differing `VARCHAR` widths, `INTEGER`/`BIGINT`, `DECIMAL` precisions, string and integer literals, an empty value, a quantified comparison, and an `exists` guard.

463 + 288 + 83 tests green across the two modules; both pre-existing negative tests keep their exact expected messages. Checkstyle clean.

## Scope

This is the engine grammar/protocol path — what Studio, services and the SQL API use. The same query authored directly in a `.pure` file resolves through legend-pure's own matcher (`GenericTypeMatch`), which applies the same exact-equality rule and is unchanged. That is also why no PCT test can cover this, and why the compiler tests are the coverage.

Not addressed here, same root cause behind different gates:
- `concatenate` on relations, via `_RelationType.canConcatenate`.
- User-defined functions taking a precise-typed `Relation` parameter, via `HelperModelBuilder.checkTypeCompatibility`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
