### PR TITLE
Legend SQL - fix key naming and relation type loss over joins

### DIFF
--- a/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/src/test/resources/parity-tests/compositions/multi_join_agg.yaml
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/src/test/resources/parity-tests/compositions/multi_join_agg.yaml
@@ -5,7 +5,7 @@ tests:
     feature: "3-table JOIN + aggregation"
     category: "compositions"
     expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   # LEFT JOIN preserving empty groups
   - id: comp_left_join_empty_groups
@@ -13,7 +13,7 @@ tests:
     feature: "LEFT JOIN preserving empty groups"
     category: "compositions"
     expected_tds_status: PASS
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   # HAVING on joined aggregate
   - id: comp_join_having
@@ -21,7 +21,7 @@ tests:
     feature: "JOIN + HAVING"
     category: "compositions"
     expected_tds_status: PASS
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   # COUNT(DISTINCT) across join
   - id: comp_count_distinct_join
@@ -29,7 +29,7 @@ tests:
     feature: "COUNT(DISTINCT) across JOIN"
     category: "compositions"
     expected_tds_status: PASS
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   # Self-join with aggregation
   - id: comp_self_join_agg
@@ -37,7 +37,7 @@ tests:
     feature: "Self-join + aggregation"
     category: "compositions"
     expected_tds_status: PASS
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   # JOIN + CASE + aggregation
   - id: comp_join_case_agg
@@ -45,7 +45,7 @@ tests:
     feature: "JOIN + CASE + aggregation"
     category: "compositions"
     expected_tds_status: PASS
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   # LEFT JOIN with COALESCE and multiple aggs
   - id: comp_left_join_coalesce_multi
@@ -53,7 +53,7 @@ tests:
     feature: "LEFT JOIN + COALESCE + multi-agg"
     category: "compositions"
     expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   # 3-table join with filter
   - id: comp_three_table_filter
@@ -69,4 +69,4 @@ tests:
     feature: "JOIN with derived table"
     category: "compositions"
     expected_tds_status: PASS
-    expected_rel_status: ERROR
+    expected_rel_status: PASS

--- a/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/src/test/resources/parity-tests/compositions/nested_subqueries.yaml
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/src/test/resources/parity-tests/compositions/nested_subqueries.yaml
@@ -74,7 +74,7 @@ tests:
     feature: "IN subquery + JOIN"
     category: "compositions"
     expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   # Derived table with window
   - id: nested_derived_window

--- a/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/src/test/resources/parity-tests/compositions/stress_queries.yaml
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/src/test/resources/parity-tests/compositions/stress_queries.yaml
@@ -37,7 +37,7 @@ tests:
     feature: "Multi-aggregate + COALESCE + JOINs"
     category: "compositions"
     expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   # Percentile simulation via ROW_NUMBER
   - id: stress_percentile_sim

--- a/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/src/test/resources/parity-tests/structural/column_resolution_across_renames.yaml
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/src/test/resources/parity-tests/structural/column_resolution_across_renames.yaml
@@ -170,21 +170,21 @@ tests:
     feature: "GROUP BY qualified key over a join with a self-named alias"
     category: "column_resolution"
     expected_tds_status: PASS
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   - id: colres_e1_group_by_key_from_right_side
     sql: "SELECT d.name AS name, COUNT(*) AS c FROM persons p INNER JOIN departments d ON p.dept_id = d.id GROUP BY d.name ORDER BY 1"
     feature: "GROUP BY key from the right join side"
     category: "column_resolution"
     expected_tds_status: PASS
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   - id: colres_e1_group_by_two_keys_both_sides
     sql: "SELECT p.dept_id AS dept_id, d.name AS name, COUNT(*) AS c FROM persons p INNER JOIN departments d ON p.dept_id = d.id GROUP BY p.dept_id, d.name ORDER BY 1, 2"
     feature: "GROUP BY keys from both join sides"
     category: "column_resolution"
     expected_tds_status: PASS
-    expected_rel_status: FAIL
+    expected_rel_status: PASS
 
   # The aggregate path, not the key list: createAggregation builds `x | $x.<col>` lambdas
   # that read the renamed relation, so those names have to follow the rename too. Here the
@@ -194,28 +194,28 @@ tests:
     feature: "GROUP BY over a join, aggregate over the other side"
     category: "column_resolution"
     expected_tds_status: PASS
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   - id: colres_e1_group_by_multiple_aggregates
     sql: "SELECT d.name AS name, COUNT(*) AS c, MIN(p.age) AS min_age, MAX(p.age) AS max_age FROM persons p INNER JOIN departments d ON p.dept_id = d.id WHERE p.age IS NOT NULL GROUP BY d.name ORDER BY 1"
     feature: "GROUP BY over a join with several aggregates"
     category: "column_resolution"
     expected_tds_status: PASS
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   - id: colres_e1_group_by_having_over_join
     sql: "SELECT d.name AS name, COUNT(*) AS c FROM persons p INNER JOIN departments d ON p.dept_id = d.id GROUP BY d.name HAVING COUNT(*) > 1 ORDER BY 1"
     feature: "GROUP BY + HAVING over a join with a self-named alias"
     category: "column_resolution"
     expected_tds_status: PASS
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   - id: colres_e1_group_by_ordinal_over_join
     sql: "SELECT d.name AS name, COUNT(*) AS c FROM persons p INNER JOIN departments d ON p.dept_id = d.id GROUP BY 1 ORDER BY 1"
     feature: "GROUP BY ordinal over a join with a self-named alias"
     category: "column_resolution"
     expected_tds_status: PASS
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   # No aggregate at all -- processGroupBy takes its restrict+distinct branch, which resolves
   # the key list through the same context.
@@ -224,7 +224,7 @@ tests:
     feature: "GROUP BY with no aggregates over a join"
     category: "column_resolution"
     expected_tds_status: PASS
-    expected_rel_status: FAIL
+    expected_rel_status: PASS
 
   # Both sides are the same table, so every column name collides and both sides get
   # suffixed.
@@ -233,14 +233,14 @@ tests:
     feature: "GROUP BY over a self-join with a self-named alias"
     category: "column_resolution"
     expected_tds_status: PASS
-    expected_rel_status: FAIL
+    expected_rel_status: PASS
 
   - id: colres_e1_group_by_over_join_ordered_by_aggregate_alias
     sql: "SELECT d.name AS name, COUNT(*) AS c FROM persons p INNER JOIN departments d ON p.dept_id = d.id GROUP BY d.name ORDER BY c DESC, name"
     feature: "GROUP BY over a join ordered by the aggregate's output alias"
     category: "column_resolution"
     expected_tds_status: PASS
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   # ==========================================================================
   # Window PARTITION BY / ORDER BY keys -- the same desync, one function over
@@ -251,28 +251,28 @@ tests:
     feature: "window PARTITION BY over a join with a self-named alias"
     category: "column_resolution"
     expected_tds_status: PASS
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   - id: colres_e2_window_order_key_over_join
     sql: "SELECT p.name AS name, p.salary AS salary, RANK() OVER (ORDER BY p.salary DESC) AS r FROM persons p INNER JOIN departments d ON p.dept_id = d.id WHERE p.salary IS NOT NULL ORDER BY 3, 1"
     feature: "window ORDER BY key over a join with a self-named alias"
     category: "column_resolution"
     expected_tds_status: PASS
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   - id: colres_e2_window_partition_and_order_from_both_sides
     sql: "SELECT p.name AS name, d.name AS dept_name, ROW_NUMBER() OVER (PARTITION BY d.name ORDER BY p.name) AS rn FROM persons p INNER JOIN departments d ON p.dept_id = d.id ORDER BY 2, 3"
     feature: "window keys drawn from both join sides"
     category: "column_resolution"
     expected_tds_status: PASS
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   - id: colres_e2_two_window_functions_over_join
     sql: "SELECT p.name AS name, p.dept_id AS dept_id, ROW_NUMBER() OVER (PARTITION BY p.dept_id ORDER BY p.name) AS rn, RANK() OVER (PARTITION BY p.dept_id ORDER BY p.id DESC) AS r FROM persons p INNER JOIN departments d ON p.dept_id = d.id ORDER BY 2, 1"
     feature: "two window functions over a join with a self-named alias"
     category: "column_resolution"
     expected_tds_status: PASS
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   - id: colres_e2_window_aggregate_over_join
     sql: "SELECT p.name AS name, p.dept_id AS dept_id, SUM(p.salary) OVER (PARTITION BY p.dept_id) AS dept_total FROM persons p INNER JOIN departments d ON p.dept_id = d.id WHERE p.salary IS NOT NULL ORDER BY 2, 1"
