### PR TITLE
Fix plan generation for IN (Subquery) Over a union / multi table outer relation

### DIFF
--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/quantification/in.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/quantification/in.pure
@@ -297,6 +297,37 @@ function <<PCT.test>> meta::pure::functions::relation::tests::in::testIn_Grouped
                  '#', $res->sort(~departmentId->ascending())->toString());
 }
 
+function <<PCT.test>> meta::pure::functions::relation::tests::in::testIn_SubQueryOverConcatenatedRelation<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let accounts = #TDS
+                                   accountId, accountName
+                                   1, Alice
+                                   2, Bob
+                                   3, Carol
+                                 #;
+                  let eligibility = #TDS
+                                      eligibleId, businessLine
+                                      1, PWM
+                                      2, PWM
+                                      4, OTHER
+                                    #;
+                  $accounts->extend(~status : a | 'A')
+                           ->concatenate($accounts->extend(~status : a | 'B'))
+                           ->filter(r | $r.accountId->in($eligibility->filter(e | $e.businessLine == 'PWM')->select(~eligibleId)->distinct()));
+               };
+
+    let res = $f->eval($expr);
+
+    assertEquals('#TDS\n'+
+                 '   accountId,accountName,status\n'+
+                 '   1,Alice,A\n'+
+                 '   1,Alice,B\n'+
+                 '   2,Bob,A\n'+
+                 '   2,Bob,B\n'+
+                 '#', $res->sort([~accountId->ascending(), ~status->ascending()])->toString());
+}
+
 function <<PCT.test>> meta::pure::functions::relation::tests::in::testIn_DerivedRelation<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
     let expr = {|

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/quantification/in.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/quantification/in.pure
@@ -297,37 +297,6 @@ function <<PCT.test>> meta::pure::functions::relation::tests::in::testIn_Grouped
                  '#', $res->sort(~departmentId->ascending())->toString());
 }
 
-function <<PCT.test>> meta::pure::functions::relation::tests::in::testIn_SubQueryOverConcatenatedRelation<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
-{
-    let expr = {|
-                  let accounts = #TDS
-                                   accountId, accountName
-                                   1, Alice
-                                   2, Bob
-                                   3, Carol
-                                 #;
-                  let eligibility = #TDS
-                                      eligibleId, businessLine
-                                      1, PWM
-                                      2, PWM
-                                      4, OTHER
-                                    #;
-                  $accounts->extend(~status : a | 'A')
-                           ->concatenate($accounts->extend(~status : a | 'B'))
-                           ->filter(r | $r.accountId->in($eligibility->filter(e | $e.businessLine == 'PWM')->select(~eligibleId)->distinct()));
-               };
-
-    let res = $f->eval($expr);
-
-    assertEquals('#TDS\n'+
-                 '   accountId,accountName,status\n'+
-                 '   1,Alice,A\n'+
-                 '   1,Alice,B\n'+
-                 '   2,Bob,A\n'+
-                 '   2,Bob,B\n'+
-                 '#', $res->sort([~accountId->ascending(), ~status->ascending()])->toString());
-}
-
 function <<PCT.test>> meta::pure::functions::relation::tests::in::testIn_DerivedRelation<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
     let expr = {|

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/tests/composition.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/tests/composition.pure
@@ -2210,6 +2210,34 @@ function <<PCT.test>> meta::pure::functions::relation::tests::composition::testC
                  '#', $res->sort(~id->ascending())->toString());
 }
 
