### PR TITLE
Drive noDebug() in core plan/SQL generation entry points via the 'ExecDebug' option

### DIFF
--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/executionPlan/executionPlan_generation.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/executionPlan/executionPlan_generation.pure
@@ -24,7 +24,7 @@ import meta::pure::executionPlan::*;
 
 function meta::pure::executionPlan::executionPlan(f:FunctionDefinition<Any>[1], extensions:meta::pure::extension::Extension[*]):ExecutionPlan[1]
 {
-   $f->executionPlan(^meta::pure::runtime::ExecutionContext(), $extensions, noDebug());
+   $f->executionPlan(^meta::pure::runtime::ExecutionContext(), $extensions, if(isOptionSet('ExecDebug'), | debug(), | noDebug()));
 }
 
 function meta::pure::executionPlan::executionPlan(f:FunctionDefinition<Any>[1], extensions:meta::pure::extension::Extension[*], debugContext:DebugContext[1]):ExecutionPlan[1]
@@ -34,7 +34,7 @@ function meta::pure::executionPlan::executionPlan(f:FunctionDefinition<Any>[1], 
 
 function meta::pure::executionPlan::executionPlan(f:FunctionDefinition<Any>[1], context:meta::pure::runtime::ExecutionContext[1], extensions:meta::pure::extension::Extension[*]):ExecutionPlan[1]
 {
-   $f->executionPlan($context, $extensions, noDebug());
+   $f->executionPlan($context, $extensions, if(isOptionSet('ExecDebug'), | debug(), | noDebug()));
 }
 
 function meta::pure::executionPlan::executionPlan(f:FunctionDefinition<Any>[1], m:Mapping[1], runtime:meta::core::runtime::Runtime[1], extensions:meta::pure::extension::Extension[*], debugContext:DebugContext[1]):ExecutionPlan[1]
@@ -44,7 +44,7 @@ function meta::pure::executionPlan::executionPlan(f:FunctionDefinition<Any>[1], 
 
 function meta::pure::executionPlan::executionPlan(f:FunctionDefinition<Any>[1], m:Mapping[1], runtime:meta::core::runtime::Runtime[1], extensions:meta::pure::extension::Extension[*]):ExecutionPlan[1]
 {
-   $f->executionPlan($m, $runtime, ^meta::pure::runtime::ExecutionContext(), $extensions, noDebug());
+   $f->executionPlan($m, $runtime, ^meta::pure::runtime::ExecutionContext(), $extensions, if(isOptionSet('ExecDebug'), | debug(), | noDebug()));
 }
 
 function meta::pure::executionPlan::executionPlan(f:FunctionDefinition<Any>[1], m:Mapping[1], runtime:meta::core::runtime::Runtime[1], shouldDebug:Boolean[1], extensions:meta::pure::extension::Extension[*]):ExecutionPlan[1]
@@ -54,7 +54,7 @@ function meta::pure::executionPlan::executionPlan(f:FunctionDefinition<Any>[1], 
 
 function meta::pure::executionPlan::executionPlan(f:FunctionDefinition<Any>[1], m:Mapping[1], runtime:meta::core::runtime::Runtime[1], context:meta::pure::runtime::ExecutionContext[1], extensions:meta::pure::extension::Extension[*]):ExecutionPlan[1]
 {
-   $f->executionPlan($m, $runtime, $context, $extensions, noDebug());
+   $f->executionPlan($m, $runtime, $context, $extensions, if(isOptionSet('ExecDebug'), | debug(), | noDebug()));
 }
 
 Class meta::pure::executionPlan::NodeAndVars

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/router_main.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/router/router_main.pure
@@ -29,7 +29,7 @@ import meta::core::runtime::*;
 
 function meta::pure::router::routeFunction(f:FunctionDefinition<Any>[1], extensions:Extension[*]):FunctionDefinition<Any>[1]
 {
-   $f->routeFunction(^meta::pure::runtime::ExecutionContext(), $extensions, noDebug());
+   $f->routeFunction(^meta::pure::runtime::ExecutionContext(), $extensions, if(isOptionSet('ExecDebug'), | debug(), | noDebug()));
 }
 
 function meta::pure::router::routeFunction(f:FunctionDefinition<Any>[1], exeCtx: meta::pure::runtime::ExecutionContext[1], extensions:Extension[*], debug:DebugContext[1]):FunctionDefinition<Any>[1]

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/transform/fromPure/toSQLString.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/transform/fromPure/toSQLString.pure
@@ -34,7 +34,7 @@ import meta::pure::router::store::metamodel::clustering::*;
 
 function meta::relational::functions::sqlstring::toSQLStringPretty(f:FunctionDefinition<{->Any[*]}>[1], mapping:Mapping[1], databaseType:DatabaseType[1], extensions:Extension[*]):String[1]
 {
-   toSQLString($f, $mapping, $databaseType, [], [], ^Format(newLine='\n', indent='\t'), $extensions, noDebug())
+   toSQLString($f, $mapping, $databaseType, [], [], ^Format(newLine='\n', indent='\t'), $extensions, if(isOptionSet('ExecDebug'), | debug(), | noDebug()))
 }
 
 function meta::relational::functions::sqlstring::toSQLStringPretty(f:FunctionDefinition<{->Any[*]}>[1], mapping:Mapping[1], runtime:Runtime[1], extensions:Extension[*]):String[1]
@@ -47,7 +47,7 @@ function meta::relational::functions::sqlstring::toSQL(f:FunctionDefinition<{->A
 {
    let databaseConnection = $runtime.connectionStores.connection->filter(c|$c->instanceOf(DatabaseConnection))->toOne()->cast(@DatabaseConnection);
    let postProcessors = meta::relational::mapping::sqlQueryDefaultPostProcessors()->map(pp | {select:SelectSQLQuery[*] | $pp->eval($select, $databaseConnection, ^meta::pure::runtime::ExecutionContext(), $extensions)})->concatenate($databaseConnection.sqlQueryPostProcessors);
-   let sql = toSQL($f, $mapping, $databaseConnection.type, $databaseConnection.timeZone, $postProcessors, $extensions, noDebug());
+   let sql = toSQL($f, $mapping, $databaseConnection.type, $databaseConnection.timeZone, $postProcessors, $extensions, if(isOptionSet('ExecDebug'), | debug(), | noDebug()));
 
    if ($databaseConnection.sqlQueryPostProcessorsConnectionAware->isEmpty(), | $sql, | let newSql = $sql.sqlQueries->map(s | $databaseConnection.sqlQueryPostProcessorsConnectionAware->fold({pp,q|$pp->eval($q, $databaseConnection->cast(@DatabaseConnection)).values->toOne()}, $s->cast(@SelectSQLQuery)));
                                                                                        ^$sql(sqlQueries=$newSql););
@@ -57,17 +57,17 @@ function meta::relational::functions::sqlstring::toSQL(f:FunctionDefinition<{->A
 
 function meta::relational::functions::sqlstring::toSQLStringPretty(f:FunctionDefinition<{->Any[*]}>[1], mapping:Mapping[1], databaseType:DatabaseType[1], dbTimeZone:String[0..1], extensions:Extension[*]):String[1]
 {
-   toSQLString($f, $mapping, $databaseType, $dbTimeZone, [], ^Format(newLine='\n', indent='\t'), $extensions, noDebug())
+   toSQLString($f, $mapping, $databaseType, $dbTimeZone, [], ^Format(newLine='\n', indent='\t'), $extensions, if(isOptionSet('ExecDebug'), | debug(), | noDebug()))
 }
 
 function meta::relational::functions::sqlstring::toSQLString(f:FunctionDefinition<{->Any[*]}>[1], mapping:Mapping[1], databaseType:DatabaseType[1], extensions:Extension[*]):String[1]
 {
-   toSQLString($f, $mapping, $databaseType, [], [], ^Format(newLine='', indent=''), $extensions, noDebug())
+   toSQLString($f, $mapping, $databaseType, [], [], ^Format(newLine='', indent=''), $extensions, if(isOptionSet('ExecDebug'), | debug(), | noDebug()))
 }
 
 function meta::relational::functions::sqlstring::toSQLString(f:FunctionDefinition<{->Any[*]}>[1], mapping:Mapping[1], databaseType:DatabaseType[1], quoteIdentifier:Boolean[0..1], extensions:Extension[*]):String[1]
 {
-   toSQLString($f, $mapping, $databaseType, [], $quoteIdentifier, [], ^Format(newLine='', indent=''), $extensions, noDebug())
+   toSQLString($f, $mapping, $databaseType, [], $quoteIdentifier, [], ^Format(newLine='', indent=''), $extensions, if(isOptionSet('ExecDebug'), | debug(), | noDebug()))
 }
 
 function meta::relational::functions::sqlstring::toSQLString(f:FunctionDefinition<{->Any[*]}>[1], mapping:Mapping[1], databaseType:DatabaseType[1], extensions:Extension[*], debug:DebugContext[1]):String[1]
@@ -77,12 +77,12 @@ function meta::relational::functions::sqlstring::toSQLString(f:FunctionDefinitio
 
 function meta::relational::functions::sqlstring::toSQLString(f:FunctionDefinition<{->Any[*]}>[1], mapping:Mapping[1], databaseType:DatabaseType[1], dbTimeZone:String[0..1], extensions:Extension[*]):String[1]
 {
-   toSQLString($f, $mapping, $databaseType, $dbTimeZone, [], ^Format(newLine='', indent=''), $extensions, noDebug())
+   toSQLString($f, $mapping, $databaseType, $dbTimeZone, [], ^Format(newLine='', indent=''), $extensions, if(isOptionSet('ExecDebug'), | debug(), | noDebug()))
 }
 
 function meta::relational::functions::sqlstring::toNonExecutableSQLString(f:FunctionDefinition<{->Any[*]}>[1], mapping:Mapping[1], databaseType:DatabaseType[1], extensions:Extension[*]):String[1]
 {
-   toSQLString($f, $mapping, $databaseType, [], {select:SelectSQLQuery[1] | meta::relational::postProcessor::nonExecutable_SelectSQLQuery_1__Extension_MANY__Result_1_->eval($select, $extensions)}, ^Format(newLine='', indent=''), $extensions, noDebug())
+   toSQLString($f, $mapping, $databaseType, [], {select:SelectSQLQuery[1] | meta::relational::postProcessor::nonExecutable_SelectSQLQuery_1__Extension_MANY__Result_1_->eval($select, $extensions)}, ^Format(newLine='', indent=''), $extensions, if(isOptionSet('ExecDebug'), | debug(), | noDebug()))
 }
 
 function meta::relational::functions::sqlstring::toSQLString(f:FunctionDefinition<{->Any[*]}>[1], mapping:Mapping[1], databaseType:DatabaseType[1], dbTimeZone:String[0..1], sqlQueryPostProcessors: Function<{SelectSQLQuery[1]->Result<SelectSQLQuery|1>[1]}>[*], format:Format[1], extensions:Extension[*], debug:DebugContext[1]):String[1]


### PR DESCRIPTION
#### What type of PR is this?

Improvement

#### What does this PR do / why is it needed ?

The convenience overloads for execution-plan generation (`meta::pure::executionPlan::executionPlan`), function routing (`meta::pure::router::routeFunction`) and relational SQL-string generation (`meta::relational::functions::sqlstring::toSQLString` / `toSQL` / `toSQLStringPretty` / `toNonExecutableSQLString`) hard-coded `noDebug()`. There was no way to get verbose planning / SQL-generation output through those entry points without editing code.

This change switches those hard-coded `noDebug()` arguments to:

```
if(isOptionSet('ExecDebug'), | debug(), | noDebug())
```

which matches the pattern already used in `core/pure/router/router_entry.pure` and `core/pure/protocol/vX_X_X/invocations/execution.pure`.

Scope is deliberately limited to the core plan-gen / routing / SQL-gen entry points — deep internal calls, lineage/analytics, external-format and test code are left untouched.

Behaviour is unchanged when the `ExecDebug` option is not set (the default), so this is a no-op for existing callers.

#### Which issue(s) this PR fixes:

Fixes #

#### Other notes for reviewers:

Overloads that already accept an explicit `DebugContext` / `shouldDebug` parameter are unchanged.

#### Does this PR introduce a user-facing change?

No (opt-in debug verbosity via an existing Pure option mechanism).