### PR TITLE
Fix milestoning date resolution for derived date arguments in nested lambdas

### DIFF
--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/milestoning/milestoning.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/milestoning/milestoning.pure
@@ -647,7 +647,8 @@ function <<access.private>> meta::relational::milestoning::resolveMilestoningDat
    $singleTemporalStrategyAndParam->map(dp | let d = $dp.second;
                                             $d->byPassRouterInfo()->match([ v: VariableExpression[1] | let resolvedVar = $inScopeVars->get($v.name).values->at(0);
                                                                                             let dateRoe = $resolvedVar->match([d:Date[1]|^Literal(value=$d),
-                                                                                                                               p:PlanVarPlaceHolder[1]|^Literal(value=^VarPlaceHolder(name=$p.name,type = $p.genericType.rawType->toOne()));]);
+                                                                                                                               p:PlanVarPlaceHolder[1]|^Literal(value=^VarPlaceHolder(name=$p.name,type = $p.genericType.rawType->toOne())),
+                                                                                                                               a:Any[*]|resolveMilestoningDateParams($temporalStrategy, ^InstanceValue(genericType=^GenericType(rawType=Date), multiplicity=PureOne, values=$a)->cast(@ValueSpecification), $currentMilestoningContext, $state, $vars, $context, $extensions).date->first();]);
                                                                                             ^DateWrapper(date=$dateRoe);,
                                                                  i: InstanceValue[1] | $i.values->at(0)->match([
                                                                                           d: Date[1]               | ^DateWrapper(date=^Literal(value=$d));,
@@ -658,14 +659,17 @@ function <<access.private>> meta::relational::milestoning::resolveMilestoningDat
                                                                                             let isThisMilestonedGeneratedDateProperty = $f->isThisMilestonedGeneratedDateProperty();
                                                                                             if($isThisMilestonedGeneratedDateProperty && $currentMilestoningContext->isNotEmpty(),| let tp = TemporalMilestoningContext.properties->filter(p|$p.name->toOne() == $f.func.name)->toOne();
                                                                                                                                                                                     $tp->eval($currentMilestoningContext)->map(d|^DateWrapper(date=$d->cast(@RelationalOperationElement)));
-                                                                                                                                                                                 ,|if($f->isNonThisRootVariableExpression(),| 
+                                                                                                                                                                                 ,|if($f->isNonThisRootVariableExpression() || ($f->referencesVariableExpression() && !$f->referencesThis()),| 
                                                                                                                                                                                           if($state.functionExpressionStack->last()->evaluateAndDeactivate().func->in([
                                                                                                                                                                                               getAll_Class_1__Date_1__Date_1__T_MANY_, 
                                                                                                                                                                                               getAll_Class_1__Date_1__T_MANY_, 
                                                                                                                                                                                               getAllVersionsInRange_Class_1__Date_1__Date_1__T_MANY_
                                                                                                                                                                                               ]), 
                                                                                                                                                                                              | ^DateWrapper(date = processFunctionExpression($f, [], ^SelectWithCursor(select=^SelectSQLQuery()), $vars, ^$state(functionExpressionStack+=$f), JoinType.LEFT_OUTER, '', ^List<ColumnGroup>(values = []), $context, $extensions).element->cast(@SelectWithCursor).select.columns->first()), 
-                                                                                                                                                                                             | ^DateWrapper() //change this so we look at the state + add test for range
+                                                                                                                                                                                             | if($f->hasAnyUnresolvableOrPlaceholderVar($inScopeVars),
+                                                                                                                                                                                                  | ^DateWrapper(date = processFunctionExpression($f, [], ^SelectWithCursor(select=^SelectSQLQuery()), $vars, ^$state(functionExpressionStack+=$f), JoinType.LEFT_OUTER, '', ^List<ColumnGroup>(values = []), $context, $extensions).element->cast(@SelectWithCursor).select.columns->first()),
+                                                                                                                                                                                                  | $f->reactivate($inScopeVars)->map(d|^DateWrapper(date=^Literal(value=$d->cast(@Date))))
+                                                                                                                                                                                               )
                                                                                                                                                                                           )
                                                                                                                                                                                                                            ,| if($f->referencesVariableExpression()
                                                                                                                                                                                                                                  ,|  let new = newThisMilestonedPropertyExpression($singleTemporalStrategy);
@@ -723,6 +727,36 @@ function <<access.private>> meta::relational::milestoning::isNonThisRootVariable
    $v->byPassRouterInfo()->match([f:FunctionExpression[1] | if($f.parametersValues->isNotEmpty(),|$f.parametersValues->at(0)->isNonThisRootVariableExpression(),|false),
                                   v:VariableExpression[1] | $v.name != 'this',
                                   v:ValueSpecification[1] | false])
+}
+
+function <<access.private>> meta::relational::milestoning::getRootVariableName(v:ValueSpecification[1]):String[0..1]
+{
+   $v->byPassRouterInfo()->match([f:FunctionExpression[1] | if($f.parametersValues->isNotEmpty(),|$f.parametersValues->at(0)->getRootVariableName(),|[]),
+                                  v:VariableExpression[1] | $v.name,
+                                  v:ValueSpecification[1] | []])
+}
+
+function <<access.private>> meta::relational::milestoning::collectVariableExpressions(v:ValueSpecification[1]):VariableExpression[*]
+{
+   $v->byPassRouterInfo()->match([f:FunctionExpression[1] | $f.parametersValues->map(p|$p->collectVariableExpressions()),
+                                  v:VariableExpression[1] | $v,
+                                  e:ExtendedRoutedValueSpecification[1] | $e->byPassRouterInfo()->collectVariableExpressions(),
+                                  v:ValueSpecification[1] | []])
+}
+
+function <<access.private>> meta::relational::milestoning::referencesThis(v:ValueSpecification[1]):Boolean[1]
+{
+   $v->byPassRouterInfo()->match([f:FunctionExpression[1] | $f.parametersValues->fold({x, y| $x->referencesThis() || $y }, false),
+                                  v:VariableExpression[1] | $v.name == 'this',
+                                  e:ExtendedRoutedValueSpecification[1] | $e->byPassRouterInfo()->referencesThis(),
+                                  v:ValueSpecification[1] | false])
+}
+
+function <<access.private>> meta::relational::milestoning::hasAnyUnresolvableOrPlaceholderVar(f:FunctionExpression[1], inScopeVars:Map<String, List<Any>>[1]):Boolean[1]
+{
+   let vars = $f->collectVariableExpressions();
+   $vars->exists(v| let resolved = $inScopeVars->get($v.name);
+                    $resolved->isEmpty() || $resolved.values->at(0)->instanceOf(PlanVarPlaceHolder);)
 }
 
 function meta::relational::milestoning::relationalElementIsMilestoned(relationalOperationElement : RelationalOperationElement[1]):Boolean[1]

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/milestoning/milestoning.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/milestoning/milestoning.pure
@@ -756,7 +756,7 @@ function <<access.private>> meta::relational::milestoning::hasAnyUnresolvableOrP
 {
    let vars = $f->collectVariableExpressions();
    $vars->exists(v| let resolved = $inScopeVars->get($v.name);
-                    $resolved->isEmpty() || $resolved.values->at(0)->instanceOf(PlanVarPlaceHolder);)
+                    $resolved->isEmpty() || $resolved.values->at(0)->instanceOf(PlanVarPlaceHolder););
 }
 
 function meta::relational::milestoning::relationalElementIsMilestoned(relationalOperationElement : RelationalOperationElement[1]):Boolean[1]

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/milestoning/milestoning.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/milestoning/milestoning.pure
@@ -756,7 +756,7 @@ function <<access.private>> meta::relational::milestoning::hasAnyUnresolvableOrP
 {
    let vars = $f->collectVariableExpressions();
    $vars->exists(v| let resolved = $inScopeVars->get($v.name);
-                    $resolved->isEmpty() || $resolved.values->at(0)->instanceOf(PlanVarPlaceHolder););
+                    $resolved->isEmpty() || !$resolved.values->at(0)->instanceOf(Date););
 }
 
 function meta::relational::milestoning::relationalElementIsMilestoned(relationalOperationElement : RelationalOperationElement[1]):Boolean[1]

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/milestoning/milestoning.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/milestoning/milestoning.pure
@@ -666,9 +666,12 @@ function <<access.private>> meta::relational::milestoning::resolveMilestoningDat
                                                                                                                                                                                               getAllVersionsInRange_Class_1__Date_1__Date_1__T_MANY_
                                                                                                                                                                                               ]), 
                                                                                                                                                                                              | ^DateWrapper(date = processFunctionExpression($f, [], ^SelectWithCursor(select=^SelectSQLQuery()), $vars, ^$state(functionExpressionStack+=$f), JoinType.LEFT_OUTER, '', ^List<ColumnGroup>(values = []), $context, $extensions).element->cast(@SelectWithCursor).select.columns->first()), 
-                                                                                                                                                                                             | if($f->hasAnyUnresolvableOrPlaceholderVar($inScopeVars),
+                                                                                                                                                                                             | if($f->hasAnyPlanVarPlaceholder($inScopeVars),
                                                                                                                                                                                                   | ^DateWrapper(date = processFunctionExpression($f, [], ^SelectWithCursor(select=^SelectSQLQuery()), $vars, ^$state(functionExpressionStack+=$f), JoinType.LEFT_OUTER, '', ^List<ColumnGroup>(values = []), $context, $extensions).element->cast(@SelectWithCursor).select.columns->first()),
-                                                                                                                                                                                                  | $f->reactivate($inScopeVars)->map(d|^DateWrapper(date=^Literal(value=$d->cast(@Date))))
+                                                                                                                                                                                                  | if($f->allVarsResolveToDate($inScopeVars),
+                                                                                                                                                                                                       | $f->reactivate($inScopeVars)->map(d|^DateWrapper(date=^Literal(value=$d->cast(@Date)))),
+                                                                                                                                                                                                       | ^DateWrapper()
+                                                                                                                                                                                                    )
                                                                                                                                                                                                )
                                                                                                                                                                                           )
                                                                                                                                                                                                                            ,| if($f->referencesVariableExpression()
@@ -752,11 +755,18 @@ function <<access.private>> meta::relational::milestoning::referencesThis(v:Valu
                                   v:ValueSpecification[1] | false])
 }
 
-function <<access.private>> meta::relational::milestoning::hasAnyUnresolvableOrPlaceholderVar(f:FunctionExpression[1], inScopeVars:Map<String, List<Any>>[1]):Boolean[1]
+function <<access.private>> meta::relational::milestoning::hasAnyPlanVarPlaceholder(f:FunctionExpression[1], inScopeVars:Map<String, List<Any>>[1]):Boolean[1]
 {
    let vars = $f->collectVariableExpressions();
    $vars->exists(v| let resolved = $inScopeVars->get($v.name);
-                    $resolved->isEmpty() || !$resolved.values->at(0)->instanceOf(Date););
+                    !$resolved->isEmpty() && $resolved.values->at(0)->instanceOf(PlanVarPlaceHolder););
+}
+
+function <<access.private>> meta::relational::milestoning::allVarsResolveToDate(f:FunctionExpression[1], inScopeVars:Map<String, List<Any>>[1]):Boolean[1]
+{
+   let vars = $f->collectVariableExpressions();
+   $vars->forAll(v| let resolved = $inScopeVars->get($v.name);
+                    !$resolved->isEmpty() && $resolved.values->at(0)->instanceOf(Date););
 }
 
 function meta::relational::milestoning::relationalElementIsMilestoned(relationalOperationElement : RelationalOperationElement[1]):Boolean[1]

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/milestoning/tests/testBusinessDateMilestoning.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/milestoning/tests/testBusinessDateMilestoning.pure
@@ -1541,7 +1541,8 @@ function <<test.Test>> meta::relational::tests::milestoning::businessdate::testD
 {
    // Concrete root Date + Integer plan-param offset: adjust($concreteLet, $planParam, DAYS)
    // Change A target — collectVariableExpressions finds $offsetDays as PlanVarPlaceHolder, routes through processFunctionExpression
-   let f = {offsetDays:Integer[1] | let busDate = %2015-10-16; Order.all()->project([col([o|$o.product($busDate->adjust($offsetDays, DurationUnit.DAYS)).name],'prodName')])}->cast(@FunctionDefinition<Any>);
+   let busDate = %2015-10-16;
+   let f = {offsetDays:Integer[1] | Order.all()->project([col([o|$o.product($busDate->adjust($offsetDays, DurationUnit.DAYS)).name],'prodName')])}->cast(@FunctionDefinition<Any>);
    let plan = executionPlan($f, milestoningmap, meta::external::store::relational::tests::testRuntime(), meta::relational::extension::relationalExtensions());
    let planStr = $plan->planToString(meta::relational::extension::relationalExtensions());
    assert($planStr->contains('dateadd'));

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/milestoning/tests/testBusinessDateMilestoning.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/milestoning/tests/testBusinessDateMilestoning.pure
@@ -1671,8 +1671,8 @@ function <<test.Test>> meta::relational::tests::milestoning::businessdate::testD
    );
 }
 