@@ -286,7 +286,7 @@ tests:
     feature: "window over a self-join with a self-named alias"
     category: "column_resolution"
     expected_tds_status: PASS
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   # ==========================================================================
   # WRONG-RESULTS GUARDS
@@ -312,7 +312,7 @@ tests:
     feature: "GROUP BY key when both join sides expose the same column name"
     category: "column_resolution"
     expected_tds_status: PASS
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   # ==========================================================================
   # KNOWN GAPS -- expected to stay ERROR

--- a/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/src/test/resources/parity-tests/structural/column_resolution_corpus_shapes.yaml
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/src/test/resources/parity-tests/structural/column_resolution_corpus_shapes.yaml
@@ -260,42 +260,42 @@ tests:
     feature: "window ORDER BY CASE null guard plus real key, over a join"
     category: "column_resolution_corpus"
     expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   - id: crcs_g1b_win_order_case_null_guard_only_over_join
     sql: "SELECT p.name AS name, d.budget AS budget, ROW_NUMBER() OVER (PARTITION BY p.dept_id ORDER BY CASE WHEN p.salary IS NULL THEN 1 ELSE 0 END, p.name) AS rn FROM persons p INNER JOIN departments d ON p.dept_id = d.id ORDER BY 1"
     feature: "window ORDER BY CASE null guard as the leading key, over a join"
     category: "column_resolution_corpus"
     expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   - id: crcs_g1b_win_order_case_null_guard_desc_over_join
     sql: "SELECT p.name AS name, d.budget AS budget, ROW_NUMBER() OVER (PARTITION BY p.dept_id ORDER BY CASE WHEN p.hire_date IS NULL THEN 1 ELSE 0 END DESC, p.hire_date ASC, p.name) AS rn FROM persons p INNER JOIN departments d ON p.dept_id = d.id ORDER BY 1"
     feature: "window ORDER BY CASE null guard with DESC, over a join"
     category: "column_resolution_corpus"
     expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   - id: crcs_g1b_win_order_case_null_guard_right_side_over_join
     sql: "SELECT p.name AS name, d.budget AS budget, ROW_NUMBER() OVER (PARTITION BY p.dept_id ORDER BY CASE WHEN d.budget IS NULL THEN 1 ELSE 0 END, d.budget DESC, p.name) AS rn FROM persons p INNER JOIN departments d ON p.dept_id = d.id ORDER BY 1"
     feature: "window ORDER BY CASE null guard on the right join side"
     category: "column_resolution_corpus"
     expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   - id: crcs_g1b_win_order_case_null_guard_over_left_join
     sql: "SELECT p.name AS name, d.budget AS budget, ROW_NUMBER() OVER (PARTITION BY p.dept_id ORDER BY CASE WHEN p.salary IS NULL THEN 1 ELSE 0 END, p.salary DESC, p.name) AS rn FROM persons p LEFT OUTER JOIN departments d ON p.dept_id = d.id ORDER BY 1"
     feature: "window ORDER BY CASE null guard over a LEFT OUTER JOIN"
     category: "column_resolution_corpus"
     expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   - id: crcs_g1b_dedup_case_null_guard_filtered
     sql: "SELECT a.name, a.budget FROM (SELECT p.name AS name, d.budget AS budget, ROW_NUMBER() OVER (PARTITION BY p.dept_id ORDER BY CASE WHEN p.salary IS NULL THEN 1 ELSE 0 END, p.salary DESC, p.name) AS rn FROM persons p INNER JOIN departments d ON p.dept_id = d.id) a WHERE a.rn = 1 ORDER BY 1"
     feature: "ROW_NUMBER dedup with a CASE null guard, filtered on rn = 1"
     category: "column_resolution_corpus"
     expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   - id: crcs_g1b_win_order_case_null_guard_no_join
     sql: "SELECT p.name AS name, ROW_NUMBER() OVER (PARTITION BY p.dept_id ORDER BY CASE WHEN p.salary IS NULL THEN 1 ELSE 0 END, p.salary DESC, p.name) AS rn FROM persons p ORDER BY 1"
@@ -318,21 +318,21 @@ tests:
     feature: "window ORDER BY UPPER(col) over a join"
     category: "column_resolution_corpus"
     expected_tds_status: PASS
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   - id: crcs_g1c_win_order_cast_to_date_over_join
     sql: "SELECT p.name AS name, d.budget AS budget, ROW_NUMBER() OVER (PARTITION BY p.dept_id ORDER BY CAST(d.created_at AS DATE), p.name) AS rn FROM persons p INNER JOIN departments d ON p.dept_id = d.id ORDER BY 1"
     feature: "window ORDER BY CAST(col AS DATE) over a join"
     category: "column_resolution_corpus"
     expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   - id: crcs_g1c_win_order_coalesce_one_side_over_join
     sql: "SELECT p.name AS name, d.budget AS budget, ROW_NUMBER() OVER (PARTITION BY p.dept_id ORDER BY COALESCE(p.salary, 0) DESC, p.name) AS rn FROM persons p INNER JOIN departments d ON p.dept_id = d.id ORDER BY 1"
     feature: "window ORDER BY COALESCE(col, literal) over a join"
     category: "column_resolution_corpus"
     expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   # A single sort key reading columns from both join sides, so both suffixes
   # have to resolve inside one expression.
@@ -341,14 +341,14 @@ tests:
     feature: "window ORDER BY an expression reading both join sides"
     category: "column_resolution_corpus"
     expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   - id: crcs_g1c_win_order_substring_over_join
     sql: "SELECT p.name AS name, d.budget AS budget, ROW_NUMBER() OVER (PARTITION BY p.dept_id ORDER BY SUBSTRING(p.name FROM 1 FOR 3), p.name) AS rn FROM persons p INNER JOIN departments d ON p.dept_id = d.id ORDER BY 1"
     feature: "window ORDER BY SUBSTRING(col ...) over a join"
     category: "column_resolution_corpus"
     expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   - id: crcs_g1c_win_order_arithmetic_both_sides_over_join
     sql: "SELECT p.name AS name, d.budget AS budget, ROW_NUMBER() OVER (PARTITION BY p.dept_id ORDER BY COALESCE(p.salary, 0) + d.budget DESC, p.name) AS rn FROM persons p INNER JOIN departments d ON p.dept_id = d.id ORDER BY 1"
@@ -362,21 +362,21 @@ tests:
     feature: "window ORDER BY EXTRACT(part FROM col) over a join"
     category: "column_resolution_corpus"
     expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   - id: crcs_g1c_win_order_nested_case_in_function_over_join
     sql: "SELECT p.name AS name, d.budget AS budget, ROW_NUMBER() OVER (PARTITION BY p.dept_id ORDER BY UPPER(CASE WHEN p.active = true THEN p.name ELSE d.name END), p.name) AS rn FROM persons p INNER JOIN departments d ON p.dept_id = d.id ORDER BY 1"
     feature: "window ORDER BY a CASE nested inside a function, over a join"
     category: "column_resolution_corpus"
     expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   - id: crcs_g1c_win_order_expression_matching_a_projection_over_join
     sql: "SELECT p.name AS name, UPPER(p.name) AS upper_name, ROW_NUMBER() OVER (PARTITION BY p.dept_id ORDER BY UPPER(p.name)) AS rn FROM persons p INNER JOIN departments d ON p.dept_id = d.id ORDER BY 1"
     feature: "window ORDER BY an expression the projection already computes"
     category: "column_resolution_corpus"
     expected_tds_status: PASS
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   # ------------------------------------------------------------------
   # Single-table controls for the same expression keys.
