### PR TITLE
[Backport release-legend-release-4.99] Fix schema generation for graphFetch openAPI specification

### DIFF
--- a/legend-engine-xts-openapi/legend-engine-xt-openapi-pure/src/main/resources/core_external_format_openapi/transformation/fromPure/pureToOpenApi.pure
+++ b/legend-engine-xts-openapi/legend-engine-xt-openapi-pure/src/main/resources/core_external_format_openapi/transformation/fromPure/pureToOpenApi.pure
@@ -26,6 +26,7 @@ import meta::external::query::sql::transformation::queryToPure::tests::*;
 import meta::pure::graphFetch::*;
 import meta::external::function::description::openapi::tostring::*;
 import meta::pure::metamodel::relation::*;
+import meta::pure::executionPlan::platformBinding::typeInfo::*;
 
 Class meta::external::function::description::openapi::transformation::fromPure::FunctionInfo
 {
@@ -133,35 +134,36 @@ function <<access.private>> meta::external::function::description::openapi::tran
 
 function <<access.private>> meta::external::function::description::openapi::transformation::fromPure::generateComponent(funcInfos: FunctionInfo[*], elements: PackageableElement[*]):Components[1]
 {
-  let functionClasses = $funcInfos->returnTypesFromFunctions();
-  let allClasses = if($funcInfos->exists(f|$f->getReturnType()->instanceOf(RootGraphFetchTree)),
-                      |$functionClasses
-                          ->concatenate($elements->filter(e|$e->instanceOf(Class))->map(e|^GenericType(rawType=$e->cast(@Class<Any>))))
-                          ->removeDuplicates(cmpGenericType_GenericType_1__GenericType_1__Boolean_1_),
-                      |$functionClasses
-                   );
-
-  let schema = $allClasses->map(
-                              c|pair(
-                                $c.rawType.name->toOne(),
-                                ^Schema
-                                (
-                                  type='object',
-                                  properties=newMap(
-                                    $c.rawType->cast(@Class<Any>).properties
-                                      ->filter(p|!$p.name->in(['elementOverride', 'classifierGenericType', 'generalizations', 'specializations']))
-                                      ->map(p|
-                                              pair
-                                              (
-                                                $p.name->toOne(),
-                                                $p->functionReturnType()->buildComponent($p.multiplicity)
-                                              )
-                                        )
+  let trees = $funcInfos->map(f|$f->getReturnType())->filter(r|$r->instanceOf(RootGraphFetchTree))->cast(@RootGraphFetchTree<Any>);
+  let schema = if($trees->isNotEmpty(),
+                | let treeInfo = $trees->fold({t, i|$i->addForGraphFetchTree($t)}, newTypeInfoSet());
+                  $treeInfo->allClassInfos()->map(ci|
+                                                  pair(
+                                                    $ci.class().name->toOne(),
+                                                    ^Schema
+                                                    (
+                                                      type='object',
+                                                      properties=newMap($treeInfo->allProperties($ci)->map(p|pair($p.name->toOne(), $p->functionReturnType()->buildComponent($p.multiplicity))))
+                                                    )
+                                                  )
+                  );,
+                | let allClasses = $funcInfos->returnTypesFromFunctions();
+                  $allClasses->map(c|
+                                   pair(
+                                    $c.rawType.name->toOne(),
+                                    ^Schema
+                                    (
+                                      type='object',
+                                      properties=newMap(
+                                        $c.rawType->cast(@Class<Any>).properties
+                                          ->filter(p|!$p.name->in(['elementOverride', 'classifierGenericType', 'generalizations', 'specializations']))
+                                          ->map(p|pair($p.name->toOne(), $p->functionReturnType()->buildComponent($p.multiplicity)))
+                                      )
+                                    )
                                   )
-                                )
-                              )
-                            );
-
+                  );
+               );
+  
   ^Components(schemas = newMap($schema));
 }
 

--- a/legend-engine-xts-openapi/legend-engine-xt-openapi-pure/src/main/resources/core_external_format_openapi/transformation/fromPure/tests/resources/testAssociationGraphFetchOpenApiSpec.txt
+++ b/legend-engine-xts-openapi/legend-engine-xt-openapi-pure/src/main/resources/core_external_format_openapi/transformation/fromPure/tests/resources/testAssociationGraphFetchOpenApiSpec.txt
@@ -1,0 +1,97 @@
+
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Legend API",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "test"
+    }
+  ],
+  "paths": {
+    "/service/testAssociationOpenApi": {
+      "get": {
+        "tags": [
+          "definition"
+        ],
+        "responses": {
+          "200": {
+            "description": "success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssociatedPerson"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "definition"
+        ],
+        "responses": {
+          "200": {
+            "description": "success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssociatedPerson"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "AssociatedFirm": {
+        "type": "object",
+        "properties": {
+          "employees": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AssociatedPerson"
+            }
+          },
+          "name": {
+            "type": "string"
+          },
+          "officeAddress": {
+            "$ref": "#/components/schemas/AssociatedAddress"
+          }
+        }
+      },
+      "AssociatedAddress": {
+        "type": "object",
+        "properties": {
+          "line": {
+            "type": "string"
+          },
+          "firms": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AssociatedFirm"
+            }
+          }
+        }
+      },
+      "AssociatedPerson": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "employer": {
+            "$ref": "#/components/schemas/AssociatedFirm"
+          }
+        }
+      }
+    }
+  }
+}