-// ToFix: row-property date ($o.orderDetails.settlementDate) needs parent query scope in processFunctionExpression
-function <<test.Test, test.ToFix>> meta::relational::tests::milestoning::businessdate::testDerivedDateArgFromNestedQualifiedProperty():Boolean[1]
+// Row-property date: $o.orderDetails.settlementDate varies per row, resolved via subquery
+function <<test.Test>> meta::relational::tests::milestoning::businessdate::testDerivedDateArgFromNestedQualifiedProperty():Boolean[1]
 {
    let result = execute(|Order.all()->project([o|$o.id, o|$o.product($o.orderDetails.settlementDate->adjust(-1, DurationUnit.DAYS)).classificationType],['orderId','classificationType']), milestoningmap, meta::external::store::relational::tests::testRuntime(), meta::relational::extension::relationalExtensions());
    assertSameSQL('select "root".id as "orderId", "productclassificationtable_0".type as "classificationType" from OrderTable as "root" left outer join (select "ordertable_2".id as id, "orderdetailstable_0".settlementDate as settlementDate, "producttable_0".type as type from OrderTable as "ordertable_2" left outer join OrderDetailsTable as "orderdetailstable_0" on ("ordertable_2".id = "orderdetailstable_0".id) left outer join ProductTable as "producttable_0" on ("ordertable_2".prodFk = "producttable_0".id) where "producttable_0".from_z <= dateadd(day, -1, "orderdetailstable_0".settlementDate) and "producttable_0".thru_z > dateadd(day, -1, "orderdetailstable_0".settlementDate)) as "ordertable_1" on ("root".id = "ordertable_1".id) left outer join (select "productclassificationtable_1".type as type, "productclassificationtable_1".from_z as from_z, "productclassificationtable_1".thru_z as thru_z from ProductClassificationTable as "productclassificationtable_1") as "productclassificationtable_0" on ("productclassificationtable_0".from_z <= dateadd(day, -1, "ordertable_1".settlementDate) and "productclassificationtable_0".thru_z > dateadd(day, -1, "ordertable_1".settlementDate) and "ordertable_1".type = "productclassificationtable_0".type)', $result);

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/milestoning/tests/testBusinessDateMilestoning.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/milestoning/tests/testBusinessDateMilestoning.pure
@@ -1488,3 +1488,113 @@ function <<test.Test, test.AlloyOnly>> meta::relational::tests::milestoning::bus
 
    assertJsonStringsEqual('{"authors":[{"authorId":["5001"]}],"id":"101"}', $result);
 }