@@ -463,63 +463,63 @@ tests:
     feature: "GROUP BY key over a LEFT OUTER JOIN"
     category: "column_resolution_corpus"
     expected_tds_status: PASS
-    expected_rel_status: FAIL
+    expected_rel_status: PASS
 
   - id: crcs_g2_group_key_over_left_join_self_named_alias
     sql: "SELECT p.dept_id AS dept_id, MAX(d.budget) AS max_budget FROM persons p LEFT OUTER JOIN departments d ON p.dept_id = d.id GROUP BY p.dept_id ORDER BY 1"
     feature: "GROUP BY alias.col AS col over a LEFT OUTER JOIN"
     category: "column_resolution_corpus"
     expected_tds_status: PASS
-    expected_rel_status: FAIL
+    expected_rel_status: PASS
 
   - id: crcs_g2_group_key_over_three_way_join
     sql: "SELECT p.dept_id AS dept_id, COUNT(o.id) AS order_count FROM persons p INNER JOIN departments d ON p.dept_id = d.id INNER JOIN orders o ON o.person_id = p.id GROUP BY p.dept_id ORDER BY 1"
     feature: "GROUP BY key over a three-way join"
     category: "column_resolution_corpus"
     expected_tds_status: PASS
-    expected_rel_status: FAIL
+    expected_rel_status: PASS
 
   - id: crcs_g2_group_keys_from_all_three_sides
     sql: "SELECT p.dept_id AS dept_id, d.name AS dept_name, o.status AS status, COUNT(*) AS n FROM persons p INNER JOIN departments d ON p.dept_id = d.id INNER JOIN orders o ON o.person_id = p.id GROUP BY p.dept_id, d.name, o.status ORDER BY 1, 2, 3"
     feature: "GROUP BY keys drawn from all three sides of a join"
     category: "column_resolution_corpus"
     expected_tds_status: PASS
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   - id: crcs_g2_group_key_over_derived_table_join
     sql: "SELECT x.dept_id AS dept_id, COUNT(*) AS n FROM (SELECT id, dept_id FROM persons) x INNER JOIN (SELECT id FROM departments) y ON x.dept_id = y.id GROUP BY x.dept_id ORDER BY 1"
     feature: "GROUP BY key over a join of two derived tables"
     category: "column_resolution_corpus"
     expected_tds_status: PASS
-    expected_rel_status: FAIL
+    expected_rel_status: PASS
 
   - id: crcs_g2_group_key_from_the_derived_side
     sql: "SELECT y.bucket AS bucket, COUNT(*) AS n FROM persons p INNER JOIN (SELECT id, CASE WHEN budget > 500000 THEN 'large' ELSE 'small' END AS bucket FROM departments) y ON p.dept_id = y.id GROUP BY y.bucket ORDER BY 1"
     feature: "GROUP BY a column computed inside the derived join side"
     category: "column_resolution_corpus"
     expected_tds_status: PASS
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   - id: crcs_g2_group_by_expression_key_over_join
     sql: "SELECT EXTRACT(YEAR FROM p.hire_date) AS hire_year, COUNT(*) AS n FROM persons p INNER JOIN departments d ON p.dept_id = d.id GROUP BY EXTRACT(YEAR FROM p.hire_date) ORDER BY 1"
     feature: "GROUP BY an expression key over a join"
     category: "column_resolution_corpus"
-    expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_tds_status: PASS
+    expected_rel_status: PASS
 
   - id: crcs_g2_group_by_concatenation_expression_over_join
     sql: "SELECT CAST(EXTRACT(YEAR FROM d.created_at) AS VARCHAR(4)) || '-' || d.name AS bucket, COUNT(DISTINCT p.id) AS n FROM persons p INNER JOIN departments d ON p.dept_id = d.id GROUP BY CAST(EXTRACT(YEAR FROM d.created_at) AS VARCHAR(4)) || '-' || d.name ORDER BY 1"
     feature: "GROUP BY a concatenation expression with COUNT(DISTINCT), over a join"
     category: "column_resolution_corpus"
-    expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_tds_status: PASS
+    expected_rel_status: PASS
 
   - id: crcs_g2_group_by_having_over_left_join
     sql: "SELECT p.dept_id AS dept_id, COUNT(*) AS n FROM persons p LEFT OUTER JOIN departments d ON p.dept_id = d.id GROUP BY p.dept_id HAVING COUNT(*) > 1 ORDER BY 1"
     feature: "GROUP BY with HAVING over a LEFT OUTER JOIN"
     category: "column_resolution_corpus"
     expected_tds_status: PASS
-    expected_rel_status: FAIL
+    expected_rel_status: PASS
 
   - id: crcs_g2_group_by_ordered_by_null_ordered_aggregate
     sql: "SELECT p.dept_id AS dept_id, MAX(p.salary) AS max_salary FROM persons p INNER JOIN departments d ON p.dept_id = d.id GROUP BY p.dept_id ORDER BY MAX(p.salary) DESC NULLS LAST, 1"
@@ -541,57 +541,57 @@ tests:
     sql: "SELECT p.name AS name, ROW_NUMBER() OVER (PARTITION BY CAST(d.created_at AS DATE) ORDER BY p.name) AS rn FROM persons p INNER JOIN departments d ON p.dept_id = d.id ORDER BY 1"
     feature: "window PARTITION BY CAST(col AS DATE) over a join"
     category: "column_resolution_corpus"
-    expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_tds_status: PASS
+    expected_rel_status: PASS
 
   - id: crcs_g3_partition_by_case_over_join
     sql: "SELECT p.name AS name, ROW_NUMBER() OVER (PARTITION BY CASE WHEN p.salary > 60000 THEN 1 ELSE 0 END ORDER BY p.name) AS rn FROM persons p INNER JOIN departments d ON p.dept_id = d.id ORDER BY 1"
     feature: "window PARTITION BY a CASE expression over a join"
     category: "column_resolution_corpus"
-    expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_tds_status: PASS
+    expected_rel_status: PASS
 
   - id: crcs_g3_partition_by_substring_over_join
     sql: "SELECT p.name AS name, ROW_NUMBER() OVER (PARTITION BY SUBSTRING(p.name FROM 1 FOR 1) ORDER BY p.name) AS rn FROM persons p INNER JOIN departments d ON p.dept_id = d.id ORDER BY 1"
     feature: "window PARTITION BY SUBSTRING(col ...) over a join"
     category: "column_resolution_corpus"
     expected_tds_status: PASS
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   - id: crcs_g3_partition_by_coalesce_both_sides_over_join
     sql: "SELECT p.name AS name, ROW_NUMBER() OVER (PARTITION BY COALESCE(p.dept_id, d.id) ORDER BY p.name) AS rn FROM persons p INNER JOIN departments d ON p.dept_id = d.id ORDER BY 1"
     feature: "window PARTITION BY an expression reading both join sides"
     category: "column_resolution_corpus"
-    expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_tds_status: PASS
+    expected_rel_status: PASS
 
   - id: crcs_g3_partition_by_upper_over_left_join
     sql: "SELECT p.name AS name, ROW_NUMBER() OVER (PARTITION BY UPPER(COALESCE(d.name, 'NONE')) ORDER BY p.name) AS rn FROM persons p LEFT OUTER JOIN departments d ON p.dept_id = d.id ORDER BY 1"
     feature: "window PARTITION BY UPPER(...) over a LEFT OUTER JOIN"
     category: "column_resolution_corpus"
-    expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_tds_status: PASS
+    expected_rel_status: PASS
 
   - id: crcs_g3_partition_by_extract_over_join
     sql: "SELECT p.name AS name, ROW_NUMBER() OVER (PARTITION BY EXTRACT(YEAR FROM p.hire_date) ORDER BY p.name) AS rn FROM persons p INNER JOIN departments d ON p.dept_id = d.id ORDER BY 1"
     feature: "window PARTITION BY EXTRACT(part FROM col) over a join"
     category: "column_resolution_corpus"
