### PR TITLE
Change cross store implementation for snowflake to stream instead of materializing to file on disc

### DIFF
--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-snowflake/pom.xml
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-snowflake/pom.xml
@@ -87,7 +87,6 @@
         <dependency>
             <groupId>net.snowflake</groupId>
             <artifactId>snowflake-jdbc</artifactId>
-            <version>3.13.19</version>
             <scope>provided</scope>
         </dependency>
 

--- a/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-snowflake/src/main/java/org/finos/legend/engine/persistence/components/relational/snowflake/jdbc/SnowflakeJdbcTransactionManager.java
+++ b/legend-engine-xts-persistence/legend-engine-xt-persistence-component/legend-engine-xt-persistence-component-relational-snowflake/src/main/java/org/finos/legend/engine/persistence/components/relational/snowflake/jdbc/SnowflakeJdbcTransactionManager.java
@@ -14,7 +14,7 @@
 
 package org.finos.legend.engine.persistence.components.relational.snowflake.jdbc;
 
-import net.snowflake.client.jdbc.SnowflakeResultSet;
+import net.snowflake.client.api.resultset.SnowflakeResultSet;
 import org.finos.legend.engine.persistence.components.executor.TabularData;
 import org.finos.legend.engine.persistence.components.relational.jdbc.JdbcTransactionManager;
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-PCT/src/main/resources/pct-manifests/relational-snowflake/EssentialFunctions_manifest.json
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-PCT/src/main/resources/pct-manifests/relational-snowflake/EssentialFunctions_manifest.json
@@ -26,7 +26,7 @@
     "expectedError" : "\"Parameter to IN operation isn't a literal!\""
   }, {
     "test" : "meta::pure::functions::collection::tests::contains::testContainsPrimitive_Function_1__Boolean_1_",
-    "expectedError" : "net.snowflake.client.jdbc.SnowflakeSQLException: SQL compilation error:\nCan not convert parameter 'CAST('2014-02-01' AS DATE)' of type [DATE] into expected type [BOOLEAN]"
+    "expectedError" : "net.snowflake.client.api.exception.SnowflakeSQLException: SQL compilation error:\nCan not convert parameter 'CAST('2014-02-01' AS DATE)' of type [DATE] into expected type [BOOLEAN]"
   }, {
     "test" : "meta::pure::functions::collection::tests::contains::testContainsWithFunction_Function_1__Boolean_1_",
     "expectedError" : "no viable alternative at input '->meta::pure::functions::collection::contains(meta::pure::functions::collection::tests::contains::ClassWithoutEquality.all()->meta::pure::functions::multiplicity::toOne(),meta::pure::functions::collection::tests::contains::comparator(a:meta::pure::functions::collection::tests::contains::ClassWithoutEquality[1],'"
@@ -143,10 +143,10 @@
     "expectedError" : "No SQL translation exists for the PURE function 'zip_T_MANY__U_MANY__Pair_MANY_'."
   }, {
     "test" : "meta::pure::functions::date::tests::testAdjustByDaysBigNumber_Function_1__Boolean_1_",
-    "expectedError" : "net.snowflake.client.jdbc.SnowflakeSQLException: Numeric value '12345678912' is out of range"
+    "expectedError" : "net.snowflake.client.api.exception.SnowflakeSQLException: Numeric value '12345678912' is out of range"
   }, {
     "test" : "meta::pure::functions::date::tests::testAdjustByHoursBigNumber_Function_1__Boolean_1_",
-    "expectedError" : "net.snowflake.client.jdbc.SnowflakeSQLException: Numeric value '12345678912' is out of range"
+    "expectedError" : "net.snowflake.client.api.exception.SnowflakeSQLException: Numeric value '12345678912' is out of range"
   }, {
     "test" : "meta::pure::functions::date::tests::testAdjustByMicrosecondsBigNumber_Function_1__Boolean_1_",
     "expectedError" : "\"\nexpected: %2021-06-21T09:37:37.4990000+0000\nactual:   %2021-06-21T09:37:37.499+0000\""
@@ -155,13 +155,13 @@
     "expectedError" : "\"\nexpected: %-21457-01-08T20:48:00+0000\nactual:   %21458-01-18T17:39:38+0000\""
   }, {
     "test" : "meta::pure::functions::date::tests::testAdjustByMonthsBigNumber_Function_1__Boolean_1_",
-    "expectedError" : "net.snowflake.client.jdbc.SnowflakeSQLException: Numeric value '9600000000' is out of range"
+    "expectedError" : "net.snowflake.client.api.exception.SnowflakeSQLException: Numeric value '9600000000' is out of range"
   }, {
     "test" : "meta::pure::functions::date::tests::testAdjustByMonths_Function_1__Boolean_1_",
     "expectedError" : "Date has no day: 2012-03"
   }, {
     "test" : "meta::pure::functions::date::tests::testAdjustByWeeksBigNumber_Function_1__Boolean_1_",
-    "expectedError" : "net.snowflake.client.jdbc.SnowflakeSQLException: Numeric value '12345678912' is out of range"
+    "expectedError" : "net.snowflake.client.api.exception.SnowflakeSQLException: Numeric value '12345678912' is out of range"
   }, {
     "test" : "meta::pure::functions::date::tests::testAdjustByYears_Function_1__Boolean_1_",
     "expectedError" : "\"Ensure the target system understands Year or Year-month semantic.\""
@@ -356,22 +356,22 @@
     "expectedError" : "\"\nexpected: 4\nactual:   5\""
   }, {
     "test" : "meta::pure::functions::string::tests::parseDate::testParseDateTypes_Function_1__Boolean_1_",
-    "expectedError" : "net.snowflake.client.jdbc.SnowflakeSQLException: Can't parse '2014-02-27T00:00:00.000000' as timestamp with format 'YYYY-MM-DD HH24:MI:SS'"
+    "expectedError" : "net.snowflake.client.api.exception.SnowflakeSQLException: Can't parse '2014-02-27T00:00:00.000000' as timestamp with format 'YYYY-MM-DD HH24:MI:SS'"
   }, {
     "test" : "meta::pure::functions::string::tests::parseDate::testParseDateWithTimezone_Function_1__Boolean_1_",
-    "expectedError" : "net.snowflake.client.jdbc.SnowflakeSQLException: Can't parse '2014-02-27T10:01:35.231-0500' as timestamp with format 'YYYY-MM-DD HH24:MI:SS'"
+    "expectedError" : "net.snowflake.client.api.exception.SnowflakeSQLException: Can't parse '2014-02-27T10:01:35.231-0500' as timestamp with format 'YYYY-MM-DD HH24:MI:SS'"
   }, {
     "test" : "meta::pure::functions::string::tests::parseDate::testParseDateWithZ_Function_1__Boolean_1_",
-    "expectedError" : "net.snowflake.client.jdbc.SnowflakeSQLException: Can't parse '2014-02-27T10:01:35.231Z' as timestamp with format 'YYYY-MM-DD HH24:MI:SS'"
+    "expectedError" : "net.snowflake.client.api.exception.SnowflakeSQLException: Can't parse '2014-02-27T10:01:35.231Z' as timestamp with format 'YYYY-MM-DD HH24:MI:SS'"
   }, {
     "test" : "meta::pure::functions::string::tests::parseDate::testParseDate_Function_1__Boolean_1_",
-    "expectedError" : "net.snowflake.client.jdbc.SnowflakeSQLException: Can't parse '2014-02-27T10:01:35.231' as timestamp with format 'YYYY-MM-DD HH24:MI:SS'"
+    "expectedError" : "net.snowflake.client.api.exception.SnowflakeSQLException: Can't parse '2014-02-27T10:01:35.231' as timestamp with format 'YYYY-MM-DD HH24:MI:SS'"
   }, {
     "test" : "meta::pure::functions::string::tests::parseDecimal::testParseDecimalWithPrecisionScale_Function_1__Boolean_1_",
     "expectedError" : "\"\nexpected: 123.12300D\nactual:   123.123D\""
   }, {
     "test" : "meta::pure::functions::string::tests::parseDecimal::testParseDecimal_Function_1__Boolean_1_",
-    "expectedError" : "net.snowflake.client.jdbc.SnowflakeSQLException: Numeric value '3.14159d' is not recognized"
+    "expectedError" : "net.snowflake.client.api.exception.SnowflakeSQLException: Numeric value '3.14159d' is not recognized"
   }, {
     "test" : "meta::pure::functions::string::tests::parseDecimal::testParseZero_Function_1__Boolean_1_",
     "expectedError" : "\"\nexpected: 0.0D\nactual:   0D\""

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-PCT/src/main/resources/pct-manifests/relational-snowflake/GrammarFunctions_manifest.json
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-PCT/src/main/resources/pct-manifests/relational-snowflake/GrammarFunctions_manifest.json
@@ -110,7 +110,7 @@
     "expectedError" : "No SQL translation exists for the PURE function 'genericType_Any_MANY__GenericType_1_'"
   }, {
     "test" : "meta::pure::functions::math::tests::minus::testSingleMinus_Function_1__Boolean_1_",
-    "expectedError" : "net.snowflake.client.jdbc.SnowflakeSQLException: SQL compilation error:\nsyntax error line 1 at position 10 unexpected '<EOF>'."
+    "expectedError" : "net.snowflake.client.api.exception.SnowflakeSQLException: SQL compilation error:\nsyntax error line 1 at position 10 unexpected '<EOF>'."
   }, {
     "test" : "meta::pure::functions::math::tests::plus::testDecimalPlus_Function_1__Boolean_1_",
     "expectedError" : "\"\nexpected: 6.0D\nactual:   6.0\""

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-PCT/src/main/resources/pct-manifests/relational-snowflake/RelationFunctions_manifest.json
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-PCT/src/main/resources/pct-manifests/relational-snowflake/RelationFunctions_manifest.json
@@ -29,10 +29,10 @@
     "expectedError" : "\nexpected: '#TDS\\n   id,grp,name,newCol\\n   10,0,J,null\\n   8,1,H,null\\n   6,1,F,6\\n   2,1,B,6\\n   5,2,E,null\\n   1,2,A,1\\n   7,3,G,null\\n   3,3,C,3\\n   4,4,D,null\\n   9,5,I,null\\n#'\nactual:   '#TDS\\n   id,grp,name,newCol\\n   10,0,J,null\\n   8,1,H,6\\n   6,1,F,6\\n   2,1,B,6\\n   5,2,E,1\\n   1,2,A,1\\n   7,3,G,3\\n   3,3,C,3\\n   4,4,D,null\\n   9,5,I,null\\n#'"
   }, {
     "test" : "meta::pure::functions::relation::tests::over::testRangeInterval_CurrentRow_CurrentRow_WithSinglePartition_WithOrderByASC_Function_1__Boolean_1_",
-    "expectedError" : "net.snowflake.client.jdbc.SnowflakeSQLException: SQL compilation error:\nInvalid RANGE BETWEEN frame 'RANGE BETWEEN CURRENT ROW AND CURRENT ROW': timestamp ORDER BY clause only allows interval window frame boundaries."
+    "expectedError" : "net.snowflake.client.api.exception.SnowflakeSQLException: SQL compilation error:\nInvalid RANGE BETWEEN frame 'RANGE BETWEEN CURRENT ROW AND CURRENT ROW': timestamp ORDER BY clause only allows interval window frame boundaries."
   }, {
     "test" : "meta::pure::functions::relation::tests::over::testRangeInterval_CurrentRow_CurrentRow_WithSinglePartition_WithOrderByDESC_Function_1__Boolean_1_",
-    "expectedError" : "net.snowflake.client.jdbc.SnowflakeSQLException: SQL compilation error:\nInvalid RANGE BETWEEN frame 'RANGE BETWEEN CURRENT ROW AND CURRENT ROW': timestamp ORDER BY clause only allows interval window frame boundaries."
+    "expectedError" : "net.snowflake.client.api.exception.SnowflakeSQLException: SQL compilation error:\nInvalid RANGE BETWEEN frame 'RANGE BETWEEN CURRENT ROW AND CURRENT ROW': timestamp ORDER BY clause only allows interval window frame boundaries."
   }, {
     "test" : "meta::pure::functions::relation::tests::over::testRows_UnboundedPreceding_UnboundedFollowing_WithMultiplePartitions_WithoutOrderBy_Function_1__Boolean_1_",
     "expectedError" : "Window frame requires an ORDER BY clause"
@@ -41,10 +41,10 @@
     "expectedError" : "Window frame requires an ORDER BY clause"
   }, {
     "test" : "meta::pure::functions::relation::tests::reduce::testRangeInterval_CurrentRow_CurrentRow_WithSinglePartition_WithOrderByASC_Function_1__Boolean_1_",
-    "expectedError" : "net.snowflake.client.jdbc.SnowflakeSQLException: SQL compilation error:\nInvalid RANGE BETWEEN frame 'RANGE BETWEEN CURRENT ROW AND CURRENT ROW': timestamp ORDER BY clause only allows interval window frame boundaries."
+    "expectedError" : "net.snowflake.client.api.exception.SnowflakeSQLException: SQL compilation error:\nInvalid RANGE BETWEEN frame 'RANGE BETWEEN CURRENT ROW AND CURRENT ROW': timestamp ORDER BY clause only allows interval window frame boundaries."
   }, {
     "test" : "meta::pure::functions::relation::tests::reduce::testRangeInterval_CurrentRow_CurrentRow_WithSinglePartition_WithOrderByDESC_Function_1__Boolean_1_",
-    "expectedError" : "net.snowflake.client.jdbc.SnowflakeSQLException: SQL compilation error:\nInvalid RANGE BETWEEN frame 'RANGE BETWEEN CURRENT ROW AND CURRENT ROW': timestamp ORDER BY clause only allows interval window frame boundaries."
+    "expectedError" : "net.snowflake.client.api.exception.SnowflakeSQLException: SQL compilation error:\nInvalid RANGE BETWEEN frame 'RANGE BETWEEN CURRENT ROW AND CURRENT ROW': timestamp ORDER BY clause only allows interval window frame boundaries."
   }, {
     "test" : "meta::pure::functions::relation::tests::reduce::testRows_UnboundedPreceding_UnboundedFollowing_WithMultiplePartitions_WithoutOrderBy_Function_1__Boolean_1_",
     "expectedError" : "Window frame requires an ORDER BY clause"

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-PCT/src/main/resources/pct-manifests/relational-snowflake/StandardFunctions_manifest.json
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-PCT/src/main/resources/pct-manifests/relational-snowflake/StandardFunctions_manifest.json
@@ -17,7 +17,7 @@
     "expectedError" : "\"Parameter to IN operation isn't a literal!\""
   }, {
     "test" : "meta::pure::functions::collection::tests::in::testInPrimitive_Function_1__Boolean_1_",
-    "expectedError" : "net.snowflake.client.jdbc.SnowflakeSQLException: SQL compilation error:\nCan not convert parameter 'CAST('2014-02-01' AS DATE)' of type [DATE] into expected type [BOOLEAN]"
+    "expectedError" : "net.snowflake.client.api.exception.SnowflakeSQLException: SQL compilation error:\nCan not convert parameter 'CAST('2014-02-01' AS DATE)' of type [DATE] into expected type [BOOLEAN]"
   }, {
     "test" : "meta::pure::functions::collection::tests::least::testLeast_DateTime_Function_1__Boolean_1_",
     "expectedError" : "\"\nexpected: %2025-01-10T15:25:30+0000\nactual:   %2025-01-10T15:25:30.000000000+0000\""
@@ -125,33 +125,33 @@
     "expectedError" : "\nexpected: '#TDS\\n   id,val,newCol\\n   1,1.0,1.8\\n   1,2.0,1.8\\n   1,3.0,1.8\\n   2,1.5,2.3\\n   2,2.5,2.3\\n   2,3.5,2.3\\n   3,1.0,1.4\\n   3,1.5,1.4\\n   3,2.0,1.4\\n#'\nactual:   '#TDS\\n   id,val,newCol\\n   1,1.0,1.7999999999999998\\n   1,2.0,1.7999999999999998\\n   1,3.0,1.7999999999999998\\n   2,1.5,2.3\\n   2,2.5,2.3\\n   2,3.5,2.3\\n   3,1.0,1.4\\n   3,1.5,1.4\\n   3,2.0,1.4\\n#'"
   }, {
     "test" : "meta::pure::functions::math::tests::stdDev::testFloatStdDev_Function_1__Boolean_1_",
-    "expectedError" : "net.snowflake.client.jdbc.SnowflakeSQLException: SQL compilation error: error line 1 at position 12\nInvalid argument types for function '*': (ARRAY, ARRAY)"
+    "expectedError" : "net.snowflake.client.api.exception.SnowflakeSQLException: SQL compilation error: error line 1 at position 12\nInvalid argument types for function '*': (ARRAY, ARRAY)"
   }, {
     "test" : "meta::pure::functions::math::tests::stdDev::testIntStdDev_Function_1__Boolean_1_",
-    "expectedError" : "net.snowflake.client.jdbc.SnowflakeSQLException: SQL compilation error: error line 1 at position 12\nInvalid argument types for function '*': (ARRAY, ARRAY)"
+    "expectedError" : "net.snowflake.client.api.exception.SnowflakeSQLException: SQL compilation error: error line 1 at position 12\nInvalid argument types for function '*': (ARRAY, ARRAY)"
   }, {
     "test" : "meta::pure::functions::math::tests::stdDev::testMixedStdDev_Function_1__Boolean_1_",
-    "expectedError" : "net.snowflake.client.jdbc.SnowflakeSQLException: SQL compilation error: error line 1 at position 12\nInvalid argument types for function '*': (ARRAY, ARRAY)"
+    "expectedError" : "net.snowflake.client.api.exception.SnowflakeSQLException: SQL compilation error: error line 1 at position 12\nInvalid argument types for function '*': (ARRAY, ARRAY)"
   }, {
     "test" : "meta::pure::functions::math::tests::stdDev::testNegativeNumberStdDev_Function_1__Boolean_1_",
-    "expectedError" : "net.snowflake.client.jdbc.SnowflakeSQLException: SQL compilation error: error line 1 at position 12\nInvalid argument types for function '*': (ARRAY, ARRAY)"
+    "expectedError" : "net.snowflake.client.api.exception.SnowflakeSQLException: SQL compilation error: error line 1 at position 12\nInvalid argument types for function '*': (ARRAY, ARRAY)"
   }, {
     "test" : "meta::pure::functions::math::tests::stdDev::testPopulationStandardDeviation_Function_1__Boolean_1_",
-    "expectedError" : "net.snowflake.client.jdbc.SnowflakeSQLException: SQL compilation error: error line 1 at position 12\nInvalid argument types for function '*': (ARRAY, ARRAY)"
+    "expectedError" : "net.snowflake.client.api.exception.SnowflakeSQLException: SQL compilation error: error line 1 at position 12\nInvalid argument types for function '*': (ARRAY, ARRAY)"
   }, {
     "test" : "meta::pure::functions::math::tests::sum::testSum_Numbers_Function_1__Boolean_1_",
     "expectedError" : "\"\nexpected: 32.0\nactual:   32\""
   }, {
     "test" : "meta::pure::functions::math::tests::variance::testVariancePopulation_Function_1__Boolean_1_",
-    "expectedError" : "net.snowflake.client.jdbc.SnowflakeSQLException: SQL compilation error: error line 1 at position 7\nInvalid argument types for function '*': (ARRAY, ARRAY)"
+    "expectedError" : "net.snowflake.client.api.exception.SnowflakeSQLException: SQL compilation error: error line 1 at position 7\nInvalid argument types for function '*': (ARRAY, ARRAY)"
   }, {
     "test" : "meta::pure::functions::math::tests::variance::testVarianceSample_Function_1__Boolean_1_",
-    "expectedError" : "net.snowflake.client.jdbc.SnowflakeSQLException: SQL compilation error: error line 1 at position 7\nInvalid argument types for function '*': (ARRAY, ARRAY)"
+    "expectedError" : "net.snowflake.client.api.exception.SnowflakeSQLException: SQL compilation error: error line 1 at position 7\nInvalid argument types for function '*': (ARRAY, ARRAY)"
   }, {
     "test" : "meta::pure::functions::math::tests::variance::testVariance_Population_Function_1__Boolean_1_",
-    "expectedError" : "net.snowflake.client.jdbc.SnowflakeSQLException: SQL compilation error: error line 1 at position 7\nInvalid argument types for function '*': (ARRAY, ARRAY)"
+    "expectedError" : "net.snowflake.client.api.exception.SnowflakeSQLException: SQL compilation error: error line 1 at position 7\nInvalid argument types for function '*': (ARRAY, ARRAY)"
   }, {
     "test" : "meta::pure::functions::math::tests::variance::testVariance_Sample_Function_1__Boolean_1_",
-    "expectedError" : "net.snowflake.client.jdbc.SnowflakeSQLException: SQL compilation error: error line 1 at position 7\nInvalid argument types for function '*': (ARRAY, ARRAY)"
+    "expectedError" : "net.snowflake.client.api.exception.SnowflakeSQLException: SQL compilation error: error line 1 at position 7\nInvalid argument types for function '*': (ARRAY, ARRAY)"
   } ]
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-PCT/src/main/resources/pct-manifests/relational-snowflake/UnclassifiedFunctions_manifest.json
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-PCT/src/main/resources/pct-manifests/relational-snowflake/UnclassifiedFunctions_manifest.json
@@ -2,7 +2,7 @@
   "adapter" : "meta::relational::tests::pct::snowflake::testAdapterForRelationalWithSnowflakeExecution_Function_1__X_o_",
   "exclusions" : [ {
     "test" : "meta::pure::functions::string::tests::base64::testDecodeBase64NoPadding_Function_1__Boolean_1_",
-    "expectedError" : "net.snowflake.client.jdbc.SnowflakeSQLException: The following string is not a legal base64-encoded value: 'SGVsbG8sIFdvcmxkIQ'"
+    "expectedError" : "net.snowflake.client.api.exception.SnowflakeSQLException: The following string is not a legal base64-encoded value: 'SGVsbG8sIFdvcmxkIQ'"
   }, {
     "test" : "meta::pure::functions::string::tests::regexpLike::testRegexpLike_CaseInsensitive_Multiline_Function_1__Boolean_1_",
     "expectedError" : "\"Assert failed\""

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-execution/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-execution/pom.xml
@@ -133,6 +133,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-csv</artifactId>
         </dependency>

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-execution/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/driver/vendors/snowflake/SnowflakeCommands.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-execution/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/driver/vendors/snowflake/SnowflakeCommands.java
@@ -14,6 +14,7 @@
 
 package org.finos.legend.engine.plan.execution.stores.relational.connection.driver.vendors.snowflake;
 
+import net.snowflake.client.api.connection.SnowflakeConnection;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.QuoteMode;
 import org.eclipse.collections.api.factory.Maps;
@@ -23,8 +24,11 @@ import org.finos.legend.engine.plan.execution.stores.relational.connection.drive
 import org.finos.legend.engine.plan.execution.stores.relational.connection.driver.commands.RelationalDatabaseCommands;
 import org.finos.legend.engine.plan.execution.stores.relational.connection.driver.commands.RelationalDatabaseCommandsVisitor;
 
-import java.util.Arrays;
+import java.io.InputStream;
+import java.sql.Connection;
+import java.sql.Statement;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 public class SnowflakeCommands extends RelationalDatabaseCommands
@@ -58,18 +62,7 @@ public class SnowflakeCommands extends RelationalDatabaseCommands
     @Override
     public List<String> createAndLoadTempTable(String tableName, List<Column> columns, String optionalCSVFileLocation)
     {
-        if (optionalCSVFileLocation.startsWith("/"))
-        {
-            optionalCSVFileLocation = optionalCSVFileLocation.substring(1);
-        }
-        List<String> strings = Arrays.asList(
-                "CREATE TEMPORARY TABLE " + tableName + " " + columns.stream().map(c -> c.name + " " + columnTypeToSqlTextMap.getIfAbsentValue(c.type, c.type)).collect(Collectors.joining(",", "(", ")")),
-                "CREATE OR REPLACE TEMPORARY STAGE " + tempStageName(),
-                "PUT file:///" + optionalCSVFileLocation + " @" + tempStageName() + "/" + optionalCSVFileLocation + " PARALLEL = 16 AUTO_COMPRESS = TRUE",
-                "COPY INTO " + tableName + " FROM @" + tempStageName() + "/" + optionalCSVFileLocation + " file_format = (type = CSV field_optionally_enclosed_by= '\"')",
-                "DROP STAGE " + tempStageName()
-        );
-        return strings;
+        throw new UnsupportedOperationException("Snowflake should use input stream to temp table load. This method should not be triggered for Snowflake.");
     }
 
     @Override
@@ -87,7 +80,7 @@ public class SnowflakeCommands extends RelationalDatabaseCommands
     @Override
     public IngestionMethod getDefaultIngestionMethod()
     {
-        return IngestionMethod.CLIENT_FILE;
+        return IngestionMethod.CLIENT_STREAM;
     }
 
     public boolean supportsHeaderOnCsvFile()
@@ -101,4 +94,47 @@ public class SnowflakeCommands extends RelationalDatabaseCommands
         return visitor.visit(this);
     }
 
+    /**
+     * Streaming data to session-scoped temp table without creating file on local file system.
+     * Source rows are consumed from {@code csvInputStream} and pushed straight to a Snowflake internal stage via the JDBC driver's {@code SnowflakeConnection.uploadStream} method.
+     */
+    @Override
+    public void ingestFromStream(Connection connection, String tableName, List<Column> columns, InputStream csvInputStream) throws Exception
+    {
+        String stageFileName = "legend_stream_" + UUID.randomUUID().toString().replace("-", "") + ".csv";
+        String stagedObjectName = stageFileName + ".gz";
+        String createTable = "CREATE TEMPORARY TABLE " + tableName + " " + columns.stream().map(c -> c.name + " " + columnTypeToSqlTextMap.getIfAbsentValue(c.type, c.type)).collect(Collectors.joining(",", "(", ")"));
+        String createStage = "CREATE OR REPLACE TEMPORARY STAGE " + tempStageName();
+        String copyInto = "COPY INTO " + tableName + " FROM @" + tempStageName() + "/" + stagedObjectName + " file_format = (type = CSV field_optionally_enclosed_by= '\"')" + " ON_ERROR = ABORT_STATEMENT";
+        String dropStage = "DROP STAGE " + tempStageName();
+
+        try (Statement statement = connection.createStatement())
+        {
+            statement.execute(dropTempTable(tableName));
+            statement.execute(createTable);
+            statement.execute(createStage);
+        }
+
+        try
+        {
+            SnowflakeConnection snowflakeConnection = connection.unwrap(SnowflakeConnection.class);
+            snowflakeConnection.uploadStream(tempStageName(), stageFileName, csvInputStream);
+
+            try (Statement copyStatement = connection.createStatement())
+            {
+                copyStatement.execute(copyInto);
+            }
+        }
+        finally
+        {
+            try (Statement dropStatement = connection.createStatement())
+            {
+                dropStatement.execute(dropStage);
+            }
+            catch (Exception dropEx)
+            {
+                //the stage is session-scoped and auto-drops with the session anyway so ignoring this exception to not mask exception with copy
+            }
+        }
+    }
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-execution/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/connection/ds/TestSnowflakeCommands.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-execution/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/connection/ds/TestSnowflakeCommands.java
@@ -14,51 +14,54 @@
 
 package org.finos.legend.engine.plan.execution.stores.relational.connection.ds;
 
+import net.snowflake.client.api.connection.SnowflakeConnection;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
 import org.apache.commons.csv.QuoteMode;
-import org.eclipse.collections.api.list.ImmutableList;
-import org.eclipse.collections.impl.factory.Lists;
 import org.finos.legend.engine.plan.execution.stores.relational.connection.driver.commands.Column;
+import org.finos.legend.engine.plan.execution.stores.relational.connection.driver.commands.IngestionMethod;
 import org.finos.legend.engine.plan.execution.stores.relational.connection.driver.vendors.snowflake.SnowflakeCommands;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.StringWriter;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class TestSnowflakeCommands
 {
+    private SnowflakeCommands snowflakeCommands = new SnowflakeCommands();
+
     @Test
-    public void testTempTableCommands() throws IOException
+    public void testDefaultIngestionMethodIsStream()
     {
-        SnowflakeCommands snowflakeCommands = new SnowflakeCommands();
-
-        ImmutableList<Column> columns = Lists.immutable.of(
-                new Column("a", "VARCHAR(100)"),
-                new Column("b", "VARCHAR(100)"),
-                new Column("c", "BIT")
-        );
-
-        List<String> sqlStatements = snowflakeCommands.createAndLoadTempTable("temp_1", columns.castToList(), "/tmp/temp.csv");
-        ImmutableList<String> expectedSQLStatements = Lists.immutable.of(
-                "CREATE TEMPORARY TABLE temp_1 (a VARCHAR(100),b VARCHAR(100),c BOOLEAN)",
-                "CREATE OR REPLACE TEMPORARY STAGE LEGEND_TEMP_DB.LEGEND_TEMP_SCHEMA.LEGEND_TEMP_STAGE",
-                "PUT file:///tmp/temp.csv @LEGEND_TEMP_DB.LEGEND_TEMP_SCHEMA.LEGEND_TEMP_STAGE/tmp/temp.csv PARALLEL = 16 AUTO_COMPRESS = TRUE",
-                "COPY INTO temp_1 FROM @LEGEND_TEMP_DB.LEGEND_TEMP_SCHEMA.LEGEND_TEMP_STAGE/tmp/temp.csv file_format = (type = CSV field_optionally_enclosed_by= '\"')",
-                "DROP STAGE LEGEND_TEMP_DB.LEGEND_TEMP_SCHEMA.LEGEND_TEMP_STAGE"
-        );
-        assertEquals(expectedSQLStatements, sqlStatements);
+        assertEquals(IngestionMethod.CLIENT_STREAM, snowflakeCommands.getDefaultIngestionMethod());
     }
 
     @Test
     public void testCsvFormatForTempFileUsesAllNonNullQuoteMode()
     {
-        CSVFormat format = new SnowflakeCommands().getCsvFormatForTempFile();
+        CSVFormat format = snowflakeCommands.getCsvFormatForTempFile();
 
         assertNotNull(format);
         assertEquals(QuoteMode.ALL_NON_NULL, format.getQuoteMode());
@@ -68,7 +71,7 @@ public class TestSnowflakeCommands
     @Test
     public void testCsvFormatForTempFileQuotesNonNullValuesAndPreservesEmbeddedNewlines() throws IOException
     {
-        CSVFormat format = new SnowflakeCommands().getCsvFormatForTempFile();
+        CSVFormat format = snowflakeCommands.getCsvFormatForTempFile();
 
         StringWriter out = new StringWriter();
         try (CSVPrinter printer = new CSVPrinter(out, format))
@@ -81,5 +84,96 @@ public class TestSnowflakeCommands
                 "\"hello\",\"\",,\"42\",\"line1\nline2,\"\"still one field\"\"\"\r\n"
                         + "\"x\",\"y\",\"z\",\"0\",\"plain\"\r\n";
         assertEquals(expected, out.toString());
+    }
+
+    @Test
+    public void testIngestFromStreamRunsFullDdlSequenceAndUploadsStream() throws Exception
+    {
+        String table = "LEGEND_TEMP_DB.LEGEND_TEMP_SCHEMA.TMP_T";
+        List<Column> columns = Arrays.asList(new Column("id", "INT"), new Column("flag", "BIT"));
+        InputStream csv = new ByteArrayInputStream("1,true\n".getBytes());
+
+        SnowflakeConnection snowflakeConnection = mock(SnowflakeConnection.class);
+        Statement ddlStmt = mock(Statement.class);
+        Statement copyStmt = mock(Statement.class);
+        Statement dropStmt = mock(Statement.class);
+        Connection connection = mock(Connection.class);
+        when(connection.createStatement()).thenReturn(ddlStmt, copyStmt, dropStmt);
+        when(connection.unwrap(SnowflakeConnection.class)).thenReturn(snowflakeConnection);
+
+        snowflakeCommands.ingestFromStream(connection, table, columns, csv);
+
+        // DDL block: three statements executed in order on the same Statement
+        ArgumentCaptor<String> ddlSql = ArgumentCaptor.forClass(String.class);
+        verify(ddlStmt, times(3)).execute(ddlSql.capture());
+        List<String> ddlCalls = ddlSql.getAllValues();
+        assertEquals("Drop table if exists " + table, ddlCalls.get(0));
+        assertTrue(ddlCalls.get(1).startsWith("CREATE TEMPORARY TABLE " + table));
+        // BIT is remapped to BOOLEAN
+        assertTrue(ddlCalls.get(1).contains("id INT"));
+        assertTrue(ddlCalls.get(1).contains("flag BOOLEAN"));
+        assertEquals("CREATE OR REPLACE TEMPORARY STAGE " + snowflakeCommands.tempStageName(), ddlCalls.get(2));
+        verify(ddlStmt).close();
+
+        // uploadStream: same InputStream instance, staged onto configured stage, csv filename
+        ArgumentCaptor<String> stageName = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> fileName = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<InputStream> streamArg = ArgumentCaptor.forClass(InputStream.class);
+        verify(snowflakeConnection).uploadStream(stageName.capture(), fileName.capture(), streamArg.capture());
+        assertEquals(snowflakeCommands.tempStageName(), stageName.getValue());
+        assertTrue(fileName.getValue().startsWith("legend_stream_"));
+        assertTrue(fileName.getValue().endsWith(".csv"));
+        assertSame(csv, streamArg.getValue());
+
+        // COPY INTO references the staged .gz object and target table
+        ArgumentCaptor<String> copySql = ArgumentCaptor.forClass(String.class);
+        verify(copyStmt).execute(copySql.capture());
+        String copy = copySql.getValue();
+        assertTrue(copy.startsWith("COPY INTO " + table + " FROM @" + snowflakeCommands.tempStageName() + "/"));
+        assertTrue(copy.contains(fileName.getValue() + ".gz"));
+        assertTrue(copy.contains("ON_ERROR = ABORT_STATEMENT"));
+        verify(copyStmt).close();
+
+        // DROP STAGE in finally
+        verify(dropStmt).execute("DROP STAGE " + snowflakeCommands.tempStageName());
+        verify(dropStmt).close();
+
+        verify(connection, times(3)).createStatement();
+    }
+
+    @Test
+    public void testIngestFromStreamPropagatesCopyFailureAndSwallowsDropStageError() throws Exception
+    {
+        String table = "T";
+        List<Column> columns = Collections.singletonList(new Column("id", "INT"));
+        InputStream csv = new ByteArrayInputStream(new byte[0]);
+
+        SnowflakeConnection snowflakeConnection = mock(SnowflakeConnection.class);
+        Statement ddlStmt = mock(Statement.class);
+        Statement copyStmt = mock(Statement.class);
+        Statement dropStmt = mock(Statement.class);
+        Connection connection = mock(Connection.class);
+        when(connection.createStatement()).thenReturn(ddlStmt, copyStmt, dropStmt);
+        when(connection.unwrap(SnowflakeConnection.class)).thenReturn(snowflakeConnection);
+
+        SQLException copyFailure = new SQLException("copy exploded");
+        doThrow(copyFailure).when(copyStmt).execute(anyString());
+        // Drop stage also fails — must be swallowed so the copy error is what surfaces
+        doThrow(new SQLException("drop stage exploded")).when(dropStmt).execute(anyString());
+
+        try
+        {
+            snowflakeCommands.ingestFromStream(connection, table, columns, csv);
+            fail("expected copy failure to propagate");
+        }
+        catch (SQLException e)
+        {
+            assertSame(copyFailure, e);
+        }
+
+        // uploadStream still ran before the failure
+        verify(snowflakeConnection).uploadStream(anyString(), anyString(), any(InputStream.class));
+        // drop stage was attempted despite copy failure
+        verify(dropStmt).execute("DROP STAGE " + snowflakeCommands.tempStageName());
     }
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan-connection/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/driver/commands/IngestionMethod.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan-connection/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/driver/commands/IngestionMethod.java
@@ -18,6 +18,7 @@ public enum IngestionMethod
 {
     BATCH_INSERT,
     CLIENT_FILE,
+    CLIENT_STREAM,
     DIRECT_INSERT
 
     }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan-connection/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/driver/commands/RelationalDatabaseCommands.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan-connection/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/driver/commands/RelationalDatabaseCommands.java
@@ -16,6 +16,8 @@ package org.finos.legend.engine.plan.execution.stores.relational.connection.driv
 
 import org.apache.commons.csv.CSVFormat;
 
+import java.io.InputStream;
+import java.sql.Connection;
 import java.util.List;
 
 public abstract class RelationalDatabaseCommands
@@ -66,6 +68,15 @@ public abstract class RelationalDatabaseCommands
     public String getSemiStructuredInsertStatement(String tableName, String columnName)
     {
         throw new RuntimeException("Insert into semi structured column in temp table not implemented for " + this.getClass().getSimpleName());
+    }
+
+    /*
+     * Streaming ingest into a session-scoped temp table without materialising a CSV on the local filesystem
+     * Called only when {@link #getDefaultIngestionMethod()} is @link IngestionMethod#CLIENT_STREAM}.
+    */
+    public void ingestFromStream(Connection connection, String tableName, List<Column> columns, InputStream csvInputStream) throws Exception
+    {
+        throw new UnsupportedOperationException("Streaming ingest (CLIENT_STREAM) not implemented for " + this.getClass().getSimpleName());
     }
 
 //    public void buildTempTableFromResult(RelationalExecutionConfiguration config, Connection connection, StreamingResult result, String tableName)

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/StreamResultToTempTableVisitor.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/StreamResultToTempTableVisitor.java
@@ -42,12 +42,17 @@ import org.finos.legend.engine.shared.core.operational.logs.LoggingEventType;
 import org.slf4j.Logger;
 
 import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -87,67 +92,26 @@ public class StreamResultToTempTableVisitor implements RelationalDatabaseCommand
     {
         if (ingestionMethod == IngestionMethod.CLIENT_FILE)
         {
-            CSVFormat csvFormat = dbCommands.getCsvFormatForTempFile();
             try (TemporaryFile tempFile = new TemporaryFile(config.tempPath))
             {
-                CsvSerializer csvSerializer;
-                boolean withHeader = dbCommands.supportsHeaderOnCsvFile();
-                if (result instanceof RelationalResult)
+                SerializerAndColumns sc = buildSerializerAndColumns(dbCommands);
+                tempFile.writeFile(sc.serializer);
+                try (Statement statement = connection.createStatement())
                 {
-                    csvSerializer = new RelationalResultToCSVSerializer((RelationalResult) result, withHeader, csvFormat);
-                    tempFile.writeFile(csvSerializer);
-                    try (Statement statement = connection.createStatement())
-                    {
-                        statement.execute(dbCommands.dropTempTable(tableName));
-
-                        RelationalResult relationalResult = (RelationalResult) result;
-
-                        if (result.getResultBuilder() instanceof TDSBuilder)
-                        {
-                            dbCommands.createAndLoadTempTable(tableName, relationalResult.getTdsColumns().stream().map(c -> new Column(c.name, c.relationalType)).collect(Collectors.toList()), tempFile.getTemporaryPathForFile()).forEach(x -> checkedExecute(statement, x));
-                        }
-                        else
-                        {
-                            dbCommands.createAndLoadTempTable(tableName, relationalResult.getSQLResultColumns().stream().map(c -> new Column(c.label, c.dataType)).collect(Collectors.toList()), tempFile.getTemporaryPathForFile()).forEach(x -> checkedExecute(statement, x));
-                        }
-                    }
+                    statement.execute(dbCommands.dropTempTable(tableName));
+                    dbCommands.createAndLoadTempTable(tableName, sc.columns, tempFile.getTemporaryPathForFile()).forEach(x -> checkedExecute(statement, x));
                 }
-                else if (result instanceof RealizedRelationalResult)
-                {
-                    csvSerializer = new RealizedRelationalResultCSVSerializer((RealizedRelationalResult) result, this.databaseTimeZone, withHeader, false, csvFormat);
-                    tempFile.writeFile(csvSerializer);
-                    try (Statement statement = connection.createStatement())
-                    {
-                        statement.execute(dbCommands.dropTempTable(tableName));
-                        RealizedRelationalResult realizedRelationalResult = (RealizedRelationalResult) result;
-                        dbCommands.createAndLoadTempTable(tableName, realizedRelationalResult.columns.stream().map(c -> new Column(c.label, c.dataType)).collect(Collectors.toList()), tempFile.getTemporaryPathForFile()).forEach(x -> checkedExecute(statement, x));
-                    }
-                }
-                else if (result instanceof StreamingObjectResult)
-                {
-                    csvSerializer = new StreamingObjectResultCSVSerializer((StreamingObjectResult) result, withHeader, csvFormat);
-                    tempFile.writeFile(csvSerializer);
-                    try (Statement statement = connection.createStatement())
-                    {
-                        statement.execute(dbCommands.dropTempTable(tableName));
-                        dbCommands.createAndLoadTempTable(tableName, csvSerializer.getHeaderColumnsAndTypes().stream().map(c -> new Column(c.getOne(), RelationalExecutor.getRelationalTypeFromDataType(c.getTwo()))).collect(Collectors.toList()), tempFile.getTemporaryPathForFile()).forEach(x -> checkedExecute(statement, x));
-                    }
-                }
-                else if (result instanceof TempTableStreamingResult)
-                {
-                    csvSerializer = new StreamingTempTableResultCSVSerializer((TempTableStreamingResult) result, withHeader, csvFormat);
-                    tempFile.writeFile(csvSerializer);
-                    try (Statement statement = connection.createStatement())
-                    {
-                        statement.execute(dbCommands.dropTempTable(tableName));
-                        dbCommands.createAndLoadTempTable(tableName, csvSerializer.getHeaderColumnsAndTypes().stream().map(c -> new Column(c.getOne(), RelationalExecutor.getRelationalTypeFromDataType(c.getTwo()))).collect(Collectors.toList()), tempFile.getTemporaryPathForFile()).forEach(x -> checkedExecute(statement, x));
-                    }
-                }
-                else
-                {
-                    throw new RuntimeException("Result not supported yet: " + result.getClass().getName());
-                }
-
+            }
+            catch (Exception e)
+            {
+                throw new RuntimeException(e);
+            }
+        }
+        else if (ingestionMethod == IngestionMethod.CLIENT_STREAM)
+        {
+            try
+            {
+                streamResultToTableViaStream(dbCommands);
             }
             catch (Exception e)
             {
@@ -159,6 +123,100 @@ public class StreamResultToTempTableVisitor implements RelationalDatabaseCommand
             streamResultToNewTarget(((RelationalResult) result).resultSet, connection, tableName, 100);
         }
         return true;
+    }
+
+    /**
+     * Streaming ingest path (no local CSV file).
+     */
+    void streamResultToTableViaStream(RelationalDatabaseCommands dbCommands) throws Exception
+    {
+        SerializerAndColumns sc = buildSerializerAndColumns(dbCommands);
+        final CsvSerializer csvSerializer = sc.serializer;
+        final List<Column> columns = sc.columns;
+
+        int pipeBufferBytes = 8 * 1024 * 1024;
+        PipedOutputStream pipedOut = new PipedOutputStream();
+        PipedInputStream pipedIn = new PipedInputStream(pipedOut, pipeBufferBytes);
+        AtomicReference<Throwable> producerError = new AtomicReference<>();
+
+        Thread producer = new Thread(() ->
+        {
+            try (OutputStream out = pipedOut)
+            {
+                csvSerializer.stream(out);
+            }
+            catch (Throwable t)
+            {
+                producerError.set(t);
+            }
+        }, "legend-stream-ingest-csv-producer");
+        producer.setDaemon(true);
+        producer.start();
+
+        try (InputStream in = pipedIn)
+        {
+            dbCommands.ingestFromStream(this.connection, this.tableName, columns, in);
+        }
+        finally
+        {
+            producer.join();
+        }
+
+        Throwable producerFailure = producerError.get();
+        if (producerFailure != null)
+        {
+            throw new RuntimeException("Streaming ingest failed in CSV producer", producerFailure);
+        }
+    }
+
+    SerializerAndColumns buildSerializerAndColumns(RelationalDatabaseCommands dbCommands)
+    {
+        CSVFormat csvFormat = dbCommands.getCsvFormatForTempFile();
+        boolean withHeader = dbCommands.supportsHeaderOnCsvFile();
+
+        if (result instanceof RelationalResult)
+        {
+            RelationalResult rr = (RelationalResult) result;
+            CsvSerializer serializer = new RelationalResultToCSVSerializer(rr, withHeader, csvFormat);
+            List<Column> columns = (rr.getResultBuilder() instanceof TDSBuilder)
+                    ? rr.getTdsColumns().stream().map(c -> new Column(c.name, c.relationalType)).collect(Collectors.toList())
+                    : rr.getSQLResultColumns().stream().map(c -> new Column(c.label, c.dataType)).collect(Collectors.toList());
+            return new SerializerAndColumns(serializer, columns);
+        }
+        if (result instanceof RealizedRelationalResult)
+        {
+            RealizedRelationalResult rrr = (RealizedRelationalResult) result;
+            CsvSerializer serializer = new RealizedRelationalResultCSVSerializer(rrr, this.databaseTimeZone, withHeader, false, csvFormat);
+            List<Column> columns = rrr.columns.stream().map(c -> new Column(c.label, c.dataType)).collect(Collectors.toList());
+            return new SerializerAndColumns(serializer, columns);
+        }
+        if (result instanceof StreamingObjectResult)
+        {
+            CsvSerializer serializer = new StreamingObjectResultCSVSerializer((StreamingObjectResult) result, withHeader, csvFormat);
+            List<Column> columns = serializer.getHeaderColumnsAndTypes().stream()
+                    .map(c -> new Column(c.getOne(), RelationalExecutor.getRelationalTypeFromDataType(c.getTwo()))).collect(Collectors.toList());
+            return new SerializerAndColumns(serializer, columns);
+        }
+        if (result instanceof TempTableStreamingResult)
+        {
+            CsvSerializer serializer = new StreamingTempTableResultCSVSerializer((TempTableStreamingResult) result, withHeader, csvFormat);
+            List<Column> columns = serializer.getHeaderColumnsAndTypes().stream()
+                    .map(c -> new Column(c.getOne(), RelationalExecutor.getRelationalTypeFromDataType(c.getTwo()))).collect(Collectors.toList());
+            return new SerializerAndColumns(serializer, columns);
+        }
+        throw new RuntimeException("Result not supported yet: " + result.getClass().getName());
+    }
+
+    static final class SerializerAndColumns
+    {
+        final CsvSerializer serializer;
+        final List<Column> columns;
+
+        SerializerAndColumns(CsvSerializer serializer, List<Column> columns)
+        {
+            this.serializer = serializer;
+            this.columns = columns;
+        }
     }
 
     public static boolean checkedExecute(Statement statement, String sql)

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/TestStreamResultToTempTableVisitor.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/TestStreamResultToTempTableVisitor.java
@@ -1,0 +1,182 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.plan.execution.stores.relational;
+
+import org.apache.commons.csv.CSVFormat;
+import org.finos.legend.engine.plan.execution.result.StreamingResult;
+import org.finos.legend.engine.plan.execution.stores.relational.connection.driver.commands.Column;
+import org.finos.legend.engine.plan.execution.stores.relational.connection.driver.commands.IngestionMethod;
+import org.finos.legend.engine.plan.execution.stores.relational.connection.driver.commands.RelationalDatabaseCommands;
+import org.finos.legend.engine.plan.execution.stores.relational.connection.driver.commands.RelationalDatabaseCommandsVisitor;
+import org.finos.legend.engine.plan.execution.stores.relational.result.RealizedRelationalResult;
+import org.finos.legend.engine.plan.execution.stores.relational.serialization.RealizedRelationalResultCSVSerializer;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model.result.SQLResultColumn;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.sql.Connection;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+public class TestStreamResultToTempTableVisitor
+{
+    @Test
+    public void buildSerializerAndColumns_realizedRelationalResult()
+    {
+        RealizedRelationalResult rrr = mock(RealizedRelationalResult.class);
+        rrr.columns = Arrays.asList(new SQLResultColumn("id", "INT"), new SQLResultColumn("name", "VARCHAR"));
+
+        StreamResultToTempTableVisitor v = newVisitor(rrr);
+        StreamResultToTempTableVisitor.SerializerAndColumns sc = v.buildSerializerAndColumns(new StubCommands());
+
+        assertTrue(sc.serializer instanceof RealizedRelationalResultCSVSerializer);
+        assertEquals(2, sc.columns.size());
+        assertEquals("id", sc.columns.get(0).name);
+        assertEquals("INT", sc.columns.get(0).type);
+        assertEquals("name", sc.columns.get(1).name);
+        assertEquals("VARCHAR", sc.columns.get(1).type);
+    }
+
+    @Test
+    public void buildSerializerAndColumns_unsupportedResult_throws()
+    {
+        StreamingResult unsupported = mock(StreamingResult.class);
+        StreamResultToTempTableVisitor v = newVisitor(unsupported);
+        RuntimeException ex = assertThrows(RuntimeException.class, () -> v.buildSerializerAndColumns(new StubCommands()));
+        assertTrue(ex.getMessage().startsWith("Result not supported yet:"));
+    }
+
+    @Test
+    public void streamResultToTableViaStream_pipesCsvToIngest() throws Exception
+    {
+        RealizedRelationalResult rrr = mock(RealizedRelationalResult.class);
+        rrr.columns = Arrays.asList(new SQLResultColumn("id", "INT"), new SQLResultColumn("name", "VARCHAR"));
+        rrr.resultSetRows = Arrays.asList(
+                Arrays.<Object>asList(1, "alice"),
+                Arrays.<Object>asList(2, "bob"));
+
+        CapturingCommands cmds = new CapturingCommands();
+        StreamResultToTempTableVisitor v = newVisitor(rrr);
+
+        v.streamResultToTableViaStream(cmds);
+
+        assertEquals("myTable", cmds.capturedTable);
+        assertEquals(Arrays.asList("id", "name"), cmds.capturedColumnNames());
+        String csv = cmds.capturedCsv.toString("UTF-8").replace("\r\n", "\n").trim();
+        assertEquals("1,alice\n2,bob", csv);
+    }
+
+    @Test
+    public void streamResultToTableViaStream_propagatesConsumerFailure()
+    {
+        RealizedRelationalResult rrr = mock(RealizedRelationalResult.class);
+        rrr.columns = Collections.singletonList(new SQLResultColumn("id", "INT"));
+        rrr.resultSetRows = Collections.singletonList(Arrays.<Object>asList(1));
+
+        RelationalDatabaseCommands failing = new StubCommands()
+        {
+            @Override
+            public void ingestFromStream(Connection connection, String tableName, List<Column> columns, InputStream csvInputStream)
+            {
+                throw new RuntimeException("boom");
+            }
+        };
+
+        StreamResultToTempTableVisitor v = newVisitor(rrr);
+        Exception ex = assertThrows(Exception.class, () -> v.streamResultToTableViaStream(failing));
+        // consumer error surfaces as-is (RuntimeException from ingestFromStream)
+        assertEquals("boom", ex.getMessage());
+    }
+
+    private static StreamResultToTempTableVisitor newVisitor(StreamingResult result)
+    {
+        StreamResultToTempTableVisitor v = new StreamResultToTempTableVisitor(null, null, result, "myTable", "GMT");
+        v.ingestionMethod = IngestionMethod.CLIENT_STREAM;
+        return v;
+    }
+
+    private static class StubCommands extends RelationalDatabaseCommands
+    {
+        @Override
+        public String dropTempTable(String tableName)
+        {
+            return "";
+        }
+
+        @Override
+        public List<String> createAndLoadTempTable(String tableName, List<Column> columns, String optionalCSVFileLocation)
+        {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public <T> T accept(RelationalDatabaseCommandsVisitor<T> visitor)
+        {
+            return visitor.visit(this);
+        }
+
+        @Override
+        public IngestionMethod getDefaultIngestionMethod()
+        {
+            return IngestionMethod.CLIENT_STREAM;
+        }
+
+        @Override
+        public boolean supportsHeaderOnCsvFile()
+        {
+            return false;
+        }
+
+        @Override
+        public CSVFormat getCsvFormatForTempFile()
+        {
+            return CSVFormat.DEFAULT;
+        }
+    }
+
+    /** Drains the streamed CSV into a byte buffer for assertions. */
+    private static class CapturingCommands extends StubCommands
+    {
+        String capturedTable;
+        List<Column> capturedColumns;
+        final ByteArrayOutputStream capturedCsv = new ByteArrayOutputStream();
+
+        List<String> capturedColumnNames()
+        {
+            return capturedColumns == null ? null : capturedColumns.stream().map(c -> c.name).collect(java.util.stream.Collectors.toList());
+        }
+
+        @Override
+        public void ingestFromStream(Connection connection, String tableName, List<Column> columns, InputStream csvInputStream) throws IOException
+        {
+            this.capturedTable = tableName;
+            this.capturedColumns = columns;
+            byte[] buf = new byte[4096];
+            int n;
+            while ((n = csvInputStream.read(buf)) != -1)
+            {
+                capturedCsv.write(buf, 0, n);
+            }
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@
         <mariadb.version>3.0.6</mariadb.version>
         <postgres.version>42.7.4</postgres.version>
         <redshiftJDBC.version>2.0.0.3</redshiftJDBC.version>
-        <snowflake.version>3.13.5</snowflake.version>
+        <snowflake.version>4.3.2</snowflake.version>
         <duckdb.version>1.3.0.0</duckdb.version>
         <clickhouse.version>0.9.6</clickhouse.version>
 


### PR DESCRIPTION
#### What type of PR is this?

- Improvement

#### What does this PR do / why is it needed ?

- Change cross store implementation for snowflake to stream instead of materializing to file on disc
- Approach/Logic is the same just the underlying implementation changes from instead of streaming data to file on disc and then copying that file to snowflake internal stage we are instead directly using the snowflake uploadStream API that will take the input stream and directly put that to the snowflake internal stage
- Upgrade snowflake driver version 4.3.2 (better support for this uploadStream method)

#### Other notes for reviewers:

- No actual logic change, we are producing the same CSV and its being triggered in the same way as before, the only change here is really to not create the CSV file on disc but to instead stream it directly to snowflake stage via the uploadStream API
