### PR TITLE
Fix HttpComponents 5.6.3 dependency convergence

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4317,6 +4317,16 @@
                 <version>5.6.3</version>
             </dependency>
             <dependency>
+                <groupId>org.apache.httpcomponents.core5</groupId>
+                <artifactId>httpcore5</artifactId>
+                <version>5.4.3</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents.core5</groupId>
+                <artifactId>httpcore5-h2</artifactId>
+                <version>5.4.3</version>
+            </dependency>
+            <dependency>
                 <groupId>io.minio</groupId>
                 <artifactId>minio</artifactId>
                 <version>${minio.version}</version>


### PR DESCRIPTION
Companion fix for #5079.

The HttpClient 5.6.3 upgrade brings `httpcore5` and `httpcore5-h2` 5.4.3, while ClickHouse JDBC 0.9.6 still requests both at 5.3.4 through its direct, `clickhouse-http-client`, `jdbc-v2`, and `client-v2` paths. Maven Enforcer therefore stops the server build on dependency convergence.

This manages both HttpCore artifacts at the 5.4.3 version required by HttpClient 5.6.3, without changing application code or unrelated dependencies.

Verification:

- Root effective POM contains managed `httpcore5` and `httpcore5-h2` 5.4.3 entries
- A focused Maven dependency-tree proof containing the exact HttpClient and ClickHouse graphs completed successfully
- Every ClickHouse 5.3.4 path resolves to 5.4.3 with `version managed from 5.3.4`
- `git diff --check`

A repository reactor validation was attempted, but this isolated checkout cannot resolve Legend’s pre-reactor internal SNAPSHOT artifacts; no reactor pass is claimed. The source PR’s CI failure is specifically Maven Enforcer convergence for these two artifacts.