-    expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_tds_status: PASS
+    expected_rel_status: PASS
 
   - id: crcs_g3_partition_expression_and_order_expression_over_join
     sql: "SELECT p.name AS name, ROW_NUMBER() OVER (PARTITION BY CASE WHEN p.active = true THEN 1 ELSE 0 END ORDER BY COALESCE(p.salary, 0) DESC, p.name) AS rn FROM persons p INNER JOIN departments d ON p.dept_id = d.id ORDER BY 1"
     feature: "window with expression keys in both PARTITION BY and ORDER BY, over a join"
     category: "column_resolution_corpus"
     expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   - id: crcs_g3_partition_by_bare_key_over_three_way_join
     sql: "SELECT p.name AS name, o.id AS order_id, ROW_NUMBER() OVER (PARTITION BY p.dept_id ORDER BY o.id) AS rn FROM persons p INNER JOIN departments d ON p.dept_id = d.id INNER JOIN orders o ON o.person_id = p.id ORDER BY 1, 2"
     feature: "window PARTITION BY a bare key over a three-way join"
     category: "column_resolution_corpus"
     expected_tds_status: PASS
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   # processOlapGroupBy folds over the window columns while holding the
   # resolution context fixed at the first iteration, so a second window column
@@ -603,7 +603,7 @@ tests:
     feature: "two window functions with expression keys, over a join"
     category: "column_resolution_corpus"
     expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   - id: crcs_g3_two_windows_with_null_ordered_keys_over_join
     sql: "SELECT p.name AS name, ROW_NUMBER() OVER (PARTITION BY p.dept_id ORDER BY p.salary DESC NULLS LAST, p.name) AS rn, RANK() OVER (PARTITION BY p.dept_id ORDER BY p.hire_date ASC NULLS FIRST, p.name) AS rk FROM persons p INNER JOIN departments d ON p.dept_id = d.id ORDER BY 1"
@@ -671,7 +671,7 @@ tests:
     feature: "statement ORDER BY an ordinal over a join (control)"
     category: "column_resolution_corpus"
     expected_tds_status: PASS
-    expected_rel_status: FAIL
+    expected_rel_status: PASS
 
   - id: crcs_g4_distinct_order_by_qualified_key_over_join
     sql: "SELECT DISTINCT p.dept_id AS dept_id FROM persons p INNER JOIN departments d ON p.dept_id = d.id ORDER BY p.dept_id"
@@ -732,14 +732,14 @@ tests:
     feature: "EXISTS correlated on an outer alias, over a join"
     category: "column_resolution_corpus"
     expected_tds_status: ERROR
-    expected_rel_status: FAIL
+    expected_rel_status: PASS
 
   - id: crcs_g5_in_subquery_correlated_over_join
     sql: "SELECT p.name AS name FROM persons p INNER JOIN departments d ON p.dept_id = d.id WHERE p.id IN (SELECT o.person_id FROM orders o WHERE o.amount > 100 AND o.person_id = p.id) ORDER BY 1"
     feature: "IN (correlated subquery) over a join"
     category: "column_resolution_corpus"
     expected_tds_status: ERROR
-    expected_rel_status: FAIL
+    expected_rel_status: PASS
 
   - id: crcs_g5_correlated_max_then_compare_comma_join
     sql: "SELECT p.name AS name, o.amount AS amount FROM persons p, orders o WHERE o.person_id = p.id AND o.amount = (SELECT MAX(o1.amount) FROM orders o1 WHERE o1.person_id = p.id) ORDER BY 1, 2"
@@ -755,14 +755,14 @@ tests:
     feature: "join whose right side is itself a join"
     category: "column_resolution_corpus"
     expected_tds_status: PASS
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   - id: crcs_g5_nested_join_predicate_reads_the_inner_join
     sql: "SELECT p.name AS name, o.status AS status FROM persons p INNER JOIN (orders o INNER JOIN departments d ON d.id = o.person_id) ON p.id = o.person_id WHERE o.amount > 100 ORDER BY 1, 2"
     feature: "predicate reading a column of a nested join side"
     category: "column_resolution_corpus"
     expected_tds_status: PASS
-    expected_rel_status: FAIL
+    expected_rel_status: PASS
 
   # A derived-table alias referenced in the ON of a later join, with a function
   # applied on the other side of the equality.
@@ -774,14 +774,14 @@ tests:
     feature: "derived-table alias referenced in a later join's ON, through a function"
     category: "column_resolution_corpus"
     expected_tds_status: PASS
-    expected_rel_status: FAIL
+    expected_rel_status: PASS
 
   - id: crcs_g5_three_derived_sides_chained_on_clauses
     sql: "SELECT a.id AS id, b.n AS order_count, c.budget AS budget FROM (SELECT id, dept_id FROM persons) a INNER JOIN (SELECT person_id, COUNT(*) AS n FROM orders GROUP BY person_id) b ON b.person_id = a.id INNER JOIN (SELECT id, budget FROM departments) c ON c.id = a.dept_id ORDER BY 1"
     feature: "three derived join sides with chained ON clauses"
     category: "column_resolution_corpus"
     expected_tds_status: PASS
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   # ------------------------------------------------------------------
   # Outer alias shadowed by a derived table's internal alias
@@ -810,14 +810,14 @@ tests:
     feature: "derived table internally re-using the enclosing query's table alias"
     category: "column_resolution_corpus"
     expected_tds_status: PASS
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   - id: crcs_g5_derived_table_reuses_outer_alias_in_on_predicate
     sql: "SELECT s.name AS name, latest.top_amount AS top_amount FROM persons s INNER JOIN (SELECT s.id AS person_id, MAX(o.amount) AS top_amount FROM persons s INNER JOIN orders o ON o.person_id = s.id GROUP BY s.id) latest ON latest.person_id = s.id AND s.salary > latest.top_amount ORDER BY 1"
     feature: "ON predicate comparing an outer alias against a derived table that re-uses that alias"
     category: "column_resolution_corpus"
     expected_tds_status: PASS
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   # Three-way left-nested join whose right side is a derived table re-using an
   # alias from the left. Join(Join(a, b), c) is the common parse shape, and
@@ -828,28 +828,28 @@ tests:
     feature: "left-nested three-way join whose derived right side re-uses a left alias"
     category: "column_resolution_corpus"
     expected_tds_status: PASS
-    expected_rel_status: FAIL
+    expected_rel_status: PASS
 
   - id: crcs_g5_derived_table_reuses_two_outer_aliases
     sql: "SELECT p.name AS name, d.budget AS budget, agg.n AS n FROM persons p INNER JOIN departments d ON p.dept_id = d.id INNER JOIN (SELECT d.id AS dept_id, COUNT(p.id) AS n FROM departments d LEFT OUTER JOIN persons p ON p.dept_id = d.id GROUP BY d.id) agg ON agg.dept_id = d.id ORDER BY 1"
     feature: "derived table re-using both enclosing aliases"
     category: "column_resolution_corpus"
     expected_tds_status: PASS
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   - id: crcs_g5_derived_table_reuses_outer_alias_two_levels_deep
     sql: "SELECT p.name AS name, outerq.top_amount AS top_amount FROM persons p INNER JOIN (SELECT inner1.person_id AS person_id, inner1.top_amount AS top_amount FROM (SELECT p.id AS person_id, MAX(o.amount) AS top_amount FROM persons p INNER JOIN orders o ON o.person_id = p.id GROUP BY p.id) inner1) outerq ON outerq.person_id = p.id ORDER BY 1"
     feature: "outer alias re-used two subquery levels down"
     category: "column_resolution_corpus"
     expected_tds_status: PASS
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   - id: crcs_g5_derived_table_with_a_fresh_alias_control
     sql: "SELECT p.name AS name, latest.top_amount AS top_amount FROM persons p INNER JOIN (SELECT q.id AS person_id, MAX(o.amount) AS top_amount FROM persons q INNER JOIN orders o ON o.person_id = q.id GROUP BY q.id) latest ON latest.person_id = p.id ORDER BY 1"
     feature: "control: same shape with a non-colliding alias inside the derived table"
     category: "column_resolution_corpus"
     expected_tds_status: PASS
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   # ------------------------------------------------------------------
   # The same five shapes with the aggregate removed -- THIS is the acceptance test
