### PR TITLE
NULLS FIRST / NULLS LAST support for the Relation API [WIP]

### DIFF
--- a/NULL_ORDERING_HANDOVER.md
+++ b/NULL_ORDERING_HANDOVER.md
@@ -1,0 +1,163 @@
+# NULLS FIRST / NULLS LAST — Handover
+
+Plan: `~/artifacts/null-ordering-plan.html` (§ references below refer to it).
+Repos: `legend-pure` (`~/legend-pure`, branch `nulls-first-last`) and `legend-engine` (this repo, branch `nulls-first-last`, fork `gs-rpant1729/legend-engine`).
+
+## Status as of 2026-09-01
+
+**H2 relational PCT: 1332 tests, 0 failures, 0 errors — fully green**, including the 3 new
+`meta::pure::functions::relation::tests::sort` null-order tests. In-memory (compiled +
+interpreted) Relation PCT: 459/459 green.
+
+Not yet run: DuckDB / cloud-store PCT (explicitly out of scope for this session — no cloud
+creds / instruction not to run cloud tests), Legend SQL parity suite, other dbExtension PCT
+suites (postgres/snowflake/databricks/etc.).
+
+## Decisions taken
+
+1. **legend-pure PR 0 (shipped).** `NullOrder` enum + `SortInfo.nullOrder[0..1]` (legend-pure,
+   commit `81fb9df6`) + relational `OrderBy`/`SortByInfo.nullOrder[0..1]` (legend-pure,
+   same commit). Installed locally as version `5.96.0` (the branch's own pom is
+   `5.97.2-SNAPSHOT`, but engine is pinned to `5.96.0` — see **Build gotchas** below for how
+   to rebuild it).
+
+2. **API surface (shipped, WIP commit `e6d27f29a1`).** `nullsFirst`/`nullsLast` modifiers,
+   2-arg `ascending(col, NullOrder)` / `descending(col, NullOrder)` sugar, in-memory
+   compiled+interpreted natives, TDS bridge, relational SQL generation (root ORDER BY, window,
+   WITHIN GROUP), Legend SQL CASE-WHEN revert. See commit message for full file list.
+
+3. **`nullsFirst`/`nullsLast` body: explicit construction, not a copy.**
+   `nullsFirst.pure`/`nullsLast.pure` now do
+   `^SortInfo<T>(column=$sortInfo.column, direction=$sortInfo.direction, nullOrder=NullOrder.FIRST)`
+   instead of `^$sortInfo(nullOrder=NullOrder.FIRST)`, matching `ascending`/`descending`'s
+   style. (This alone did not fix the NPE below — kept for consistency.)
+
+4. **Root cause + fix for the `->nullsFirst()`/`->nullsLast()` NPE on the relational path.**
+   `X->nullsLast()` (chained modifier) NPE'd only when relationally routed — never in-memory.
+   Traced (via a temporary `printStackTrace` patch to legend-pure's
+   `CompiledSupport.executePCTTest`, since the PCT surveyor collapses every `NullPointerException`
+   to the string `"NullPointer exception"`) to:
+   `router preval → addToScope → resolveGenericType` NPE, because `Handlers.java`'s
+   `nullsFirst`/`nullsLast` registrations computed their resolved type parameter as
+   `ps.get(0)._genericType()._typeArguments().getFirst()` — copied verbatim from
+   `ascending`/`descending`, whose argument is a `ColSpec<T>` (always carries its type
+   argument). `nullsFirst`/`nullsLast`'s argument is a `SortInfo<T>` produced by a **nested**
+   normalize-required call (e.g. `descending(~id)`), whose `genericType` has **no** type
+   arguments yet at handler time → `.getFirst()` → `null` → `resolvedTypeParameters = [null]`
+   → NPE in `resolveGenericType`.
+   **Fix:** `Handlers.java` — guard with
+   `ta.isEmpty() ? ps.get(0)._genericType() : ta.getFirst()`, mirroring the existing
+   `over(SortInfo...)` handlers, which face the same shape and already do this.
+
+5. **H2 unspecified-sort → canonical (shipped, pending your sign-off — see Decisions pending).**
+   `toPostgresModel::convertOrderBy` now emits the canonical clause (`NULLS LAST` on ASC,
+   `NULLS FIRST` on DESC) when `OrderBy.nullOrder` is empty, unconditionally. In production
+   this only affects **H2** (`useDialectTranslation` gates the whole `toPostgresModel` path to
+   H2 today — see `relationalMappingExecution.pure:429-432` — postgres/snowflake/duckdb
+   `SqlDialect` defs exist but aren't live), so it's currently H2-scoped in practice despite
+   being unconditional in the code.
+
+6. **Other-DB unspecified-sort reconciliation, legacy string path (shipped, per §2.3, NOT
+   cloud-verified).** `extensionDefaults.pure`:
+   - `renderNullOrder(nullOrder, direction, dbConfig)` — was 1-arg (explicit-only), now 3-arg.
+   - `reconcileUnspecifiedNullOrder` / `supportsNullOrderingSyntax` / `nativeNullOrdering` —
+     new classification helpers.
+   - Wired into the 3 shared chokepoints every dialect but 3 goes through: `processOrderBy`
+     (root), default `processWindowColumn` (window), `withinGroupOrderBy` (ordered
+     aggregates). DuckDB/Databricks/Snowflake override `processWindowColumn` with their own
+     logic (DuckDB/Databricks already nullOrder-aware from the WIP; Snowflake hardcodes
+     canonical unconditionally, pre-existing, untouched) — see **Per-DB status** below.
+
+## Decisions pending (yours to make)
+
+1. **H2 approach.** Two options were on the table (see conversation with the user — they said
+   "I will decide for H2"):
+   - **(A) Keep `convertOrderBy`'s unconditional canonical emit** (current state, H2 PCT green
+     with it). Cost: every H2 dialect-translation ORDER BY now carries an explicit
+     `NULLS LAST`/`NULLS FIRST` — **untested** against the SQL-string-assertion test corpus
+     outside the PCT suite (roughly a dozen files across `sqlQueryToString/tests`, Legend-SQL
+     H2 tests, execution-plan tests reference `H2`+`order by`; exact count not measured).
+   - **(B) `;DEFAULT_NULL_ORDERING=HIGH` on the H2 JDBC URLs** (`H2Defaults.java`,
+     `H2Manager.java`, `TestH2Abstract.java` — H2 currently runs `MODE=LEGACY`, which defaults
+     `DEFAULT_NULL_ORDERING` to `LOW`) + **revert** `convertOrderBy` back to
+     `nullOrdering = $o.nullOrder->convertNullOrder()` (UNDEFINED on empty). Zero SQL-string
+     churn — H2 handles it natively. Cost: flips H2's null-order for **all** Legend queries,
+     not just Relation API; any existing test asserting H2's nulls-low *result* order (not
+     just SQL text) would flip. Not yet probed for how many, if any, exist.
+   - If you pick (B): revert `toPostgresModel.pure`'s `convertOrderBy` hunk, add the URL param
+     in the three files above, then re-run the full H2 PCT + a broader `mvn test` sweep of
+     `sqlQueryToString`/Legend-SQL/exec-plan H2 tests to confirm zero churn.
+
+2. **§2.3 per-dialect null-ordering matrix — NOT cloud-probe-verified.** The classification in
+   `extensionDefaults.pure::nativeNullOrdering` is built from vendor-documentation knowledge,
+   not empirical probes, **except H2** (confirmed empirically this session: nulls-low under
+   `MODE=LEGACY`). Plan §2.3 explicitly says: "verify each with a one-off probe PCT test before
+   wiring the config — do not trust documentation." This has not been done for any store other
+   than H2. Do this via `-P pct-cloud-test` before treating the matrix as authoritative.
+
+## Per-DB status
+
+| DB | Classification (unverified except H2) | Root ORDER BY | Window ORDER BY | WITHIN GROUP | Notes |
+|---|---|---|---|---|---|
+| **H2** | nulls-low, `MODE=LEGACY` (**verified**) | canonical emitted (dialect-translation path, `convertOrderBy`) | n/a — H2 uses dialect-translation only, no separate window fix needed there | n/a | See "Decisions pending #1" |
+| Postgres | canonical (nulls-high) | no-op (shared helper) | no-op (uses default `processWindowColumn`) | no-op | `toPostgresModel` dialect-translation SqlDialect exists but not live in prod (`useDialectTranslation` = H2 only) |
+| Oracle | canonical | no-op | no-op | no-op | |
+| Redshift | canonical | no-op | no-op | no-op | |
+| Trino / Presto | canonical | no-op | no-op | no-op | Not cloud-verified |
+| Snowflake | canonical | no-op (shared helper) | **unaffected by this change** — `processWindowColumnForSnowflake` hardcodes canonical unconditionally (pre-existing code, redundant-but-correct SQL even on unspecified) | no-op | Not cloud-verified |
+| Databricks | nulls-low | canonical emitted via shared helper | already nullOrder-aware from WIP (`processWindowColumnForDatabricks`) | canonical emitted via shared helper | Not cloud-verified |
+| SparkSQL | nulls-low | canonical emitted | uses default `processWindowColumn` → canonical emitted | canonical emitted | Not cloud-verified |
+| Hive | nulls-low | canonical emitted | uses default → canonical emitted | canonical emitted | Not cloud-verified |
+| BigQuery | nulls-low | canonical emitted | uses default → canonical emitted | canonical emitted | Not cloud-verified |
+| Spanner | nulls-low | canonical emitted | uses default → canonical emitted | canonical emitted | Not cloud-verified |
+| DuckDB | uniform NULLS LAST (diverges on DESC only) | canonical emitted on DESC via shared helper | already nullOrder-aware from WIP (`processWindowColumnForDuckDB`) | canonical emitted via shared helper | Not cloud/local-DuckDB-verified this session |
+| ClickHouse | uniform NULLS LAST (diverges on DESC only) | canonical emitted on DESC | uses default → canonical emitted | canonical emitted | Not verified |
+| **SQL Server** | nulls-low, **no `NULLS FIRST/LAST` syntax** | **not reconciled** — `supportsNullOrderingSyntax` returns false, so unspecified sorts render nothing (unchanged from before this session) | same | same | **Emulation not implemented.** Needs an `isnull(col)`/`CASE` prefix sort key in the dialect's own ORDER BY processor (plan §2.3), or a PCT `expectedError` exclusion. Not started. |
+| **MemSQL / SingleStore** | nulls-low, no syntax | not reconciled | same | same | Same as SQL Server — not started |
+| **Sybase ASE** | nulls-low, no syntax | not reconciled | same | same | Same — not started |
+| **Sybase IQ** | nulls-low, no syntax | not reconciled | same | same | Same — not started |
+| DB2 | canonical (assumed) | no-op | no-op | no-op | Not verified |
+| Aurora, Athena | assumed canonical (postgres/trino-compatible) | no-op | no-op | no-op | Not verified — not in the plan's explicit matrix, included here by inference only |
+
+## Known follow-ups (not started)
+
+- Emulation for the 4 no-syntax dialects (SQL Server, MemSQL, Sybase ASE, Sybase IQ).
+- Cloud probe verification of the whole matrix (`-P pct-cloud-test`).
+- PCT manifest exclusions for adapters/positions that can't be reconciled (plan §J).
+- `order_limit_offset.yaml` Legend-SQL parity refresh (plan §I).
+- New PCT tests: window `over` with explicit null order, `joinStrings`/ordered-aggregate with
+  nulls in the sort key (plan §5) — the WIP only added the 3 root-sort tests.
+- `docs/engineering/reference/tds-and-relation.md` + `docs/pct/*` documentation (plan §J).
+
+## Build gotchas (read before touching anything here)
+
+- **Always `mvn -o clean install -DskipTests -pl <module>`** for any module you change, never
+  bare `install`/`test` — a stale `target/` + the PAR-generation plugin double-registers the
+  module's own code repository (`Error serializing Pure PAR: The code repository
+  core_functions_unclassified already exists!` / same for `core_relational_h2_pct` etc.) unless
+  `clean` runs first. Full detail: `[[build-legend-engine-stale-modules]]` (session memory) —
+  also holds true for the PCT test module itself (`mvn -o clean test -pl <h2-PCT>`).
+- **legend-pure `-pl` builds fail** on this branch (`nulls-first-last`) because its pom is
+  `5.97.2-SNAPSHOT` but engine is pinned to `5.96.0` (deps don't resolve). To rebuild any
+  legend-pure module against what engine actually uses: `git checkout legend-pure-5.96.0`
+  (detached tag — the nullOrder commit `81fb9df6` is a descendant of it, not the tag itself, so
+  the tag alone does NOT have nullOrder; only rebuild modules that don't touch the nullOrder
+  files, e.g. `legend-pure-runtime-java-engine-compiled`), build, then `git checkout
+  nulls-first-last` to restore.
+- **A temporary debug patch is currently baked into the locally-installed pure 5.96.0 jar**
+  (`~/.m2/repository/org/finos/legend/pure/legend-pure-runtime-java-engine-compiled/5.96.0/`):
+  a `System.err.println(...) + e.printStackTrace()` in `CompiledSupport.executePCTTest`'s
+  `catch (Throwable e)` block, added to get the real NPE stack past the PCT surveyor's
+  `"NullPointer exception"` masking. The source is `git stash`ed in `~/legend-pure` (not
+  committed anywhere). It's harmless — just noisy stderr on every already-expected PCT failure
+  — but should be cleaned up: `git checkout legend-pure-5.96.0 && git stash pop` (drops it) or
+  just checkout-clean + rebuild `legend-pure-runtime-java-engine-compiled` at the tag.
+
+## Files changed this session (uncommitted → see accompanying commit)
+
+- `Handlers.java` — nullsFirst/nullsLast type-param guard
+- `nullsFirst.pure`, `nullsLast.pure` — copy → explicit construction
+- `pureToSQLQuery_deprecated.pure` — window `SortByInfo.nullOrder` wiring (pre-existing
+  uncommitted change from before this session, carried through untouched)
+- `toPostgresModel.pure` — H2 unspecified-sort canonical emit (decision #1 above)
+- `extensionDefaults.pure` — other-DB reconciliation helpers (decision #2 above)

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/handlers/Handlers.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/handlers/Handlers.java
@@ -2371,8 +2371,11 @@ public class Handlers
         register(h("meta::pure::functions::relation::descending_ColSpec_1__SortInfo_1_", "descending", false, ps -> res("meta::pure::functions::relation::SortInfo", "one"), ps -> Lists.fixedSize.of(ps.get(0)._genericType()._typeArguments().getFirst()), ps -> true));
         register(h("meta::pure::functions::relation::ascending_ColSpec_1__NullOrder_1__SortInfo_1_", "ascending", false, ps -> res("meta::pure::functions::relation::SortInfo", "one"), ps -> Lists.fixedSize.of(ps.get(0)._genericType()._typeArguments().getFirst()), ps -> true));
         register(h("meta::pure::functions::relation::descending_ColSpec_1__NullOrder_1__SortInfo_1_", "descending", false, ps -> res("meta::pure::functions::relation::SortInfo", "one"), ps -> Lists.fixedSize.of(ps.get(0)._genericType()._typeArguments().getFirst()), ps -> true));
-        register(h("meta::pure::functions::relation::nullsFirst_SortInfo_1__SortInfo_1_", "nullsFirst", false, ps -> res("meta::pure::functions::relation::SortInfo", "one"), ps -> Lists.fixedSize.of(ps.get(0)._genericType()._typeArguments().getFirst()), ps -> true));
-        register(h("meta::pure::functions::relation::nullsLast_SortInfo_1__SortInfo_1_", "nullsLast", false, ps -> res("meta::pure::functions::relation::SortInfo", "one"), ps -> Lists.fixedSize.of(ps.get(0)._genericType()._typeArguments().getFirst()), ps -> true));
+        // The SortInfo<T> argument may itself be the not-yet-fully-resolved result of ascending()/descending(),
+        // whose genericType can carry no typeArguments at handler time; fall back to the whole genericType then
+        // (mirrors the over(SortInfo...) handlers) instead of NPEing on an absent type argument during preval.
+        register(h("meta::pure::functions::relation::nullsFirst_SortInfo_1__SortInfo_1_", "nullsFirst", false, ps -> res("meta::pure::functions::relation::SortInfo", "one"), ps -> Lists.fixedSize.of(ps.get(0)._genericType()._typeArguments().isEmpty() ? ps.get(0)._genericType() : ps.get(0)._genericType()._typeArguments().getFirst()), ps -> true));
+        register(h("meta::pure::functions::relation::nullsLast_SortInfo_1__SortInfo_1_", "nullsLast", false, ps -> res("meta::pure::functions::relation::SortInfo", "one"), ps -> Lists.fixedSize.of(ps.get(0)._genericType()._typeArguments().isEmpty() ? ps.get(0)._genericType() : ps.get(0)._genericType()._typeArguments().getFirst()), ps -> true));
 
         register(grp(JoinInference, h("meta::pure::functions::relation::join_Relation_1__Relation_1__JoinKind_1__Function_1__Relation_1_", "join", true, ps -> JoinReturnInference(ps, this.pureModel), ps -> true)));
 

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/handlers/Handlers.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/handlers/Handlers.java
@@ -2369,6 +2369,10 @@ public class Handlers
 
         register(h("meta::pure::functions::relation::ascending_ColSpec_1__SortInfo_1_", "ascending", false, ps -> res("meta::pure::functions::relation::SortInfo", "one"), ps -> Lists.fixedSize.of(ps.get(0)._genericType()._typeArguments().getFirst()), ps -> true));
         register(h("meta::pure::functions::relation::descending_ColSpec_1__SortInfo_1_", "descending", false, ps -> res("meta::pure::functions::relation::SortInfo", "one"), ps -> Lists.fixedSize.of(ps.get(0)._genericType()._typeArguments().getFirst()), ps -> true));
+        register(h("meta::pure::functions::relation::ascending_ColSpec_1__NullOrder_1__SortInfo_1_", "ascending", false, ps -> res("meta::pure::functions::relation::SortInfo", "one"), ps -> Lists.fixedSize.of(ps.get(0)._genericType()._typeArguments().getFirst()), ps -> true));
+        register(h("meta::pure::functions::relation::descending_ColSpec_1__NullOrder_1__SortInfo_1_", "descending", false, ps -> res("meta::pure::functions::relation::SortInfo", "one"), ps -> Lists.fixedSize.of(ps.get(0)._genericType()._typeArguments().getFirst()), ps -> true));
+        register(h("meta::pure::functions::relation::nullsFirst_SortInfo_1__SortInfo_1_", "nullsFirst", false, ps -> res("meta::pure::functions::relation::SortInfo", "one"), ps -> Lists.fixedSize.of(ps.get(0)._genericType()._typeArguments().getFirst()), ps -> true));
+        register(h("meta::pure::functions::relation::nullsLast_SortInfo_1__SortInfo_1_", "nullsLast", false, ps -> res("meta::pure::functions::relation::SortInfo", "one"), ps -> Lists.fixedSize.of(ps.get(0)._genericType()._typeArguments().getFirst()), ps -> true));
 
         register(grp(JoinInference, h("meta::pure::functions::relation::join_Relation_1__Relation_1__JoinKind_1__Function_1__Relation_1_", "join", true, ps -> JoinReturnInference(ps, this.pureModel), ps -> true)));
 

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/resources/handlers_dispatch_functions.txt
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/resources/handlers_dispatch_functions.txt
@@ -484,10 +484,12 @@ meta::pure::functions::multiplicity::toOne_T_MANY__T_1_
 meta::pure::functions::relation::asOfJoin_Relation_1__Relation_1__Function_1__Function_1__Relation_1_
 meta::pure::functions::relation::asOfJoin_Relation_1__Relation_1__Function_1__Relation_1_
 meta::pure::functions::relation::ascending_ColSpec_1__SortInfo_1_
+meta::pure::functions::relation::ascending_ColSpec_1__NullOrder_1__SortInfo_1_
 meta::pure::functions::relation::concatenate_Relation_1__Relation_1__Relation_1_
 meta::pure::functions::relation::cumulativeDistribution_Relation_1___Window_1__T_1__Float_1_
 meta::pure::functions::relation::denseRank_Relation_1___Window_1__T_1__Integer_1_
 meta::pure::functions::relation::descending_ColSpec_1__SortInfo_1_
+meta::pure::functions::relation::descending_ColSpec_1__NullOrder_1__SortInfo_1_
 meta::pure::functions::relation::distinct_Relation_1__ColSpecArray_1__Relation_1_
 meta::pure::functions::relation::distinct_Relation_1__Relation_1_
 meta::pure::functions::relation::drop_Relation_1__Integer_1__Relation_1_
@@ -537,6 +539,8 @@ meta::pure::functions::relation::lessThanEqualAll_U_$0_1$__Relation_1__Boolean_1
 meta::pure::functions::relation::lessThanEqualAny_U_$0_1$__Relation_1__Boolean_1_
 meta::pure::functions::relation::limit_Relation_1__Integer_1__Relation_1_
 meta::pure::functions::relation::nth_Relation_1___Window_1__T_1__Integer_1__T_$0_1$_
+meta::pure::functions::relation::nullsFirst_SortInfo_1__SortInfo_1_
+meta::pure::functions::relation::nullsLast_SortInfo_1__SortInfo_1_
 meta::pure::functions::relation::ntile_Relation_1__T_1__Integer_1__Integer_1_
 meta::pure::functions::relation::over_ColSpecArray_1__SortInfo_MANY___Window_1_
 meta::pure::functions::relation::over_ColSpecArray_1___Window_1_

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/tds/tds.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/tds/tds.pure
@@ -162,6 +162,7 @@ Class meta::pure::tds::SortInformation
 {
    column : String[1];
    direction : SortDirection[1];
+   nullOrder : meta::pure::functions::relation::NullOrder[0..1];
 }
 
 Class meta::pure::tds::ColumnSort<T>

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/order/ascending.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/order/ascending.pure
@@ -20,3 +20,9 @@ function <<PCT.function,
 {
    ^SortInfo<T>(column=$column, direction=SortType.ASC)
 }
+
+function <<PCT.function,
+           functionType.NormalizeRequiredFunction>> meta::pure::functions::relation::ascending<T> (column:ColSpec<T>[1], nullOrder:NullOrder[1]):SortInfo<T>[1]
+{
+   ^SortInfo<T>(column=$column, direction=SortType.ASC, nullOrder=$nullOrder)
+}

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/order/nullsFirst.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/order/nullsFirst.pure
@@ -23,5 +23,7 @@ function
    }
    meta::pure::functions::relation::nullsFirst<T>(sortInfo:SortInfo<T>[1]):SortInfo<T>[1]
 {
-   ^$sortInfo(nullOrder=NullOrder.FIRST)
+   // Explicit construction (not a ^$sortInfo(..) copy) so the router's NormalizeRequiredFunction
+   // preval folds this the same way it folds ascending()/descending().
+   ^SortInfo<T>(column=$sortInfo.column, direction=$sortInfo.direction, nullOrder=NullOrder.FIRST)
 }

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/order/nullsFirst.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/order/nullsFirst.pure
@@ -15,14 +15,13 @@
 import meta::pure::test::pct::*;
 import meta::pure::metamodel::relation::*;
 
-function <<PCT.function,
-           functionType.NormalizeRequiredFunction>> meta::pure::functions::relation::descending<T>(column:ColSpec<T>[1]):SortInfo<T>[1]
+function
+   <<PCT.function,
+     functionType.NormalizeRequiredFunction>>
+   {
+      doc.doc = 'Places null values first in the sort defined by the given sort spec (SQL \'NULLS FIRST\'). Without a null order the platform\'s canonical order applies: nulls sort as the largest value, i.e. NULLS LAST on ascending, NULLS FIRST on descending.'
+   }
+   meta::pure::functions::relation::nullsFirst<T>(sortInfo:SortInfo<T>[1]):SortInfo<T>[1]
 {
-   ^SortInfo<T>(column=$column, direction=SortType.DESC)
-}
-
-function <<PCT.function,
-           functionType.NormalizeRequiredFunction>> meta::pure::functions::relation::descending<T>(column:ColSpec<T>[1], nullOrder:NullOrder[1]):SortInfo<T>[1]
-{
-   ^SortInfo<T>(column=$column, direction=SortType.DESC, nullOrder=$nullOrder)
+   ^$sortInfo(nullOrder=NullOrder.FIRST)
 }

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/order/nullsLast.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/order/nullsLast.pure
@@ -23,5 +23,7 @@ function
    }
    meta::pure::functions::relation::nullsLast<T>(sortInfo:SortInfo<T>[1]):SortInfo<T>[1]
 {
-   ^$sortInfo(nullOrder=NullOrder.LAST)
+   // Explicit construction (not a ^$sortInfo(..) copy) so the router's NormalizeRequiredFunction
+   // preval folds this the same way it folds ascending()/descending().
+   ^SortInfo<T>(column=$sortInfo.column, direction=$sortInfo.direction, nullOrder=NullOrder.LAST)
 }

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/order/nullsLast.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/order/nullsLast.pure
@@ -15,14 +15,13 @@
 import meta::pure::test::pct::*;
 import meta::pure::metamodel::relation::*;
 
-function <<PCT.function,
-           functionType.NormalizeRequiredFunction>> meta::pure::functions::relation::descending<T>(column:ColSpec<T>[1]):SortInfo<T>[1]
+function
+   <<PCT.function,
+     functionType.NormalizeRequiredFunction>>
+   {
+      doc.doc = 'Places null values last in the sort defined by the given sort spec (SQL \'NULLS LAST\'). Without a null order the platform\'s canonical order applies: nulls sort as the largest value, i.e. NULLS LAST on ascending, NULLS FIRST on descending.'
+   }
+   meta::pure::functions::relation::nullsLast<T>(sortInfo:SortInfo<T>[1]):SortInfo<T>[1]
 {
-   ^SortInfo<T>(column=$column, direction=SortType.DESC)
-}
-
-function <<PCT.function,
-           functionType.NormalizeRequiredFunction>> meta::pure::functions::relation::descending<T>(column:ColSpec<T>[1], nullOrder:NullOrder[1]):SortInfo<T>[1]
-{
-   ^SortInfo<T>(column=$column, direction=SortType.DESC, nullOrder=$nullOrder)
+   ^$sortInfo(nullOrder=NullOrder.LAST)
 }

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/order/sort.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/order/sort.pure
@@ -90,6 +90,87 @@ function <<PCT.test>> meta::pure::functions::relation::tests::sort::testSimpleSo
                 '#', $res3->toString());
 }
 
+function <<PCT.test>> meta::pure::functions::relation::tests::sort::testSortNullsLast<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+  let res = $f->eval({|
+              #TDS
+                id, name
+                2, George
+                null, Pierre
+                1, Sachin
+                null, Neema
+                3, David
+              #->sort([~id->ascending()->nullsLast(), ~name->ascending()]);
+            });
+
+  assertEquals('#TDS\n'+
+               '   id,name\n'+
+               '   1,Sachin\n'+
+               '   2,George\n'+
+               '   3,David\n'+
+               '   null,Neema\n'+
+               '   null,Pierre\n'+
+               '#', $res->toString());
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::sort::testSortNullsFirst<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+  let res = $f->eval({|
+              #TDS
+                id, name
+                2, George
+                null, Pierre
+                1, Sachin
+                3, David
+              #->sort([~id->descending()->nullsLast(), ~name->ascending()]);
+            });
+
+  assertEquals('#TDS\n'+
+               '   id,name\n'+
+               '   3,David\n'+
+               '   2,George\n'+
+               '   1,Sachin\n'+
+               '   null,Pierre\n'+
+               '#', $res->toString());
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::sort::testSortNullOrderTwoArgAndCanonical<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+  // 2-argument sugar - nulls first on ascending
+  let res = $f->eval({|
+              #TDS
+                id, name
+                2, George
+                null, Pierre
+                1, Sachin
+              #->sort(~id->ascending(meta::pure::functions::relation::NullOrder.FIRST));
+            });
+
+  assertEquals('#TDS\n'+
+               '   id,name\n'+
+               '   null,Pierre\n'+
+               '   1,Sachin\n'+
+               '   2,George\n'+
+               '#', $res->toString());
+
+  // unspecified => canonical (nulls sort high): NULLS LAST on ascending
+  let canonical = $f->eval({|
+              #TDS
+                id, name
+                2, George
+                null, Pierre
+                1, Sachin
+              #->sort(~id->ascending());
+            });
+
+  assertEquals('#TDS\n'+
+               '   id,name\n'+
+               '   1,Sachin\n'+
+               '   2,George\n'+
+               '   null,Pierre\n'+
+               '#', $canonical->toString());
+}
+
 function <<PCT.test>> meta::pure::functions::relation::tests::sort::testSimpleSort_MultipleExpressions<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
   let expr = {| 

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-runtime-java-extension-compiled-functions-relation/src/main/java/org/finos/legend/pure/runtime/java/extension/external/relation/compiled/RelationNativeImplementation.java
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-runtime-java-extension-compiled-functions-relation/src/main/java/org/finos/legend/pure/runtime/java/extension/external/relation/compiled/RelationNativeImplementation.java
@@ -77,6 +77,7 @@ import org.finos.legend.pure.runtime.java.extension.external.relation.shared.Tes
 import org.finos.legend.pure.runtime.java.extension.external.relation.shared.window.Frame;
 import org.finos.legend.pure.runtime.java.extension.external.relation.shared.window.Range;
 import org.finos.legend.pure.runtime.java.extension.external.relation.shared.window.RangeInterval;
+import org.finos.legend.pure.runtime.java.extension.external.relation.shared.window.NullOrder;
 import org.finos.legend.pure.runtime.java.extension.external.relation.shared.window.SortDirection;
 import org.finos.legend.pure.runtime.java.extension.external.relation.shared.window.SortInfo;
 import org.finos.legend.pure.runtime.java.extension.external.relation.shared.window.Window;
@@ -581,11 +582,11 @@ public class RelationNativeImplementation
         return new TDSContainer(filtered, ps);
     }
 
-    public static <T> Relation<? extends T> sort(Relation<? extends T> rel, RichIterable<Pair<Enum, String>> collect, ExecutionSupport es)
+    public static <T> Relation<? extends T> sort(Relation<? extends T> rel, RichIterable<Pair<Enum, Pair<Enum, String>>> collect, ExecutionSupport es)
     {
         ProcessorSupport ps = ((CompiledExecutionSupport) es).getProcessorSupport();
         TestTDSCompiled tds1 = RelationNativeImplementation.getTDS(rel, es);
-        return new TDSContainer((TestTDSCompiled) tds1.sort(collect.collect(c -> new SortInfo(c.getTwo(), SortDirection.valueOf(c.getOne()._name()))).toList()).getOne(), ps);
+        return new TDSContainer((TestTDSCompiled) tds1.sort(collect.collect(c -> new SortInfo(c.getTwo().getTwo(), SortDirection.valueOf(c.getOne()._name()), c.getTwo().getOne() == null ? null : NullOrder.valueOf(c.getTwo().getOne()._name()))).toList()).getOne(), ps);
     }
 
     public abstract static class AggColSpecTrans

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-runtime-java-extension-compiled-functions-relation/src/main/java/org/finos/legend/pure/runtime/java/extension/external/relation/compiled/natives/Sort.java
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-runtime-java-extension-compiled-functions-relation/src/main/java/org/finos/legend/pure/runtime/java/extension/external/relation/compiled/natives/Sort.java
@@ -42,12 +42,12 @@ public class Sort extends AbstractNative implements Native
     public static void processSortInfo(StringBuilder result, String param)
     {
         result.append("((RichIterable<? extends  Root_meta_pure_functions_relation_SortInfo<?>>)(Object)CompiledSupport.toPureCollection(" + param + "))");
-        result.append(".collect(new DefendedFunction<Root_meta_pure_functions_relation_SortInfo<? extends Object>, org.eclipse.collections.api.tuple.Pair<org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Enum, String>>()\n" +
+        result.append(".collect(new DefendedFunction<Root_meta_pure_functions_relation_SortInfo<? extends Object>, org.eclipse.collections.api.tuple.Pair<org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Enum, org.eclipse.collections.api.tuple.Pair<org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Enum, String>>>()\n" +
                 "{\n" +
                 "    @Override\n" +
-                "    public org.eclipse.collections.api.tuple.Pair<org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Enum, String> valueOf(Root_meta_pure_functions_relation_SortInfo<?> it)\n" +
+                "    public org.eclipse.collections.api.tuple.Pair<org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Enum, org.eclipse.collections.api.tuple.Pair<org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Enum, String>> valueOf(Root_meta_pure_functions_relation_SortInfo<?> it)\n" +
                 "    {\n" +
-                "        return org.eclipse.collections.impl.tuple.Tuples.pair(it._direction(), it._column()._name());\n" +
+                "        return org.eclipse.collections.impl.tuple.Tuples.pair(it._direction(), org.eclipse.collections.impl.tuple.Tuples.pair(it._nullOrder(), it._column()._name()));\n" +
                 "    }\n" +
                 "})");
     }

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-runtime-java-extension-interpreted-functions-relation/src/main/java/org/finos/legend/pure/runtime/java/extension/external/relation/interpreted/natives/Sort.java
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-runtime-java-extension-interpreted-functions-relation/src/main/java/org/finos/legend/pure/runtime/java/extension/external/relation/interpreted/natives/Sort.java
@@ -27,6 +27,7 @@ import org.finos.legend.pure.m4.ModelRepository;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.runtime.java.extension.external.relation.interpreted.natives.shared.Shared;
 import org.finos.legend.pure.runtime.java.extension.external.relation.interpreted.natives.shared.TDSCoreInstance;
+import org.finos.legend.pure.runtime.java.extension.external.relation.shared.window.NullOrder;
 import org.finos.legend.pure.runtime.java.extension.external.relation.shared.window.SortDirection;
 import org.finos.legend.pure.runtime.java.extension.external.relation.shared.window.SortInfo;
 import org.finos.legend.pure.runtime.java.extension.external.relation.shared.TestTDS;
@@ -60,7 +61,9 @@ public class Sort extends Shared
         {
             String name = c.getValueForMetaPropertyToOne("column").getValueForMetaPropertyToOne("name").getName();
             SortDirection direction = SortDirection.valueOf(c.getValueForMetaPropertyToOne("direction").getName());
-            return new SortInfo(name, direction);
+            CoreInstance nullOrderInstance = c.getValueForMetaPropertyToOne("nullOrder");
+            NullOrder nullOrder = nullOrderInstance == null ? null : NullOrder.valueOf(nullOrderInstance.getName());
+            return new SortInfo(name, direction, nullOrder);
         });
         return sortInfos;
     }

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-runtime-java-extension-shared-functions-relation/src/main/java/org/finos/legend/pure/runtime/java/extension/external/relation/shared/TestTDS.java
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-runtime-java-extension-shared-functions-relation/src/main/java/org/finos/legend/pure/runtime/java/extension/external/relation/shared/TestTDS.java
@@ -67,6 +67,7 @@ import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.m4.coreinstance.primitive.date.DateFunctions;
 import org.finos.legend.pure.m4.coreinstance.primitive.date.PureDate;
 import org.finos.legend.pure.runtime.java.extension.external.relation.shared.window.SortDirection;
+import org.finos.legend.pure.runtime.java.extension.external.relation.shared.window.NullOrder;
 import org.finos.legend.pure.runtime.java.extension.external.relation.shared.window.SortInfo;
 import org.finos.legend.pure.runtime.java.extension.external.relation.shared.window.Window;
 import org.finos.legend.pure.runtime.java.extension.external.variant.VariantInstanceImpl;
@@ -696,6 +697,15 @@ public abstract class TestTDS
         if (sortInfo.direction == SortDirection.DESC)
         {
             list.reverseThis();
+        }
+        if (sortInfo.nullOrder != null)
+        {
+            MutableList<Pair<Integer, Comparable<Object>>> nulls = list.select(p -> p.getTwo() == null);
+            if (nulls.notEmpty() && nulls.size() != list.size())
+            {
+                MutableList<Pair<Integer, Comparable<Object>>> nonNulls = list.reject(p -> p.getTwo() == null);
+                list = sortInfo.nullOrder == NullOrder.FIRST ? nulls.withAll(nonNulls) : nonNulls.withAll(nulls);
+            }
         }
         this.reorder(copy, list.collect(Pair::getOne), start, end);
     }

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-runtime-java-extension-shared-functions-relation/src/main/java/org/finos/legend/pure/runtime/java/extension/external/relation/shared/window/NullOrder.java
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-runtime-java-extension-shared-functions-relation/src/main/java/org/finos/legend/pure/runtime/java/extension/external/relation/shared/window/NullOrder.java
@@ -12,17 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import meta::pure::test::pct::*;
-import meta::pure::metamodel::relation::*;
+package org.finos.legend.pure.runtime.java.extension.external.relation.shared.window;
 
-function <<PCT.function,
-           functionType.NormalizeRequiredFunction>> meta::pure::functions::relation::descending<T>(column:ColSpec<T>[1]):SortInfo<T>[1]
+public enum NullOrder
 {
-   ^SortInfo<T>(column=$column, direction=SortType.DESC)
-}
-
-function <<PCT.function,
-           functionType.NormalizeRequiredFunction>> meta::pure::functions::relation::descending<T>(column:ColSpec<T>[1], nullOrder:NullOrder[1]):SortInfo<T>[1]
-{
-   ^SortInfo<T>(column=$column, direction=SortType.DESC, nullOrder=$nullOrder)
+    FIRST,
+    LAST
 }

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-runtime-java-extension-shared-functions-relation/src/main/java/org/finos/legend/pure/runtime/java/extension/external/relation/shared/window/SortInfo.java
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-runtime-java-extension-shared-functions-relation/src/main/java/org/finos/legend/pure/runtime/java/extension/external/relation/shared/window/SortInfo.java
@@ -18,11 +18,18 @@ public class SortInfo
 {
     public String columnName;
     public SortDirection direction;
+    public NullOrder nullOrder;
 
     public SortInfo(String name, SortDirection direction)
     {
+        this(name, direction, null);
+    }
+
+    public SortInfo(String name, SortDirection direction, NullOrder nullOrder)
+    {
         this.columnName = name;
         this.direction = direction;
+        this.nullOrder = nullOrder;
     }
 
     public String getColumnName()
@@ -33,5 +40,10 @@ public class SortInfo
     public SortDirection getDirection()
     {
         return direction;
+    }
+
+    public NullOrder getNullOrder()
+    {
+        return nullOrder;
     }
 }

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-runtime-java-extension-shared-functions-relation/src/main/java/org/finos/legend/pure/runtime/java/extension/external/relation/shared/window/Window.java
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-runtime-java-extension-shared-functions-relation/src/main/java/org/finos/legend/pure/runtime/java/extension/external/relation/shared/window/Window.java
@@ -28,9 +28,9 @@ public class Window
     MutableList<SortInfo> sorts = Lists.mutable.empty();
     Frame frame;
 
-    public Window(MutableList<? extends String> colSpec, RichIterable<Pair<Enum, String>> sorts, Frame frame)
+    public Window(MutableList<? extends String> colSpec, RichIterable<Pair<Enum, Pair<Enum, String>>> sorts, Frame frame)
     {
-        this(colSpec, sorts.toList().collect(c -> new SortInfo(c.getTwo(), SortDirection.valueOf(c.getOne()._name()))).toList(), frame);
+        this(colSpec, sorts.toList().collect(c -> new SortInfo(c.getTwo().getTwo(), SortDirection.valueOf(c.getOne()._name()), c.getTwo().getOne() == null ? null : NullOrder.valueOf(c.getTwo().getOne()._name()))).toList(), frame);
     }
 
     public Window(MutableList<? extends String> colSpec, MutableList<SortInfo> sorts, Frame frame)
@@ -69,7 +69,14 @@ public class Window
     {
         return new Window(
                 window.getValueForMetaPropertyToMany("partition").collect(CoreInstance::getName).toList(),
-                window.getValueForMetaPropertyToMany("sortInfo").collect(c -> new SortInfo(c.getValueForMetaPropertyToOne("column").getValueForMetaPropertyToOne("name").getName(), SortDirection.valueOf(c.getValueForMetaPropertyToOne("direction").getName()))).toList(),
+                window.getValueForMetaPropertyToMany("sortInfo").collect(c ->
+                {
+                    CoreInstance nullOrderInstance = c.getValueForMetaPropertyToOne("nullOrder");
+                    return new SortInfo(
+                            c.getValueForMetaPropertyToOne("column").getValueForMetaPropertyToOne("name").getName(),
+                            SortDirection.valueOf(c.getValueForMetaPropertyToOne("direction").getName()),
+                            nullOrderInstance == null ? null : NullOrder.valueOf(nullOrderInstance.getName()));
+                }).toList(),
                 Frame.build(window.getValueForMetaPropertyToOne("frame"), processorSupport, primitiveHandler)
         );
     }
@@ -93,6 +100,12 @@ public class Window
         CoreInstance sortTypeEnum = ps.package_getByUserPath("meta::pure::functions::relation::SortType");
         CoreInstance sortDir = sortTypeEnum.getValueForMetaPropertyToMany("values").detect(e -> sortInfo.getDirection().name().equals(e.getValueForMetaPropertyToOne("name").getName()));
         result.setKeyValues(Lists.mutable.with("direction"), Lists.mutable.with(sortDir));
+        if (sortInfo.getNullOrder() != null)
+        {
+            CoreInstance nullOrderEnum = ps.package_getByUserPath("meta::pure::functions::relation::NullOrder");
+            CoreInstance nullOrderValue = nullOrderEnum.getValueForMetaPropertyToMany("values").detect(e -> sortInfo.getNullOrder().name().equals(e.getValueForMetaPropertyToOne("name").getName()));
+            result.setKeyValues(Lists.mutable.with("nullOrder"), Lists.mutable.with(nullOrderValue));
+        }
         return result;
     }
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-databricks/legend-engine-xt-relationalStore-databricks-pure/src/main/resources/core_relational_databricks/relational/sqlQueryToString/databricksExtension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-databricks/legend-engine-xt-relationalStore-databricks-pure/src/main/resources/core_relational_databricks/relational/sqlQueryToString/databricksExtension.pure
@@ -344,7 +344,7 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::datab
         |'Partition By ' + $w.window.partition->map(f|$f->processOperation($sgc))->joinStrings(','),
         |'');
    let orderByTranslation = if($w.window.sortBy->isNotEmpty(),
-        |'Order By '+ $w.window.sortBy->map(s|$s.sortByElement->toOne()->processOperation($sgc) + if($s.sortDirection->isNotEmpty(), | ' ' +$s.sortDirection->toOne().name + if($s.sortDirection == meta::relational::metamodel::SortDirection.ASC, | ' NULLS LAST', | ' NULLS FIRST') , | ''))->joinStrings(', '),
+        |'Order By '+ $w.window.sortBy->map(s|$s.sortByElement->toOne()->processOperation($sgc) + if($s.sortDirection->isNotEmpty(), | ' ' +$s.sortDirection->toOne().name + if($s.nullOrder->isNotEmpty(), | if($s.nullOrder->toOne() == meta::relational::metamodel::NullOrder.FIRST, | ' NULLS FIRST', | ' NULLS LAST'), | if($s.sortDirection == meta::relational::metamodel::SortDirection.ASC, | ' NULLS LAST', | ' NULLS FIRST')) , | ''))->joinStrings(', '),
         |'');
    let windowFrameTranslation = if($w.window.frame->isNotEmpty(),
         |$w.window.frame->toOne()->processWindowFrame($sgc),

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-duckdb/legend-engine-xt-relationalStore-duckdb-pure/src/main/resources/core_relational_duckdb/relational/sqlQueryToString/duckdbExtension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-duckdb/legend-engine-xt-relationalStore-duckdb-pure/src/main/resources/core_relational_duckdb/relational/sqlQueryToString/duckdbExtension.pure
@@ -557,7 +557,7 @@ function meta::relational::functions::sqlQueryToString::duckDB::processWindowCol
         |'Partition By ' + $w.window.partition->map(f|$f->processOperation($sgc))->joinStrings(','),
         |'');
    let orderByTranslation = if($w.window.sortBy->isNotEmpty(),
-        |'Order By '+ $w.window.sortBy->map(s|$s.sortByElement->toOne()->processOperation($sgc) + if($s.sortDirection->isNotEmpty(), | ' ' +$s.sortDirection->toOne().name + if($s.sortDirection == meta::relational::metamodel::SortDirection.ASC, | ' NULLS LAST', | ' NULLS FIRST') , | ''))->joinStrings(', '),
+        |'Order By '+ $w.window.sortBy->map(s|$s.sortByElement->toOne()->processOperation($sgc) + if($s.sortDirection->isNotEmpty(), | ' ' +$s.sortDirection->toOne().name + if($s.nullOrder->isNotEmpty(), | if($s.nullOrder->toOne() == meta::relational::metamodel::NullOrder.FIRST, | ' NULLS FIRST', | ' NULLS LAST'), | if($s.sortDirection == meta::relational::metamodel::SortDirection.ASC, | ' NULLS LAST', | ' NULLS FIRST')) , | ''))->joinStrings(', '),
         |'');
    let windowFrameTranslation = if($w.window.frame->isNotEmpty(),
         |$w.window.frame->toOne()->processWindowFrameForDuckDB($sgc),

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery.pure
@@ -3764,7 +3764,7 @@ function meta::relational::functions::pureToSqlQuery::processRelationWinAggColSp
 {
    let window = $f.parametersValues->at(1)->cast(@InstanceValue).values->at(0)->cast(@meta::pure::functions::relation::_Window<Any>);
    let partitionKeys = $window.partition;
-   let sortInfo = $window.sortInfo->map(s | ^SortInformation(column = $s.column.name, direction = if($s.direction == SortType.ASC, |meta::pure::tds::SortDirection.ASC,|meta::pure::tds::SortDirection.DESC)));
+   let sortInfo = $window.sortInfo->map(s | ^SortInformation(column = $s.column.name, direction = if($s.direction == SortType.ASC, |meta::pure::tds::SortDirection.ASC,|meta::pure::tds::SortDirection.DESC), nullOrder = $s.nullOrder));
    let frame = $window.frame;
    let newColumnName = $f.parametersValues->last()->cast(@InstanceValue).values->at(0)->extractName();
    let topQuery = processValueSpecification($f.parametersValues->at(0), $currentPropertyMapping, $operation, $vars, $state, $joinType, $nodeId, $aggFromMap, $context, $extensions)->toOne()->cast(@SelectWithCursor);
@@ -3775,7 +3775,7 @@ function meta::relational::functions::pureToSqlQuery::processRelationWinAggColSp
 {
    let window = $f.parametersValues->at(1)->cast(@InstanceValue).values->at(0)->cast(@meta::pure::functions::relation::_Window<Any>);
    let partitionKeys = $window.partition;
-   let sortInfo = $window.sortInfo->map(s | ^SortInformation(column = $s.column.name, direction = if($s.direction == SortType.ASC, |meta::pure::tds::SortDirection.ASC,|meta::pure::tds::SortDirection.DESC)));
+   let sortInfo = $window.sortInfo->map(s | ^SortInformation(column = $s.column.name, direction = if($s.direction == SortType.ASC, |meta::pure::tds::SortDirection.ASC,|meta::pure::tds::SortDirection.DESC), nullOrder = $s.nullOrder));
    let frame = $window.frame;
    let aggColSpec = $f.parametersValues->at(2)->cast(@InstanceValue).values->at(0)->cast(@meta::pure::metamodel::relation::AggColSpecArray<Any,Any,Any>);
    let topQuery = processValueSpecification($f.parametersValues->at(0), $currentPropertyMapping, $operation, $vars, $state, $joinType, $nodeId, $aggFromMap, $context, $extensions)->toOne()->cast(@SelectWithCursor);
@@ -3790,7 +3790,7 @@ function meta::relational::functions::pureToSqlQuery::processRelationWinFuncColS
 {
    let window = $f.parametersValues->at(1)->cast(@InstanceValue).values->at(0)->cast(@meta::pure::functions::relation::_Window<Any>);
    let partitionKeys = $window.partition;
-   let sortInfo = $window.sortInfo->map(s | ^SortInformation(column = $s.column.name, direction = if($s.direction == SortType.ASC, |meta::pure::tds::SortDirection.ASC,|meta::pure::tds::SortDirection.DESC)));
+   let sortInfo = $window.sortInfo->map(s | ^SortInformation(column = $s.column.name, direction = if($s.direction == SortType.ASC, |meta::pure::tds::SortDirection.ASC,|meta::pure::tds::SortDirection.DESC), nullOrder = $s.nullOrder));
    let frame = $window.frame;
    let newColumnName = $f.parametersValues->last()->cast(@InstanceValue).values->at(0)->extractName();
    let topQuery = processValueSpecification($f.parametersValues->at(0), $currentPropertyMapping, $operation, $vars, $state, $joinType, $nodeId, $aggFromMap, $context, $extensions)->toOne()->cast(@SelectWithCursor);
@@ -3801,7 +3801,7 @@ function meta::relational::functions::pureToSqlQuery::processRelationWinFuncColS
 {
    let window = $f.parametersValues->at(1)->cast(@InstanceValue).values->at(0)->cast(@meta::pure::functions::relation::_Window<Any>);
    let partitionKeys = $window.partition;
-   let sortInfo = $window.sortInfo->map(s | ^SortInformation(column = $s.column.name, direction = if($s.direction == SortType.ASC, |meta::pure::tds::SortDirection.ASC,|meta::pure::tds::SortDirection.DESC)));
+   let sortInfo = $window.sortInfo->map(s | ^SortInformation(column = $s.column.name, direction = if($s.direction == SortType.ASC, |meta::pure::tds::SortDirection.ASC,|meta::pure::tds::SortDirection.DESC), nullOrder = $s.nullOrder));
    let frame = $window.frame;
    let funcColSpec = $f.parametersValues->at(2)->cast(@InstanceValue).values->at(0)->cast(@meta::pure::metamodel::relation::FuncColSpecArray<Any,Any>);
    let topQuery = processValueSpecification($f.parametersValues->at(0), $currentPropertyMapping, $operation, $vars, $state, $joinType, $nodeId, $aggFromMap, $context, $extensions)->toOne()->cast(@SelectWithCursor);
@@ -3884,8 +3884,9 @@ function meta::relational::functions::pureToSqlQuery::processRelationWindowColum
    assert(!$mainSelect.columns->map(col | $col->extractColumnName())->contains($newColumnName), | 'Attempting to reuse the same column name: '+ $newColumnName);
 
    let windowElement = $partitionKeys->map(columnName|findAliasOrFail($columnName, $mainSelect).relationalElement);
-   let sortElements = $sortInfo->map(si|^SortByInfo(sortByElement=findAliasOrFail($si.column, $mainSelect).relationalElement, 
-                                                    sortDirection = if($si.direction.name == meta::pure::tds::SortDirection.DESC.name,| meta::relational::metamodel::SortDirection.DESC,| meta::relational::metamodel::SortDirection.ASC)));
+   let sortElements = $sortInfo->map(si|^SortByInfo(sortByElement=findAliasOrFail($si.column, $mainSelect).relationalElement,
+                                                    sortDirection = if($si.direction.name == meta::pure::tds::SortDirection.DESC.name,| meta::relational::metamodel::SortDirection.DESC,| meta::relational::metamodel::SortDirection.ASC),
+                                                    nullOrder = $si.nullOrder->map(no | if($no == meta::pure::functions::relation::NullOrder.FIRST,| meta::relational::metamodel::NullOrder.FIRST,| meta::relational::metamodel::NullOrder.LAST))));
    let newFrame = if($frame->isEmpty(), | [], | $frame->toOne()->processWindowFrame());
    let window = ^meta::relational::metamodel::WindowColumn(
       columnName = $newColumnName,
@@ -4731,12 +4732,13 @@ function meta::relational::functions::pureToSqlQuery::processRelationReduce(f:Fu
    // filters window columns out of what the aggregate sees -- match it so the ordering cannot drift.
    let sortAliases = $state.aliases->filter(c | !$c->instanceOf(meta::relational::metamodel::WindowColumn));
 
-   // Alternating column/direction parameters because DynaFunction.parameters is a RelationalOperationElement
-   // list and SortByInfo is not one.
+   // column/direction/nullOrder triples because DynaFunction.parameters is a RelationalOperationElement
+   // list and SortByInfo is not one. nullOrder is 'FIRST', 'LAST' or 'NONE'.
    let result = if ($sorts->isEmpty(),
                     | $agg,
                     | let sortParams = $sorts->map(s | findAliasOrFail($s.column.name, $sortAliases).relationalElement
-                                                         ->concatenate(^Literal(value = if($s.direction == meta::pure::functions::relation::SortType.ASC, |'ASC', |'DESC'))));
+                                                         ->concatenate(^Literal(value = if($s.direction == meta::pure::functions::relation::SortType.ASC, |'ASC', |'DESC')))
+                                                         ->concatenate(^Literal(value = if($s.nullOrder->isEmpty(), |'NONE', |$s.nullOrder->toOne().name->toOne()))));
                       newDynaFunction('withinGroup', $agg->concatenate($sortParams));
                 );
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery_deprecated.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery_deprecated.pure
@@ -421,8 +421,9 @@ function meta::relational::functions::pureToSqlQuery::processTdsWindowColumn(
    assert(!$mainSelect.columns->map(col | $col->extractColumnName())->contains($newColumnName), | 'Attempting to reuse the same column name: '+ $newColumnName);
 
    let windowElement = $partitionKeys->map(columnName|findAliasOrFail($columnName, $mainSelect).relationalElement);
-   let sortElements = $sortInfo->map(si|^SortByInfo(sortByElement=findAliasOrFail($si.column, $mainSelect).relationalElement, 
-                                                    sortDirection = if($si.direction.name == meta::pure::tds::SortDirection.DESC.name,| meta::relational::metamodel::SortDirection.DESC,| meta::relational::metamodel::SortDirection.ASC)));
+   let sortElements = $sortInfo->map(si|^SortByInfo(sortByElement=findAliasOrFail($si.column, $mainSelect).relationalElement,
+                                                    sortDirection = if($si.direction.name == meta::pure::tds::SortDirection.DESC.name,| meta::relational::metamodel::SortDirection.DESC,| meta::relational::metamodel::SortDirection.ASC),
+                                                    nullOrder = $si.nullOrder->map(no | if($no == meta::pure::functions::relation::NullOrder.FIRST,| meta::relational::metamodel::NullOrder.FIRST,| meta::relational::metamodel::NullOrder.LAST))));
    let newFrame = if($frame->isEmpty(), | [], | $frame->toOne()->processWindowFrame());
    let window = ^meta::relational::metamodel::WindowColumn(
       columnName = $newColumnName,

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery_deprecated.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery_deprecated.pure
@@ -43,7 +43,7 @@ function meta::relational::functions::pureToSqlQuery::processTDSSortColumns(f:Fu
 
 function meta::relational::functions::pureToSqlQuery::processTDSSortSortInfo(f:FunctionExpression[1], currentPropertyMapping:PropertyMapping[*], operation:SelectWithCursor[1], vars:Map<VariableExpression, ValueSpecification>[1], state:State[1], joinType:JoinType[1], nodeId:String[1], aggFromMap:List<ColumnGroup>[1], context:DebugContext[1], extensions:Extension[*]):RelationalOperationElement[1]
 {
-   let sortInfo = $f->instanceValuesAtParameter(1,$vars, $state.inScopeVars)->cast(@SortInfo<Any>)->map(s | ^SortInformation(column = $s.column.name, direction = if($s.direction == SortType.ASC, |meta::pure::tds::SortDirection.ASC,|meta::pure::tds::SortDirection.DESC)));
+   let sortInfo = $f->instanceValuesAtParameter(1,$vars, $state.inScopeVars)->cast(@SortInfo<Any>)->map(s | ^SortInformation(column = $s.column.name, direction = if($s.direction == SortType.ASC, |meta::pure::tds::SortDirection.ASC,|meta::pure::tds::SortDirection.DESC), nullOrder = $s.nullOrder));
    $f->processTDSSort($currentPropertyMapping, $operation, $vars, $state, $joinType, $nodeId, $aggFromMap, $context, $sortInfo, $extensions);
 }
 
@@ -63,7 +63,8 @@ function meta::relational::functions::pureToSqlQuery::processTDSSort(f:FunctionE
                      let direction = if ($info.direction == meta::pure::tds::SortDirection.DESC,
                         | meta::relational::metamodel::SortDirection.DESC,
                         | meta::relational::metamodel::SortDirection.ASC);
-                     ^OrderBy(column = $info.column->findAliasOrFail($mainSelect), direction = $direction);
+                     ^OrderBy(column = $info.column->findAliasOrFail($mainSelect), direction = $direction,
+                              nullOrder = $info.nullOrder->map(no | if($no == meta::pure::functions::relation::NullOrder.FIRST,| meta::relational::metamodel::NullOrder.FIRST,| meta::relational::metamodel::NullOrder.LAST)));
                      )->concatenate($mainSelect.orderBy)
                   )
       );

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/sqlDialectTranslation/toPostgresModel.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/sqlDialectTranslation/toPostgresModel.pure
@@ -186,8 +186,15 @@ function <<access.private>> meta::relational::functions::toPostgresModel::conver
 {
   $orderBy->map(o|^SortItem(sortKey = $o.column->convertElementToExpression($state),
                             ordering = $o.direction->convertSortDirection(),
-                            nullOrdering = SortItemNullOrdering.UNDEFINED
+                            nullOrdering = $o.nullOrder->convertNullOrder()
                           ));
+}
+
+function <<access.private>> meta::relational::functions::toPostgresModel::convertNullOrder(n:meta::relational::metamodel::NullOrder[0..1]):SortItemNullOrdering[1]
+{
+  if($n->isEmpty(),
+     | SortItemNullOrdering.UNDEFINED,
+     | if($n->toOne() == meta::relational::metamodel::NullOrder.FIRST, | SortItemNullOrdering.FIRST, | SortItemNullOrdering.LAST));
 }
 
 function <<access.private>> meta::relational::functions::toPostgresModel::convertSortDirection(s:meta::relational::metamodel::SortDirection[0..1]):SortItemOrdering[1]
@@ -660,13 +667,18 @@ function <<access.private>> meta::relational::functions::toPostgresModel::within
 {
   let inner = $p->at(0)->cast(@FunctionCall);
   let rest = $p->tail();
-  assert($rest->size() > 0 && $rest->size()->mod(2) == 0, | 'withinGroup expects an aggregate followed by column/direction pairs');
-  let items = range(0, $rest->size(), 2)->map(i |
+  assert($rest->size() > 0 && $rest->size()->mod(3) == 0, | 'withinGroup expects an aggregate followed by column/direction/nullOrder triples');
+  let items = range(0, $rest->size(), 3)->map(i |
+    let nullOrder = $rest->at($i + 2)->cast(@meta::external::query::sql::metamodel::StringLiteral).value;
     ^SortItem(
       sortKey = $rest->at($i),
       ordering = if($rest->at($i + 1)->cast(@meta::external::query::sql::metamodel::StringLiteral).value == 'ASC', | SortItemOrdering.ASCENDING, | SortItemOrdering.DESCENDING),
-      nullOrdering = SortItemNullOrdering.UNDEFINED
-    )
+      nullOrdering = [
+         pair('FIRST', SortItemNullOrdering.FIRST),
+         pair('LAST', SortItemNullOrdering.LAST),
+         pair('NONE', SortItemNullOrdering.UNDEFINED)
+      ]->newMap()->get($nullOrder)->toOne()
+    );
   );
   ^$inner(orderBy = $items);
 }
@@ -861,7 +873,9 @@ function <<access.private>> meta::relational::functions::toPostgresModel::conver
   let partitions = $w.window.partition->map(p|$p->convertElementToExpression($state));
   let orderBy = $w.window.sortBy->map(s|^SortItem(sortKey = $s.sortByElement->convertElementToExpression($state),
                                                   ordering = $s.sortDirection->convertSortDirection(),
-                                                  nullOrdering = if($s.sortDirection == meta::relational::metamodel::SortDirection.ASC, | SortItemNullOrdering.LAST, | SortItemNullOrdering.FIRST)
+                                                  nullOrdering = if($s.nullOrder->isNotEmpty(),
+                                                                    | $s.nullOrder->convertNullOrder(),
+                                                                    | if($s.sortDirection == meta::relational::metamodel::SortDirection.ASC, | SortItemNullOrdering.LAST, | SortItemNullOrdering.FIRST))
                                                 ));
   let windowFrame = if($w.window.frame->isNotEmpty(),
                        | $w.window.frame->toOne()->convertWindowFrame($state),

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/sqlDialectTranslation/toPostgresModel.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/sqlDialectTranslation/toPostgresModel.pure
@@ -186,7 +186,11 @@ function <<access.private>> meta::relational::functions::toPostgresModel::conver
 {
   $orderBy->map(o|^SortItem(sortKey = $o.column->convertElementToExpression($state),
                             ordering = $o.direction->convertSortDirection(),
-                            nullOrdering = $o.nullOrder->convertNullOrder()
+                            nullOrdering = if($o.nullOrder->isNotEmpty(),
+                                              | $o.nullOrder->convertNullOrder(),
+                                              // No explicit null order => render the platform's canonical order (nulls sort high:
+                                              // NULLS LAST on ASC, NULLS FIRST on DESC) so it is portable across dialects whose native default diverges.
+                                              | if($o.direction == meta::relational::metamodel::SortDirection.DESC, | SortItemNullOrdering.FIRST, | SortItemNullOrdering.LAST))
                           ));
 }
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/sqlQueryToString/extensionDefaults.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/sqlQueryToString/extensionDefaults.pure
@@ -333,7 +333,7 @@ function meta::relational::functions::sqlQueryToString::default::processWindowCo
         |'Partition By ' + $w.window.partition->map(f|$f->processOperation($sgc))->joinStrings(','),
         |'');
    let orderByTranslation = if($w.window.sortBy->isNotEmpty(),
-        |'Order By '+ $w.window.sortBy->map(s|$s.sortByElement->toOne()->processOperation($sgc) + if($s.sortDirection->isNotEmpty(), | ' ' +$s.sortDirection->toOne().name, | ''))->joinStrings(', '),
+        |'Order By '+ $w.window.sortBy->map(s|$s.sortByElement->toOne()->processOperation($sgc) + if($s.sortDirection->isNotEmpty(), | ' ' +$s.sortDirection->toOne().name, | '') + $s.nullOrder->renderNullOrder())->joinStrings(', '),
         |'');
    let windowFrameTranslation = if($w.window.frame->isNotEmpty(),
         |$w.window.frame->toOne()->processWindowFrame($sgc),
@@ -507,7 +507,14 @@ function meta::relational::functions::sqlQueryToString::default::processOrderBy(
    $orderBy->map(o | $o.column->match([
         a:Alias[1]|$dbConfig.identifierProcessor($a.name),
         r:RelationalOperationElement[1]|$r->processOperation($dbConfig, $format, $config, $extensions)
-   ]) + if ($o.direction == meta::relational::metamodel::SortDirection.ASC, |'', | ' desc'));
+   ]) + if ($o.direction == meta::relational::metamodel::SortDirection.ASC, |'', | ' desc') + $o.nullOrder->renderNullOrder());
+}
+
+function meta::relational::functions::sqlQueryToString::default::renderNullOrder(nullOrder:meta::relational::metamodel::NullOrder[0..1]):String[1]
+{
+   if($nullOrder->isEmpty(),
+      | '',
+      | if($nullOrder->toOne() == meta::relational::metamodel::NullOrder.FIRST, | ' nulls first', | ' nulls last'));
 }
 
 function meta::relational::functions::sqlQueryToString::default::processLimit(s:SelectSQLQuery[1], dbConfig : DbConfig[1], format:Format[1], extensions:Extension[*],
@@ -801,12 +808,16 @@ function meta::relational::functions::sqlQueryToString::default::transformLikePa
       ->concatenate('');
 }
 
-// Alternating column/direction parameters follow the aggregate; see processRelationReduce.
+// column/direction/nullOrder triples follow the aggregate; see processRelationReduce.
 function meta::relational::functions::sqlQueryToString::default::withinGroupOrderBy(f:DynaFunction[1], sgc:SqlGenerationContext[1]):String[1]
 {
    let rest = $f.parameters->tail();
-   assert($rest->size() > 0 && $rest->size()->mod(2) == 0, | 'withinGroup expects an aggregate followed by column/direction pairs, got ' + $rest->size()->toString() + ' trailing parameters');
-   range(0, $rest->size(), 2)->map(i | $rest->at($i)->processOperation($sgc) + ' ' + $rest->at($i + 1)->cast(@Literal).value->cast(@String)->toLower())->joinStrings(', ');
+   assert($rest->size() > 0 && $rest->size()->mod(3) == 0, | 'withinGroup expects an aggregate followed by column/direction/nullOrder triples, got ' + $rest->size()->toString() + ' trailing parameters');
+   range(0, $rest->size(), 3)->map(i |
+      let nullOrder = $rest->at($i + 2)->cast(@Literal).value->cast(@String);
+      $rest->at($i)->processOperation($sgc) + ' ' + $rest->at($i + 1)->cast(@Literal).value->cast(@String)->toLower()
+         + if($nullOrder == 'NONE', | '', | ' nulls ' + $nullOrder->toLower());
+   )->joinStrings(', ');
 }
 
 // Dialects wanting the ordering inside the aggregate's parentheses override this and rebuild from the inner

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/sqlQueryToString/extensionDefaults.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/sqlQueryToString/extensionDefaults.pure
@@ -333,7 +333,7 @@ function meta::relational::functions::sqlQueryToString::default::processWindowCo
         |'Partition By ' + $w.window.partition->map(f|$f->processOperation($sgc))->joinStrings(','),
         |'');
    let orderByTranslation = if($w.window.sortBy->isNotEmpty(),
-        |'Order By '+ $w.window.sortBy->map(s|$s.sortByElement->toOne()->processOperation($sgc) + if($s.sortDirection->isNotEmpty(), | ' ' +$s.sortDirection->toOne().name, | '') + $s.nullOrder->renderNullOrder())->joinStrings(', '),
+        |'Order By '+ $w.window.sortBy->map(s|$s.sortByElement->toOne()->processOperation($sgc) + if($s.sortDirection->isNotEmpty(), | ' ' +$s.sortDirection->toOne().name, | '') + renderNullOrder($s.nullOrder, $s.sortDirection, $sgc.dbConfig))->joinStrings(', '),
         |'');
    let windowFrameTranslation = if($w.window.frame->isNotEmpty(),
         |$w.window.frame->toOne()->processWindowFrame($sgc),
@@ -507,14 +507,59 @@ function meta::relational::functions::sqlQueryToString::default::processOrderBy(
    $orderBy->map(o | $o.column->match([
         a:Alias[1]|$dbConfig.identifierProcessor($a.name),
         r:RelationalOperationElement[1]|$r->processOperation($dbConfig, $format, $config, $extensions)
-   ]) + if ($o.direction == meta::relational::metamodel::SortDirection.ASC, |'', | ' desc') + $o.nullOrder->renderNullOrder());
+   ]) + if ($o.direction == meta::relational::metamodel::SortDirection.ASC, |'', | ' desc') + renderNullOrder($o.nullOrder, $o.direction, $dbConfig));
 }
 
-function meta::relational::functions::sqlQueryToString::default::renderNullOrder(nullOrder:meta::relational::metamodel::NullOrder[0..1]):String[1]
+// Renders the ' nulls first' / ' nulls last' suffix for a sort key.
+//  - explicit null order  => always rendered
+//  - no explicit order    => render the platform's canonical order (nulls sort high: NULLS LAST on ASC,
+//                            NULLS FIRST on DESC) only for dialects whose native default diverges from it
+//                            and that support the NULLS FIRST/LAST syntax. Dialects that already match
+//                            canonical emit nothing, so their SQL is byte-identical to before.
+function meta::relational::functions::sqlQueryToString::default::renderNullOrder(nullOrder:meta::relational::metamodel::NullOrder[0..1], direction:meta::relational::metamodel::SortDirection[0..1], dbConfig:DbConfig[1]):String[1]
 {
-   if($nullOrder->isEmpty(),
+   let effective = if($nullOrder->isNotEmpty(),
+                      | $nullOrder,
+                      | reconcileUnspecifiedNullOrder($direction, $dbConfig));
+   if($effective->isEmpty(),
       | '',
-      | if($nullOrder->toOne() == meta::relational::metamodel::NullOrder.FIRST, | ' nulls first', | ' nulls last'));
+      | if($effective->toOne() == meta::relational::metamodel::NullOrder.FIRST, | ' nulls first', | ' nulls last'));
+}
+
+function meta::relational::functions::sqlQueryToString::default::reconcileUnspecifiedNullOrder(direction:meta::relational::metamodel::SortDirection[0..1], dbConfig:DbConfig[1]):meta::relational::metamodel::NullOrder[0..1]
+{
+   let dir = $direction->defaultIfEmpty(meta::relational::metamodel::SortDirection.ASC)->toOne();
+   let canonical = if($dir == meta::relational::metamodel::SortDirection.DESC,
+                      | meta::relational::metamodel::NullOrder.FIRST,
+                      | meta::relational::metamodel::NullOrder.LAST);
+   // Dialects with no NULLS FIRST/LAST syntax cannot be reconciled here; emulation is a follow-up.
+   if(!$dbConfig.dbType->supportsNullOrderingSyntax(),
+      | [],
+      | if($dbConfig.dbType->nativeNullOrdering($dir) == $canonical, | [], | $canonical));
+}
+
+function meta::relational::functions::sqlQueryToString::default::supportsNullOrderingSyntax(dbType:meta::relational::runtime::DatabaseType[1]):Boolean[1]
+{
+   !$dbType->in([meta::relational::runtime::DatabaseType.SqlServer, meta::relational::runtime::DatabaseType.MemSQL,
+                 meta::relational::runtime::DatabaseType.Sybase, meta::relational::runtime::DatabaseType.SybaseIQ]);
+}
+
+// The dialect's NULLS position when no explicit clause is given. Verify each against a real instance
+// (PCT cloud probe) before trusting -- vendor documentation is unreliable here.
+function meta::relational::functions::sqlQueryToString::default::nativeNullOrdering(dbType:meta::relational::runtime::DatabaseType[1], direction:meta::relational::metamodel::SortDirection[1]):meta::relational::metamodel::NullOrder[1]
+{
+   let nullsLow = $dbType->in([meta::relational::runtime::DatabaseType.H2, meta::relational::runtime::DatabaseType.Hive,
+                               meta::relational::runtime::DatabaseType.SparkSQL, meta::relational::runtime::DatabaseType.Databricks,
+                               meta::relational::runtime::DatabaseType.BigQuery, meta::relational::runtime::DatabaseType.Spanner,
+                               meta::relational::runtime::DatabaseType.SqlServer, meta::relational::runtime::DatabaseType.MemSQL,
+                               meta::relational::runtime::DatabaseType.Sybase, meta::relational::runtime::DatabaseType.SybaseIQ]);
+   let uniformLast = $dbType->in([meta::relational::runtime::DatabaseType.DuckDB, meta::relational::runtime::DatabaseType.ClickHouse]);
+   if($uniformLast,
+      | meta::relational::metamodel::NullOrder.LAST,
+      | if($nullsLow,
+           | if($direction == meta::relational::metamodel::SortDirection.DESC, | meta::relational::metamodel::NullOrder.LAST, | meta::relational::metamodel::NullOrder.FIRST),
+           // Canonical / nulls-high: Postgres, Oracle, Redshift, Aurora, Athena, Presto, Trino, Snowflake, DB2, ...
+           | if($direction == meta::relational::metamodel::SortDirection.DESC, | meta::relational::metamodel::NullOrder.FIRST, | meta::relational::metamodel::NullOrder.LAST)));
 }
 
 function meta::relational::functions::sqlQueryToString::default::processLimit(s:SelectSQLQuery[1], dbConfig : DbConfig[1], format:Format[1], extensions:Extension[*],
@@ -814,9 +859,12 @@ function meta::relational::functions::sqlQueryToString::default::withinGroupOrde
    let rest = $f.parameters->tail();
    assert($rest->size() > 0 && $rest->size()->mod(3) == 0, | 'withinGroup expects an aggregate followed by column/direction/nullOrder triples, got ' + $rest->size()->toString() + ' trailing parameters');
    range(0, $rest->size(), 3)->map(i |
-      let nullOrder = $rest->at($i + 2)->cast(@Literal).value->cast(@String);
-      $rest->at($i)->processOperation($sgc) + ' ' + $rest->at($i + 1)->cast(@Literal).value->cast(@String)->toLower()
-         + if($nullOrder == 'NONE', | '', | ' nulls ' + $nullOrder->toLower());
+      let directionStr = $rest->at($i + 1)->cast(@Literal).value->cast(@String);
+      let nullOrderStr = $rest->at($i + 2)->cast(@Literal).value->cast(@String);
+      let direction = if($directionStr->toUpper() == 'DESC', | meta::relational::metamodel::SortDirection.DESC, | meta::relational::metamodel::SortDirection.ASC);
+      let explicitNullOrder = [pair('FIRST', meta::relational::metamodel::NullOrder.FIRST), pair('LAST', meta::relational::metamodel::NullOrder.LAST)]->newMap()->get($nullOrderStr);
+      $rest->at($i)->processOperation($sgc) + ' ' + $directionStr->toLower()
+         + renderNullOrder($explicitNullOrder, $direction, $sgc.dbConfig);
    )->joinStrings(', ');
 }
 

--- a/legend-engine-xts-sql/legend-engine-xt-sql-transformation/legend-engine-xt-sql-pure/src/main/resources/core_external_query_sql/binding/fromPure/fromPure.pure
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-transformation/legend-engine-xt-sql-pure/src/main/resources/core_external_query_sql/binding/fromPure/fromPure.pure
@@ -558,12 +558,10 @@ function <<access.private>> meta::external::query::sql::transformation::queryToP
 
     //  debug(|'processed where: '+$withWhere.expression->evaluateAndDeactivate()->map(x|$x->meta::pure::metamodel::serialization::grammar::printValueSpecification(^GContext(space='')))->joinStrings(''), $context.debug->indent());
 
-      let rewrittenOrderBy = $querySpec.orderBy->rewriteNullOrdering();
-
-      let projection = $querySpec.select->processProjection($querySpec.groupBy, $querySpec.having, $rewrittenOrderBy.sortKey, $withWhere);
+      let projection = $querySpec.select->processProjection($querySpec.groupBy, $querySpec.having, $querySpec.orderBy.sortKey, $withWhere);
 
       let query = $querySpec.limit->processLimitOffset($querySpec.offset,
-        $rewrittenOrderBy->processOrderBy($projection.second.selectItems,
+        $querySpec.orderBy->processOrderBy($projection.second.selectItems,
           $querySpec.having->processHaving($projection.second,
             $projection.first
           )
@@ -1857,27 +1855,6 @@ function <<access.private>> meta::external::query::sql::transformation::queryToP
   ]->getValue($joinType, | unsupported('unsupported join type ' + $joinType.name);  meta::pure::functions::relation::JoinKind.INNER;)->eval();
 }
 
-function <<access.private>> meta::external::query::sql::transformation::queryToPure::rewriteNullOrdering(sortItems: SortItem[*]):SortItem[*]
-{
-  $sortItems->map(si |
-    if ($si.nullOrdering == SortItemNullOrdering.UNDEFINED,
-      | $si,
-      | let nullCase = ^SearchedCaseExpression(
-            whenClauses = [^WhenClause(operand = ^IsNullPredicate(value = $si.sortKey), result = ^IntegerLiteral(value = 0))],
-            defaultValue = ^IntegerLiteral(value = 1));
-
-        let caseDirection = if ($si.nullOrdering == SortItemNullOrdering.FIRST,
-                              | SortItemOrdering.ASCENDING,
-                              | SortItemOrdering.DESCENDING);
-
-        [
-          ^SortItem(sortKey = $nullCase, ordering = $caseDirection, nullOrdering = SortItemNullOrdering.UNDEFINED),
-          ^SortItem(sortKey = $si.sortKey, ordering = $si.ordering, nullOrdering = SortItemNullOrdering.UNDEFINED)
-        ];
-    )
-  );
-}
-
 function <<access.private>> meta::external::query::sql::transformation::queryToPure::processOrderBy(sortItems: meta::external::query::sql::metamodel::SortItem[*], selectItems:SelectItem[*], _context: SqlTransformContext[1]): SqlTransformContext[1]
 {
   debug(|'processOrderBy', $_context.debug);
@@ -1901,8 +1878,6 @@ function <<access.private>> meta::external::query::sql::transformation::queryToP
 //need this because a materialised key does not resolve through the context - see materialisedKeyName.
 function <<access.private>> meta::external::query::sql::transformation::queryToPure::createSortItemFunctionForColumn(si:SortItem[1], column:String[1], context: SqlTransformContext[1]):ValueSpecification[1]
 {
-    assert($si.nullOrdering == SortItemNullOrdering.UNDEFINED, 'null ordering type not yet supported');
-
     ^TDSBuilder().sortItem($si, $column, $context.relation->isTrue());
 }
 
@@ -5195,13 +5170,13 @@ Class meta::external::query::sql::transformation::queryToPure::TDSBuilder
     column:String[1],
     relation:Boolean[1])
   {
-    assert($si.nullOrdering == SortItemNullOrdering.UNDEFINED, 'null ordering type not yet supported');
+    assert($relation || $si.nullOrdering == SortItemNullOrdering.UNDEFINED, 'null ordering is only supported on the relation binding');
 
     let col = if ($relation,
                 | iv(^meta::pure::metamodel::relation::ColSpec<Any>(name = $column)),
                 | iv($column));
 
-    [
+    let sortInfo = [
       pair(SortItemOrdering.ASCENDING, | [
         pair(false, | sfe(asc_String_1__SortInformation_1_, $col)),
         pair(true, | sfe(ascending_ColSpec_1__SortInfo_1_, $col))
@@ -5212,7 +5187,11 @@ Class meta::external::query::sql::transformation::queryToPure::TDSBuilder
       ])
     ]->getValue($si.ordering)->eval()->getValue($relation)->eval();
 
-
+    if (!$relation || $si.nullOrdering == SortItemNullOrdering.UNDEFINED,
+      | $sortInfo,
+      | if ($si.nullOrdering == SortItemNullOrdering.FIRST,
+          | sfe(nullsFirst_SortInfo_1__SortInfo_1_, $sortInfo->evaluateAndDeactivate().genericType, $sortInfo),
+          | sfe(nullsLast_SortInfo_1__SortInfo_1_, $sortInfo->evaluateAndDeactivate().genericType, $sortInfo)));
   }:ValueSpecification[1];
 
 

--- a/legend-engine-xts-sql/legend-engine-xt-sql-transformation/legend-engine-xt-sql-pure/src/main/resources/core_external_query_sql/binding/fromPure/tests/testTranspile.pure
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-transformation/legend-engine-xt-sql-pure/src/main/resources/core_external_query_sql/binding/fromPure/tests/testTranspile.pure
@@ -5626,8 +5626,8 @@ function <<test.Test>> meta::external::query::sql::transformation::queryToPure::
   )
 }
 
-// The shape seen in practice: Engine rejects NULLS FIRST/LAST, so the upstream
-// converter rewrites null ordering into a CASE sort key, which hits the gap above.
+// A user-written CASE expression as an ORDER BY key still has to be materialised
+// through the same expression path as testOrderByFunctionExpression above.
 function <<test.Test>> meta::external::query::sql::transformation::queryToPure::tests::testOrderByNullOrderingCaseKey():Boolean[1]
 {
   test(
@@ -5723,15 +5723,14 @@ function <<test.Test>> meta::external::query::sql::transformation::queryToPure::
 
 function <<test.Test>> meta::external::query::sql::transformation::queryToPure::tests::testOrderByNullsFirst():Boolean[1]
 {
-  // NULLS FIRST: rewritten as CASE WHEN String IS NULL THEN 0 ELSE 1 END ASC, String ASC
+  // NULLS FIRST renders natively as a sort-spec modifier
   test(
     'SELECT "String", "Integer" FROM service."/service/service1" ORDER BY "String" NULLS FIRST',
     [
       {| FlatInput.all()
             ->project(~[ Boolean: x | $x.booleanIn, Integer: x | $x.integerIn, Float: x | $x.floatIn, Decimal: x | $x.decimalIn, StrictDate: x | $x.strictDateIn, DateTime: x | $x.dateTimeIn, String: x | $x.stringIn])
             ->select(~[String, Integer])
-            ->extend(~['CASE WHEN String IS NULL THEN 0 ELSE 1 END': x | $x.String->isEmpty()->if(|0, |1)])
-            ->sort([~'CASE WHEN String IS NULL THEN 0 ELSE 1 END'->ascending(), ~String->ascending()])
+            ->sort([~String->ascending()->nullsFirst()])
             ->select(~[String, Integer])
         }
     ]
@@ -5772,15 +5771,14 @@ function <<test.Test>> meta::external::query::sql::transformation::queryToPure::
 
 function <<test.Test>> meta::external::query::sql::transformation::queryToPure::tests::testOrderByNullsLast():Boolean[1]
 {
-  // NULLS LAST: rewritten as CASE WHEN String IS NULL THEN 0 ELSE 1 END DESC, String ASC
+  // NULLS LAST renders natively as a sort-spec modifier
   test(
     'SELECT "String", "Integer" FROM service."/service/service1" ORDER BY "String" NULLS LAST',
     [
       {| FlatInput.all()
             ->project(~[ Boolean: x | $x.booleanIn, Integer: x | $x.integerIn, Float: x | $x.floatIn, Decimal: x | $x.decimalIn, StrictDate: x | $x.strictDateIn, DateTime: x | $x.dateTimeIn, String: x | $x.stringIn])
             ->select(~[String, Integer])
-            ->extend(~['CASE WHEN String IS NULL THEN 0 ELSE 1 END': x | $x.String->isEmpty()->if(|0, |1)])
-            ->sort([~'CASE WHEN String IS NULL THEN 0 ELSE 1 END'->descending(), ~String->ascending()])
+            ->sort([~String->ascending()->nullsLast()])
             ->select(~[String, Integer])
         }
     ]
@@ -5807,15 +5805,14 @@ function <<test.Test>> meta::external::query::sql::transformation::queryToPure::
 
 function <<test.Test>> meta::external::query::sql::transformation::queryToPure::tests::testOrderByDescNullsFirst():Boolean[1]
 {
-  // DESC NULLS FIRST: rewritten as CASE WHEN String IS NULL THEN 0 ELSE 1 END ASC, String DESC
+  // DESC NULLS FIRST renders natively as a sort-spec modifier
   test(
     'SELECT "String", "Integer" FROM service."/service/service1" ORDER BY "String" DESC NULLS FIRST',
     [
       {| FlatInput.all()
             ->project(~[ Boolean: x | $x.booleanIn, Integer: x | $x.integerIn, Float: x | $x.floatIn, Decimal: x | $x.decimalIn, StrictDate: x | $x.strictDateIn, DateTime: x | $x.dateTimeIn, String: x | $x.stringIn])
             ->select(~[String, Integer])
-            ->extend(~['CASE WHEN String IS NULL THEN 0 ELSE 1 END': x | $x.String->isEmpty()->if(|0, |1)])
-            ->sort([~'CASE WHEN String IS NULL THEN 0 ELSE 1 END'->ascending(), ~String->descending()])
+            ->sort([~String->descending()->nullsFirst()])
             ->select(~[String, Integer])
         }
     ]
@@ -5843,15 +5840,14 @@ function <<test.Test>> meta::external::query::sql::transformation::queryToPure::
 
 function <<test.Test>> meta::external::query::sql::transformation::queryToPure::tests::testOrderByMultiColumnMixedNulls():Boolean[1]
 {
-  // String NULLS FIRST, Integer DESC NULLS LAST: two CASE extend columns, four sort keys
+  // String NULLS FIRST, Integer DESC NULLS LAST render natively as sort-spec modifiers
   test(
     'SELECT "String", "Integer" FROM service."/service/service1" ORDER BY "String" NULLS FIRST, "Integer" DESC NULLS LAST',
     [
       {| FlatInput.all()
             ->project(~[ Boolean: x | $x.booleanIn, Integer: x | $x.integerIn, Float: x | $x.floatIn, Decimal: x | $x.decimalIn, StrictDate: x | $x.strictDateIn, DateTime: x | $x.dateTimeIn, String: x | $x.stringIn])
             ->select(~[String, Integer])
-            ->extend(~['CASE WHEN String IS NULL THEN 0 ELSE 1 END': x | $x.String->isEmpty()->if(|0, |1), 'CASE WHEN Integer IS NULL THEN 0 ELSE 1 END': x | $x.Integer->isEmpty()->if(|0, |1)])
-            ->sort([~'CASE WHEN String IS NULL THEN 0 ELSE 1 END'->ascending(), ~String->ascending(), ~'CASE WHEN Integer IS NULL THEN 0 ELSE 1 END'->descending(), ~Integer->descending()])
+            ->sort([~String->ascending()->nullsFirst(), ~Integer->descending()->nullsLast()])
             ->select(~[String, Integer])
         }
     ]


### PR DESCRIPTION
> **Draft / WIP** — opened for early review. Known-incomplete items listed at the bottom; CI will not go green until the dependency below is released.

## Depends on

- **finos/legend-pure#1329** — adds the `NullOrder` metamodel (`SortInfo.nullOrder`, relational `OrderBy`/`SortByInfo.nullOrder`). This engine PR does not compile until that is merged + released and the root pom `legend.pure.version` is bumped.

Single commit, 23 files, forked from `master` a few commits back so the local Maven build state stays valid.

## What this adds

End-to-end null ordering for every sort surface in the Relation API, replacing the CASE-WHEN rewrite in the Legend SQL transpiler (revert of 13d801714c).

### Pure API
- New `<<PCT.function>>` `nullsFirst` / `nullsLast` sort-spec modifiers: `~col->ascending()->nullsFirst()`.
- 2-arg sugar: `~col->ascending(NullOrder.FIRST)` / `descending(~col, NullOrder.LAST)`.
- `NormalizeRequiredFunction` stereotype ⇒ the router folds the modifier into `^SortInfo(nullOrder=…)` before store dispatch, so no per-store wiring and no router change.
- `doc.doc` on both functions states the SQL equivalence and the canonical default.

### Semantics
- **Unspecified** = the platform's canonical order: nulls sort high, i.e. `NULLS LAST` on ASC, `NULLS FIRST` on DESC (matches Postgres/Oracle, no in-memory change).
- **Explicit** `->nullsFirst()/->nullsLast()` is honored on every backend.

### In-memory
`TestTDS.sortOneLevel` partitions null rows out after direction is applied and re-attaches them at the requested end; unspecified is byte-for-byte unchanged. Interpreted + compiled `Sort`/`Window`/`RelationNativeImplementation` carry the new property.

### Relational SQL
- Root `OrderBy` and window `SortByInfo` carry `nullOrder` through `pureToSQLQuery`.
- `extensionDefaults` gains a shared `renderNullOrder` helper used by `processOrderBy`, the window ORDER BY fragment, and `withinGroupOrderBy` (the WITHIN GROUP DynaFunction goes from `(column, direction)` pairs to `(column, direction, nullOrder)` triples; MemSQL inherits via the shared helper).
- `toPostgresModel` maps `nullOrder` → `SortItem.nullOrdering`; `withinGroupConverter` updated for triples.
- DuckDB / Databricks window rendering now honors an explicit request while keeping their canonical default for unspecified sorts.

### Legend SQL
`rewriteNullOrdering()` deleted; `TDSBuilder.sortItem` wraps the sort spec with `nullsFirst`/`nullsLast` from `SortItem.nullOrdering` (root and window paths). `testTranspile` null-ordering tests rewritten to the direct modifier form.

## Testing done

- Compiled + interpreted Relation PCT: **459 / 459** including new `sort` null-order tests.
- Full `-am` build of `legend-engine-xt-relationalStore-core-pure` (111 modules): green.
- H2 relational PCT (1332 tests): surfaced the known-incomplete items below.

## Known-incomplete (do not merge yet)

1. Explicit `->nullsFirst()/->nullsLast()` **NPEs in the H2 relational SQL path** — needs a fix in the relational renderer.
2. The WITHIN GROUP triple / nested-pair change **trips a `String → Pair` cast** in window/reduce scenario PCT tests.
3. Per-dialect reconciliation for *unspecified* sorts is **not wired**: H2 is empirically nulls-low, so unspecified sorts on H2/DuckDB currently disagree with the in-memory engines. Cloud stores (Snowflake/BigQuery/Databricks/…) need a probe run against the `pct-cloud-test` profile to establish their native defaults.
4. Still to add: PCT exclusion manifests for stores without `NULLS FIRST/LAST` syntax (SQL Server / MemSQL / Sybase), `order_limit_offset.yaml` parity refresh, window + `joinStrings` PCT tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)