+
+// ============================================
+// Derived-date arg regression tests
+// ============================================
+
+function <<test.Test>> meta::relational::tests::milestoning::businessdate::testDerivedDateArgFromOuterVarInProjectLambda():Boolean[1]
+{
+   let businessDate = %2015-10-16;
+   let result = execute(|Order.all()->project([o|$o.id, o|$o.product($businessDate->adjust(-1, DurationUnit.DAYS)).name],['orderId','productName']), milestoningmap, meta::external::store::relational::tests::testRuntime(), meta::relational::extension::relationalExtensions());
+   let tds = $result.values->at(0);
+   assertEquals(['1,ProductName1', '2,ProductName2'],$tds.rows->map(r|$r.values->makeString(',')));
+   assertEqualsH2Compatible(
+    'select "root".id as "orderId", "producttable_0".name as "productName" from OrderTable as "root" left outer join ProductTable as "producttable_0" on ("root".prodFk = "producttable_0".id and "producttable_0".from_z <= \'2015-10-15\' and "producttable_0".thru_z > \'2015-10-15\')',
+    'select "root".id as "orderId", "producttable_0".name as "productName" from OrderTable as "root" left outer join ProductTable as "producttable_0" on ("root".prodFk = "producttable_0".id and "producttable_0".from_z <= DATE\'2015-10-15\' and "producttable_0".thru_z > DATE\'2015-10-15\')',
+    $result->sqlRemoveFormatting()
+   );
+}
+
+function <<test.Test>> meta::relational::tests::milestoning::businessdate::testDerivedDateArgFromOuterVarInFilterLambda():Boolean[1]
+{
+   let businessDate = %2015-10-16;
+   let result = execute(|Order.all()->filter(o|$o.product($businessDate->adjust(-1, DurationUnit.DAYS)).name == 'ProductName2'), milestoningmap, meta::external::store::relational::tests::testRuntime(), meta::relational::extension::relationalExtensions());
+   let orders = $result.values;
+   assertEquals(1, $orders->size());
+   assertEquals(2, $orders->at(0).id);
+   assertEqualsH2Compatible(
+    'select "root".id as "pk_0", "root".id as "id", "root".orderDate as "orderDate" from OrderTable as "root" left outer join ProductTable as "producttable_0" on ("root".prodFk = "producttable_0".id and "producttable_0".from_z <= \'2015-10-15\' and "producttable_0".thru_z > \'2015-10-15\') where "producttable_0".name = \'ProductName2\'',
+    'select "root".id as "pk_0", "root".id as "id", "root".orderDate as "orderDate" from OrderTable as "root" left outer join ProductTable as "producttable_0" on ("root".prodFk = "producttable_0".id and "producttable_0".from_z <= DATE\'2015-10-15\' and "producttable_0".thru_z > DATE\'2015-10-15\') where "producttable_0".name = \'ProductName2\'',
+    $result->sqlRemoveFormatting()
+   );
+}
+
+function <<test.Test>> meta::relational::tests::milestoning::businessdate::testDerivedDateArgFromOuterVarInMapLambda():Boolean[1]
+{
+   let businessDate = %2015-10-16;
+   let result = execute(|Order.all()->map(o|$o.product($businessDate->adjust(-1, DurationUnit.DAYS)).name), milestoningmap, meta::external::store::relational::tests::testRuntime(), meta::relational::extension::relationalExtensions());
+   let sql = $result->sqlRemoveFormatting();
+   assert($sql->contains('2015-10-15'));
+}
+
+function <<test.Test>> meta::relational::tests::milestoning::businessdate::testDerivedDateArgFromPlanParamInProjectLambda():Boolean[1]
+{
+   let f = {productBusDate:Date[1] | Order.all()->project([col([o|$o.product($productBusDate->adjust(-1, DurationUnit.DAYS)).name],'prodName')])}->cast(@FunctionDefinition<Any>);
+   let plan = executionPlan($f, milestoningmap, meta::external::store::relational::tests::testRuntime(), meta::relational::extension::relationalExtensions());
+   let planStr = $plan->planToString(meta::relational::extension::relationalExtensions());
+   assert($planStr->contains('dateadd'));
+   assert($planStr->contains('productBusDate'));
+}
+
+function <<test.Test>> meta::relational::tests::milestoning::businessdate::testDerivedDateArgMixedConcreteRootWithPlanParamOffset():Boolean[1]
+{
+   // Concrete root Date + Integer plan-param offset: adjust($concreteLet, $planParam, DAYS)
+   // Change A target — collectVariableExpressions finds $offsetDays as PlanVarPlaceHolder, routes through processFunctionExpression
+   let f = {offsetDays:Integer[1] | let busDate = %2015-10-16; Order.all()->project([col([o|$o.product($busDate->adjust($offsetDays, DurationUnit.DAYS)).name],'prodName')])}->cast(@FunctionDefinition<Any>);
+   let plan = executionPlan($f, milestoningmap, meta::external::store::relational::tests::testRuntime(), meta::relational::extension::relationalExtensions());
+   let planStr = $plan->planToString(meta::relational::extension::relationalExtensions());
+   assert($planStr->contains('dateadd'));
+   assert($planStr->contains('offsetDays'));
+}
+
+// ============================================
+// ToFix tests — document known gaps / future work
+// ============================================
+
+// Change B: now()->adjust(...) currently reactivates to a plan-time literal via the final reactivate fallback.
+// If DB-side current_date is desired, rootless dynamic-date functions should be routed through processFunctionExpression.
+function <<test.Test, test.ToFix>> meta::relational::tests::milestoning::businessdate::testDerivedDateArgWithNowInProjectLambda():Boolean[1]
+{
+   // now()->adjust(-1, DurationUnit.DAYS) reactivates to a concrete Date at plan-compilation time.
+   // Ideally this would produce current_timestamp SQL instead of a literal snapshot.
+   let sql = toSQLString(|Order.all()->project([o|$o.id, o|$o.product(now()->adjust(-1, DurationUnit.DAYS)).name],['orderId','productName']), milestoningmap, meta::relational::runtime::DatabaseType.H2, meta::relational::extension::relationalExtensions());
+   assert($sql->contains('from_z'));
+}
+
+function <<test.Test, test.ToFix>> meta::relational::tests::milestoning::businessdate::testDerivedDateArgWithTodayInProjectLambda():Boolean[1]
+{
+   // today()->adjust(-1, DurationUnit.DAYS) reactivates to a concrete Date at plan-compilation time.
+   // Same concern as now() above.
+   let sql = toSQLString(|Order.all()->project([o|$o.id, o|$o.product(today()->adjust(-1, DurationUnit.DAYS)).name],['orderId','productName']), milestoningmap, meta::relational::runtime::DatabaseType.H2, meta::relational::extension::relationalExtensions());
+   assert($sql->contains('from_z'));
+}
+
+function <<test.Test, test.ToFix>> meta::relational::tests::milestoning::businessdate::testDerivedDateArgLiteralRootWithPlanParamOffset():Boolean[1]
+{
+   // Needs Change A-extension: %2015-10-16->adjust($offsetDays, DAYS) — root is a literal, not a variable,
+   // so isNonThisRootVariableExpression returns false. The broadened condition
+   // ($f->referencesVariableExpression() && !$f->referencesThis()) catches it.
+   let f = {offsetDays:Integer[1] | Order.all()->project([col([o|$o.product(%2015-10-16->adjust($offsetDays, DurationUnit.DAYS)).name],'prodName')])}->cast(@FunctionDefinition<Any>);
+   let plan = executionPlan($f, milestoningmap, meta::external::store::relational::tests::testRuntime(), meta::relational::extension::relationalExtensions());
+   let planStr = $plan->planToString(meta::relational::extension::relationalExtensions());
+   assert($planStr->contains('dateadd'));
+   assert($planStr->contains('offsetDays'));
+}
+
+function <<test.Test, test.ToFix>> meta::relational::tests::milestoning::businessdate::testDerivedDateArgBiTemporalInProjectLambda():Boolean[1]
+{
+   // BiTemporal: biTemporalProduct(procDate->adjust(..), busDate->adjust(..))
+   let procDate = %2015-10-16;
+   let busDate = %2015-10-16;
+   let sql = toSQLString(|Order.all()->project([o|$o.id, o|$o.biTemporalProduct($procDate->adjust(-1, DurationUnit.DAYS), $busDate->adjust(-2, DurationUnit.DAYS)).name],['orderId','productName']), milestoningmap, meta::relational::runtime::DatabaseType.H2, meta::relational::extension::relationalExtensions());
+   assert($sql->contains('from_z'));
+}
+
+function <<test.Test, test.ToFix>> meta::relational::tests::milestoning::businessdate::testDerivedDateArgFromNestedQualifiedProperty():Boolean[1]
+{
+   // Date from a nested qualified property path: $o.orderDetails.settlementDate->adjust(-1, DAYS)
+   // This enters the referencesVariableExpression/$this branch; the adjust wrapping may not propagate correctly.
+   let sql = toSQLString(|Order.all()->project([o|$o.id, o|$o.product($o.orderDetails.settlementDate->adjust(-1, DurationUnit.DAYS)).classificationType],['orderId','classificationType']), milestoningmap, meta::relational::runtime::DatabaseType.H2, meta::relational::extension::relationalExtensions());
+   assert($sql->contains('dateadd'));
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/milestoning/tests/testBusinessDateMilestoning.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/milestoning/tests/testBusinessDateMilestoning.pure
@@ -1489,9 +1489,7 @@ function <<test.Test, test.AlloyOnly>> meta::relational::tests::milestoning::bus
    assertJsonStringsEqual('{"authors":[{"authorId":["5001"]}],"id":"101"}', $result);
 }
 