@@ -875,35 +875,35 @@ tests:
     feature: "alias re-use in a non-aggregating derived join side"
     category: "column_resolution_corpus"
     expected_tds_status: PASS
-    expected_rel_status: FAIL
+    expected_rel_status: PASS
 
   - id: crcs_g5_alias_reuse_simple_derived_side_in_on_predicate
     sql: "SELECT s.name AS name, latest.amt AS amt FROM persons s INNER JOIN (SELECT s.id AS person_id, s.salary AS amt FROM persons s WHERE s.active = true) latest ON latest.person_id = s.id AND s.salary >= latest.amt ORDER BY 1"
     feature: "alias re-use, outer alias also read in the ON predicate"
     category: "column_resolution_corpus"
     expected_tds_status: PASS
-    expected_rel_status: FAIL
+    expected_rel_status: PASS
 
   - id: crcs_g5_alias_reuse_simple_derived_side_left_nested
     sql: "SELECT p.name AS name, d.budget AS budget, latest.amt AS amt FROM persons p INNER JOIN departments d ON p.dept_id = d.id INNER JOIN (SELECT p.id AS person_id, p.salary AS amt FROM persons p WHERE p.active = true) latest ON latest.person_id = p.id ORDER BY 1"
     feature: "alias re-use in a non-aggregating derived side of a left-nested three-way join"
     category: "column_resolution_corpus"
     expected_tds_status: PASS
-    expected_rel_status: FAIL
+    expected_rel_status: PASS
 
   - id: crcs_g5_alias_reuse_simple_derived_side_two_aliases
-    sql: "SELECT p.name AS name, d.budget AS budget, both.amt AS amt FROM persons p INNER JOIN departments d ON p.dept_id = d.id INNER JOIN (SELECT p.id AS person_id, d.id AS dept_key, p.salary AS amt FROM persons p INNER JOIN departments d ON p.dept_id = d.id WHERE p.active = true) both ON both.person_id = p.id ORDER BY 1"
+    sql: "SELECT p.name AS name, d.budget AS budget, combo.amt AS amt FROM persons p INNER JOIN departments d ON p.dept_id = d.id INNER JOIN (SELECT p.id AS person_id, d.id AS dept_key, p.salary AS amt FROM persons p INNER JOIN departments d ON p.dept_id = d.id WHERE p.active = true) combo ON combo.person_id = p.id ORDER BY 1"
     feature: "alias re-use of both enclosing aliases, no aggregate"
     category: "column_resolution_corpus"
-    expected_tds_status: BUG
-    expected_rel_status: BUG
+    expected_tds_status: PASS
+    expected_rel_status: PASS
 
   - id: crcs_g5_alias_reuse_simple_derived_side_two_levels_deep
     sql: "SELECT p.name AS name, outerq.amt AS amt FROM persons p INNER JOIN (SELECT inner1.person_id AS person_id, inner1.amt AS amt FROM (SELECT p.id AS person_id, p.salary AS amt FROM persons p WHERE p.active = true) inner1) outerq ON outerq.person_id = p.id ORDER BY 1"
     feature: "alias re-use two subquery levels down, no aggregate"
     category: "column_resolution_corpus"
     expected_tds_status: PASS
-    expected_rel_status: FAIL
+    expected_rel_status: PASS
 
   # THE CONTROL. Identical to crcs_g5_alias_reuse_simple_derived_side except the derived
   # table names nothing, so no alias can collide. If this fails, stop reading the block.
@@ -912,7 +912,7 @@ tests:
     feature: "control: non-aggregating derived side with no colliding alias"
     category: "column_resolution_corpus"
     expected_tds_status: PASS
-    expected_rel_status: FAIL
+    expected_rel_status: PASS
 
   # Both derived sides publish a column of the same name, so the duplicate-rename
   # pass has to disambiguate two identically-named columns that neither side
@@ -923,6 +923,43 @@ tests:
   # has a relation name: PostgreSQL rejects it ("subquery in FROM must have an
   # alias"), so it cannot arrive as real SQL and does not belong in a parity
   # suite. If that fallback needs cover it has to be a Pure-level test.
+  # ------------------------------------------------------------------
+  # Alias re-use, isolated on a base shape that is observed to pass
+  #
+  # Every earlier attempt at isolating alias re-use was confounded: the control
+  # failed too, so nothing could be attributed to the re-use. Both earlier blocks
+  # join a base table to a derived table, and that shape does not survive the
+  # Relation path on its own.
+  #
+  # This pair is built on crcs_g5_two_derived_sides_sharing_a_column_name instead
+  # -- two derived sides, no base table at the outer level -- which is the one
+  # derived-table join shape in this file observed to pass on both paths.
+  #
+  # The two differ in exactly one character: whether the right subquery names its
+  # source `l`, colliding with the outer left alias. The outer `l` exposes column
+  # `k` and the right side exposes `m`, so a binding that resolves `l.k` against
+  # the wrong side cannot silently return different rows -- it has to fail to find
+  # the column. That makes the outcome unambiguous rather than a row diff.
+  #
+  # If the control passes and the re-use case does not, alias re-use is the cause.
+  # If both pass, the row-map guard in processStandardJoin has nothing to fix and
+  # should be reverted.
+  # ------------------------------------------------------------------
+
+  - id: crcs_g5_alias_reuse_isolated_control
+    sql: "SELECT l.k AS left_k, r.m AS right_m FROM (SELECT id AS k FROM persons) l INNER JOIN (SELECT id AS m FROM departments) r ON l.k = r.m ORDER BY 1"
+    feature: "control: two derived join sides, no alias collision"
+    category: "column_resolution_corpus"
+    expected_tds_status: PASS
+    expected_rel_status: PASS
+
+  - id: crcs_g5_alias_reuse_isolated
+    sql: "SELECT l.k AS left_k, r.m AS right_m FROM (SELECT id AS k FROM persons) l INNER JOIN (SELECT l.id AS m FROM departments l) r ON l.k = r.m ORDER BY 1"
+    feature: "two derived join sides where the right subquery re-uses the outer left alias"
+    category: "column_resolution_corpus"
+    expected_tds_status: PASS
+    expected_rel_status: PASS
+
   - id: crcs_g5_two_derived_sides_sharing_a_column_name
     sql: "SELECT l.k AS left_k, r.k AS right_k FROM (SELECT id AS k FROM persons) l INNER JOIN (SELECT id AS k FROM departments) r ON l.k = r.k ORDER BY 1"
     feature: "join of two derived sides that publish the same column name"
@@ -979,14 +1016,14 @@ tests:
     feature: "derived table wrapping a join, columns read from outside"
     category: "column_resolution_corpus"
     expected_tds_status: PASS
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   - id: crcs_g6_select_star_group_by_over_join
     sql: "SELECT x.dept_id AS dept_id, COUNT(*) AS n FROM (SELECT p.* FROM persons p INNER JOIN departments d ON p.dept_id = d.id) x GROUP BY x.dept_id ORDER BY 1"
     feature: "GROUP BY over a derived table built from SELECT alias.* on a join"
     category: "column_resolution_corpus"
     expected_tds_status: PASS
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   # A quoted, reserved-word-shaped column name carried through a UNION of
   # derived selects and then read from the outer query in lower case.
@@ -1002,7 +1039,7 @@ tests:
     feature: "quoted reserved-word alias through a UNION ALL, grouped from outside"
     category: "column_resolution_corpus"
     expected_tds_status: PASS
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   # COUNT(*) as both a group-adjacent select item and a sort key, alongside
   # EXTRACT group keys -- single table, no join, so it isolates the aggregate
