### PR TITLE
Fail release workflows early when the release version is already used

### DIFF
--- a/.github/workflows/release-large-runner.yml
+++ b/.github/workflows/release-large-runner.yml
@@ -35,6 +35,30 @@ jobs:
   release:
     runs-on: ubuntu-latest-16-cores
     steps:
+      # Fail fast on a duplicate version: Central is immutable, and without
+      # this the collision only surfaces at the final upload step.
+      - name: Check release version is unused
+        env:
+          RELEASE_VERSION: ${{ github.event.inputs.releaseVersion }}
+          TAG: ${{ github.event.repository.name }}-${{ github.event.inputs.releaseVersion }}
+        run: |
+          if ! [[ "$RELEASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Release version '$RELEASE_VERSION' is not of the form MAJOR.MINOR.PATCH"
+            exit 1
+          fi
+          if git ls-remote --exit-code --tags "https://github.com/${{ github.repository }}.git" "refs/tags/$TAG" ; then
+            echo "::error::Tag $TAG already exists -- version $RELEASE_VERSION has already been released (or a failed release was not cleaned up)"
+            exit 1
+          fi
+          url="https://repo1.maven.org/maven2/org/finos/legend/engine/legend-engine/${RELEASE_VERSION}/legend-engine-${RELEASE_VERSION}.pom"
+          http_status=$(curl -s -o /dev/null -w '%{http_code}' "$url")
+          if [ "$http_status" = "200" ]; then
+            echo "::error::Version $RELEASE_VERSION is already published on Maven Central: $url"
+            exit 1
+          elif [ "$http_status" != "404" ]; then
+            echo "::warning::Unexpected HTTP $http_status from Maven Central while checking $url -- continuing"
+          fi
+
       - name: Checkout repo
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,9 +36,50 @@ on:
         default: false
 
 jobs:
+  # workflow_dispatch inputs cannot be validated at submission time, so this
+  # runs first and everything else gates on it. Central is immutable: a
+  # duplicate version would otherwise only surface at the final upload, after
+  # the tag has already been pushed and the full build and test matrix has run.
+  validate:
+    name: Check Release Version Is Unused
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_VERSION: ${{ github.event.inputs.releaseVersion }}
+    steps:
+      - name: Check version format
+        run: |
+          if ! [[ "$RELEASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Release version '$RELEASE_VERSION' is not of the form MAJOR.MINOR.PATCH"
+            exit 1
+          fi
+
+      - name: Check release tag does not already exist
+        env:
+          TAG: ${{ github.event.repository.name }}-${{ github.event.inputs.releaseVersion }}
+        run: |
+          if git ls-remote --exit-code --tags "https://github.com/${{ github.repository }}.git" "refs/tags/$TAG" ; then
+            echo "::error::Tag $TAG already exists -- version $RELEASE_VERSION has already been released (or a failed release was not cleaned up)"
+            exit 1
+          fi
+
+      - name: Check version is not already on Maven Central
+        # Guards the case where the tag was deleted (e.g. by release cleanup)
+        # but artifacts still made it to Central, which cannot be overwritten.
+        run: |
+          url="https://repo1.maven.org/maven2/org/finos/legend/engine/legend-engine/${RELEASE_VERSION}/legend-engine-${RELEASE_VERSION}.pom"
+          http_status=$(curl -s -o /dev/null -w '%{http_code}' "$url")
+          if [ "$http_status" = "200" ]; then
+            echo "::error::Version $RELEASE_VERSION is already published on Maven Central: $url"
+            exit 1
+          elif [ "$http_status" != "404" ]; then
+            echo "::warning::Unexpected HTTP $http_status from Maven Central while checking $url -- continuing"
+          fi
+
   build:
     name: Prepare Release Artifacts
     runs-on: ubuntu-latest-16-cores
+    needs:
+      - validate
     outputs:
       testMatrix: ${{ steps.testMatrix.outputs.testMatrix }}
 


### PR DESCRIPTION
## What

Adds an up-front validation of the `releaseVersion` input to the `Release` and `Release (Large Runner)` workflows:

1. **Format check** — version must be `MAJOR.MINOR.PATCH` (a malformed input would otherwise produce a garbage tag and break the next-development-version computation).
2. **Tag check** — `git ls-remote` against the repo for `<repo-name>-<version>`; fails if the release tag already exists.
3. **Maven Central check** — HTTP check for the root `legend-engine-<version>.pom` on repo1.maven.org; catches the case where a failed release's tag was cleaned up but artifacts already reached Central (which is immutable). A Central outage only warns rather than blocking a release; only a definitive HTTP 200 fails.

In `release.yml` this is a dedicated `validate` job that the `build` job `needs`; in `release-large-runner.yml` it is the first step of the single job.

## Why

Re-running a release with an already-used version currently only fails at the very last step — the Maven Central upload — after the tag has been pushed, the development version bumped, and the full build and test matrix has run (~45+ min). With this change a duplicate version fails within seconds of dispatch, before `release:prepare` pushes anything.

## How tested

- Both workflow files validated as YAML.
- Tag check verified to detect the existing `legend-engine-4.100.0` tag.
- Central check verified: HTTP 200 for published `4.100.0`, 404 for an unused version.
