### PR TITLE
Fix scalar semi-structured (variant) property access in where predicates

### DIFF
--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/iteration/filter.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/iteration/filter.pure
@@ -107,6 +107,49 @@ function <<PCT.test, PCTRelationQualifier.relation, PCTCoreQualifier.variant>> m
                 '#', $res->toString());
 }
 
+function <<PCT.test, PCTRelationQualifier.relation, PCTCoreQualifier.variant>> meta::pure::functions::relation::tests::filter::testVariantColumn_filterOnIsEmptyOfKeyExtraction<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+   let tds = #TDS
+     id, payload:meta::pure::metamodel::variant::Variant
+     1, '{"businessData":{"signalId":"s1"}}'
+     2, '{"businessData":{}}'
+     3, '{"businessData":{"signalId":"s3"}}'
+   #;
+
+   let expr = {|
+                  $tds->filter(x | $x.payload->get('businessData')->get('signalId')->isEmpty())
+              };
+
+   let res =  $f->eval($expr);
+
+   assertEquals('#TDS\n'+
+                '   id,payload\n'+
+                '   2,\'{"businessData":{}}\'\n'+
+                '#', $res->toString());
+}
+
+function <<PCT.test, PCTRelationQualifier.relation, PCTCoreQualifier.variant>> meta::pure::functions::relation::tests::filter::testVariantColumn_filterOnIsNotEmptyOfKeyExtraction<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+   let tds = #TDS
+     id, payload:meta::pure::metamodel::variant::Variant
+     1, '{"businessData":{"signalId":"s1"}}'
+     2, '{"businessData":{}}'
+     3, '{"businessData":{"signalId":"s3"}}'
+   #;
+
+   let expr = {|
+                  $tds->filter(x | $x.payload->get('businessData')->get('signalId')->isNotEmpty())
+              };
+
+   let res =  $f->eval($expr);
+
+   assertEquals('#TDS\n'+
+                '   id,payload\n'+
+                '   1,\'{"businessData":{"signalId":"s1"}}\'\n'+
+                '   3,\'{"businessData":{"signalId":"s3"}}\'\n'+
+                '#', $res->toString());
+}
+
 function <<PCT.test, PCTRelationQualifier.relation, PCTCoreQualifier.variant>> meta::pure::functions::relation::tests::filter::testVariantColumn_filterOutputFromLambda<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
    let tds = #TDS