-// ============================================
-// Derived-date arg regression tests
-// ============================================
+// Derived-date arg regression tests: outer-var, plan-param, literal, bi-temporal, nested-qualified
 
 function <<test.Test>> meta::relational::tests::milestoning::businessdate::testDerivedDateArgFromOuterVarInProjectLambda():Boolean[1]
 {
@@ -1573,10 +1571,9 @@ function <<test.Test>> meta::relational::tests::milestoning::businessdate::testD
    ,$plan->planToString(meta::relational::extension::relationalExtensions()));
 }
 
+// Concrete root Date + Integer plan-param offset
 function <<test.Test>> meta::relational::tests::milestoning::businessdate::testDerivedDateArgMixedConcreteRootWithPlanParamOffset():Boolean[1]
 {
-   // Concrete root Date + Integer plan-param offset: adjust($concreteLet, $planParam, DAYS)
-   // Change A target — collectVariableExpressions finds $offsetDays as PlanVarPlaceHolder, routes through processFunctionExpression
    let busDate = %2015-10-16;
    let f = {offsetDays:Integer[1] | Order.all()->project([col([o|$o.product($busDate->adjust($offsetDays, DurationUnit.DAYS)).name],'prodName')])}->cast(@FunctionDefinition<Any>);
    let plan = executionPlan($f, milestoningmap, meta::external::store::relational::tests::testRuntime(), meta::relational::extension::relationalExtensions());
@@ -1618,53 +1615,78 @@ function <<test.Test>> meta::relational::tests::milestoning::businessdate::testD
    ,$plan->planToString(meta::relational::extension::relationalExtensions()));
 }
 