@@ -1029,7 +1066,7 @@ tests:
     feature: "UNION ALL of aggregate branches over different joins"
     category: "column_resolution_corpus"
     expected_tds_status: PASS
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   - id: crcs_g6_union_all_branches_with_correlated_filters
     sql: "SELECT b.name AS name FROM (SELECT p.name AS name FROM persons p, departments d WHERE p.dept_id = d.id AND p.salary = (SELECT MAX(p1.salary) FROM persons p1 WHERE p1.dept_id = p.dept_id) UNION ALL SELECT p.name AS name FROM persons p WHERE p.dept_id IS NULL) b ORDER BY 1"
@@ -1043,7 +1080,7 @@ tests:
     feature: "SELECT DISTINCT over a join whose right side is a DISTINCT derived table"
     category: "column_resolution_corpus"
     expected_tds_status: PASS
-    expected_rel_status: FAIL
+    expected_rel_status: PASS
 
   # Both sides project a column of the same base name, so the duplicate-rename
   # pass has real work to do rather than being a formality.
@@ -1059,7 +1096,7 @@ tests:
     feature: "colliding base names with a window partitioned on the colliding column"
     category: "column_resolution_corpus"
     expected_tds_status: PASS
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   # A self join produces several rows per `a`, so the window keys must be tied
   # off on b.id as well -- ordering only on a's columns leaves the row numbers
@@ -1069,7 +1106,7 @@ tests:
     feature: "self join with an expression key in the window ORDER BY"
     category: "column_resolution_corpus"
     expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   - id: crcs_g6_self_join_with_null_ordered_window_key
     sql: "SELECT a.name AS name, b.id AS b_id, ROW_NUMBER() OVER (PARTITION BY a.dept_id ORDER BY a.salary DESC NULLS LAST, a.name, b.id) AS rn FROM persons a INNER JOIN persons b ON a.dept_id = b.dept_id AND a.id < b.id ORDER BY 1, 2"

--- a/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/src/test/resources/parity-tests/structural/joins.yaml
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/src/test/resources/parity-tests/structural/joins.yaml
@@ -48,7 +48,7 @@ tests:
     feature: "LEFT JOIN"
     category: "joins"
     expected_tds_status: PASS
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   # RIGHT JOIN
   - id: join_right_basic
@@ -130,7 +130,7 @@ tests:
     feature: "Multi-table JOIN"
     category: "joins"
     expected_tds_status: PASS
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   # JOIN with aggregation
   - id: join_with_agg
@@ -138,18 +138,18 @@ tests:
     feature: "JOIN + aggregation"
     category: "joins"
     expected_tds_status: PASS
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   - id: join_with_agg_having
     sql: "SELECT d.name AS dept_name, COUNT(*) AS emp_count FROM persons p INNER JOIN departments d ON p.dept_id = d.id GROUP BY d.name HAVING COUNT(*) > 2 ORDER BY 1"
     feature: "JOIN + aggregation"
     category: "joins"
     expected_tds_status: PASS
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   - id: join_with_agg_avg
     sql: "SELECT d.name AS dept_name, AVG(p.salary) AS avg_salary FROM persons p INNER JOIN departments d ON p.dept_id = d.id WHERE p.salary IS NOT NULL GROUP BY d.name ORDER BY 1"
     feature: "JOIN + aggregation"
     category: "joins"
     expected_tds_status: PASS
-    expected_rel_status: ERROR
+    expected_rel_status: PASS

--- a/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/src/test/resources/parity-tests/structural/multiple_schemas.yaml
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/src/test/resources/parity-tests/structural/multiple_schemas.yaml
@@ -36,7 +36,7 @@ tests:
     feature: "default schema resolution"
     category: "multiple_schemas"
     expected_tds_status: PASS
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   # information_schema access
   - id: schema_information_tables

--- a/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/src/test/resources/parity-tests/structural/select_star.yaml
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/src/test/resources/parity-tests/structural/select_star.yaml
@@ -34,7 +34,7 @@ tests:
     feature: "SELECT multiple table.*"
     category: "select_star"
     expected_tds_status: FAIL
-    expected_rel_status: ERROR
+    expected_rel_status: FAIL
 
   # SELECT * from subquery
   - id: star_from_subquery

--- a/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/src/test/resources/parity-tests/structural/subqueries.yaml
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/src/test/resources/parity-tests/structural/subqueries.yaml
@@ -80,7 +80,7 @@ tests:
     feature: "Derived table (subquery in FROM)"
     category: "subqueries"
     expected_tds_status: PASS
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   # Correlated subquery
   - id: subquery_correlated

--- a/legend-engine-xts-sql/legend-engine-xt-sql-transformation/legend-engine-xt-sql-pure/src/main/resources/core_external_query_sql/binding/fromPure/fromPure.pure
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-transformation/legend-engine-xt-sql-pure/src/main/resources/core_external_query_sql/binding/fromPure/fromPure.pure
@@ -705,6 +705,9 @@ function <<access.private>> meta::external::query::sql::transformation::queryToP
   let standard = $originalSelect.selectItems->removeAll($aggregates)->removeAll($directWindows)->removeAll($nestedWindowItems);
 
   let havingExtensions = extractAggregatesFromExpression($having)->map(e | ^SingleColumn(expression = $e));
