### PR TITLE
Review variant reuse func

### DIFF
--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/tests/composition.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/tests/composition.pure
@@ -1517,8 +1517,8 @@ function <<PCT.test, PCTRelationQualifier.relation, PCTCoreQualifier.variant>> m
  
    assertEquals('#TDS\n'+
                 '   id,payload\n'+
-                '   1,\'{"person": {"name": "Jose"}}\'\n'+
-                '   3,\'{"person": {"name": "Pedro"}}\'\n'+
+                '   1,\'{"person":{"name":"Jose"}}\'\n'+
+                '   3,\'{"person":{"name":"Pedro"}}\'\n'+
                 '#', $res->toString());
 }
 

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/tests/composition.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/tests/composition.pure
@@ -1483,6 +1483,45 @@ Class <<access.private>> meta::pure::functions::relation::tests::composition::Pe
   <<equality.Key>> name: String[1];
 }
 
+function <<PCT.test, PCTRelationQualifier.relation, PCTCoreQualifier.variant>> meta::pure::functions::relation::tests::composition::testVariantColumn_filterOnIsEmptyOfModelConversion<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {
+                | #TDS
+                  id, payload:meta::pure::metamodel::variant::Variant
+                  1, '{"person": {"name": "Jose"}}'
+                  2, '{}'
+                  3, '{"person": {"name": "Pedro"}}'
+                #->filter(x | $x.payload->get('person')->to(@meta::pure::functions::relation::tests::composition::Person)->isEmpty())
+              };
+ 
+   let res =  $f->eval($expr);
+ 
+   assertEquals('#TDS\n'+
+                '   id,payload\n'+
+                '   2,\'{}\'\n'+
+                '#', $res->toString());
+}
+ 
+function <<PCT.test, PCTRelationQualifier.relation, PCTCoreQualifier.variant>> meta::pure::functions::relation::tests::composition::testVariantColumn_filterOnIsNotEmptyOfModelConversion<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {
+                | #TDS
+                  id, payload:meta::pure::metamodel::variant::Variant
+                  1, '{"person": {"name": "Jose"}}'
+                  2, '{}'
+                  3, '{"person": {"name": "Pedro"}}'
+                #->filter(x | $x.payload->get('person')->to(@meta::pure::functions::relation::tests::composition::Person)->isNotEmpty())
+              };
+ 
+   let res =  $f->eval($expr);
+ 
+   assertEquals('#TDS\n'+
+                '   id,payload\n'+
+                '   1,\'{"person": {"name": "Jose"}}\'\n'+
+                '   3,\'{"person": {"name": "Pedro"}}\'\n'+
+                '#', $res->toString());
+}
+
 function <<PCT.test, PCTRelationQualifier.relation>> meta::pure::functions::relation::tests::composition::testMultiIfTDS<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
   let expr = {

--- a/legend-engine-xts-deephaven/legend-engine-xt-deephaven-PCT/src/main/resources/pct-manifests/deephaven/RelationFunctions_manifest.json
+++ b/legend-engine-xts-deephaven/legend-engine-xt-deephaven-PCT/src/main/resources/pct-manifests/deephaven/RelationFunctions_manifest.json
@@ -181,7 +181,7 @@
     "test" : "meta::pure::functions::relation::tests::composition::testVariantColumn_filterOnIsNotEmptyOfModelConversion_Function_1__Boolean_1_",
     "expectedError" : "Cannot cast a collection of size 0 to multiplicity [1]"
   }, {
-    "test" : "meta::pure::functions::relation::tests::composition::testVariantColumn_filterOnIsEmptyOfModelConversionToMany_Function_1__Boolean_1_",
+    "test" : "meta::pure::functions::relation::tests::composition::testVariantColumn_filterOnIsEmptyOfModelConversion_Function_1__Boolean_1_",
     "expectedError" : "Cannot cast a collection of size 0 to multiplicity [1]"
   }, {
     "test" : "meta::pure::functions::relation::tests::filter::testVariantColumn_filterOnIsEmptyOfKeyExtraction_Function_1__Boolean_1_",

--- a/legend-engine-xts-deephaven/legend-engine-xt-deephaven-PCT/src/main/resources/pct-manifests/deephaven/RelationFunctions_manifest.json
+++ b/legend-engine-xts-deephaven/legend-engine-xt-deephaven-PCT/src/main/resources/pct-manifests/deephaven/RelationFunctions_manifest.json
@@ -178,6 +178,12 @@
     "test" : "meta::pure::functions::relation::tests::composition::testVariant_if_Function_1__Boolean_1_",
     "expectedError" : "Cannot cast a collection of size 0 to multiplicity [1]"
   }, {
+    "test" : "meta::pure::functions::relation::tests::composition::testVariantColumn_filterOnIsNotEmptyOfModelConversion_Function_1__Boolean_1_",
+    "expectedError" : "Cannot cast a collection of size 0 to multiplicity [1]"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::composition::testVariantColumn_filterOnIsEmptyOfModelConversionToMany_Function_1__Boolean_1_",
+    "expectedError" : "Cannot cast a collection of size 0 to multiplicity [1]"
+  }, {
     "test" : "meta::pure::functions::relation::tests::filter::testVariantColumn_filterOnIsEmptyOfKeyExtraction_Function_1__Boolean_1_",
     "expectedError" : "Cannot cast a collection of size 0 to multiplicity [1]"
   }, {

--- a/legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-PCT/src/main/resources/pct-manifests/java/Test_JAVA_RelationFunction_manifest.json
+++ b/legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-PCT/src/main/resources/pct-manifests/java/Test_JAVA_RelationFunction_manifest.json
@@ -1802,7 +1802,7 @@
       "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
     },
     {
-      "test": "meta::pure::functions::relation::tests::composition::testVariantColumn_filterOnIsEmptyOfModelConversionToMany_Function_1__Boolean_1_",
+      "test": "meta::pure::functions::relation::tests::composition::testVariantColumn_filterOnIsEmptyOfModelConversion_Function_1__Boolean_1_",
       "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
     },
     {

--- a/legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-PCT/src/main/resources/pct-manifests/java/Test_JAVA_RelationFunction_manifest.json
+++ b/legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-PCT/src/main/resources/pct-manifests/java/Test_JAVA_RelationFunction_manifest.json
@@ -1798,6 +1798,14 @@
       "expectedError": "\"Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated\""
     },
     {
+      "test": "meta::pure::functions::relation::tests::composition::testVariantColumn_filterOnIsNotEmptyOfModelConversion_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
+      "test": "meta::pure::functions::relation::tests::composition::testVariantColumn_filterOnIsEmptyOfModelConversionToMany_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
       "test": "meta::pure::functions::relation::tests::filter::testVariantColumn_filterOnIsEmptyOfKeyExtraction_Function_1__Boolean_1_",
       "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
     },

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-clickhouse/legend-engine-xt-relationalStore-clickhouse-PCT/src/main/resources/pct-manifests/relational-clickhouse/RelationFunctions_manifest.json
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-clickhouse/legend-engine-xt-relationalStore-clickhouse-PCT/src/main/resources/pct-manifests/relational-clickhouse/RelationFunctions_manifest.json
@@ -223,7 +223,7 @@
     "test" : "meta::pure::functions::relation::tests::composition::testVariantColumn_filterOnIsNotEmptyOfModelConversion_Function_1__Boolean_1_",
     "expectedError" : "\"[unsupported-api] Semi structured array element processing not supported for Database Type: ClickHouse\""
   }, {
-    "test" : "meta::pure::functions::relation::tests::composition::testVariantColumn_filterOnIsEmptyOfModelConversionToMany_Function_1__Boolean_1_",
+    "test" : "meta::pure::functions::relation::tests::composition::testVariantColumn_filterOnIsEmptyOfModelConversion_Function_1__Boolean_1_",
     "expectedError" : "\"[unsupported-api] Semi structured array element processing not supported for Database Type: ClickHouse\""
   }, {
     "test": "meta::pure::functions::relation::tests::filter::testVariantColumn_filterOnIsEmptyOfKeyExtraction_Function_1__Boolean_1_",

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-clickhouse/legend-engine-xt-relationalStore-clickhouse-PCT/src/main/resources/pct-manifests/relational-clickhouse/RelationFunctions_manifest.json
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-clickhouse/legend-engine-xt-relationalStore-clickhouse-PCT/src/main/resources/pct-manifests/relational-clickhouse/RelationFunctions_manifest.json
@@ -220,6 +220,12 @@
     "test" : "meta::pure::functions::relation::tests::extend::testVariantColumn_map_Function_1__Boolean_1_",
     "expectedError" : "\"[unsupported-api] The function 'toVariant' (state: [Select, false]) is not supported yet\""
   }, {
+    "test" : "meta::pure::functions::relation::tests::composition::testVariantColumn_filterOnIsNotEmptyOfModelConversion_Function_1__Boolean_1_",
+    "expectedError" : "\"[unsupported-api] Semi structured array element processing not supported for Database Type: ClickHouse\""
+  }, {
+    "test" : "meta::pure::functions::relation::tests::composition::testVariantColumn_filterOnIsEmptyOfModelConversionToMany_Function_1__Boolean_1_",
+    "expectedError" : "\"[unsupported-api] Semi structured array element processing not supported for Database Type: ClickHouse\""
+  }, {
     "test": "meta::pure::functions::relation::tests::filter::testVariantColumn_filterOnIsEmptyOfKeyExtraction_Function_1__Boolean_1_",
     "expectedError": "\"[unsupported-api] Semi structured array element processing not supported for Database Type: ClickHouse\""
   }, {

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-PCT/src/main/resources/pct-manifests/relational-memsql/RelationFunctions_manifest.json
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-PCT/src/main/resources/pct-manifests/relational-memsql/RelationFunctions_manifest.json
@@ -73,6 +73,12 @@
     "test" : "meta::pure::functions::relation::tests::filter::testVariantColumn_filterOnIsNotEmptyOfKeyExtraction_Function_1__Boolean_1_",
     "expectedError" : "Error while executing: CREATE TEMPORARY TABLE leSchema.tb"
   }, {
+    "test" : "meta::pure::functions::relation::tests::composition::testVariantColumn_filterOnIsNotEmptyOfModelConversion_Function_1__Boolean_1_",
+    "expectedError" : "Error while executing: CREATE TEMPORARY TABLE leSchema.tb"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::composition::testVariantColumn_filterOnIsEmptyOfModelConversionToMany_Function_1__Boolean_1_",
+    "expectedError" : "Error while executing: CREATE TEMPORARY TABLE leSchema.tb"
+  }, {
     "test" : "meta::pure::functions::relation::tests::composition::testVariantColumn_slice_Function_1__Boolean_1_",
     "expectedError" : "[unsupported-api] The function 'toVariant' (state: [Select, false]) is not supported yet"
   }, {

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-PCT/src/main/resources/pct-manifests/relational-memsql/RelationFunctions_manifest.json
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-PCT/src/main/resources/pct-manifests/relational-memsql/RelationFunctions_manifest.json
@@ -76,7 +76,7 @@
     "test" : "meta::pure::functions::relation::tests::composition::testVariantColumn_filterOnIsNotEmptyOfModelConversion_Function_1__Boolean_1_",
     "expectedError" : "Error while executing: CREATE TEMPORARY TABLE leSchema.tb"
   }, {
-    "test" : "meta::pure::functions::relation::tests::composition::testVariantColumn_filterOnIsEmptyOfModelConversionToMany_Function_1__Boolean_1_",
+    "test" : "meta::pure::functions::relation::tests::composition::testVariantColumn_filterOnIsEmptyOfModelConversion_Function_1__Boolean_1_",
     "expectedError" : "Error while executing: CREATE TEMPORARY TABLE leSchema.tb"
   }, {
     "test" : "meta::pure::functions::relation::tests::composition::testVariantColumn_slice_Function_1__Boolean_1_",

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-oracle/legend-engine-xt-relationalStore-oracle-PCT/src/main/resources/pct-manifests/relational-oracle/RelationFunctions_manifest.json
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-oracle/legend-engine-xt-relationalStore-oracle-PCT/src/main/resources/pct-manifests/relational-oracle/RelationFunctions_manifest.json
@@ -148,7 +148,7 @@
     "test" : "meta::pure::functions::relation::tests::composition::testVariantColumn_filterOnIsNotEmptyOfModelConversion_Function_1__Boolean_1_",
     "expectedError" : "\"[unsupported-api] Semi structured array element processing not supported for Database Type: Oracle\""
   }, {
-    "test" : "meta::pure::functions::relation::tests::composition::testVariantColumn_filterOnIsEmptyOfModelConversionToMany_Function_1__Boolean_1_",
+    "test" : "meta::pure::functions::relation::tests::composition::testVariantColumn_filterOnIsEmptyOfModelConversion_Function_1__Boolean_1_",
     "expectedError" : "\"[unsupported-api] Semi structured array element processing not supported for Database Type: Oracle\""
   }, {
     "test" : "meta::pure::functions::relation::tests::filter::testVariantColumn_filterOnKeyExtractionValue_Function_1__Boolean_1_",

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-oracle/legend-engine-xt-relationalStore-oracle-PCT/src/main/resources/pct-manifests/relational-oracle/RelationFunctions_manifest.json
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-oracle/legend-engine-xt-relationalStore-oracle-PCT/src/main/resources/pct-manifests/relational-oracle/RelationFunctions_manifest.json
@@ -145,6 +145,12 @@
     "test" : "meta::pure::functions::relation::tests::filter::testVariantColumn_filterOnIsNotEmptyOfKeyExtraction_Function_1__Boolean_1_",
     "expectedError" : "[unsupported-api] Semi structured array element processing not supported for Database Type: Oracle"
   }, {
+    "test" : "meta::pure::functions::relation::tests::composition::testVariantColumn_filterOnIsNotEmptyOfModelConversion_Function_1__Boolean_1_",
+    "expectedError" : "\"[unsupported-api] Semi structured array element processing not supported for Database Type: Oracle\""
+  }, {
+    "test" : "meta::pure::functions::relation::tests::composition::testVariantColumn_filterOnIsEmptyOfModelConversionToMany_Function_1__Boolean_1_",
+    "expectedError" : "\"[unsupported-api] Semi structured array element processing not supported for Database Type: Oracle\""
+  }, {
     "test" : "meta::pure::functions::relation::tests::filter::testVariantColumn_filterOnKeyExtractionValue_Function_1__Boolean_1_",
     "expectedError" : "\"[unsupported-api] Semi structured array element processing not supported for Database Type: Oracle\""
   }, {

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-spanner/legend-engine-xt-relationalStore-spanner-PCT/src/main/resources/pct-manifests/relational-spanner/RelationFunctions_manifest.json
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-spanner/legend-engine-xt-relationalStore-spanner-PCT/src/main/resources/pct-manifests/relational-spanner/RelationFunctions_manifest.json
@@ -94,7 +94,7 @@
     "test" : "meta::pure::functions::relation::tests::composition::testVariantColumn_filterOnIsNotEmptyOfModelConversion_Function_1__Boolean_1_",
     "expectedError" : "[unsupported-api] Semi structured array element processing not supported for Database Type: Spanner"
   }, {
-    "test" : "meta::pure::functions::relation::tests::composition::testVariantColumn_filterOnIsEmptyOfModelConversionToMany_Function_1__Boolean_1_",
+    "test" : "meta::pure::functions::relation::tests::composition::testVariantColumn_filterOnIsEmptyOfModelConversion_Function_1__Boolean_1_",
     "expectedError" : "[unsupported-api] Semi structured array element processing not supported for Database Type: Spanner"
   }, {
     "test" : "meta::pure::functions::relation::tests::filter::testVariantColumn_filterOnIsNotEmptyOfKeyExtraction_Function_1__Boolean_1_",

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-spanner/legend-engine-xt-relationalStore-spanner-PCT/src/main/resources/pct-manifests/relational-spanner/RelationFunctions_manifest.json
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-spanner/legend-engine-xt-relationalStore-spanner-PCT/src/main/resources/pct-manifests/relational-spanner/RelationFunctions_manifest.json
@@ -91,6 +91,12 @@
     "test" : "meta::pure::functions::relation::tests::filter::testVariantColumn_filterOnIsEmptyOfKeyExtraction_Function_1__Boolean_1_",
     "expectedError" : "[unsupported-api] Semi structured array element processing not supported for Database Type: Spanner"
   }, {
+    "test" : "meta::pure::functions::relation::tests::composition::testVariantColumn_filterOnIsNotEmptyOfModelConversion_Function_1__Boolean_1_",
+    "expectedError" : "[unsupported-api] Semi structured array element processing not supported for Database Type: Spanner"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::composition::testVariantColumn_filterOnIsEmptyOfModelConversionToMany_Function_1__Boolean_1_",
+    "expectedError" : "[unsupported-api] Semi structured array element processing not supported for Database Type: Spanner"
+  }, {
     "test" : "meta::pure::functions::relation::tests::filter::testVariantColumn_filterOnIsNotEmptyOfKeyExtraction_Function_1__Boolean_1_",
     "expectedError" : "[unsupported-api] Semi structured array element processing not supported for Database Type: Spanner"
   }, {

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-sqlserver/legend-engine-xt-relationalStore-sqlserver-PCT/src/main/resources/pct-manifests/relational-sqlserver/RelationFunctions_manifest.json
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-sqlserver/legend-engine-xt-relationalStore-sqlserver-PCT/src/main/resources/pct-manifests/relational-sqlserver/RelationFunctions_manifest.json
@@ -163,7 +163,7 @@
     "test" : "meta::pure::functions::relation::tests::composition::testVariantColumn_filterOnIsNotEmptyOfModelConversion_Function_1__Boolean_1_",
     "expectedError" : "[unsupported-api] Semi structured array element processing not supported for Database Type: SqlServer"
   }, {
-    "test" : "meta::pure::functions::relation::tests::composition::testVariantColumn_filterOnIsEmptyOfModelConversionToMany_Function_1__Boolean_1_",
+    "test" : "meta::pure::functions::relation::tests::composition::testVariantColumn_filterOnIsEmptyOfModelConversion_Function_1__Boolean_1_",
     "expectedError" : "[unsupported-api] Semi structured array element processing not supported for Database Type: SqlServer"
   }, {
     "test": "meta::pure::functions::relation::tests::filter::testVariantColumn_filterOnIsNotEmptyOfKeyExtraction_Function_1__Boolean_1_",

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-sqlserver/legend-engine-xt-relationalStore-sqlserver-PCT/src/main/resources/pct-manifests/relational-sqlserver/RelationFunctions_manifest.json
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-sqlserver/legend-engine-xt-relationalStore-sqlserver-PCT/src/main/resources/pct-manifests/relational-sqlserver/RelationFunctions_manifest.json
@@ -160,6 +160,12 @@
     "test": "meta::pure::functions::relation::tests::filter::testVariantColumn_filterOnIsEmptyOfKeyExtraction_Function_1__Boolean_1_",
     "expectedError": "[unsupported-api] Semi structured array element processing not supported for Database Type: SqlServer"
   }, {
+    "test" : "meta::pure::functions::relation::tests::composition::testVariantColumn_filterOnIsNotEmptyOfModelConversion_Function_1__Boolean_1_",
+    "expectedError" : "[unsupported-api] Semi structured array element processing not supported for Database Type: SqlServer"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::composition::testVariantColumn_filterOnIsEmptyOfModelConversionToMany_Function_1__Boolean_1_",
+    "expectedError" : "[unsupported-api] Semi structured array element processing not supported for Database Type: SqlServer"
+  }, {
     "test": "meta::pure::functions::relation::tests::filter::testVariantColumn_filterOnIsNotEmptyOfKeyExtraction_Function_1__Boolean_1_",
     "expectedError": "[unsupported-api] Semi structured array element processing not supported for Database Type: SqlServer"
   }, {

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-trino/legend-engine-xt-relationalStore-trino-PCT/src/main/resources/pct-manifests/relational-trino/RelationFunctions_manifest.json
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-trino/legend-engine-xt-relationalStore-trino-PCT/src/main/resources/pct-manifests/relational-trino/RelationFunctions_manifest.json
@@ -160,6 +160,12 @@
     "test" : "meta::pure::functions::relation::tests::filter::testVariantColumn_filterOnKeyExtractionValue_Function_1__Boolean_1_",
     "expectedError" : "[unsupported-api] Semi structured array element processing not supported for Database Type: Trino"
   }, {
+    "test" : "meta::pure::functions::relation::tests::composition::testVariantColumn_filterOnIsNotEmptyOfModelConversion_Function_1__Boolean_1_",
+    "expectedError" : "[unsupported-api] Semi structured array element processing not supported for Database Type: Trino"
+  }, {
+    "test" : "meta::pure::functions::relation::tests::composition::testVariantColumn_filterOnIsEmptyOfModelConversionToMany_Function_1__Boolean_1_",
+    "expectedError" : "[unsupported-api] Semi structured array element processing not supported for Database Type: Trino"
+  }, {
     "test": "meta::pure::functions::relation::tests::filter::testVariantColumn_filterOnIsEmptyOfKeyExtraction_Function_1__Boolean_1_",
     "expectedError": "[unsupported-api] Semi structured array element processing not supported for Database Type: Trino"
   }, {

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-trino/legend-engine-xt-relationalStore-trino-PCT/src/main/resources/pct-manifests/relational-trino/RelationFunctions_manifest.json
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-trino/legend-engine-xt-relationalStore-trino-PCT/src/main/resources/pct-manifests/relational-trino/RelationFunctions_manifest.json
@@ -163,7 +163,7 @@
     "test" : "meta::pure::functions::relation::tests::composition::testVariantColumn_filterOnIsNotEmptyOfModelConversion_Function_1__Boolean_1_",
     "expectedError" : "[unsupported-api] Semi structured array element processing not supported for Database Type: Trino"
   }, {
-    "test" : "meta::pure::functions::relation::tests::composition::testVariantColumn_filterOnIsEmptyOfModelConversionToMany_Function_1__Boolean_1_",
+    "test" : "meta::pure::functions::relation::tests::composition::testVariantColumn_filterOnIsEmptyOfModelConversion_Function_1__Boolean_1_",
     "expectedError" : "[unsupported-api] Semi structured array element processing not supported for Database Type: Trino"
   }, {
     "test": "meta::pure::functions::relation::tests::filter::testVariantColumn_filterOnIsEmptyOfKeyExtraction_Function_1__Boolean_1_",

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery.pure
@@ -4440,7 +4440,7 @@ function meta::relational::functions::pureToSqlQuery::processEmpty(f:FunctionExp
             $fe.genericType.rawType->match(
                   [
                      d:DataType[1]| $f->processSubEmpty($currentPropertyMapping, $operation, $vars, $state, $joinType, $nodeId, $aggFromMap, $context, $extensions);
-                     ,c:Class<Any>[1] | if($fe->isScalarVariantExpression(),
+                     ,c:Class<Any>[1] | if($fe.multiplicity->hasToOneUpperBound() && $fe->isVariantInput($vars, $state),
                                                 | $f->processSubEmpty($currentPropertyMapping, $operation, $vars, $state, $joinType, $nodeId, $aggFromMap, $context, $extensions),
                                                 | processExists($f, $not, $currentPropertyMapping, $operation, $vars, $state, $nodeId, $aggFromMap, $context, $extensions)
                                           )
@@ -4513,7 +4513,7 @@ function meta::relational::functions::pureToSqlQuery::processSubEmpty(f:Function
    let parameters = $f.parametersValues->at(0);
    let isParameterPlanVarOfTypeList = isParamPlanVar($parameters, $vars, $state.inScopeVars) && $parameters.multiplicity == ZeroMany;
 
-   let isEmptyExpressionValid = $parameters->match([v:FunctionExpression[1]| $v.func == map_T_m__Function_1__V_m_  || $v.func == map_T_MANY__Function_1__V_MANY_ || !$v.genericType.rawType->toOne()->instanceOf(Class) || $v->isScalarVariantExpression();,
+   let isEmptyExpressionValid = $parameters->match([v:FunctionExpression[1]| $v.func == map_T_m__Function_1__V_m_  || $v.func == map_T_MANY__Function_1__V_MANY_ || !$v.genericType.rawType->toOne()->instanceOf(Class) || ($v.multiplicity->hasToOneUpperBound() && $v->isVariantInput($vars, $state));,
                                                     a:Any[1]| true;]);
 
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery_variant.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery_variant.pure
@@ -569,14 +569,6 @@ function meta::relational::functions::pureToSqlQuery::processVariantAt(f:Functio
   ^$operation(select = $state.inFilter->if(|^$select(filteringOperation = $relOpElement),|^$select(columns = $relOpElement)));
 }
 
-// Variant is a Class in the metamodel but a value in SQL, so a to-one Variant expression is a
-// scalar: a null check on it is a plain IS NULL predicate, not the existence check needed for a
-// to-many navigation (a variant array, or a navigation to a mapped class).
-function meta::relational::functions::pureToSqlQuery::isScalarVariantExpression(v: ValueSpecification[1]):Boolean[1]
-{
-  $v.genericType.rawType == meta::pure::metamodel::variant::Variant && $v.multiplicity->hasToOneUpperBound();
-}
-
 function meta::relational::functions::pureToSqlQuery::processMapGet(f:FunctionExpression[1], currentPropertyMapping:PropertyMapping[*], operation:SelectWithCursor[1], vars:Map<VariableExpression, ValueSpecification>[1], state:State[1], joinType:JoinType[1], nodeId:String[1], aggFromMap:List<ColumnGroup>[1], context:DebugContext[1], extensions:Extension[*]):RelationalOperationElement[1]
 {
   let params = $f.parametersValues->evaluateAndDeactivate();


### PR DESCRIPTION
#### What type of PR is this?

Choose one of the following labels :
- Improvement

#### What does this PR do / why is it needed ?

The previous revision added a new helper isScalarVariantExpression(), which only compared the final raw type to Vairant. That is narrow, and it misses expressions whose source was a variant but whose type no lnger is variant, also that function is a bit redundant. Hence, use the existing isVariantInput, which walks the expression to see whether it was ever sourced from a variant.