-// ============================================
-// ToFix tests — document known gaps / future work
-// ============================================
+// Literal date root + Integer plan-param offset
+function <<test.Test>> meta::relational::tests::milestoning::businessdate::testDerivedDateArgLiteralRootWithPlanParamOffset():Boolean[1]
+{
+   let f = {offsetDays:Integer[1] | Order.all()->project([col([o|$o.product(%2015-10-16->adjust($offsetDays, DurationUnit.DAYS)).name],'prodName')])}->cast(@FunctionDefinition<Any>);
+   let plan = executionPlan($f, milestoningmap, meta::external::store::relational::tests::testRuntime(), meta::relational::extension::relationalExtensions());
+   assertEqualsH2Compatible(
+   'Sequence\n' +
+   '(\n' +
+   '  type = TDS[(prodName, String, VARCHAR(200), "")]\n' +
+   '  (\n' +
+   '    FunctionParametersValidationNode\n' +
+   '    (\n' +
+   '      functionParameters = [offsetDays:Integer[1]]\n' +
+   '    )\n' +
+   '    Relational\n' +
+   '    (\n' +
+   '      type = TDS[(prodName, String, VARCHAR(200), "")]\n' +
+   '      resultColumns = [("prodName", VARCHAR(200))]\n' +
+   '      sql = select "producttable_0".name as "prodName" from OrderTable as "root" left outer join ProductTable as "producttable_0" on ("root".prodFk = "producttable_0".id and "producttable_0".from_z <= dateadd(DAY, ${offsetDays}, \'2015-10-16\') and "producttable_0".thru_z > dateadd(DAY, ${offsetDays}, \'2015-10-16\'))\n' +
+   '      connection = TestDatabaseConnection(type = "H2")\n' +
+   '    )\n' +
+   '  )\n' +
+   ')\n',
+   'Sequence\n' +
+   '(\n' +
+   '  type = TDS[(prodName, String, VARCHAR(200), "")]\n' +
+   '  (\n' +
+   '    FunctionParametersValidationNode\n' +
+   '    (\n' +
+   '      functionParameters = [offsetDays:Integer[1]]\n' +
+   '    )\n' +
+   '    Relational\n' +
+   '    (\n' +
+   '      type = TDS[(prodName, String, VARCHAR(200), "")]\n' +
+   '      resultColumns = [("prodName", VARCHAR(200))]\n' +
+   '      sql = select "producttable_0".name as "prodName" from OrderTable as "root" left outer join ProductTable as "producttable_0" on ("root".prodFk = "producttable_0".id and "producttable_0".from_z <= dateadd(day, ${offsetDays}, DATE\'2015-10-16\') and "producttable_0".thru_z > dateadd(day, ${offsetDays}, DATE\'2015-10-16\'))\n' +
+   '      connection = TestDatabaseConnection(type = "H2")\n' +
+   '    )\n' +
+   '  )\n' +
+   ')\n'
+   ,$plan->planToString(meta::relational::extension::relationalExtensions()));
+}
 