--- a/legend-engine-xts-deephaven/legend-engine-xt-deephaven-PCT/src/main/resources/pct-manifests/deephaven/RelationFunctions_manifest.json
+++ b/legend-engine-xts-deephaven/legend-engine-xt-deephaven-PCT/src/main/resources/pct-manifests/deephaven/RelationFunctions_manifest.json
@@ -178,6 +178,12 @@
     "test" : "meta::pure::functions::relation::tests::composition::testVariant_if_Function_1__Boolean_1_",
     "expectedError" : "Cannot cast a collection of size 0 to multiplicity [1]"
   }, {
+    "test" : "meta::pure::functions::relation::tests::filter::testVariantColumn_filterOnIsEmptyOfKeyExtraction_Function_1__Boolean_1_",
+    "expectedError" : "Cannot cast a collection of size 0 to multiplicity [1]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::filter::testVariantColumn_filterOnIsNotEmptyOfKeyExtraction_Function_1__Boolean_1_",
+    "expectedError" : "Cannot cast a collection of size 0 to multiplicity [1]"
+  },{
     "test" : "meta::pure::functions::relation::tests::composition::testWindowFunctionsAfterProject_Function_1__Boolean_1_",
     "expectedError" : "function not supported yet: meta::pure::functions::relation::project_C_MANY__FuncColSpecArray_1__Relation_1_"
   }, {

--- a/legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-PCT/src/main/resources/pct-manifests/java/Test_JAVA_RelationFunction_manifest.json
+++ b/legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-PCT/src/main/resources/pct-manifests/java/Test_JAVA_RelationFunction_manifest.json
@@ -1798,6 +1798,14 @@
       "expectedError": "\"Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated\""
     },
     {
+      "test": "meta::pure::functions::relation::tests::filter::testVariantColumn_filterOnIsEmptyOfKeyExtraction_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::filter::testVariantColumn_filterOnIsNotEmptyOfKeyExtraction_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
       "test": "meta::pure::functions::relation::variant::tests::flatten::testFlatten_Scalar_Function_1__Boolean_1_",
       "expectedError": "\"meta::pure::functions::relation::variant::flatten_T_MANY__ColSpec_1__Relation_1_ is not supported yet!\""
     },

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-clickhouse/legend-engine-xt-relationalStore-clickhouse-PCT/src/main/resources/pct-manifests/relational-clickhouse/RelationFunctions_manifest.json
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-clickhouse/legend-engine-xt-relationalStore-clickhouse-PCT/src/main/resources/pct-manifests/relational-clickhouse/RelationFunctions_manifest.json
@@ -220,6 +220,12 @@
     "test" : "meta::pure::functions::relation::tests::extend::testVariantColumn_map_Function_1__Boolean_1_",
     "expectedError" : "\"[unsupported-api] The function 'toVariant' (state: [Select, false]) is not supported yet\""
   }, {
+    "test": "meta::pure::functions::relation::tests::filter::testVariantColumn_filterOnIsEmptyOfKeyExtraction_Function_1__Boolean_1_",
+    "expectedError": "\"[unsupported-api] Semi structured array element processing not supported for Database Type: ClickHouse\""
+  }, {
+    "test": "meta::pure::functions::relation::tests::filter::testVariantColumn_filterOnIsNotEmptyOfKeyExtraction_Function_1__Boolean_1_",
+    "expectedError": "\"[unsupported-api] Semi structured array element processing not supported for Database Type: ClickHouse\""
+  }, {
     "test" : "meta::pure::functions::relation::tests::filter::testVariantColumn_filterOnIndexExtractionValue_Function_1__Boolean_1_",
     "expectedError" : "\"[unsupported-api] Semi structured array element processing not supported for Database Type: ClickHouse\""
   }, {

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-duckdb/legend-engine-xt-relationalStore-duckdb-pure/src/main/resources/core_relational_duckdb/relational/sqlQueryToString/duckdbExtension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-duckdb/legend-engine-xt-relationalStore-duckdb-pure/src/main/resources/core_relational_duckdb/relational/sqlQueryToString/duckdbExtension.pure
@@ -756,6 +756,8 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::duckD
 {
    let processedOperand = $s.operand->processOperation($sgc);
 
+   // The navigation is parenthesised because DuckDB binds '->' looser than a trailing
+   // predicate - a naked x->'k' is null parses as x->('k' is null).
    // A SemiStructuredPropertyAccess carries an OPTIONAL index of its own - 'addresses'->at(0)
    // is one property access with index 0, not a separate SemiStructuredArrayElementAccess.
    // Dropping that index makes every element of an array resolve to the same value.
@@ -763,12 +765,12 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::duckD
    // String, and rendering the String form through processOperation would quote it into a key.
    let navigation = $s->match([
       p: SemiStructuredPropertyAccess[1] |
-            let propertyAccess = '%s->%s'->format([$processedOperand, $p.property->processOperation($sgc)]);
+            let propertyAccess = '(%s->%s)'->format([$processedOperand, $p.property->processOperation($sgc)]);
             if($p.index->isEmpty(),
                | $propertyAccess,
-               | '%s->\'$[%s]\''->format([$propertyAccess, $p.index->toOne()->cast(@Literal).value->toString()]));,
+               | '(%s->\'$[%s]\')'->format([$propertyAccess, $p.index->toOne()->cast(@Literal).value->toString()]));,
       a: SemiStructuredArrayElementAccess[1] |
-            '%s->\'$[%s]\''->format([$processedOperand, $a.index->cast(@Literal).value->toString()])
+            '(%s->\'$[%s]\')'->format([$processedOperand, $a.index->cast(@Literal).value->toString()])
    ]);
 
    // '->' yields JSON, so a navigated string comes back still quoted. Cast to the navigated

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-PCT/src/main/resources/pct-manifests/relational-memsql/RelationFunctions_manifest.json
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-PCT/src/main/resources/pct-manifests/relational-memsql/RelationFunctions_manifest.json
@@ -67,6 +67,12 @@
     "test" : "meta::pure::functions::relation::tests::composition::testVariantColumn_projectModelProperty_Function_1__Boolean_1_",
     "expectedError" : "Error while executing: CREATE TEMPORARY TABLE leSchema.tb"
   }, {
+    "test" : "meta::pure::functions::relation::tests::filter::testVariantColumn_filterOnIsEmptyOfKeyExtraction_Function_1__Boolean_1_",
+    "expectedError" : "Error while executing: CREATE TEMPORARY TABLE leSchema.tb"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::filter::testVariantColumn_filterOnIsNotEmptyOfKeyExtraction_Function_1__Boolean_1_",
+    "expectedError" : "Error while executing: CREATE TEMPORARY TABLE leSchema.tb"
+  }, {
     "test" : "meta::pure::functions::relation::tests::composition::testVariantColumn_slice_Function_1__Boolean_1_",
     "expectedError" : "[unsupported-api] The function 'toVariant' (state: [Select, false]) is not supported yet"
   }, {

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-oracle/legend-engine-xt-relationalStore-oracle-PCT/src/main/resources/pct-manifests/relational-oracle/RelationFunctions_manifest.json
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-oracle/legend-engine-xt-relationalStore-oracle-PCT/src/main/resources/pct-manifests/relational-oracle/RelationFunctions_manifest.json
@@ -139,6 +139,12 @@
     "test" : "meta::pure::functions::relation::tests::filter::testVariantColumn_filterOnIndexExtractionValue_Function_1__Boolean_1_",
     "expectedError" : "\"[unsupported-api] Semi structured array element processing not supported for Database Type: Oracle\""
   }, {
+    "test" : "meta::pure::functions::relation::tests::filter::testVariantColumn_filterOnIsEmptyOfKeyExtraction_Function_1__Boolean_1_",
+    "expectedError" : "[unsupported-api] Semi structured array element processing not supported for Database Type: Oracle"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::filter::testVariantColumn_filterOnIsNotEmptyOfKeyExtraction_Function_1__Boolean_1_",
+    "expectedError" : "[unsupported-api] Semi structured array element processing not supported for Database Type: Oracle"
+  }, {
     "test" : "meta::pure::functions::relation::tests::filter::testVariantColumn_filterOnKeyExtractionValue_Function_1__Boolean_1_",
     "expectedError" : "\"[unsupported-api] Semi structured array element processing not supported for Database Type: Oracle\""
   }, {

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-spanner/legend-engine-xt-relationalStore-spanner-PCT/src/main/resources/pct-manifests/relational-spanner/RelationFunctions_manifest.json
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-spanner/legend-engine-xt-relationalStore-spanner-PCT/src/main/resources/pct-manifests/relational-spanner/RelationFunctions_manifest.json
@@ -88,6 +88,12 @@
     "test" : "meta::pure::functions::relation::tests::composition::testVariantColumn_extend_indexExtraction_filter_Function_1__Boolean_1_",
     "expectedError" : "[unsupported-api] Semi structured array element processing not supported for Database Type: Spanner"
   }, {
+    "test" : "meta::pure::functions::relation::tests::filter::testVariantColumn_filterOnIsEmptyOfKeyExtraction_Function_1__Boolean_1_",
+    "expectedError" : "[unsupported-api] Semi structured array element processing not supported for Database Type: Spanner"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::filter::testVariantColumn_filterOnIsNotEmptyOfKeyExtraction_Function_1__Boolean_1_",
+    "expectedError" : "[unsupported-api] Semi structured array element processing not supported for Database Type: Spanner"
+  }, {
     "test" : "meta::pure::functions::relation::tests::composition::testVariantColumn_functionComposition_Function_1__Boolean_1_",
     "expectedError" : "[unsupported-api] The function 'array_size' (state: [Where, false]) is not supported yet"
   }, {

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-sqlserver/legend-engine-xt-relationalStore-sqlserver-PCT/src/main/resources/pct-manifests/relational-sqlserver/RelationFunctions_manifest.json
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-sqlserver/legend-engine-xt-relationalStore-sqlserver-PCT/src/main/resources/pct-manifests/relational-sqlserver/RelationFunctions_manifest.json
@@ -157,6 +157,12 @@
     "test" : "meta::pure::functions::relation::tests::extend::testOLAPWithPartitionAndMultipleOrderWindowMultipleColumns_Function_1__Boolean_1_",
     "expectedError" : "ORDER BY list of RANGE window frame has total size of 1028 bytes. Largest size supported is 900 bytes."
   }, {
+    "test": "meta::pure::functions::relation::tests::filter::testVariantColumn_filterOnIsEmptyOfKeyExtraction_Function_1__Boolean_1_",
+    "expectedError": "[unsupported-api] Semi structured array element processing not supported for Database Type: SqlServer"
+  }, {
+    "test": "meta::pure::functions::relation::tests::filter::testVariantColumn_filterOnIsNotEmptyOfKeyExtraction_Function_1__Boolean_1_",
+    "expectedError": "[unsupported-api] Semi structured array element processing not supported for Database Type: SqlServer"
+  }, {
     "test" : "meta::pure::functions::relation::tests::extend::testVariantColumn_filter_Function_1__Boolean_1_",
     "expectedError" : "[unsupported-api] The function 'toVariant' (state: [Select, false]) is not supported yet"
   }, {

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-trino/legend-engine-xt-relationalStore-trino-PCT/src/main/resources/pct-manifests/relational-trino/RelationFunctions_manifest.json
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-trino/legend-engine-xt-relationalStore-trino-PCT/src/main/resources/pct-manifests/relational-trino/RelationFunctions_manifest.json
@@ -160,6 +160,12 @@
     "test" : "meta::pure::functions::relation::tests::filter::testVariantColumn_filterOnKeyExtractionValue_Function_1__Boolean_1_",
     "expectedError" : "[unsupported-api] Semi structured array element processing not supported for Database Type: Trino"
   }, {
+    "test": "meta::pure::functions::relation::tests::filter::testVariantColumn_filterOnIsEmptyOfKeyExtraction_Function_1__Boolean_1_",
+    "expectedError": "[unsupported-api] Semi structured array element processing not supported for Database Type: Trino"
+  }, {
+    "test": "meta::pure::functions::relation::tests::filter::testVariantColumn_filterOnIsNotEmptyOfKeyExtraction_Function_1__Boolean_1_",
+    "expectedError": "[unsupported-api] Semi structured array element processing not supported for Database Type: Trino"
+  },{
     "test" : "meta::pure::functions::relation::tests::filter::testVariantColumn_filterOutputFromLambda_Function_1__Boolean_1_",
     "expectedError" : "[unsupported-api] The function 'array_size' (state: [Where, false]) is not supported yet"
   }, {

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery.pure
@@ -4181,6 +4181,8 @@ function meta::relational::functions::pureToSqlQuery::processMap(f:FunctionExpre
       let milestoningContext=$newQuery.milestoningContext->concatenate($operation.milestoningContext)->first();
 
       let isSemiStructuredPropertyMapping = ($newCurrentPropertyMapping->size() >= 1) && $newCurrentPropertyMapping->forAll(pm | $pm->instanceOf(SemiStructuredRelationalPropertyMapping));
+      // in a filter the processed input is carried by filteringOperation, not columns
+      let mappedInput = $state.inFilter->if(|$select.filteringOperation, |$select.columns);
       let isVariant = $f.parametersValues->at(0)->isVariantInput($vars, $state);
       // The lambda's parameter binds to the source's column, so that column has to survive into
       // sourceOp. It is needed whenever the parameter denotes a single value: a DataType, i.e. a
@@ -4199,7 +4201,7 @@ function meta::relational::functions::pureToSqlQuery::processMap(f:FunctionExpre
                                    ]);
       let extraColumn = if($lambdaParamIsDataType || $isSemiStructuredPropertyMapping || $isVariant,
                             | let aliasRemap = $mainQuery.currentTreeNode.alias.name->map(n | ^OldAliasToNewAlias(first = $n, second = $newQuery.currentTreeNode.alias->toOne()));
-                              $select.columns->map(c | $c->reprocessAliases($aliasRemap));,
+                              $mappedInput->map(c | $c->reprocessAliases($aliasRemap));,
                             | []);
 
       $func->match(
@@ -4438,7 +4440,10 @@ function meta::relational::functions::pureToSqlQuery::processEmpty(f:FunctionExp
             $fe.genericType.rawType->match(
                   [
                      d:DataType[1]| $f->processSubEmpty($currentPropertyMapping, $operation, $vars, $state, $joinType, $nodeId, $aggFromMap, $context, $extensions);
-                     ,c:Class<Any>[1] | processExists($f, $not, $currentPropertyMapping, $operation, $vars, $state, $nodeId, $aggFromMap, $context, $extensions)
+                     ,c:Class<Any>[1] | if($fe->isScalarVariantExpression(),
+                                                | $f->processSubEmpty($currentPropertyMapping, $operation, $vars, $state, $joinType, $nodeId, $aggFromMap, $context, $extensions),
+                                                | processExists($f, $not, $currentPropertyMapping, $operation, $vars, $state, $nodeId, $aggFromMap, $context, $extensions)
+                                          )
                   ]
             )
         ,a:Any[1] | $f->processSubEmpty($currentPropertyMapping, $operation, $vars, $state, $joinType, $nodeId, $aggFromMap, $context, $extensions);
@@ -4508,7 +4513,7 @@ function meta::relational::functions::pureToSqlQuery::processSubEmpty(f:Function
    let parameters = $f.parametersValues->at(0);
    let isParameterPlanVarOfTypeList = isParamPlanVar($parameters, $vars, $state.inScopeVars) && $parameters.multiplicity == ZeroMany;
 
-   let isEmptyExpressionValid = $parameters->match([v:FunctionExpression[1]| $v.func == map_T_m__Function_1__V_m_  || $v.func == map_T_MANY__Function_1__V_MANY_ || !$v.genericType.rawType->toOne()->instanceOf(Class);,
+   let isEmptyExpressionValid = $parameters->match([v:FunctionExpression[1]| $v.func == map_T_m__Function_1__V_m_  || $v.func == map_T_MANY__Function_1__V_MANY_ || !$v.genericType.rawType->toOne()->instanceOf(Class) || $v->isScalarVariantExpression();,
                                                     a:Any[1]| true;]);
 
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery_variant.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery_variant.pure
@@ -569,6 +569,14 @@ function meta::relational::functions::pureToSqlQuery::processVariantAt(f:Functio
   ^$operation(select = $state.inFilter->if(|^$select(filteringOperation = $relOpElement),|^$select(columns = $relOpElement)));
 }
 
+// Variant is a Class in the metamodel but a value in SQL, so a to-one Variant expression is a
+// scalar: a null check on it is a plain IS NULL predicate, not the existence check needed for a
+// to-many navigation (a variant array, or a navigation to a mapped class).
+function meta::relational::functions::pureToSqlQuery::isScalarVariantExpression(v: ValueSpecification[1]):Boolean[1]
+{
+  $v.genericType.rawType == meta::pure::metamodel::variant::Variant && $v.multiplicity->hasToOneUpperBound();
+}
+
 function meta::relational::functions::pureToSqlQuery::processMapGet(f:FunctionExpression[1], currentPropertyMapping:PropertyMapping[*], operation:SelectWithCursor[1], vars:Map<VariableExpression, ValueSpecification>[1], state:State[1], joinType:JoinType[1], nodeId:String[1], aggFromMap:List<ColumnGroup>[1], context:DebugContext[1], extensions:Extension[*]):RelationalOperationElement[1]
 {
   let params = $f.parametersValues->evaluateAndDeactivate();

--- a/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/src/test/resources/parity-tests/structural/json_operators.yaml
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/src/test/resources/parity-tests/structural/json_operators.yaml
@@ -300,3 +300,38 @@ tests:
     category: "json_operators"
     expected_tds_status: ERROR
     expected_rel_status: ERROR
+
+  - id: json_column_nested_extract_in_where_is_null
+    sql: "SELECT id FROM json_data WHERE json_val -> 'a' -> 'b' IS NULL ORDER BY 1"
+    feature: "JSON column nested extract IS NULL in WHERE"
+    category: "json_operators"
+    expected_tds_status: ERROR
+    expected_rel_status: PASS
+
+  - id: json_column_nested_extract_in_where_is_not_null
+    sql: "SELECT id FROM json_data WHERE json_val -> 'a' -> 'b' IS NOT NULL ORDER BY 1"
+    feature: "JSON column nested extract IS NOT NULL in WHERE"
+    category: "json_operators"
+    expected_tds_status: ERROR
+    expected_rel_status: PASS
+
+  - id: json_column_nested_extract_in_where_not_is_null
+    sql: "SELECT id FROM json_data WHERE NOT json_val -> 'a' -> 'b' IS NULL ORDER BY 1"
+    feature: "JSON column nested extract NOT ... IS NULL in WHERE"
+    category: "json_operators"
+    expected_tds_status: ERROR
+    expected_rel_status: PASS
+
+  - id: json_column_extract_text_in_where_equals
+    sql: "SELECT id FROM json_data WHERE json_val ->> 'b' = 'hello' ORDER BY 1"
+    feature: "JSON column extract as text compared in WHERE"
+    category: "json_operators"
+    expected_tds_status: ERROR
+    expected_rel_status: PASS
+
+  - id: json_column_nested_extract_in_select_and_where
+    sql: "SELECT id, json_val -> 'a' -> 'b' AS nested FROM json_data WHERE json_val -> 'a' -> 'b' IS NOT NULL ORDER BY 1"
+    feature: "JSON column nested extract in SELECT and WHERE"
+    category: "json_operators"
+    expected_tds_status: ERROR
+    expected_rel_status: PASS


### PR DESCRIPTION
#### What type of PR is this?

- Bug Fix

#### What does this PR do / why is it needed ?

Two unrelated bugs on the same path both only reachable in filter position. Each one alone still fails, so both are fixed here.

#### Which issue(s) this PR fixes:

Filtering on a nested semi-structured (JSON/Variant) navigation fails at plan generation, no SQL is produced, the user gets an internal multiplcity error.