--- a/legend-engine-xts-openapi/legend-engine-xt-openapi-pure/src/main/resources/core_external_format_openapi/transformation/fromPure/tests/resources/testCyclicGraphFetchOpenApiSpec.txt
+++ b/legend-engine-xts-openapi/legend-engine-xt-openapi-pure/src/main/resources/core_external_format_openapi/transformation/fromPure/tests/resources/testCyclicGraphFetchOpenApiSpec.txt
@@ -10,7 +10,7 @@
     }
   ],
   "paths": {
-    "/service/testOpenApi": {
+    "/service/testCyclicOpenApi": {
       "get": {
         "tags": [
           "definition"
@@ -21,7 +21,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Person"
+                  "$ref": "#/components/schemas/CyclicPerson"
                 }
               }
             }
@@ -38,7 +38,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Person"
+                  "$ref": "#/components/schemas/CyclicPerson"
                 }
               }
             }
@@ -49,13 +49,30 @@
   },
   "components": {
     "schemas": {
-      "Person": {
+      "CyclicPerson": {
         "type": "object",
         "properties": {
-          "lastName": {
+          "name": {
             "type": "string"
           },
-          "firstName": {
+          "manager": {
+            "$ref": "#/components/schemas/CyclicPerson"
+          },
+          "firm": {
+            "$ref": "#/components/schemas/CyclicFirm"
+          }
+        }
+      },
+      "CyclicFirm": {
+        "type": "object",
+        "properties": {
+          "employees": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CyclicPerson"
+            }
+          },
+          "name": {
             "type": "string"
           }
         }

--- a/legend-engine-xts-openapi/legend-engine-xt-openapi-pure/src/main/resources/core_external_format_openapi/transformation/fromPure/tests/resources/testGraphFetchOpenApiSpecWithoutElements.txt
+++ b/legend-engine-xts-openapi/legend-engine-xt-openapi-pure/src/main/resources/core_external_format_openapi/transformation/fromPure/tests/resources/testGraphFetchOpenApiSpecWithoutElements.txt
@@ -1,1 +1,65 @@
-{"openapi":"3.0.0","info":{"title":"Legend API","version":"1.0.0"},"servers":[{"url":"test"}],"paths":{"/service/testOpenApi":{"get":{"tags":["definition"],"responses":{"200":{"description":"success","content":{"application/json":{"schema":{"$ref":"#/components/schemas/Person"}}}}}},"post":{"tags":["definition"],"responses":{"200":{"description":"success","content":{"application/json":{"schema":{"$ref":"#/components/schemas/Person"}}}}}}}},"components":{"schemas":{"Person":{"type":"object","properties":{"lastName":{"type":"string"},"employerID":{"type":"integer"},"age":{"type":"integer"},"firstName":{"type":"string"}}}}}}
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Legend API",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "test"
+    }
+  ],
+  "paths": {
+    "/service/testOpenApi": {
+      "get": {
+        "tags": [
+          "definition"
+        ],
+        "responses": {
+          "200": {
+            "description": "success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Person"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "definition"
+        ],
+        "responses": {
+          "200": {
+            "description": "success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Person"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Person": {
+        "type": "object",
+        "properties": {
+          "lastName": {
+            "type": "string"
+          },
+          "firstName": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/legend-engine-xts-openapi/legend-engine-xt-openapi-pure/src/main/resources/core_external_format_openapi/transformation/fromPure/tests/tests.pure
+++ b/legend-engine-xts-openapi/legend-engine-xt-openapi-pure/src/main/resources/core_external_format_openapi/transformation/fromPure/tests/tests.pure
@@ -48,6 +48,61 @@ Class meta::external::function::description::openapi::transformation::fromPure::
   price: Float[1];
 }
 
+Class meta::external::function::description::openapi::transformation::fromPure::tests::CyclicPerson
+{
+  name: String[1];
+  firm: CyclicFirm[0..1];
+  manager: CyclicPerson[0..1];
+  address: CyclicAddress[0..1];
+}
+
+Class meta::external::function::description::openapi::transformation::fromPure::tests::CyclicFirm
+{
+  name: String[1];
+  employees: CyclicPerson[*];
+  address: CyclicAddress[0..1];
+}
+
+Class meta::external::function::description::openapi::transformation::fromPure::tests::CyclicAddress
+{
+  line: String[1];
+  occupants: CyclicPerson[*];
+  firms: CyclicFirm[*];
+}
+
+Class meta::external::function::description::openapi::transformation::fromPure::tests::AssociatedPerson
+{
+  name: String[1];
+}
+
+Class meta::external::function::description::openapi::transformation::fromPure::tests::AssociatedFirm
+{
+  name: String[1];
+}
+
+Class meta::external::function::description::openapi::transformation::fromPure::tests::AssociatedAddress
+{
+  line: String[1];
+}
+
+Association meta::external::function::description::openapi::transformation::fromPure::tests::PersonFirm
+{
+  employer: AssociatedFirm[0..1];
+  employees: AssociatedPerson[*];
+}
+
+Association meta::external::function::description::openapi::transformation::fromPure::tests::PersonAddress
+{
+  homeAddress: AssociatedAddress[0..1];
+  occupants: AssociatedPerson[*];
+}
+
+Association meta::external::function::description::openapi::transformation::fromPure::tests::FirmAddress
+{
+  officeAddress: AssociatedAddress[0..1];
+  firms: AssociatedFirm[*];
+}
+
 function <<meta::external::function::description::openapi::profiles::ServiceSpecGeneration.OpenAPI>> {doc.doc = 'Legend openapi test simple service join'} meta::external::function::description::openapi::transformation::fromPure::tests::simpleServiceJoin():Service[1]
 {
  ^Service
@@ -297,6 +352,58 @@ function <<meta::external::function::description::openapi::profiles::ServiceSpec
   );
 }
 
+function <<meta::external::function::description::openapi::profiles::ServiceSpecGeneration.OpenAPI>> {doc.doc = 'Legend openapi test service over a cyclic model'} meta::external::function::description::openapi::transformation::fromPure::tests::serviceWithCyclicGraphFetch():Service[1]
+{
+  let tree = #{CyclicPerson{name, manager{name}, firm{name, employees{name}}}}#;
+  let func = {|CyclicPerson.all()->graphFetchChecked($tree)->serialize($tree)};
+  ^Service
+  (
+    pattern = '/service/testCyclicOpenApi',
+    owners = ['dummy'],
+    documentation = 'test service over a cyclic model',
+    autoActivateUpdates = true,
+    execution = ^PureSingleExecution
+                (
+                  func = $func,
+                  mapping = cyclicMapping,
+                  runtime = []
+                )
+  );
+}
+
+function <<meta::external::function::description::openapi::profiles::ServiceSpecGeneration.OpenAPI>> {doc.doc = 'Legend openapi test service over a model cyclic through associations'} meta::external::function::description::openapi::transformation::fromPure::tests::serviceWithAssociationGraphFetch():Service[1]
+{
+  let tree = #{AssociatedPerson{name, employer{name, officeAddress{line}}}}#;
+  let func = {|AssociatedPerson.all()->graphFetchChecked($tree)->serialize($tree)};
+  ^Service
+  (
+    pattern = '/service/testAssociationOpenApi',
+    owners = ['dummy'],
+    documentation = 'test service over a model cyclic through associations',
+    autoActivateUpdates = true,
+    execution = ^PureSingleExecution
+                (
+                  func = $func,
+                  mapping = associationMapping,
+                  runtime = []
+                )
+  );
+}
+
+function <<test.Test>> meta::external::function::description::openapi::transformation::fromPure::tests::testCyclicGraphFetchServiceShouldReturnCorrectOpenapiString():Boolean[1]
+{
+  let openapi = serviceWithCyclicGraphFetch()->serviceToOpenApi(^Server(url='test'), meta::relational::extension::relationalExtensions());
+  let expected = readFile('/core_external_format_openapi/transformation/fromPure/tests/resources/testCyclicGraphFetchOpenApiSpec.txt')->toOne();
+  assertJsonStringsEqual($expected, $openapi);
+}
+
+function <<test.Test>> meta::external::function::description::openapi::transformation::fromPure::tests::testAssociationGraphFetchServiceShouldReturnCorrectOpenapiString():Boolean[1]
+{
+  let openapi = serviceWithAssociationGraphFetch()->serviceToOpenApi(^Server(url='test'), meta::relational::extension::relationalExtensions());
+  let expected = readFile('/core_external_format_openapi/transformation/fromPure/tests/resources/testAssociationGraphFetchOpenApiSpec.txt')->toOne();
+  assertJsonStringsEqual($expected, $openapi);
+}
+
 function meta::external::function::description::openapi::transformation::fromPure::tests::packageableElemWithTrade():PackageableElement[*]
 {
   [
@@ -333,5 +440,23 @@ Mapping meta::external::function::description::openapi::transformation::fromPure
     tradeId : $src.tradeId;
     quantity : $src.quantity;
     price : $src.price;
+  }
+)
+
+Mapping meta::external::function::description::openapi::transformation::fromPure::tests::cyclicMapping
+(
+  CyclicPerson : Pure
+  {
+    ~src CyclicPerson
+    name : $src.name;
+  }
+)
+
+Mapping meta::external::function::description::openapi::transformation::fromPure::tests::associationMapping
+(
+  AssociatedPerson : Pure
+  {
+    ~src AssociatedPerson
+    name : $src.name;
   }
 )


### PR DESCRIPTION
Backport of #5119 to `release-legend-release-4.99`.

Created automatically by the backport workflow. If this PR has
conflicts or CI failures, the assignee (the original author) is
responsible for resolving them.