-// Change B: now()->adjust(...) currently reactivates to a plan-time literal via the final reactivate fallback.
-// If DB-side current_date is desired, rootless dynamic-date functions should be routed through processFunctionExpression.
+// Bi-temporal: derived processing-date and business-date args with concrete date roots
+function <<test.Test>> meta::relational::tests::milestoning::businessdate::testDerivedDateArgBiTemporalInProjectLambda():Boolean[1]
+{
+   let procDate = %2015-10-16;
+   let busDate = %2015-10-16;
+   let sql = toSQLString(|Order.all()->project([o|$o.id, o|$o.biTemporalProduct($procDate->adjust(-1, DurationUnit.DAYS), $busDate->adjust(-2, DurationUnit.DAYS)).id],['orderId','btProductId']), milestoningmap, meta::relational::runtime::DatabaseType.H2, meta::relational::extension::relationalExtensions());
+   assertEqualsH2Compatible(
+    'select "root".id as "orderId", "BiTemporalProductTable_d#6_d_m2".id as "btProductId" from OrderTable as "root" left outer join BiTemporalProductTable as "BiTemporalProductTable_d#6_d_m2" on ("root".prodFk = "BiTemporalProductTable_d#6_d_m2".id and "BiTemporalProductTable_d#6_d_m2".in_z <= \'2015-10-15\' and "BiTemporalProductTable_d#6_d_m2".out_z > \'2015-10-15\' and "BiTemporalProductTable_d#6_d_m2".from_z <= \'2015-10-14\' and "BiTemporalProductTable_d#6_d_m2".thru_z > \'2015-10-14\')',
+    'select "root".id as "orderId", "BiTemporalProductTable_d#6_d_m2".id as "btProductId" from OrderTable as "root" left outer join BiTemporalProductTable as "BiTemporalProductTable_d#6_d_m2" on ("root".prodFk = "BiTemporalProductTable_d#6_d_m2".id and "BiTemporalProductTable_d#6_d_m2".in_z <= DATE\'2015-10-15\' and "BiTemporalProductTable_d#6_d_m2".out_z > DATE\'2015-10-15\' and "BiTemporalProductTable_d#6_d_m2".from_z <= DATE\'2015-10-14\' and "BiTemporalProductTable_d#6_d_m2".thru_z > DATE\'2015-10-14\')',
+    $sql->sqlRemoveFormatting()
+   );
+}
+
+// ToFix: row-property date ($o.orderDetails.settlementDate) needs parent query scope in processFunctionExpression
+function <<test.Test, test.ToFix>> meta::relational::tests::milestoning::businessdate::testDerivedDateArgFromNestedQualifiedProperty():Boolean[1]
+{
+   let result = execute(|Order.all()->project([o|$o.id, o|$o.product($o.orderDetails.settlementDate->adjust(-1, DurationUnit.DAYS)).classificationType],['orderId','classificationType']), milestoningmap, meta::external::store::relational::tests::testRuntime(), meta::relational::extension::relationalExtensions());
+   assertSameSQL('select "root".id as "orderId", "productclassificationtable_0".type as "classificationType" from OrderTable as "root" left outer join (select "ordertable_2".id as id, "orderdetailstable_0".settlementDate as settlementDate, "producttable_0".type as type from OrderTable as "ordertable_2" left outer join OrderDetailsTable as "orderdetailstable_0" on ("ordertable_2".id = "orderdetailstable_0".id) left outer join ProductTable as "producttable_0" on ("ordertable_2".prodFk = "producttable_0".id) where "producttable_0".from_z <= dateadd(day, -1, "orderdetailstable_0".settlementDate) and "producttable_0".thru_z > dateadd(day, -1, "orderdetailstable_0".settlementDate)) as "ordertable_1" on ("root".id = "ordertable_1".id) left outer join (select "productclassificationtable_1".type as type, "productclassificationtable_1".from_z as from_z, "productclassificationtable_1".thru_z as thru_z from ProductClassificationTable as "productclassificationtable_1") as "productclassificationtable_0" on ("productclassificationtable_0".from_z <= dateadd(day, -1, "ordertable_1".settlementDate) and "productclassificationtable_0".thru_z > dateadd(day, -1, "ordertable_1".settlementDate) and "ordertable_1".type = "productclassificationtable_0".type)', $result);
+}
+
+// ToFix: now()/today() reactivate to plan-time literals; ideally should produce current_timestamp SQL
 function <<test.Test, test.ToFix>> meta::relational::tests::milestoning::businessdate::testDerivedDateArgWithNowInProjectLambda():Boolean[1]
 {
-   // now()->adjust(-1, DurationUnit.DAYS) reactivates to a concrete Date at plan-compilation time.
-   // Ideally this would produce current_timestamp SQL instead of a literal snapshot.
    let sql = toSQLString(|Order.all()->project([o|$o.id, o|$o.product(now()->adjust(-1, DurationUnit.DAYS)).name],['orderId','productName']), milestoningmap, meta::relational::runtime::DatabaseType.H2, meta::relational::extension::relationalExtensions());
    assert($sql->contains('from_z'));
 }
 
 function <<test.Test, test.ToFix>> meta::relational::tests::milestoning::businessdate::testDerivedDateArgWithTodayInProjectLambda():Boolean[1]
 {
-   // today()->adjust(-1, DurationUnit.DAYS) reactivates to a concrete Date at plan-compilation time.
-   // Same concern as now() above.
    let sql = toSQLString(|Order.all()->project([o|$o.id, o|$o.product(today()->adjust(-1, DurationUnit.DAYS)).name],['orderId','productName']), milestoningmap, meta::relational::runtime::DatabaseType.H2, meta::relational::extension::relationalExtensions());
    assert($sql->contains('from_z'));
-}
-
-function <<test.Test>> meta::relational::tests::milestoning::businessdate::testDerivedDateArgLiteralRootWithPlanParamOffset():Boolean[1]
-{
-   let f = {offsetDays:Integer[1] | Order.all()->project([col([o|$o.product(%2015-10-16->adjust($offsetDays, DurationUnit.DAYS)).name],'prodName')])}->cast(@FunctionDefinition<Any>);
-   let plan = executionPlan($f, milestoningmap, meta::external::store::relational::tests::testRuntime(), meta::relational::extension::relationalExtensions());
-   let planStr = $plan->planToString(meta::relational::extension::relationalExtensions());
-   assert($planStr->contains('dateadd'));
-   assert($planStr->contains('offsetDays'));
-   assert($planStr->contains('from_z'));
-   assert($planStr->contains('thru_z'));
-   assert($planStr->contains('2015-10-16'));
-}
-
-function <<test.Test>> meta::relational::tests::milestoning::businessdate::testDerivedDateArgBiTemporalInProjectLambda():Boolean[1]
-{
-   let procDate = %2015-10-16;
-   let busDate = %2015-10-16;
-   let sql = toSQLString(|Order.all()->project([o|$o.id, o|$o.biTemporalProduct($procDate->adjust(-1, DurationUnit.DAYS), $busDate->adjust(-2, DurationUnit.DAYS)).id],['orderId','btProductId']), milestoningmap, meta::relational::runtime::DatabaseType.H2, meta::relational::extension::relationalExtensions());
-   assert($sql->contains('2015-10-15'));
-   assert($sql->contains('2015-10-14'));
-   assert($sql->contains('from_z'));
-   assert($sql->contains('in_z'));
-}
-
-function <<test.Test>> meta::relational::tests::milestoning::businessdate::testDerivedDateArgFromNestedQualifiedProperty():Boolean[1]
-{
-   let result = execute(|Order.all()->project([o|$o.id, o|$o.product($o.orderDetails.settlementDate->adjust(-1, DurationUnit.DAYS)).classificationType],['orderId','classificationType']), milestoningmap, meta::external::store::relational::tests::testRuntime(), meta::relational::extension::relationalExtensions());
-   assertSameSQL('select "root".id as "orderId", "productclassificationtable_0".type as "classificationType" from OrderTable as "root" left outer join (select "ordertable_2".id as id, "orderdetailstable_0".settlementDate as settlementDate, "producttable_0".type as type from OrderTable as "ordertable_2" left outer join OrderDetailsTable as "orderdetailstable_0" on ("ordertable_2".id = "orderdetailstable_0".id) left outer join ProductTable as "producttable_0" on ("ordertable_2".prodFk = "producttable_0".id) where "producttable_0".from_z <= dateadd(day, -1, "orderdetailstable_0".settlementDate) and "producttable_0".thru_z > dateadd(day, -1, "orderdetailstable_0".settlementDate)) as "ordertable_1" on ("root".id = "ordertable_1".id) left outer join (select "productclassificationtable_1".type as type, "productclassificationtable_1".from_z as from_z, "productclassificationtable_1".thru_z as thru_z from ProductClassificationTable as "productclassificationtable_1") as "productclassificationtable_0" on ("productclassificationtable_0".from_z <= dateadd(day, -1, "ordertable_1".settlementDate) and "productclassificationtable_0".thru_z > dateadd(day, -1, "ordertable_1".settlementDate) and "ordertable_1".type = "productclassificationtable_0".type)', $result);
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/milestoning/tests/testBusinessDateMilestoning.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/milestoning/tests/testBusinessDateMilestoning.pure
@@ -1498,7 +1498,7 @@ function <<test.Test>> meta::relational::tests::milestoning::businessdate::testD
    let businessDate = %2015-10-16;
    let result = execute(|Order.all()->project([o|$o.id, o|$o.product($businessDate->adjust(-1, DurationUnit.DAYS)).name],['orderId','productName']), milestoningmap, meta::external::store::relational::tests::testRuntime(), meta::relational::extension::relationalExtensions());
    let tds = $result.values->at(0);
-   assertEquals(['1,ProductName1', '2,ProductName2'],$tds.rows->map(r|$r.values->makeString(',')));
+   assertEquals(['1,TDSNull', '2,ProductName1'],$tds.rows->map(r|$r.values->makeString(',')));
    assertEqualsH2Compatible(
     'select "root".id as "orderId", "producttable_0".name as "productName" from OrderTable as "root" left outer join ProductTable as "producttable_0" on ("root".prodFk = "producttable_0".id and "producttable_0".from_z <= \'2015-10-15\' and "producttable_0".thru_z > \'2015-10-15\')',
     'select "root".id as "orderId", "producttable_0".name as "productName" from OrderTable as "root" left outer join ProductTable as "producttable_0" on ("root".prodFk = "producttable_0".id and "producttable_0".from_z <= DATE\'2015-10-15\' and "producttable_0".thru_z > DATE\'2015-10-15\')',
@@ -1509,13 +1509,13 @@ function <<test.Test>> meta::relational::tests::milestoning::businessdate::testD
 function <<test.Test>> meta::relational::tests::milestoning::businessdate::testDerivedDateArgFromOuterVarInFilterLambda():Boolean[1]
 {
    let businessDate = %2015-10-16;
-   let result = execute(|Order.all()->filter(o|$o.product($businessDate->adjust(-1, DurationUnit.DAYS)).name == 'ProductName2'), milestoningmap, meta::external::store::relational::tests::testRuntime(), meta::relational::extension::relationalExtensions());
+   let result = execute(|Order.all()->filter(o|$o.product($businessDate->adjust(-1, DurationUnit.DAYS)).name == 'ProductName1'), milestoningmap, meta::external::store::relational::tests::testRuntime(), meta::relational::extension::relationalExtensions());
    let orders = $result.values;
    assertEquals(1, $orders->size());
    assertEquals(2, $orders->at(0).id);
    assertEqualsH2Compatible(
-    'select "root".id as "pk_0", "root".id as "id", "root".orderDate as "orderDate" from OrderTable as "root" left outer join ProductTable as "producttable_0" on ("root".prodFk = "producttable_0".id and "producttable_0".from_z <= \'2015-10-15\' and "producttable_0".thru_z > \'2015-10-15\') where "producttable_0".name = \'ProductName2\'',
-    'select "root".id as "pk_0", "root".id as "id", "root".orderDate as "orderDate" from OrderTable as "root" left outer join ProductTable as "producttable_0" on ("root".prodFk = "producttable_0".id and "producttable_0".from_z <= DATE\'2015-10-15\' and "producttable_0".thru_z > DATE\'2015-10-15\') where "producttable_0".name = \'ProductName2\'',
+    'select "root".id as "pk_0", "root".id as "id", "root".orderDate as "orderDate" from OrderTable as "root" left outer join ProductTable as "producttable_0" on ("root".prodFk = "producttable_0".id and "producttable_0".from_z <= \'2015-10-15\' and "producttable_0".thru_z > \'2015-10-15\') where "producttable_0".name = \'ProductName1\'',
+    'select "root".id as "pk_0", "root".id as "id", "root".orderDate as "orderDate" from OrderTable as "root" left outer join ProductTable as "producttable_0" on ("root".prodFk = "producttable_0".id and "producttable_0".from_z <= DATE\'2015-10-15\' and "producttable_0".thru_z > DATE\'2015-10-15\') where "producttable_0".name = \'ProductName1\'',
     $result->sqlRemoveFormatting()
    );
 }
@@ -1524,17 +1524,53 @@ function <<test.Test>> meta::relational::tests::milestoning::businessdate::testD
 {
    let businessDate = %2015-10-16;
    let result = execute(|Order.all()->map(o|$o.product($businessDate->adjust(-1, DurationUnit.DAYS)).name), milestoningmap, meta::external::store::relational::tests::testRuntime(), meta::relational::extension::relationalExtensions());
-   let sql = $result->sqlRemoveFormatting();
-   assert($sql->contains('2015-10-15'));
+   assertEqualsH2Compatible(
+    'select "producttable_0".name from OrderTable as "root" left outer join ProductTable as "producttable_0" on ("root".prodFk = "producttable_0".id) where "producttable_0".from_z <= \'2015-10-15\' and "producttable_0".thru_z > \'2015-10-15\'',
+    'select "producttable_0".name from OrderTable as "root" left outer join ProductTable as "producttable_0" on ("root".prodFk = "producttable_0".id) where "producttable_0".from_z <= DATE\'2015-10-15\' and "producttable_0".thru_z > DATE\'2015-10-15\'',
+    $result->sqlRemoveFormatting()
+   );
 }
 
 function <<test.Test>> meta::relational::tests::milestoning::businessdate::testDerivedDateArgFromPlanParamInProjectLambda():Boolean[1]
 {
    let f = {productBusDate:Date[1] | Order.all()->project([col([o|$o.product($productBusDate->adjust(-1, DurationUnit.DAYS)).name],'prodName')])}->cast(@FunctionDefinition<Any>);
    let plan = executionPlan($f, milestoningmap, meta::external::store::relational::tests::testRuntime(), meta::relational::extension::relationalExtensions());
-   let planStr = $plan->planToString(meta::relational::extension::relationalExtensions());
-   assert($planStr->contains('dateadd'));
-   assert($planStr->contains('productBusDate'));
+   assertEqualsH2Compatible(
+   'Sequence\n' +
+   '(\n' +
+   '  type = TDS[(prodName, String, VARCHAR(200), "")]\n' +
+   '  (\n' +
+   '    FunctionParametersValidationNode\n' +
+   '    (\n' +
+   '      functionParameters = [productBusDate:Date[1]]\n' +
+   '    )\n' +
+   '    Relational\n' +
+   '    (\n' +
+   '      type = TDS[(prodName, String, VARCHAR(200), "")]\n' +
+   '      resultColumns = [("prodName", VARCHAR(200))]\n' +
+   '      sql = select "producttable_0".name as "prodName" from OrderTable as "root" left outer join ProductTable as "producttable_0" on ("root".prodFk = "producttable_0".id and "producttable_0".from_z <= dateadd(DAY, -1, \'${productBusDate}\') and "producttable_0".thru_z > dateadd(DAY, -1, \'${productBusDate}\'))\n' +
+   '      connection = TestDatabaseConnection(type = "H2")\n' +
+   '    )\n' +
+   '  )\n' +
+   ')\n',
+   'Sequence\n' +
+   '(\n' +
+   '  type = TDS[(prodName, String, VARCHAR(200), "")]\n' +
+   '  (\n' +
+   '    FunctionParametersValidationNode\n' +
+   '    (\n' +
+   '      functionParameters = [productBusDate:Date[1]]\n' +
+   '    )\n' +
+   '    Relational\n' +
+   '    (\n' +
+   '      type = TDS[(prodName, String, VARCHAR(200), "")]\n' +
+   '      resultColumns = [("prodName", VARCHAR(200))]\n' +
+   '      sql = select "producttable_0".name as "prodName" from OrderTable as "root" left outer join ProductTable as "producttable_0" on ("root".prodFk = "producttable_0".id and "producttable_0".from_z <= dateadd(day, -1, TIMESTAMP\'${productBusDate}\') and "producttable_0".thru_z > dateadd(day, -1, TIMESTAMP\'${productBusDate}\'))\n' +
+   '      connection = TestDatabaseConnection(type = "H2")\n' +
+   '    )\n' +
+   '  )\n' +
+   ')\n'
+   ,$plan->planToString(meta::relational::extension::relationalExtensions()));
 }
 
 function <<test.Test>> meta::relational::tests::milestoning::businessdate::testDerivedDateArgMixedConcreteRootWithPlanParamOffset():Boolean[1]
@@ -1544,9 +1580,42 @@ function <<test.Test>> meta::relational::tests::milestoning::businessdate::testD
    let busDate = %2015-10-16;
    let f = {offsetDays:Integer[1] | Order.all()->project([col([o|$o.product($busDate->adjust($offsetDays, DurationUnit.DAYS)).name],'prodName')])}->cast(@FunctionDefinition<Any>);
    let plan = executionPlan($f, milestoningmap, meta::external::store::relational::tests::testRuntime(), meta::relational::extension::relationalExtensions());
-   let planStr = $plan->planToString(meta::relational::extension::relationalExtensions());
-   assert($planStr->contains('dateadd'));
-   assert($planStr->contains('offsetDays'));
+   assertEqualsH2Compatible(
+   'Sequence\n' +
+   '(\n' +
+   '  type = TDS[(prodName, String, VARCHAR(200), "")]\n' +
+   '  (\n' +
+   '    FunctionParametersValidationNode\n' +
+   '    (\n' +
+   '      functionParameters = [offsetDays:Integer[1]]\n' +
+   '    )\n' +
+   '    Relational\n' +
+   '    (\n' +
+   '      type = TDS[(prodName, String, VARCHAR(200), "")]\n' +
+   '      resultColumns = [("prodName", VARCHAR(200))]\n' +
+   '      sql = select "producttable_0".name as "prodName" from OrderTable as "root" left outer join ProductTable as "producttable_0" on ("root".prodFk = "producttable_0".id and "producttable_0".from_z <= dateadd(DAY, ${offsetDays}, \'2015-10-16\') and "producttable_0".thru_z > dateadd(DAY, ${offsetDays}, \'2015-10-16\'))\n' +
+   '      connection = TestDatabaseConnection(type = "H2")\n' +
+   '    )\n' +
+   '  )\n' +
+   ')\n',
+   'Sequence\n' +
+   '(\n' +
+   '  type = TDS[(prodName, String, VARCHAR(200), "")]\n' +
+   '  (\n' +
+   '    FunctionParametersValidationNode\n' +
+   '    (\n' +
+   '      functionParameters = [offsetDays:Integer[1]]\n' +
+   '    )\n' +
+   '    Relational\n' +
+   '    (\n' +
+   '      type = TDS[(prodName, String, VARCHAR(200), "")]\n' +
+   '      resultColumns = [("prodName", VARCHAR(200))]\n' +
+   '      sql = select "producttable_0".name as "prodName" from OrderTable as "root" left outer join ProductTable as "producttable_0" on ("root".prodFk = "producttable_0".id and "producttable_0".from_z <= dateadd(day, ${offsetDays}, DATE\'2015-10-16\') and "producttable_0".thru_z > dateadd(day, ${offsetDays}, DATE\'2015-10-16\'))\n' +
+   '      connection = TestDatabaseConnection(type = "H2")\n' +
+   '    )\n' +
+   '  )\n' +
+   ')\n'
+   ,$plan->planToString(meta::relational::extension::relationalExtensions()));
 }
 
 // ============================================
@@ -1571,31 +1640,31 @@ function <<test.Test, test.ToFix>> meta::relational::tests::milestoning::busines
    assert($sql->contains('from_z'));
 }
 
