### PR TITLE
Replace time zone +0530 with Asia/Kolkata and fix tests

### DIFF
--- a/legend-engine-xts-snowflake/legend-engine-xt-snowflake-pure-test/src/main/resources/core_snowflake_test/core_snowflakeapp/showcase/showcaseElements.legend
+++ b/legend-engine-xts-snowflake/legend-engine-xt-snowflake-pure-test/src/main/resources/core_snowflake_test/core_snowflakeapp/showcase/showcaseElements.legend
@@ -41,7 +41,7 @@ function meta::external::function::activator::snowflakeApp::tests::testRuntime(d
 
 function meta::external::function::activator::snowflakeApp::tests::testRuntimeWithTimeZone(db:Database[1]):Runtime[1]
 {
-    testRuntime(testDatabaseConnection($db, '+0530'));
+    testRuntime(testDatabaseConnection($db, 'Asia/Kolkata'));
 }
 
 function meta::external::function::activator::snowflakeApp::tests::testRelationalConnection():ConnectionStore[1]

--- a/legend-engine-xts-snowflake/legend-engine-xt-snowflake-pure-test/src/main/resources/core_snowflake_test/core_snowflakeapp/tests/testSnowflakeAppGeneration.pure
+++ b/legend-engine-xts-snowflake/legend-engine-xt-snowflake-pure-test/src/main/resources/core_snowflake_test/core_snowflakeapp/tests/testSnowflakeAppGeneration.pure
@@ -43,7 +43,7 @@ function meta::external::function::activator::snowflakeApp::tests::checkSnowflak
 function meta::external::function::activator::snowflakeApp::tests::checkSnowflakeAppGrammar(function:String[1],  expected:String[1]): Boolean[1]
 {
   let artifact  = checkSnowflakeAppGrammar($function);
-  assertEquals($artifact.createQuery, $expected);
+  assertEquals($expected, $artifact.createQuery);
 }
 
 
@@ -91,8 +91,8 @@ function <<test.Test>> meta::external::function::activator::snowflakeApp::tests:
 
 function <<test.Test>> meta::external::function::activator::snowflakeApp::tests::testRelationalfunctionWithDateTimeHardCoded():Boolean[1]
 {
-  // the time zone info in the connection should be ignored in the generated sql
-  let expected = 'CREATE OR REPLACE SECURE FUNCTION ${catalogSchemaName}.LEGEND_NATIVE_APPS.APP1() RETURNS TABLE ("FIRSTNAME" VARCHAR,"LASTNAME" VARCHAR) LANGUAGE SQL AS $$ select "root".FIRSTNAME as "firstName", "root".LASTNAME as "lastName" from personTable as "root" where cast("root".LAST_UPDATED as TIMESTAMP) = \'2024-02-27 16:21:53\'::timestamp $$;';
+  // the time zone info in the connection (Asia/Kolkata) shifts the date in the generated SQL
+  let expected = 'CREATE OR REPLACE SECURE FUNCTION ${catalogSchemaName}.LEGEND_NATIVE_APPS.APP1() RETURNS TABLE ("FIRSTNAME" VARCHAR,"LASTNAME" VARCHAR) LANGUAGE SQL AS $$ select "root".FIRSTNAME as "firstName", "root".LASTNAME as "lastName" from personTable as "root" where cast("root".LAST_UPDATED as TIMESTAMP) = \'2024-02-27 21:51:53\'::timestamp $$;';
 
   let function = ' function : meta::external::function::activator::snowflakeApp::tests::simpleRelationalfunctionWithDateTimeHardCoded():TabularDataSet[1];\n';
 

--- a/legend-engine-xts-snowflake/legend-engine-xt-snowflake-pure/src/main/resources/core_snowflake/core_snowflakeapp/showcase/showcaseModel.pure
+++ b/legend-engine-xts-snowflake/legend-engine-xt-snowflake-pure/src/main/resources/core_snowflake/core_snowflakeapp/showcase/showcaseModel.pure
@@ -42,7 +42,7 @@ function meta::external::function::activator::snowflakeApp::tests::testRuntime(d
 
 function meta::external::function::activator::snowflakeApp::tests::testRuntimeWithTimeZone(db:Database[1]):Runtime[1]
 {
-    testRuntime(testDatabaseConnection($db, '+0530'));
+    testRuntime(testDatabaseConnection($db, 'Asia/Kolkata'));
 }
 
 function meta::external::function::activator::snowflakeApp::tests::defaultConfig():SnowflakeDeploymentConfiguration[1]


### PR DESCRIPTION
Replace time zone +0530 with Asia/Kolkata and fix tests.

In Java, TimeZone.getTimeZone does not recognize +0530 as a valid time zone id, and so it defaults to GMT. This method is what we're currently using in the platform to resolve time zones. Consequently, using ```'+0530'``` as the connection time zone does not actually test what it's intended to test. This PR changes it to ```'Asia/Kolkata'```, which is recognized.

Separately, the platform should be changed to move away from using TimeZone.getTimeZone. That change will need to happen in legend-pure.