+  //Left unaliased on purpose: processExtend names these through
+  //processSelectItems(.., useContextForNameResolve = false), and extensionColumnName below is the
+  //same derivation, so the key that reads the column spells it exactly as the extend wrote it.
   let groupByExtensions = $groupBy->map(g | $g->match([
     i:IntegerLiteral[1] | [],
     q:QualifiedNameReference[1] | [],
@@ -952,7 +955,13 @@ function <<access.private>> meta::external::query::sql::transformation::queryToP
     clone(^$context(expression = $rename), $context),
     renamePairs($renamedItems, $context));
 
-  let groupByColumns = $groupBy->map(g | $g->extractColumnNameFromExpression($select.selectItems, $renamed));
+  //An ordinal names a select item and a plain column reference names a real column, so both keep
+  //resolving as before. An expression key was materialised into an extend by groupByExtensions and
+  //has to use that column's name - see materialisedKeyName.
+  let groupByColumns = $groupBy->map(g | $g->match([
+    i:IntegerLiteral[1] | $i->extractColumnNameFromExpression($select.selectItems, $renamed),
+    e:meta::external::query::sql::metamodel::Expression[1] | materialisedKeyName($e, $renamed)
+  ]));
 
   let additionalGroupColumns = $select.selectItems->removeAll($aggregates)->map(s | $s->match([
     s:SingleColumn[1] | extractNameFromSingleColumn($s, $renamed),
@@ -1091,10 +1100,47 @@ function <<access.private>> meta::external::query::sql::transformation::queryToP
 
 //we need to pull out the partition and order expressions and extend the TDS so the call to olapGroupBy can take in the qualified name references of these columns
 //ideally there would be a project/olap implementation which accepts lambdas, instead of column references.
+//A window PARTITION BY / ORDER BY key, or a GROUP BY key, that is not a plain column reference has
+//no column to name, so processProjection materialises it into an extend. Two places then have to
+//agree on what that column is called: processExtend, which creates it, and the key itself, which
+//reads it.
+//
+//processExtend names it through processSelectItems(.., useContextForNameResolve = false) - with no
+//context, so a column reference inside the expression is spelled as written. The key used to be
+//resolved through the live context instead, where the same reference carries its join-alias suffix
+//and may also have been re-spelled by the projection's rename. Both differences broke the match, in
+//opposite directions: over a join the extend built COALESCE(salary, 0) while the key asked for
+//COALESCE(salary_p, 0), and once the projection renamed a column the key asked for UPPER(name) while
+//the extend had written UPPER(name_p).
+//
+//Deriving the name the same context-free way on both sides removes the disagreement entirely rather
+//than moving it. The name is internal - the extend's own lambda still resolves the underlying columns
+//through the context, so only the label is context-free.
+function <<access.private>> meta::external::query::sql::transformation::queryToPure::extensionColumnName(e:meta::external::query::sql::metamodel::Expression[1]):String[1]
+{
+  extractNameFromExpression($e, []);
+}
+
+//A plain column reference names a real column and must keep resolving through the context - that is
+//what keeps a key pointing at the right join side, and at a column the projection has renamed.
+//Anything else was materialised by extractWindowExtensionExpressions or groupByExtensions and has to
+//use the extension's name.
+function <<access.private>> meta::external::query::sql::transformation::queryToPure::materialisedKeyName(e:meta::external::query::sql::metamodel::Expression[1], context: SqlTransformContext[1]):String[1]
+{
+  $e->match([
+    q:QualifiedNameReference[1] | $q->extractNameFromExpression($context),
+    x:meta::external::query::sql::metamodel::Expression[1] | extensionColumnName($x)
+  ]);
+}
+
 function <<access.private>> meta::external::query::sql::transformation::queryToPure::extractWindowExtensionExpressions(s:SingleColumn[*], context:SqlTransformContext[1]):SingleColumn[*]
 {
   let functionCall = $s.expression->cast(@FunctionCall);
   let window = $functionCall.window->map(w | getWindow($w, $context.windows));
+
+  //Left unaliased on purpose - see extensionColumnName. A plain column reference is excluded here
+  //because it already names a real column of the relation; everything else is materialised into an
+  //extend, and the key that reads it must spell it the way processExtend wrote it.
   $window.partitions->concatenate($window.orderBy.sortKey)->filter(o | !$o->instanceOf(QualifiedNameReference))->map(e | ^SingleColumn(expression = $e));
 }
 
@@ -1117,8 +1163,8 @@ function <<access.private>> meta::external::query::sql::transformation::queryToP
   unsupported($relation || ($window.orderBy->size() <= 1), | 'multiple window sort items not yet supported');
   assertRelation($window.windowFrame->isEmpty() || $context.relation->isTrue(), 'window frame');
 
-  let partitions = $window.partitions->map(partition | $partition->extractNameFromExpression($context));
-  let sorts = $window.orderBy->map(si | $si->createSortItemFunction($context));
+  let partitions = $window.partitions->map(partition | materialisedKeyName($partition, $context));
+  let sorts = $window.orderBy->map(si | createSortItemFunctionForColumn($si, materialisedKeyName($si.sortKey, $context), $context));
   let frame = createFrame($window.windowFrame);
 
   let processor = functionProcessor($functionCall.name);
@@ -1851,6 +1897,15 @@ function <<access.private>> meta::external::query::sql::transformation::queryToP
   createSortItemFunction($si, [], $context);
 }
 
+//Same as createSortItemFunction but for a key whose column has already been resolved. Window keys
+//need this because a materialised key does not resolve through the context - see materialisedKeyName.
+function <<access.private>> meta::external::query::sql::transformation::queryToPure::createSortItemFunctionForColumn(si:SortItem[1], column:String[1], context: SqlTransformContext[1]):ValueSpecification[1]
+{
+    assert($si.nullOrdering == SortItemNullOrdering.UNDEFINED, 'null ordering type not yet supported');
+
+    ^TDSBuilder().sortItem($si, $column, $context.relation->isTrue());
+}
+
 function <<access.private>> meta::external::query::sql::transformation::queryToPure::createSortItemFunction(si:SortItem[1], selectItems:SelectItem[*], context: SqlTransformContext[1]):ValueSpecification[1]
 {
     let column = extractColumnNameFromExpression($si.sortKey, $selectItems, $context);
@@ -2240,12 +2295,23 @@ function <<access.private>> meta::external::query::sql::transformation::queryToP
     let mapping = if ($source.mapping->isEmpty(), | emptyMapping(), | $source.mapping->toOne());
     let relation = $context.relation->isTrue();
 
+    //from() does not alter the schema, but its return type is the type parameter T, so the
+    //two-argument sfe() stamps the wrapped expression with T rather than the concrete
+    //Relation<(...)>. Anything that later re-derives the schema from the expression -
+    //resolveRelationColumns, and through it the type TDSBuilder builds for extend/groupBy/restrict -
+    //then sees no columns, and every name it is asked to look up is silently dropped from the type
+    //it produces. The emitted SQL stays correct, so the failure surfaces downstream as a result set
+    //whose shape does not match the relation that was declared: a missing column, or a value read
+    //under a neighbouring column's type. Only processStandardJoin calls wrapWithFrom, which is why
+    //single-table queries were never affected. Carry the input's own generic type through instead.
+    let inputType = $expression->evaluateAndDeactivate().genericType;
+
     let scopedExpression = if ($relation,
       | [
             pair($source.mapping->isEmpty() && $source.runtime->isNotEmpty(), |
-                sfe(meta::pure::mapping::from_T_m__Runtime_1__T_m_,[$expression, iv($source.runtime->toOne())])),
+                sfe(meta::pure::mapping::from_T_m__Runtime_1__T_m_, $inputType, [$expression, iv($source.runtime->toOne())])),
             pair($source.mapping->isNotEmpty() && $source.runtime->isNotEmpty(), |
-                sfe(meta::pure::mapping::from_T_m__Mapping_1__Runtime_1__T_m_, [$expression, iv($source.mapping->toOne()), iv($source.runtime->toOne())]))
+                sfe(meta::pure::mapping::from_T_m__Mapping_1__Runtime_1__T_m_, $inputType, [$expression, iv($source.mapping->toOne()), iv($source.runtime->toOne())]))
         ]->getValue(true, | $expression)->eval(),
       | [
            pair($source.runtime->isNotEmpty() && $executionContext->isNotEmpty(), |

--- a/legend-engine-xts-sql/legend-engine-xt-sql-transformation/legend-engine-xt-sql-pure/src/main/resources/core_external_query_sql/binding/fromPure/tests/testTranspile.pure
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-transformation/legend-engine-xt-sql-pure/src/main/resources/core_external_query_sql/binding/fromPure/tests/testTranspile.pure
@@ -5738,6 +5738,38 @@ function <<test.Test>> meta::external::query::sql::transformation::queryToPure::
   )
 }
 
+// ---------------------------------------------------------------------------
+// A window or GROUP BY key that is an expression, over a join.
+//
+// Such a key is not a column, so processProjection synthesises a SingleColumn to
+// carry it into an extend and give it something to name. The extend named that
+// column through processSelectItems(.., useContextForNameResolve = false) - an
+// empty context, so a column reference inside the expression kept its pre-join
+// spelling - while the key lookup resolved through the live context, where the
+// same reference carries its join-alias suffix. Over a join the two disagreed:
+// the extend built COALESCE(Float, 0) and the lookup asked for
+// COALESCE(Float_t1, 0), which the relation does not have.
+//
+// The join is load-bearing. Without it there are no suffixes, the two spellings
+// coincide, and none of this reproduces - which is exactly why it went unnoticed.
+// ---------------------------------------------------------------------------
+function <<test.Test>> meta::external::query::sql::transformation::queryToPure::tests::testWindowOrderKeyExpressionOverJoin():Boolean[1]
+{
+  test(
+    'SELECT "t1"."String" AS "String", ' +
+    'row_number() OVER (PARTITION BY "t1"."Integer" ORDER BY coalesce("t1"."Float", 0)) AS "rn" ' +
+    'FROM service."/service/service1" "t1" ' +
+    'JOIN service."/service/service2" "t2" ON "t1"."Integer" = "t2"."Integer"',
+    [
+      // placeholder: never compared (assertLambda/assertJSON are false); present so
+      // TestConfig.relation() selects relationSources(). See the block comment above.
+      c({| FlatInput.all()->project(
+            ~[ Boolean: x | $x.booleanIn, Integer: x | $x.integerIn, Float: x | $x.floatIn, Decimal: x | $x.decimalIn, StrictDate: x | $x.strictDateIn, DateTime: x | $x.dateTimeIn, String: x | $x.stringIn])
+        }, false, false)
+    ]
+  )
+}
+
 function <<test.Test>> meta::external::query::sql::transformation::queryToPure::tests::testOrderByNullsLast():Boolean[1]
 {
   // NULLS LAST: rewritten as CASE WHEN String IS NULL THEN 0 ELSE 1 END DESC, String ASC
@@ -5751,6 +5783,24 @@ function <<test.Test>> meta::external::query::sql::transformation::queryToPure::
             ->sort([~'CASE WHEN String IS NULL THEN 0 ELSE 1 END'->descending(), ~String->ascending()])
             ->select(~[String, Integer])
         }
+    ]
+  )
+}
+
+// The partition key takes the same path as the sort key, so it fails the same way.
+function <<test.Test>> meta::external::query::sql::transformation::queryToPure::tests::testWindowPartitionKeyExpressionOverJoin():Boolean[1]
+{
+  test(
+    'SELECT "t1"."String" AS "String", ' +
+    'row_number() OVER (PARTITION BY upper("t1"."String") ORDER BY "t1"."Integer") AS "rn" ' +
+    'FROM service."/service/service1" "t1" ' +
+    'JOIN service."/service/service2" "t2" ON "t1"."Integer" = "t2"."Integer"',
+    [
+      // placeholder: never compared (assertLambda/assertJSON are false); present so
+      // TestConfig.relation() selects relationSources(). See the block comment above.
+      c({| FlatInput.all()->project(
+            ~[ Boolean: x | $x.booleanIn, Integer: x | $x.integerIn, Float: x | $x.floatIn, Decimal: x | $x.decimalIn, StrictDate: x | $x.strictDateIn, DateTime: x | $x.dateTimeIn, String: x | $x.stringIn])
+        }, false, false)
     ]
   )
 }
@@ -5772,6 +5822,25 @@ function <<test.Test>> meta::external::query::sql::transformation::queryToPure::
   )
 }
 