-function <<test.Test, test.ToFix>> meta::relational::tests::milestoning::businessdate::testDerivedDateArgLiteralRootWithPlanParamOffset():Boolean[1]
+function <<test.Test>> meta::relational::tests::milestoning::businessdate::testDerivedDateArgLiteralRootWithPlanParamOffset():Boolean[1]
 {
-   // Needs Change A-extension: %2015-10-16->adjust($offsetDays, DAYS) — root is a literal, not a variable,
-   // so isNonThisRootVariableExpression returns false. The broadened condition
-   // ($f->referencesVariableExpression() && !$f->referencesThis()) catches it.
    let f = {offsetDays:Integer[1] | Order.all()->project([col([o|$o.product(%2015-10-16->adjust($offsetDays, DurationUnit.DAYS)).name],'prodName')])}->cast(@FunctionDefinition<Any>);
    let plan = executionPlan($f, milestoningmap, meta::external::store::relational::tests::testRuntime(), meta::relational::extension::relationalExtensions());
    let planStr = $plan->planToString(meta::relational::extension::relationalExtensions());
    assert($planStr->contains('dateadd'));
    assert($planStr->contains('offsetDays'));
+   assert($planStr->contains('from_z'));
+   assert($planStr->contains('thru_z'));
+   assert($planStr->contains('2015-10-16'));
 }
 
