### PR TITLE
Add Legend LSP server wiring to Pure IDE light module

### DIFF
--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-http-server/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-http-server/pom.xml
@@ -106,6 +106,10 @@
             <groupId>org.finos.legend.pure</groupId>
             <artifactId>legend-pure-m3-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-lsp-server</artifactId>
+        </dependency>
         <!-- PURE -->
 
         <dependency>

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-http-server/src/main/java/org/finos/legend/engine/ide/LegendLspServer.java
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-http-server/src/main/java/org/finos/legend/engine/ide/LegendLspServer.java
@@ -1,0 +1,138 @@
+//  Copyright 2026 Goldman Sachs
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package org.finos.legend.engine.ide;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.finos.legend.pure.lsp.LegendPureLspServer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * IDE-runnable entry point for the Legend Pure LSP server, alongside {@link PureIDELight}.
+ * <p>
+ * {@code LegendPureLspServer.main()} (in legend-pure-lsp-server) is designed to be launched as a bare
+ * {@code java -cp <computed-classpath> ...} subprocess, because on its own it has no engine-scale
+ * classpath - the pure-lsp-server dev-loop skill computes one via Maven and passes it in via
+ * {@code --classpath-file}. This class needs none of that: it runs inside this module, which (like
+ * {@link PureIDELight}) already carries the full engine-scale classpath as ordinary Maven dependencies,
+ * so it only needs a config JSON telling it which repos to source-root, which port to listen on, and
+ * which Pure/backend-Server options to set.
+ * <p>
+ * The payoff is that this becomes a plain "Run"/"Debug" configuration in any IDE (main class + one
+ * program arg, the config path) - no skill, no computed classpath file, full user control over every
+ * option in {@link LegendLspServerConfiguration}. Running it under "Debug" means Java breakpoints set
+ * directly in the LSP server's own code (e.g. {@code LegendPureSession}, {@code LegendDebugSession},
+ * {@code DebugService}) simply work under the IDE's normal debugger, with no DAP/socket-forwarding
+ * layer involved - point a real LSP client (e.g. the Legend Pure IntelliJ plugin, configured to CONNECT
+ * to this port rather than spawn its own process) at the port from {@link LegendLspServerConfiguration#port},
+ * then drive it and step through the server-side Java directly.
+ */
+public class LegendLspServer
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(LegendLspServer.class);
+
+    // Matches PureIDELight's own convention of defaulting to the source-tree path (read as a plain
+    // file relative to the process's working directory, i.e. the repo root) rather than a packaged
+    // classpath resource - this module's resource-copy build step is overridden for web-content only.
+    private static final String DEFAULT_CONFIG_RESOURCE =
+            "legend-engine-core/legend-engine-core-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-http-server/src/main/resources/legendLspServerConfig.json";
+
+    public static void main(String[] args) throws Exception
+    {
+        System.setProperty("user.timezone", "GMT");
+
+        String configPath = args.length > 0 ? args[0] : DEFAULT_CONFIG_RESOURCE;
+        LegendLspServerConfiguration config = loadConfig(configPath);
+        if (config.port <= 0)
+        {
+            throw new IllegalArgumentException("Config field 'port' must be a positive port number (got " + config.port + "). "
+                    + "This entry point only supports socket mode - see LegendLspServerConfiguration#port.");
+        }
+
+        applySystemProperties(config);
+
+        List<Path> repoRoots = config.repoRoots.stream().map(Paths::get).collect(Collectors.toList());
+        Set<String> classpathRepositoryNames = new LinkedHashSet<>(config.classpathRepositoryNames);
+
+        LegendPureLspServer server = new LegendPureLspServer();
+        LOGGER.info("Legend LSP server: pre-configuring workspace from {}", repoRoots);
+        server.preconfigureAndWarm(repoRoots, classpathRepositoryNames);
+
+        LOGGER.info("Legend LSP server: warm and listening on 127.0.0.1:{}", config.port);
+        LegendPureLspServer.runSocketMode(server, config.port);
+    }
+
+    private static LegendLspServerConfiguration loadConfig(String path) throws Exception
+    {
+        ObjectMapper mapper = new ObjectMapper();
+        File file = new File(path);
+        if (file.isFile())
+        {
+            LOGGER.info("Legend LSP server: loading config from file {}", file.getAbsolutePath());
+            return mapper.readValue(file, LegendLspServerConfiguration.class);
+        }
+        try (InputStream resource = LegendLspServer.class.getClassLoader().getResourceAsStream(path))
+        {
+            if (resource == null)
+            {
+                throw new FileNotFoundException("Legend LSP server config not found (not a file on disk, not a classpath resource): " + path);
+            }
+            LOGGER.info("Legend LSP server: loading config from classpath resource {}", path);
+            return mapper.readValue(resource, LegendLspServerConfiguration.class);
+        }
+    }
+
+    private static void applySystemProperties(LegendLspServerConfiguration config)
+    {
+        for (Map.Entry<String, Boolean> entry : config.pureOptions.entrySet())
+        {
+            System.setProperty("pure.options." + entry.getKey(), String.valueOf(entry.getValue()));
+        }
+
+        LegendLspServerConfiguration.BackendServerConfiguration backendServer = config.backendServer;
+        if (backendServer != null)
+        {
+            setIfPresent("legend.test.server.host", backendServer.host);
+            setIfPresent("legend.test.server.port", backendServer.port);
+            setIfPresent("legend.test.clientVersion", backendServer.clientVersion);
+            setIfPresent("legend.test.serverVersion", backendServer.serverVersion);
+            setIfPresent("legend.test.serializationKind", backendServer.serializationKind);
+            setIfPresent("legend.test.h2.port", backendServer.h2Port);
+        }
+
+        for (Map.Entry<String, String> entry : config.additionalSystemProperties.entrySet())
+        {
+            System.setProperty(entry.getKey(), entry.getValue());
+        }
+    }
+
+    private static void setIfPresent(String key, String value)
+    {
+        if (value != null)
+        {
+            System.setProperty(key, value);
+        }
+    }
+}

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-http-server/src/main/java/org/finos/legend/engine/ide/LegendLspServerConfiguration.java
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-http-server/src/main/java/org/finos/legend/engine/ide/LegendLspServerConfiguration.java
@@ -1,0 +1,118 @@
+//  Copyright 2026 Goldman Sachs
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package org.finos.legend.engine.ide;
+
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Config JSON shape for {@link LegendLspServer}. Every field mirrors a configuration knob already
+ * exposed by the pure-lsp-server dev-loop skill / LegendPureLspServer's own CLI flags - this exists so
+ * a human can write/edit the same parameters directly instead of relying on that skill to compute them.
+ */
+public class LegendLspServerConfiguration
+{
+    /**
+     * Loopback TCP port the LSP server listens on (LegendPureLspServer's {@code --socket}/
+     * {@code -Dlegend.lsp.socketPort} mode). Required - this class only supports socket mode, since the
+     * point of running it under an IDE is that a separate LSP client (e.g. the Legend Pure IntelliJ
+     * plugin, configured to connect rather than spawn its own process) connects in over this port while
+     * this JVM sits under the IDE's own debugger.
+     */
+    public int port;
+
+    /**
+     * Filesystem directories to scan for workspace repos (each is expected to contain, somewhere
+     * below it, module directories with a matching {@code &lt;name&gt;.definition.json} under their
+     * {@code src/main/resources}) - equivalent to one
+     * {@code --repo-root} per entry in the pure-lsp-server skill / pure-lsp-roots. A repo found under
+     * ANY of these loads from live source and overrides the same-named repo that would otherwise load
+     * from this module's own classpath jars. Relative paths resolve against the process's working
+     * directory. Empty means "everything from the classpath jars, nothing source-backed."
+     */
+    public List<String> repoRoots = new java.util.ArrayList<>();
+
+    /**
+     * Repo names to treat as classpath-provided regardless of whether a same-named repo is also found
+     * under repoRoots - passed straight through to LegendPureSession/PureRuntimeManager's
+     * classpathRepositoryNames parameter. Most users can leave this empty; it mainly matters for
+     * SHARED-mode debug-session scoping (see LegendDebug.ExecutionMode server-side).
+     */
+    public Set<String> classpathRepositoryNames = new LinkedHashSet<>();
+
+    /**
+     * Pure runtime options (the flags read by {@code isOptionSet('X')} in Pure, e.g.
+     * {@code ForceInterpreted}, {@code ExecPlan}, {@code PlanLocal}, {@code FullInteractiveExec},
+     * {@code ExecDebug}, {@code ShowLocalPlan} - see execution.pure / router_entry.pure). Each entry
+     * becomes the system property {@code pure.options.<key>=<value>}, read live on every
+     * execute()/go() call - equivalent to the pure-lsp-set-option skill's /set-option endpoint, but
+     * fixed at launch instead of toggled at runtime.
+     */
+    public Map<String, Boolean> pureOptions = new LinkedHashMap<>();
+
+    /**
+     * Optional: backend Server integration for plan-gen + compiled execution instead of a purely
+     * interpreted session (see the engine-server-start skill and pure-lsp-start's "backend Server
+     * wanted" mode). Leave null for interpreted-only.
+     */
+    public BackendServerConfiguration backendServer;
+
+    /**
+     * Escape hatch for any other {@code -D} system property not covered by a named field above -
+     * applied as-is, key/value verbatim.
+     */
+    public Map<String, String> additionalSystemProperties = new LinkedHashMap<>();
+
+    /**
+     * The {@code -Dlegend.test.*} properties the pure-lsp-start skill passes as {@code --jvm-arg}s when
+     * a real backend Server (started via engine-server-start) is wanted for plan generation/execution,
+     * named here instead of left as raw system-property strings to spell.
+     */
+    public static class BackendServerConfiguration
+    {
+        /**
+         * {@code legend.test.server.host} - typically {@code 127.0.0.1}.
+         */
+        public String host;
+
+        /**
+         * {@code legend.test.server.port} - the backend Server's HTTP port.
+         */
+        public String port;
+
+        /**
+         * {@code legend.test.clientVersion} - e.g. {@code vX_X_X}.
+         */
+        public String clientVersion;
+
+        /**
+         * {@code legend.test.serverVersion} - e.g. {@code v1}.
+         */
+        public String serverVersion;
+
+        /**
+         * {@code legend.test.serializationKind} - e.g. {@code json}.
+         */
+        public String serializationKind;
+
+        /**
+         * {@code legend.test.h2.port} - the backend Server's embedded H2 port.
+         */
+        public String h2Port;
+    }
+}

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-http-server/src/main/resources/legendLspServerConfig.json
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-http-server/src/main/resources/legendLspServerConfig.json
@@ -1,0 +1,25 @@
+{
+  "port": 9100,
+  "repoRoots": [
+    "/home/developer/projects/finos-legend-pure",
+    "/home/developer/projects/finos-legend-engine"
+  ],
+  "classpathRepositoryNames": [],
+  "pureOptions": {
+    "ExecPlan": true,
+    "PlanLocal": true,
+    "FullInteractiveExec": true,
+    "ExecDebug": false,
+    "ForceInterpreted": false,
+    "ShowLocalPlan": false
+  },
+  "backendServer": {
+    "host": "127.0.0.1",
+    "port": "9090",
+    "clientVersion": "vX_X_X",
+    "serverVersion": "v1",
+    "serializationKind": "json",
+    "h2Port": "9092"
+  },
+  "additionalSystemProperties": {}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
 
     <properties>
         <!-- Legend -->
-        <legend.pure.version>5.96.0</legend.pure.version>
+        <legend.pure.version>5.97.1</legend.pure.version>
         <legend.shared.version>0.37.0</legend.shared.version>
         <legend.web-application.version>13.2.0</legend.web-application.version>
         <legend.pylegend.version>0.21.0</legend.pylegend.version>
@@ -179,11 +179,13 @@
         <dropwizard.metrics.version>4.1.16</dropwizard.metrics.version>
         <dropwizard.version>1.3.29</dropwizard.version>
         <eclipsecollections.version>10.2.0</eclipsecollections.version>
+        <error-prone-annotations.version>2.48.0</error-prone-annotations.version>
         <flatbuffers-java.version>24.3.25</flatbuffers-java.version>
         <freemarker.version>2.3.34</freemarker.version>
         <github.classgraph.version>4.8.25</github.classgraph.version>
         <google.api.grpc.version>2.21.0</google.api.grpc.version>
         <grpc.version>1.65.1</grpc.version>
+        <gson.version>2.14.0</gson.version>
         <guava.version>33.4.6-jre</guava.version>
         <hamcrest.core.version>1.3</hamcrest.core.version>
         <hibernate-validator.version>5.4.3.Final</hibernate-validator.version>
@@ -636,6 +638,8 @@
                                         <exclude>com.databricks:databricks-jdbc</exclude>
                                         <exclude>org.mongodb:bson-record-codec</exclude>
                                         <exclude>com.oracle.database.jdbc:ojdbc11</exclude>
+
+                                        <exclude>org.eclipse.lsp4j:*</exclude>
                                     </excludes>
                                 </enforceBytecodeVersion>
                             </rules>
@@ -3474,6 +3478,11 @@
                 <artifactId>legend-pure-ide-light</artifactId>
                 <version>${legend.pure.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.finos.legend.pure</groupId>
+                <artifactId>legend-pure-lsp-server</artifactId>
+                <version>${legend.pure.version}</version>
+            </dependency>
             <!-- PURE -->
 
             <dependency>
@@ -4140,6 +4149,18 @@
                 <groupId>org.freemarker</groupId>
                 <artifactId>freemarker</artifactId>
                 <version>${freemarker.version}</version>
+            </dependency>
+            <dependency>
+                <!-- Needed to resolve dependency convergence issue -->
+                <groupId>com.google.errorprone</groupId>
+                <artifactId>error_prone_annotations</artifactId>
+                <version>${error-prone-annotations.version}</version>
+            </dependency>
+            <dependency>
+                <!-- Needed to resolve dependency convergence issue -->
+                <groupId>com.google.code.gson</groupId>
+                <artifactId>gson</artifactId>
+                <version>${gson.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>


### PR DESCRIPTION
Introduces LegendLspServer, its Dropwizard configuration, and the default legendLspServerConfig.json, plus the module pom.xml dependency on legend-pure-lsp-server needed to build them.

#### What type of PR is this?

<!--
Choose one of the following labels :
- Improvement
- Bug Fix
-->

#### What does this PR do / why is it needed ?

<!--
Describe change being introduced by this PR.
-->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