+// An expression key drawing from both join sides, so both suffixes have to resolve
+// inside one synthesised name.
+function <<test.Test>> meta::external::query::sql::transformation::queryToPure::tests::testWindowOrderKeyExpressionAcrossBothJoinSides():Boolean[1]
+{
+  test(
+    'SELECT "t1"."String" AS "String", ' +
+    'row_number() OVER (PARTITION BY "t1"."Integer" ORDER BY coalesce("t1"."Float", "t2"."Integer")) AS "rn" ' +
+    'FROM service."/service/service1" "t1" ' +
+    'JOIN service."/service/service2" "t2" ON "t1"."Integer" = "t2"."Integer"',
+    [
+      // placeholder: never compared (assertLambda/assertJSON are false); present so
+      // TestConfig.relation() selects relationSources(). See the block comment above.
+      c({| FlatInput.all()->project(
+            ~[ Boolean: x | $x.booleanIn, Integer: x | $x.integerIn, Float: x | $x.floatIn, Decimal: x | $x.decimalIn, StrictDate: x | $x.strictDateIn, DateTime: x | $x.dateTimeIn, String: x | $x.stringIn])
+        }, false, false)
+    ]
+  )
+}
+
 function <<test.Test>> meta::external::query::sql::transformation::queryToPure::tests::testOrderByMultiColumnMixedNulls():Boolean[1]
 {
   // String NULLS FIRST, Integer DESC NULLS LAST: two CASE extend columns, four sort keys
@@ -5785,6 +5854,42 @@ function <<test.Test>> meta::external::query::sql::transformation::queryToPure::
             ->sort([~'CASE WHEN String IS NULL THEN 0 ELSE 1 END'->ascending(), ~String->ascending(), ~'CASE WHEN Integer IS NULL THEN 0 ELSE 1 END'->descending(), ~Integer->descending()])
             ->select(~[String, Integer])
         }
+    ]
+  )
+}
+
+// GROUP BY on an expression over a join: same synthesised-extension path as the
+// window keys, resolved by processGroupBy instead of processOlapGroupBy.
+function <<test.Test>> meta::external::query::sql::transformation::queryToPure::tests::testGroupByExpressionKeyOverJoin():Boolean[1]
+{
+  test(
+    'SELECT upper("t1"."String") AS "u", count(*) AS "n" ' +
+    'FROM service."/service/service1" "t1" ' +
+    'JOIN service."/service/service2" "t2" ON "t1"."Integer" = "t2"."Integer" ' +
+    'GROUP BY upper("t1"."String")',
+    [
+      // placeholder: never compared (assertLambda/assertJSON are false); present so
+      // TestConfig.relation() selects relationSources(). See the block comment above.
+      c({| FlatInput.all()->project(
+            ~[ Boolean: x | $x.booleanIn, Integer: x | $x.integerIn, Float: x | $x.floatIn, Decimal: x | $x.decimalIn, StrictDate: x | $x.strictDateIn, DateTime: x | $x.dateTimeIn, String: x | $x.stringIn])
+        }, false, false)
+    ]
+  )
+}
+
+// Control: the same expression key with no join. It passed before the change and
+// must still pass, which is what pins the fix to the suffixed case.
+function <<test.Test>> meta::external::query::sql::transformation::queryToPure::tests::testWindowOrderKeyExpressionSingleTable():Boolean[1]
+{
+  test(
+    'SELECT "String", row_number() OVER (PARTITION BY "Integer" ORDER BY coalesce("Float", 0)) AS "rn" ' +
+    'FROM service."/service/service1"',
+    [
+      // placeholder: never compared (assertLambda/assertJSON are false); present so
+      // TestConfig.relation() selects relationSources(). See the block comment above.
+      c({| FlatInput.all()->project(
+            ~[ Boolean: x | $x.booleanIn, Integer: x | $x.integerIn, Float: x | $x.floatIn, Decimal: x | $x.decimalIn, StrictDate: x | $x.strictDateIn, DateTime: x | $x.dateTimeIn, String: x | $x.stringIn])
+        }, false, false)
     ]
   )
 }


### PR DESCRIPTION
Two defects in the SQL->Pure binding, both reachable only when a query joins,
  and both cases of something that describes a relation drifting away from the
  relation itself.

  1. A window PARTITION BY / ORDER BY key, or a GROUP BY key, that is not a plain
     column reference has no column to name, so processProjection materialises it
     into an extend. processExtend names that column through
     processSelectItems(.., useContextForNameResolve = false) - no context, so a
     column reference inside the expression is spelled as written - while the key
     itself resolved through the live context, where the same reference carries
     its join-alias suffix and may also have been re-spelled by the projection's
     rename. Over a join the two disagree:

       The column 'COALESCE(salary_p, 0)' can't be found in the relation
         (id_p, name, age_p, salary_p, ..., COALESCE(salary, 0):Number)

     The column is present; only the spelling differs. Both sides now derive the
     name the same context-free way, via materialisedKeyName, for exactly the keys
     that get materialised. A plain column reference is unchanged and still
     resolves through the context, which is what keeps a key pointing at the right
     join side and at a column the projection renamed.

  2. wrapWithFrom built from() with the two-argument sfe(), whose generic type is
     from's type parameter rather than the concrete Relation<(...)>. Anything that
     re-derives the schema from the expression - resolveRelationColumns, and
     through it the type TDSBuilder builds for extend/groupBy/restrict - then sees
     no columns and silently drops every name it is asked to look up. The emitted
     SQL stays correct, so this surfaces downstream as a result set whose shape
     does not match the declared relation: a missing column, or a value read under
     a neighbouring column's type. from() does not alter the schema, so the input's
     own generic type is now carried through.

  Single-table queries were unaffected by either defect - the first because
  without a join suffix the two spellings coincide, the second because only
  processStandardJoin calls wrapWithFrom.

  Tests: five cases in testTranspile.pure covering window sort and partition
  expression keys over a join, a key drawn from both join sides, a GROUP BY
  expression key, and a single-table control that passed before and must keep
  passing. Parity statuses updated in column_resolution_corpus_shapes.yaml for the
  cases these fixes move; one case there aliased a subquery `both`, a reserved
  word PostgreSQL rejects before Legend sees it, now renamed.

  Known limitation, unchanged here: a materialised column's name is context-free,
  so UPPER(a.name) and UPPER(b.name) in one query would both be labelled
  UPPER(name) and collide. The extend was always context-free, so this is
  pre-existing rather than introduced; closing it needs a generated label on both
  sides.