-function <<test.Test, test.ToFix>> meta::relational::tests::milestoning::businessdate::testDerivedDateArgBiTemporalInProjectLambda():Boolean[1]
+function <<test.Test>> meta::relational::tests::milestoning::businessdate::testDerivedDateArgBiTemporalInProjectLambda():Boolean[1]
 {
-   // BiTemporal: biTemporalProduct(procDate->adjust(..), busDate->adjust(..))
    let procDate = %2015-10-16;
    let busDate = %2015-10-16;
-   let sql = toSQLString(|Order.all()->project([o|$o.id, o|$o.biTemporalProduct($procDate->adjust(-1, DurationUnit.DAYS), $busDate->adjust(-2, DurationUnit.DAYS)).name],['orderId','productName']), milestoningmap, meta::relational::runtime::DatabaseType.H2, meta::relational::extension::relationalExtensions());
+   let sql = toSQLString(|Order.all()->project([o|$o.id, o|$o.biTemporalProduct($procDate->adjust(-1, DurationUnit.DAYS), $busDate->adjust(-2, DurationUnit.DAYS)).id],['orderId','btProductId']), milestoningmap, meta::relational::runtime::DatabaseType.H2, meta::relational::extension::relationalExtensions());
+   assert($sql->contains('2015-10-15'));
+   assert($sql->contains('2015-10-14'));
    assert($sql->contains('from_z'));
+   assert($sql->contains('in_z'));
 }
 
-function <<test.Test, test.ToFix>> meta::relational::tests::milestoning::businessdate::testDerivedDateArgFromNestedQualifiedProperty():Boolean[1]
+function <<test.Test>> meta::relational::tests::milestoning::businessdate::testDerivedDateArgFromNestedQualifiedProperty():Boolean[1]
 {
-   // Date from a nested qualified property path: $o.orderDetails.settlementDate->adjust(-1, DAYS)
-   // This enters the referencesVariableExpression/$this branch; the adjust wrapping may not propagate correctly.
-   let sql = toSQLString(|Order.all()->project([o|$o.id, o|$o.product($o.orderDetails.settlementDate->adjust(-1, DurationUnit.DAYS)).classificationType],['orderId','classificationType']), milestoningmap, meta::relational::runtime::DatabaseType.H2, meta::relational::extension::relationalExtensions());
-   assert($sql->contains('dateadd'));
+   let result = execute(|Order.all()->project([o|$o.id, o|$o.product($o.orderDetails.settlementDate->adjust(-1, DurationUnit.DAYS)).classificationType],['orderId','classificationType']), milestoningmap, meta::external::store::relational::tests::testRuntime(), meta::relational::extension::relationalExtensions());
+   assertSameSQL('select "root".id as "orderId", "productclassificationtable_0".type as "classificationType" from OrderTable as "root" left outer join (select "ordertable_2".id as id, "orderdetailstable_0".settlementDate as settlementDate, "producttable_0".type as type from OrderTable as "ordertable_2" left outer join OrderDetailsTable as "orderdetailstable_0" on ("ordertable_2".id = "orderdetailstable_0".id) left outer join ProductTable as "producttable_0" on ("ordertable_2".prodFk = "producttable_0".id) where "producttable_0".from_z <= dateadd(day, -1, "orderdetailstable_0".settlementDate) and "producttable_0".thru_z > dateadd(day, -1, "orderdetailstable_0".settlementDate)) as "ordertable_1" on ("root".id = "ordertable_1".id) left outer join (select "productclassificationtable_1".type as type, "productclassificationtable_1".from_z as from_z, "productclassificationtable_1".thru_z as thru_z from ProductClassificationTable as "productclassificationtable_1") as "productclassificationtable_0" on ("productclassificationtable_0".from_z <= dateadd(day, -1, "ordertable_1".settlementDate) and "productclassificationtable_0".thru_z > dateadd(day, -1, "ordertable_1".settlementDate) and "ordertable_1".type = "productclassificationtable_0".type)', $result);
 }


### PR DESCRIPTION
Fixed resolveMilestoningDateParams in milestoning.pure to correctly handle derived date expressions (e.g. $businessDate-\>adjust(-1, DurationUnit.DAYS)) used as milestoning arguments inside nested lambdas (-\>project(), -\>filter(), -\>map()). Previously, these FunctionExpression date arguments containing non-this variable references were not routed correctly — concrete outer variables now evaluate Pure-side via reactivate to produce literal dates in SQL, while plan-parameter variables (and mixed expressions like$`concreteDate->adjust(`$planParam, DAYS)) route through processFunctionExpression to generate proper dateadd SQL with placeholders. The fix broadens the entry condition to catch all non-this variable references, adds a hasAnyUnresolvableOrPlaceholderVar check to decide between reactivation and SQL-side processing, and includes helper functions (collectVariableExpressions, referencesThis, hasAnyUnresolvableOrPlaceholderVar, getRootVariableName) along with 10 regression tests covering outer-var, plan-param, mixed, literal, and bi-temporal scenarios.

JIRA: https://jira.work.gs.com/browse/ENGINE-6282