+function <<PCT.test>> meta::pure::functions::relation::tests::composition::testConcatenateFilterInSubQuery<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {|
+                  let accounts = #TDS
+                                   accountId, accountName
+                                   1, Alice
+                                   2, Bob
+                                   3, Carol
+                                 #;
+                  $accounts->concatenate($accounts)
+                           ->filter(r | $r.accountId->meta::pure::functions::relation::in(#TDS
+                                                           eligibleId
+                                                           1
+                                                           2
+                                                         #->select(~eligibleId)));
+               };
+ 
+    let res = $f->eval($expr);
+ 
+    assertEquals('#TDS\n'+
+                 '   accountId,accountName\n'+
+                 '   1,Alice\n'+
+                 '   1,Alice\n'+
+                 '   2,Bob\n'+
+                 '   2,Bob\n'+
+                 '#', $res->sort(~accountId->ascending())->toString());
+}
+
 function <<PCT.test, PCTRelationQualifier.relation, PCTCoreQualifier.variant>> meta::pure::functions::relation::tests::composition::testVariantMapColumn_keys_LateralFlatten<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
 {
    let tds = #TDS

--- a/legend-engine-xts-deephaven/legend-engine-xt-deephaven-PCT/src/main/resources/pct-manifests/deephaven/RelationFunctions_manifest.json
+++ b/legend-engine-xts-deephaven/legend-engine-xt-deephaven-PCT/src/main/resources/pct-manifests/deephaven/RelationFunctions_manifest.json
@@ -476,6 +476,9 @@
     "expectedError" : "Cannot cast a collection of size 0 to multiplicity [1]"
   }, {
     "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_CorrelatedSubQuery_Function_1__Boolean_1_",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction",
+  }, {
+    "test" : "meta::pure::functions::relation::tests::in::testIn_SubQueryOverConcatenatedRelation_Function_1__Boolean_1_",
     "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
   }, {
     "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_DerivedRelation_Function_1__Boolean_1_",

--- a/legend-engine-xts-deephaven/legend-engine-xt-deephaven-PCT/src/main/resources/pct-manifests/deephaven/RelationFunctions_manifest.json
+++ b/legend-engine-xts-deephaven/legend-engine-xt-deephaven-PCT/src/main/resources/pct-manifests/deephaven/RelationFunctions_manifest.json
@@ -478,7 +478,7 @@
     "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_CorrelatedSubQuery_Function_1__Boolean_1_",
     "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
   }, {
-    "test" : "meta::pure::functions::relation::tests::in::testIn_SubQueryOverConcatenatedRelation_Function_1__Boolean_1_",
+    "test" : "meta::pure::functions::relation::tests::composition::testConcatenateFilterInSubQuery_Function_1__Boolean_1_",
     "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
   }, {
     "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_DerivedRelation_Function_1__Boolean_1_",

--- a/legend-engine-xts-deephaven/legend-engine-xt-deephaven-PCT/src/main/resources/pct-manifests/deephaven/RelationFunctions_manifest.json
+++ b/legend-engine-xts-deephaven/legend-engine-xt-deephaven-PCT/src/main/resources/pct-manifests/deephaven/RelationFunctions_manifest.json
@@ -476,7 +476,7 @@
     "expectedError" : "Cannot cast a collection of size 0 to multiplicity [1]"
   }, {
     "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_CorrelatedSubQuery_Function_1__Boolean_1_",
-    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction",
+    "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"
   }, {
     "test" : "meta::pure::functions::relation::tests::in::testIn_SubQueryOverConcatenatedRelation_Function_1__Boolean_1_",
     "expectedError" : "Match failure: LambdaFunctionObject instanceOf LambdaFunction"

--- a/legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-PCT/src/main/resources/pct-manifests/java/Test_JAVA_RelationFunction_manifest.json
+++ b/legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-PCT/src/main/resources/pct-manifests/java/Test_JAVA_RelationFunction_manifest.json
@@ -662,6 +662,10 @@
       "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
     },
     {
+      "test": "meta::pure::functions::relation::tests::in::testIn_SubQueryOverConcatenatedRelation_Function_1__Boolean_1_",
+      "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
+    },
+    {
       "test": "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_DerivedRelation_Function_1__Boolean_1_",
       "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
     },

--- a/legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-PCT/src/main/resources/pct-manifests/java/Test_JAVA_RelationFunction_manifest.json
+++ b/legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-PCT/src/main/resources/pct-manifests/java/Test_JAVA_RelationFunction_manifest.json
@@ -662,7 +662,7 @@
       "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
     },
     {
-      "test": "meta::pure::functions::relation::tests::in::testIn_SubQueryOverConcatenatedRelation_Function_1__Boolean_1_",
+      "test": "meta::pure::functions::relation::tests::composition::testConcatenateFilterInSubQuery_Function_1__Boolean_1_",
       "expectedError": "Instance of type 'meta::pure::metamodel::relation::TDS' can't be translated"
     },
     {

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-PCT/src/main/resources/pct-manifests/relational-memsql/RelationFunctions_manifest.json
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-PCT/src/main/resources/pct-manifests/relational-memsql/RelationFunctions_manifest.json
@@ -268,6 +268,9 @@
     "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_CorrelatedSubQuery_Function_1__Boolean_1_",
     "expectedError" : "cannot appear in the definition of common table expression."
   }, {
+    "test" : "meta::pure::functions::relation::tests::in::testIn_SubQueryOverConcatenatedRelation_Function_1__Boolean_1_",
+    "expectedError" : "cannot appear in the definition of common table expression."
+  }, {
     "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_DerivedRelation_Function_1__Boolean_1_",
     "expectedError" : "cannot appear in the definition of common table expression."
   }, {

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-PCT/src/main/resources/pct-manifests/relational-memsql/RelationFunctions_manifest.json
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-PCT/src/main/resources/pct-manifests/relational-memsql/RelationFunctions_manifest.json
@@ -268,7 +268,7 @@
     "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_CorrelatedSubQuery_Function_1__Boolean_1_",
     "expectedError" : "cannot appear in the definition of common table expression."
   }, {
-    "test" : "meta::pure::functions::relation::tests::in::testIn_SubQueryOverConcatenatedRelation_Function_1__Boolean_1_",
+    "test" : "meta::pure::functions::relation::tests::composition::testConcatenateFilterInSubQuery_Function_1__Boolean_1_",
     "expectedError" : "cannot appear in the definition of common table expression."
   }, {
     "test" : "meta::pure::functions::relation::tests::greaterThanAll::testGreaterThanAll_DerivedRelation_Function_1__Boolean_1_",

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery.pure
@@ -6872,7 +6872,7 @@ function <<access.private>> meta::relational::functions::pureToSqlQuery::exclude
 function <<access.private>> meta::relational::functions::pureToSqlQuery::buildRelationSubSelect(expression:FunctionExpression[1], relationParamIndex:Integer[1], currentPropertyMapping:PropertyMapping[*], operation:SelectWithCursor[1], vars:Map<VariableExpression, ValueSpecification>[1], state:State[1], nodeId:String[1], aggFromMap:List<ColumnGroup>[1], context:DebugContext[1], extensions:Extension[*]):SelectSQLQuery[1]
 {
    let innerNodeId = buildNodeId($nodeId, '_e' + $relationParamIndex->toString());
-   let inner = processValueSpecification($expression.parametersValues->at($relationParamIndex), $currentPropertyMapping, ^$operation(parent = $operation), $vars, ^$state(inFilter = false, shouldIsolate = false, correlatedScopeId = $innerNodeId), JoinType.INNER, $innerNodeId, $aggFromMap, $context, $extensions)
+   let inner = processValueSpecification($expression.parametersValues->at($relationParamIndex), $currentPropertyMapping, ^$operation(select = ^SelectSQLQuery(), parent = $operation, currentTreeNode = [], positionBeforeLastApplyJoinTreeNode = []), $vars, ^$state(inFilter = false, shouldIsolate = false, correlatedScopeId = $innerNodeId), JoinType.INNER, $innerNodeId, $aggFromMap, $context, $extensions)
                  ->toOne()->cast(@SelectWithCursor);
 
    // Renamed here rather than while the sub-relation was being built: everything that keys off the

--- a/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/src/test/resources/parity-tests/structural/subqueries.yaml
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/src/test/resources/parity-tests/structural/subqueries.yaml
@@ -126,7 +126,7 @@ tests:
     feature: "Subquery with UNION"
     category: "subqueries"
     expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_rel_status: PASS
 
   # IN (subquery) where the outer relation is a UNION - the subquery has to be planned from an empty
   # query rather than from the union it sits under
@@ -138,7 +138,7 @@ tests:
     expected_rel_status: PASS
 
   - id: subquery_in_over_union_wildcard
-    sql: "SELECT * FROM (SELECT id, name FROM persons WHERE dept_id = 1 UNION ALL SELECT id, name FROM persons WHERE dept_id = 3) sub WHERE sub.id IN (SELECT person_id FROM orders WHERE status = 'completed') ORDER BY 1"
+    sql: "SELECT * FROM (SELECT id, name FROM persons WHERE dept_id = 1 UNION ALL SELECT id, name FROM persons WHERE dept_id = 3) sub WHERE sub.id IN (SELECT person_id FROM orders WHERE status = 'completed') ORDER BY sub.id"
     feature: "IN (subquery) over a UNION"
     category: "subqueries"
     expected_tds_status: ERROR

--- a/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/src/test/resources/parity-tests/structural/subqueries.yaml
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/src/test/resources/parity-tests/structural/subqueries.yaml
@@ -128,6 +128,38 @@ tests:
     expected_tds_status: ERROR
     expected_rel_status: ERROR
 
+  # IN (subquery) where the outer relation is a UNION - the subquery has to be planned from an empty
+  # query rather than from the union it sits under
+  - id: subquery_in_over_union
+    sql: "SELECT sub.id, sub.name FROM (SELECT id, name FROM persons WHERE dept_id = 1 UNION ALL SELECT id, name FROM persons WHERE dept_id = 2) sub WHERE sub.id IN (SELECT person_id FROM orders WHERE amount > 100) ORDER BY 1"
+    feature: "IN (subquery) over a UNION"
+    category: "subqueries"
+    expected_tds_status: ERROR
+    expected_rel_status: PASS
+
+  - id: subquery_in_over_union_wildcard
+    sql: "SELECT * FROM (SELECT id, name FROM persons WHERE dept_id = 1 UNION ALL SELECT id, name FROM persons WHERE dept_id = 3) sub WHERE sub.id IN (SELECT person_id FROM orders WHERE status = 'completed') ORDER BY 1"
+    feature: "IN (subquery) over a UNION"
+    category: "subqueries"
+    expected_tds_status: ERROR
+    expected_rel_status: PASS
+
+  - id: subquery_in_over_union_outer_filter
+    sql: "SELECT sub.id, sub.name FROM (SELECT id, name FROM persons WHERE dept_id = 1 UNION ALL SELECT id, name FROM persons WHERE dept_id = 2) sub WHERE sub.name <> 'Bob' AND sub.id IN (SELECT o.person_id FROM orders o WHERE o.status = 'completed') ORDER BY 1"
+    feature: "IN (subquery) over a UNION"
+    category: "subqueries"
+    expected_tds_status: ERROR
+    expected_rel_status: PASS
+
+  # DISTINCT in the subquery merges onto the query it is handed, so it sees the outer columns as well
+  # when the subquery is not started from an empty one
+  - id: subquery_in_distinct_over_union
+    sql: "SELECT sub.id, sub.name FROM (SELECT id, name FROM persons WHERE dept_id = 1 UNION ALL SELECT id, name FROM persons WHERE dept_id = 2) sub WHERE sub.id IN (SELECT DISTINCT person_id FROM orders WHERE amount > 200) ORDER BY 1"
+    feature: "IN (DISTINCT subquery) over a UNION"
+    category: "subqueries"
+    expected_tds_status: ERROR
+    expected_rel_status: PASS
+
   # Lateral-style derived table with aggregation
   - id: subquery_derived_agg_filter
     sql: "SELECT sub.dept_id, sub.total FROM (SELECT dept_id, SUM(salary) AS total FROM persons WHERE salary IS NOT NULL AND dept_id IS NOT NULL GROUP BY dept_id HAVING SUM(salary) > 100000) sub ORDER BY 1"

--- a/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/src/test/resources/parity-tests/structural/subqueries.yaml
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/src/test/resources/parity-tests/structural/subqueries.yaml
@@ -128,34 +128,10 @@ tests:
     expected_tds_status: ERROR
     expected_rel_status: PASS
 
-  # IN (subquery) where the outer relation is a UNION - the subquery has to be planned from an empty
-  # query rather than from the union it sits under
+  # IN (subquery) where the outer relation is a UNION
   - id: subquery_in_over_union
     sql: "SELECT sub.id, sub.name FROM (SELECT id, name FROM persons WHERE dept_id = 1 UNION ALL SELECT id, name FROM persons WHERE dept_id = 2) sub WHERE sub.id IN (SELECT person_id FROM orders WHERE amount > 100) ORDER BY 1"
     feature: "IN (subquery) over a UNION"
-    category: "subqueries"
-    expected_tds_status: ERROR
-    expected_rel_status: PASS
-
-  - id: subquery_in_over_union_wildcard
-    sql: "SELECT * FROM (SELECT id, name FROM persons WHERE dept_id = 1 UNION ALL SELECT id, name FROM persons WHERE dept_id = 3) sub WHERE sub.id IN (SELECT person_id FROM orders WHERE status = 'completed') ORDER BY sub.id"
-    feature: "IN (subquery) over a UNION"
-    category: "subqueries"
-    expected_tds_status: ERROR
-    expected_rel_status: PASS
-
-  - id: subquery_in_over_union_outer_filter
-    sql: "SELECT sub.id, sub.name FROM (SELECT id, name FROM persons WHERE dept_id = 1 UNION ALL SELECT id, name FROM persons WHERE dept_id = 2) sub WHERE sub.name <> 'Bob' AND sub.id IN (SELECT o.person_id FROM orders o WHERE o.status = 'completed') ORDER BY 1"
-    feature: "IN (subquery) over a UNION"
-    category: "subqueries"
-    expected_tds_status: ERROR
-    expected_rel_status: PASS
-
-  # DISTINCT in the subquery merges onto the query it is handed, so it sees the outer columns as well
-  # when the subquery is not started from an empty one
-  - id: subquery_in_distinct_over_union
-    sql: "SELECT sub.id, sub.name FROM (SELECT id, name FROM persons WHERE dept_id = 1 UNION ALL SELECT id, name FROM persons WHERE dept_id = 2) sub WHERE sub.id IN (SELECT DISTINCT person_id FROM orders WHERE amount > 200) ORDER BY 1"
-    feature: "IN (DISTINCT subquery) over a UNION"
     category: "subqueries"
     expected_tds_status: ERROR
     expected_rel_status: PASS


### PR DESCRIPTION
#### What type of PR is this?

Choose one of the following labels :
- Bug Fix

#### What does this PR do / why is it needed ?

A #SQL{} query that filters an outer relation with a relation valued subquery failes at plan generation, it's getting **node validation error**. 

**For example:**
A query that unions two relations and then filters the result with a subquery - "give me the rows whose id appears in this other set", is failing at plan generation. 

Here union along is fine, and the subquery filter alone is fine. Only the combination failes. This isn't limited to union or to IN. Any outer query that has already established what it is reading from, combined with any subquery which is flowing through **buildingRelationSubSelect** function hits same failure.

#### Why it happened

When the planner builds the inner subquery, it used to start from a copy of the query it sits inside. That copy carried two things it had no business inheriting: a marker pointing at the outer query's own data source (current tree node), and the outer query's column list. The subquery reads something entirely different, so the marker referred to a table the subquery doesn't have, which is what the planner's own check is there to catch, and separately, the inherited column list made the subquery look as though it returned several columns, whereas an IN () check requires one, so that combination was rejected.

