### PR TITLE
Legend SQL - resolve statement-level ORDER BY keys against the projected relation

### DIFF
--- a/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/src/test/resources/parity-tests/compositions/multi_join_agg.yaml
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/src/test/resources/parity-tests/compositions/multi_join_agg.yaml
@@ -60,8 +60,8 @@ tests:
     sql: "SELECT p.name, d.name AS dept, o.amount FROM persons p INNER JOIN departments d ON p.dept_id = d.id INNER JOIN orders o ON o.person_id = p.id WHERE o.amount > 100 AND d.budget > 500000 ORDER BY 1, 3"
     feature: "3-table JOIN + filter"
     category: "compositions"
-    expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_tds_status: PASS
+    expected_rel_status: PASS
 
   # JOIN with derived table
   - id: comp_join_derived

--- a/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/src/test/resources/parity-tests/structural/aliases.yaml
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/src/test/resources/parity-tests/structural/aliases.yaml
@@ -33,8 +33,8 @@ tests:
     sql: "SELECT p1.name, p2.name AS colleague FROM persons p1 JOIN persons p2 ON p1.dept_id = p2.dept_id AND p1.id < p2.id ORDER BY 1, 2"
     feature: "self-join with aliases"
     category: "aliases"
-    expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_tds_status: PASS
+    expected_rel_status: PASS
 
   # Alias usage in clauses
   - id: alias_in_order_by

--- a/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/src/test/resources/parity-tests/structural/column_resolution_across_renames.yaml
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/src/test/resources/parity-tests/structural/column_resolution_across_renames.yaml
@@ -101,12 +101,20 @@ tests:
     expected_tds_status: PASS
     expected_rel_status: PASS
 
+  # FAIL, not ERROR, and the distinction is the whole point: the sort key now
+  # resolves, which exposes that the helper column it resolves to holds the wrong
+  # value. processProjection materialises UPPER(d.name) with processExtend against
+  # projectedContext, whose contexts list is empty, so the qualifier `d` cannot
+  # resolve and the inner reference falls back to the bare name `name` -- p's
+  # column. The generated SQL reads upper("name_p"). Resolving the key against the
+  # projected relation did not cause this and cannot repair it; the fix is to
+  # rewrite the key's references to their output names before extending.
   - id: colres_e3_order_by_expression_over_join
     sql: "SELECT p.name AS name, d.name AS dept_name FROM persons p INNER JOIN departments d ON p.dept_id = d.id ORDER BY UPPER(d.name), name"
     feature: "ORDER BY expression over a join"
     category: "column_resolution"
-    expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_tds_status: FAIL
+    expected_rel_status: FAIL
 
   # --- design guards -----------------------------------------------------
   #
@@ -332,8 +340,8 @@ tests:
     sql: "SELECT dept_id, COUNT(*) AS c FROM persons WHERE dept_id IS NOT NULL GROUP BY dept_id ORDER BY COUNT(*) DESC, dept_id"
     feature: "ORDER BY aggregate expression (excluded from materialisation)"
     category: "column_resolution"
-    expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_tds_status: PASS
+    expected_rel_status: PASS
 
   # Nor for a window query, for the same reason.
   - id: colres_gap_order_by_expression_in_window_query

--- a/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/src/test/resources/parity-tests/structural/column_resolution_corpus_shapes.yaml
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/src/test/resources/parity-tests/structural/column_resolution_corpus_shapes.yaml
@@ -233,15 +233,15 @@ tests:
     sql: "SELECT p.name AS name, p.salary AS salary FROM persons p INNER JOIN departments d ON p.dept_id = d.id ORDER BY p.salary DESC NULLS LAST, p.name"
     feature: "statement-level ORDER BY ... NULLS LAST over a join (control: no window)"
     category: "column_resolution_corpus"
-    expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_tds_status: PASS
+    expected_rel_status: PASS
 
   - id: crcs_g1a_statement_order_nulls_first_over_join
     sql: "SELECT p.name AS name, p.hire_date AS hire_date FROM persons p LEFT OUTER JOIN departments d ON p.dept_id = d.id ORDER BY p.hire_date ASC NULLS FIRST, p.name"
     feature: "statement-level ORDER BY ... NULLS FIRST over a LEFT JOIN (control: no window)"
     category: "column_resolution_corpus"
-    expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_tds_status: PASS
+    expected_rel_status: PASS
 
   # ==========================================================================
   # G1b. The CASE null-ordering guard inside a window's ORDER BY, over a join
@@ -618,8 +618,17 @@ tests:
   # Mostly bare qualified references. The ORDER BY extension collection in
   # processProjection skips QualifiedNameReference keys by construction, and the
   # alias repair runs only inside processGroupBy / processOlapGroupBy, never in
-  # the plain projection path -- so a qualified sort key over a join has neither
-  # mechanism behind it.
+  # the plain projection path -- so a qualified sort key over a join had neither
+  # mechanism behind it and named a pre-projection column the sorted relation no
+  # longer had.
+  #
+  # projectedSortKeyName now resolves these against the relation the sort applies
+  # to rather than against the context, which is why most of this section is PASS.
+  # Two shapes it deliberately does not reach, and their status says which:
+  #   * a key the projection keeps only through a CAST is materialised by nothing,
+  #     so there is no column to resolve to -- still ERROR;
+  #   * an expression key over a join resolves to a helper column that processExtend
+  #     computed from the wrong join side -- FAIL, and a separate defect.
   # ==========================================================================
 
   # Two derived tables projecting the SAME output name is load-bearing: with a
@@ -628,22 +637,22 @@ tests:
     sql: "SELECT a.id AS id, org.val AS org_val, ent.val AS ent_val FROM persons a LEFT OUTER JOIN (SELECT person_id, MAX(status) AS val FROM orders GROUP BY person_id) org ON a.id = org.person_id LEFT OUTER JOIN (SELECT person_id, MIN(status) AS val FROM orders GROUP BY person_id) ent ON a.id = ent.person_id ORDER BY a.id"
     feature: "statement ORDER BY a qualified key, two derived sides sharing an output name"
     category: "column_resolution_corpus"
-    expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_tds_status: PASS
+    expected_rel_status: PASS
 
   - id: crcs_g4_order_by_qualified_key_over_left_join
     sql: "SELECT p.name AS name, d.budget AS budget FROM persons p LEFT OUTER JOIN departments d ON p.dept_id = d.id ORDER BY p.name"
     feature: "statement ORDER BY a qualified key over a LEFT OUTER JOIN"
     category: "column_resolution_corpus"
-    expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_tds_status: PASS
+    expected_rel_status: PASS
 
   - id: crcs_g4_order_by_qualified_key_over_three_way_join
     sql: "SELECT p.name AS name, o.id AS order_id, d.budget AS budget FROM persons p INNER JOIN departments d ON p.dept_id = d.id INNER JOIN orders o ON o.person_id = p.id ORDER BY p.name, o.id"
     feature: "statement ORDER BY qualified keys over a three-way join"
     category: "column_resolution_corpus"
-    expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_tds_status: PASS
+    expected_rel_status: PASS
 
   - id: crcs_g4_order_by_column_projected_only_through_a_cast
     sql: "SELECT CAST(p.id AS VARCHAR(10)) AS id_text, p.name AS name FROM persons p INNER JOIN departments d ON p.dept_id = d.id ORDER BY p.id"
@@ -652,19 +661,24 @@ tests:
     expected_tds_status: ERROR
     expected_rel_status: ERROR
 
+  # FAIL rather than ERROR: the key resolves to its materialised helper column, and
+  # that column holds UPPER(p.name). See colres_e3_order_by_expression_over_join in
+  # column_resolution_across_renames.yaml for the root cause -- processExtend cannot
+  # resolve the qualifier `d` against projectedContext, so d.name falls back to the
+  # bare name and picks up p's column instead.
   - id: crcs_g4_order_by_expression_over_join
     sql: "SELECT p.name AS name, d.name AS dept_name FROM persons p INNER JOIN departments d ON p.dept_id = d.id ORDER BY UPPER(d.name), p.name"
     feature: "statement ORDER BY an expression over a join"
     category: "column_resolution_corpus"
-    expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_tds_status: FAIL
+    expected_rel_status: FAIL
 
   - id: crcs_g4_order_by_aggregate_expression_over_join
     sql: "SELECT p.dept_id AS dept_id, COUNT(*) AS n FROM persons p INNER JOIN departments d ON p.dept_id = d.id GROUP BY p.dept_id ORDER BY COUNT(*) DESC, p.dept_id"
     feature: "statement ORDER BY an aggregate expression over a join"
     category: "column_resolution_corpus"
-    expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_tds_status: PASS
+    expected_rel_status: PASS
 
   - id: crcs_g4_order_by_ordinal_over_join
     sql: "SELECT p.name AS name, d.budget AS budget FROM persons p INNER JOIN departments d ON p.dept_id = d.id ORDER BY 1, 2"
@@ -677,15 +691,54 @@ tests:
     sql: "SELECT DISTINCT p.dept_id AS dept_id FROM persons p INNER JOIN departments d ON p.dept_id = d.id ORDER BY p.dept_id"
     feature: "SELECT DISTINCT with a qualified statement ORDER BY key, over a join"
     category: "column_resolution_corpus"
-    expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_tds_status: PASS
+    expected_rel_status: PASS
 
   - id: crcs_g4_order_by_qualified_key_renamed_by_projection
     sql: "SELECT p.name AS person_name, d.name AS dept_name FROM persons p INNER JOIN departments d ON p.dept_id = d.id ORDER BY p.name"
     feature: "statement ORDER BY a source column the projection renamed away"
     category: "column_resolution_corpus"
-    expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_tds_status: PASS
+    expected_rel_status: PASS
+
+  # The ordinal picking the RIGHT side, so it is not the mirror of
+  # join_inner_basic: what the two share is the base-name collision that makes
+  # the suffix appear at all.
+  - id: crcs_g4_order_by_ordinal_over_join_with_colliding_base_name
+    sql: "SELECT d.name, p.name AS person_name FROM persons p INNER JOIN departments d ON p.dept_id = d.id ORDER BY 1"
+    feature: "statement ORDER BY an ordinal naming an unaliased column whose base name collides across the join"
+    category: "column_resolution_corpus"
+    expected_tds_status: PASS
+    expected_rel_status: PASS
+
+  # A results test, not a compile test. Both output names exist, so resolving the
+  # key by its bare rendering picks `name` (p.name) and still compiles -- it just
+  # sorts by the wrong join side. Only a row comparison catches that, which is
+  # why this case is here and not only in testTranspile.pure.
+  - id: crcs_g4_order_by_qualified_key_names_the_second_join_side
+    sql: "SELECT p.name AS name, d.name AS dept_name FROM persons p INNER JOIN departments d ON p.dept_id = d.id ORDER BY d.name, p.name"
+    feature: "statement ORDER BY a qualified key whose base name also matches an earlier select item"
+    category: "column_resolution_corpus"
+    expected_tds_status: PASS
+    expected_rel_status: PASS
+
+  # Grouping has already discarded p.salary by the time the sort runs, so the key
+  # can only resolve by matching the select item that computes it.
+  - id: crcs_g4_order_by_aliased_aggregate_over_join
+    sql: "SELECT p.dept_id AS dept_id, MAX(p.salary) AS max_sal FROM persons p INNER JOIN departments d ON p.dept_id = d.id GROUP BY p.dept_id ORDER BY MAX(p.salary) DESC, p.dept_id"
+    feature: "statement ORDER BY an aggregate the projection aliased, over a join"
+    category: "column_resolution_corpus"
+    expected_tds_status: PASS
+    expected_rel_status: PASS
+
+  # The output alias as the key, rather than the source column: no select item
+  # renders to `person_name`, so this exercises the fallback rather than a match.
+  - id: crcs_g4_order_by_output_alias_over_join
+    sql: "SELECT p.name AS person_name, d.name AS dept_name FROM persons p INNER JOIN departments d ON p.dept_id = d.id ORDER BY person_name"
+    feature: "statement ORDER BY the projection's own output alias, over a join"
+    category: "column_resolution_corpus"
+    expected_tds_status: PASS
+    expected_rel_status: PASS
 
   # ==========================================================================
   # G5. Correlated subqueries and nested joins
@@ -1048,15 +1101,15 @@ tests:
     sql: "SELECT EXTRACT(MONTH FROM o.order_date) AS order_month, EXTRACT(YEAR FROM o.order_date) AS order_year, COUNT(*) AS n FROM orders o GROUP BY EXTRACT(MONTH FROM o.order_date), EXTRACT(YEAR FROM o.order_date) ORDER BY EXTRACT(MONTH FROM o.order_date) DESC, EXTRACT(YEAR FROM o.order_date) DESC, COUNT(*) DESC"
     feature: "COUNT(*) as a sort key with EXTRACT group keys"
     category: "column_resolution_corpus"
-    expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_tds_status: PASS
+    expected_rel_status: PASS
 
   - id: crcs_g6_count_star_as_sort_key_over_join
     sql: "SELECT d.name AS dept_name, COUNT(*) AS n FROM persons p INNER JOIN departments d ON p.dept_id = d.id GROUP BY d.name ORDER BY COUNT(*) DESC, d.name"
     feature: "COUNT(*) as a sort key over a join"
     category: "column_resolution_corpus"
-    expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_tds_status: PASS
+    expected_rel_status: PASS
 
   # UNION ALL of aggregate branches drawn from different joins, each branch
   # grouping on its own side, so the two arms reach processUnion with separately

--- a/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/src/test/resources/parity-tests/structural/group_by.yaml
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/src/test/resources/parity-tests/structural/group_by.yaml
@@ -72,15 +72,15 @@ tests:
     sql: "SELECT dept_id, SUM(salary) AS total FROM persons WHERE dept_id IS NOT NULL AND salary IS NOT NULL GROUP BY dept_id ORDER BY SUM(salary) DESC"
     feature: "ORDER BY aggregate"
     category: "group_by"
-    expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_tds_status: PASS
+    expected_rel_status: PASS
 
   - id: group_by_order_count
     sql: "SELECT dept_id, COUNT(*) AS cnt FROM persons WHERE dept_id IS NOT NULL GROUP BY dept_id ORDER BY COUNT(*) DESC, dept_id"
     feature: "ORDER BY aggregate"
     category: "group_by"
-    expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_tds_status: PASS
+    expected_rel_status: PASS
 
   # Conditional aggregation
   - id: group_by_cond_agg

--- a/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/src/test/resources/parity-tests/structural/joins.yaml
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/src/test/resources/parity-tests/structural/joins.yaml
@@ -4,44 +4,44 @@ tests:
     sql: "SELECT p.name, d.name AS dept_name FROM persons p INNER JOIN departments d ON p.dept_id = d.id ORDER BY 1"
     feature: "INNER JOIN"
     category: "joins"
-    expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_tds_status: PASS
+    expected_rel_status: PASS
 
   - id: join_inner_multi_condition
     sql: "SELECT p.name, d.name AS dept_name FROM persons p INNER JOIN departments d ON p.dept_id = d.id AND d.budget > 500000 ORDER BY 1"
     feature: "INNER JOIN"
     category: "joins"
-    expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_tds_status: PASS
+    expected_rel_status: PASS
 
   - id: join_inner_with_where
     sql: "SELECT p.name, d.name AS dept_name FROM persons p INNER JOIN departments d ON p.dept_id = d.id WHERE p.salary > 60000 ORDER BY 1"
     feature: "INNER JOIN"
     category: "joins"
-    expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_tds_status: PASS
+    expected_rel_status: PASS
 
   - id: join_inner_implicit
     sql: "SELECT p.name, d.name AS dept_name FROM persons p JOIN departments d ON p.dept_id = d.id ORDER BY 1"
     feature: "INNER JOIN"
     category: "joins"
-    expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_tds_status: PASS
+    expected_rel_status: PASS
 
   # LEFT JOIN
   - id: join_left_basic
     sql: "SELECT p.name, d.name AS dept_name FROM persons p LEFT JOIN departments d ON p.dept_id = d.id ORDER BY 1"
     feature: "LEFT JOIN"
     category: "joins"
-    expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_tds_status: PASS
+    expected_rel_status: PASS
 
   - id: join_left_null_fk
     sql: "SELECT p.name, COALESCE(d.name, 'No Dept') AS dept_name FROM persons p LEFT JOIN departments d ON p.dept_id = d.id WHERE d.id IS NULL ORDER BY 1"
     feature: "LEFT JOIN"
     category: "joins"
-    expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_tds_status: PASS
+    expected_rel_status: PASS
 
   - id: join_left_with_agg
     sql: "SELECT d.name AS dept_name, COUNT(p.id) AS cnt FROM departments d LEFT JOIN persons p ON p.dept_id = d.id GROUP BY d.name ORDER BY 1"
@@ -55,8 +55,8 @@ tests:
     sql: "SELECT p.name, d.name AS dept_name FROM persons p RIGHT JOIN departments d ON p.dept_id = d.id ORDER BY 1"
     feature: "RIGHT JOIN"
     category: "joins"
-    expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_tds_status: PASS
+    expected_rel_status: PASS
 
   - id: join_right_unmatched
     sql: "SELECT COALESCE(p.name, 'N/A') AS person, d.name AS dept_name FROM persons p RIGHT JOIN departments d ON p.dept_id = d.id ORDER BY 2"
@@ -85,8 +85,8 @@ tests:
     sql: "SELECT p.name, d.name AS dept_name FROM persons p CROSS JOIN departments d WHERE p.id <= 2 ORDER BY 1, 2"
     feature: "CROSS JOIN"
     category: "joins"
-    expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_tds_status: PASS
+    expected_rel_status: PASS
 
   - id: join_cross_count
     sql: "SELECT COUNT(*) AS total FROM persons p CROSS JOIN departments d WHERE p.id <= 3"
@@ -115,15 +115,15 @@ tests:
     sql: "SELECT p.name, d.name AS dept_name, o.amount FROM persons p INNER JOIN departments d ON p.dept_id = d.id INNER JOIN orders o ON o.person_id = p.id ORDER BY 1, 3"
     feature: "Multi-table JOIN"
     category: "joins"
-    expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_tds_status: PASS
+    expected_rel_status: PASS
 
   - id: join_three_tables_mixed
     sql: "SELECT p.name, d.name AS dept_name, COALESCE(o.amount, 0) AS amount FROM persons p INNER JOIN departments d ON p.dept_id = d.id LEFT JOIN orders o ON o.person_id = p.id WHERE p.salary IS NOT NULL ORDER BY 1, 3"
     feature: "Multi-table JOIN"
     category: "joins"
-    expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_tds_status: PASS
+    expected_rel_status: PASS
 
   - id: join_three_tables_agg
     sql: "SELECT d.name AS dept, COUNT(DISTINCT p.id) AS emps, COUNT(o.id) AS orders FROM departments d LEFT JOIN persons p ON p.dept_id = d.id LEFT JOIN orders o ON o.person_id = p.id GROUP BY d.name ORDER BY 1"

--- a/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/src/test/resources/parity-tests/structural/multiple_schemas.yaml
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/src/test/resources/parity-tests/structural/multiple_schemas.yaml
@@ -19,8 +19,8 @@ tests:
     sql: "SELECT p.name, d.name AS dept FROM public.persons p JOIN public.departments d ON p.dept_id = d.id ORDER BY 1"
     feature: "schema-qualified join"
     category: "multiple_schemas"
-    expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_tds_status: PASS
+    expected_rel_status: PASS
 
   # Schema-qualified in subquery
   - id: schema_qualified_subquery

--- a/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/src/test/resources/parity-tests/structural/select_star.yaml
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/src/test/resources/parity-tests/structural/select_star.yaml
@@ -26,8 +26,8 @@ tests:
     sql: "SELECT p.*, d.name AS dept_name FROM persons p JOIN departments d ON p.dept_id = d.id ORDER BY p.id"
     feature: "SELECT table.* with join"
     category: "select_star"
-    expected_tds_status: ERROR
-    expected_rel_status: ERROR
+    expected_tds_status: PASS
+    expected_rel_status: PASS
 
   - id: star_multiple_tables
     sql: "SELECT p.*, d.* FROM persons p JOIN departments d ON p.dept_id = d.id WHERE p.id <= 3 ORDER BY p.id"

--- a/legend-engine-xts-sql/legend-engine-xt-sql-transformation/legend-engine-xt-sql-pure/src/main/resources/core_external_query_sql/binding/fromPure/fromPure.pure
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-transformation/legend-engine-xt-sql-pure/src/main/resources/core_external_query_sql/binding/fromPure/fromPure.pure
@@ -1891,13 +1891,92 @@ function <<access.private>> meta::external::query::sql::transformation::queryToP
   );
 }
 
+//The select item an ORDER BY ordinal points at. extractColumnNameFromExpression carries its own copy
+//of these asserts for the GROUP BY path, which must keep resolving pre-projection and so cannot share
+//this code.
+function <<access.private>> meta::external::query::sql::transformation::queryToPure::ordinalSelectItem(ordinal:IntegerLiteral[1], selectItems:SelectItem[*]):SingleColumn[1]
+{
+  let index = $ordinal.value - 1; //0 index offset in sql is 1;
+  assert($index < $selectItems->size(), 'No select column at index ' + $ordinal.value->toString());
+  assert($selectItems->at($index)->instanceOf(SingleColumn), 'select * not currently supported for index order by');
+  $selectItems->at($index)->cast(@SingleColumn);
+}
+
+//The select item a statement-level sort key names, or nothing. A qualified key is matched on its
+//full name parts first, so 'ORDER BY d.name' over 'SELECT p.name, d.name AS dept_name' finds
+//d.name rather than the first item that happens to end in 'name'. Anything else - an aggregate, an
+//expression - is matched on its context-free rendering, which is how 'ORDER BY COUNT(*)' finds the
+//item the projection called 'cnt'.
+function <<access.private>> meta::external::query::sql::transformation::queryToPure::projectedSortKeySelectItem(sortKey:meta::external::query::sql::metamodel::Expression[1], selectItems:SelectItem[*]):SingleColumn[0..1]
+{
+  let columns = $selectItems->filter(si | $si->instanceOf(SingleColumn))->cast(@SingleColumn);
+
+  //empty for anything but a qualified reference, which then matches no select item
+  let keyParts = if (!$sortKey->instanceOf(QualifiedNameReference), | [], | $sortKey->cast(@QualifiedNameReference).name.parts->joinStrings('.'));
+
+  let qualified = $columns->filter(si | $si.expression->instanceOf(QualifiedNameReference))
+                          ->filter(si | $si.expression->cast(@QualifiedNameReference).name.parts->joinStrings('.') == $keyParts)
+                          ->first();
+
+  let rendered = extractNameFromExpression($sortKey, []);
+
+  if ($qualified->isNotEmpty(),
+    | $qualified,
+    | $columns->filter(si | extractNameFromExpression($si.expression, []) == $rendered)->first());
+}
+
+//The statement-level sibling of extensionColumnName and materialisedKeyName. processOrderBy runs
+//after the projection, so its keys have to name columns of the relation the projection produced -
+//and there is no single derivation that always does.
+//
+//The projection uses two naming schemes. When it renames, an output column takes the select item's
+//AS alias ('SELECT p.name AS person_name' over a join yields person_name); when it does not -
+//allColumnsSimpleSelect, or an unaliased item on the GROUP BY path - the column keeps the physical
+//name processDuplicateRenames gave it ('name_p'). Resolving through the context always yields the
+//latter, which is why keys broke over a join; resolving through the select list always yields the
+//former, which breaks the queries the projection left alone.
+//
+//So both are derived and offered as candidates, and the relation itself decides. That is sound here
+//because a candidate is only ever accepted if the relation has a column of that name, and each
+//candidate is join-side precise: the select-list one via the name-parts match above, the context one
+//via the alias map. Only the last resort - the context-free rendering, which names a key
+//processProjection materialised into an extend - is a bare name, and it is reached only when neither
+//precise candidate exists.
+//
+//columns is the post-projection schema: processProjection's closing clone recomputed it, and neither
+//having nor sort alters it. When it is empty there is nothing to probe, so the pre-existing context
+//resolution stands - which is also what a key naming no column at all reports, keeping those errors
+//as informative as they were.
+function <<access.private>> meta::external::query::sql::transformation::queryToPure::projectedSortKeyName(sortKey:meta::external::query::sql::metamodel::Expression[1], selectItems:SelectItem[*], context: SqlTransformContext[1]):String[1]
+{
+  let contextName = extractColumnNameFromExpression($sortKey, $selectItems, $context);
+
+  let outputName = $sortKey->match([
+    i:IntegerLiteral[1] | ordinalSelectItem($i, $selectItems)->extractNameFromSingleColumn([]),
+    e:meta::external::query::sql::metamodel::Expression[1] | projectedSortKeySelectItem($e, $selectItems)->map(si | $si->extractNameFromSingleColumn([]))
+  ]);
+
+  //an ordinal names a select item, never a materialised key, so it has no extend to fall back on
+  let extendName = $sortKey->match([
+    i:IntegerLiteral[1] | [],
+    e:meta::external::query::sql::metamodel::Expression[1] | extractNameFromExpression($e, [])
+  ]);
+
+  let candidates = $outputName->concatenate($contextName)->concatenate($extendName)->removeDuplicates();
+
+  let available = $context.columns.name;
+  let resolved = $candidates->filter(c | $c->in($available))->first();
+
+  if ($resolved->isEmpty(), | $contextName, | $resolved->toOne());
+}
+
 function <<access.private>> meta::external::query::sql::transformation::queryToPure::processOrderBy(sortItems: meta::external::query::sql::metamodel::SortItem[*], selectItems:SelectItem[*], _context: SqlTransformContext[1]): SqlTransformContext[1]
 {
   debug(|'processOrderBy', $_context.debug);
 
   let context = ^$_context(debug = $_context.debug->indent());
 
-  let sortInformation = $sortItems->map(si| createSortItemFunction($si, $selectItems, $context));
+  let sortInformation = $sortItems->map(si| createProjectedSortItemFunction($si, $selectItems, $context));
 
   let newExp = ^TDSBuilder().sort($context.expression->toOne(), $sortInformation, $context.relation->isTrue());
 
@@ -1924,6 +2003,15 @@ function <<access.private>> meta::external::query::sql::transformation::queryToP
     let column = extractColumnNameFromExpression($si.sortKey, $selectItems, $context);
 
     ^TDSBuilder().sortItem($si, $column, $context.relation->isTrue());
+}
+
+//Statement-level keys only. They apply to the projected relation, so their column comes from
+//projectedSortKeyName rather than from the context - see the comment there. The two functions above
+//keep resolving through the context: the 3-arg form is reached from ordered aggregation, which runs
+//before any projection, and createSortItemFunctionForColumn serves the window path.
+function <<access.private>> meta::external::query::sql::transformation::queryToPure::createProjectedSortItemFunction(si:SortItem[1], selectItems:SelectItem[*], context: SqlTransformContext[1]):ValueSpecification[1]
+{
+    ^TDSBuilder().sortItem($si, projectedSortKeyName($si.sortKey, $selectItems, $context), $context.relation->isTrue());
 }
 
 function <<access.private>> meta::external::query::sql::transformation::queryToPure::processLimitOffset(limit: meta::external::query::sql::metamodel::Expression[0..1], offset: meta::external::query::sql::metamodel::Expression[0..1], _context: SqlTransformContext[1]): SqlTransformContext[1]

--- a/legend-engine-xts-sql/legend-engine-xt-sql-transformation/legend-engine-xt-sql-pure/src/main/resources/core_external_query_sql/binding/fromPure/tests/testTranspile.pure
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-transformation/legend-engine-xt-sql-pure/src/main/resources/core_external_query_sql/binding/fromPure/tests/testTranspile.pure
@@ -5932,6 +5932,101 @@ function <<test.Test>> meta::external::query::sql::transformation::queryToPure::
   )
 }
 
+// ---------------------------------------------------------------------------
+// Statement-level ORDER BY keys resolved against the projected relation.
+//
+// processOrderBy runs after the projection but used to resolve its keys through
+// the pre-projection context, so over a join it asked for the suffixed name
+// processDuplicateRenames had set - 'String_t1' for a column the projection
+// outputs as 'String'. projectedSortKeyName matches the key against the select
+// list instead and takes the matching item's output name.
+//
+// The join is load-bearing throughout: without it there are no suffixes and the
+// two spellings coincide.
+// ---------------------------------------------------------------------------
+
+// The ordinal path. Select item 1 is unaliased and its base name collides with
+// the other join side, which is what makes the suffix appear.
+function <<test.Test>> meta::external::query::sql::transformation::queryToPure::tests::testOrderByOrdinalOverJoinWithCollidingBaseName():Boolean[1]
+{
+  test(
+    'SELECT "t1"."String", "t2"."String" AS "other" ' +
+    'FROM service."/service/service1" "t1" ' +
+    'JOIN service."/service/service2" "t2" ON "t1"."Integer" = "t2"."Integer" ' +
+    'ORDER BY 1',
+    [
+      // placeholder: never compared (assertLambda/assertJSON are false); present so
+      // TestConfig.relation() selects relationSources(). See the block comment above.
+      c({| FlatInput.all()->project(
+            ~[ Boolean: x | $x.booleanIn, Integer: x | $x.integerIn, Float: x | $x.floatIn, Decimal: x | $x.decimalIn, StrictDate: x | $x.strictDateIn, DateTime: x | $x.dateTimeIn, String: x | $x.stringIn])
+        }, false, false)
+    ]
+  )
+}
+
+// An explicit qualified key naming a column the projection renamed: the key must
+// follow the rename onto "s" rather than keep spelling the source column.
+function <<test.Test>> meta::external::query::sql::transformation::queryToPure::tests::testOrderByQualifiedKeyRenamedByProjectionOverJoin():Boolean[1]
+{
+  test(
+    'SELECT "t1"."String" AS "s", "t2"."ID" AS "i" ' +
+    'FROM service."/service/service1" "t1" ' +
+    'JOIN service."/service/service2" "t2" ON "t1"."Integer" = "t2"."Integer" ' +
+    'ORDER BY "t1"."String"',
+    [
+      // placeholder: never compared (assertLambda/assertJSON are false); present so
+      // TestConfig.relation() selects relationSources(). See the block comment above.
+      c({| FlatInput.all()->project(
+            ~[ Boolean: x | $x.booleanIn, Integer: x | $x.integerIn, Float: x | $x.floatIn, Decimal: x | $x.decimalIn, StrictDate: x | $x.strictDateIn, DateTime: x | $x.dateTimeIn, String: x | $x.stringIn])
+        }, false, false)
+    ]
+  )
+}
+
+// An aggregate key the projection aliased. The key is not a column at all, so it
+// can only resolve by matching the select item that computes it and taking its
+// alias - grouping has already discarded anything the aggregate was built from.
+function <<test.Test>> meta::external::query::sql::transformation::queryToPure::tests::testOrderByAggregateKeyAliasedByProjectionOverJoin():Boolean[1]
+{
+  test(
+    'SELECT "t1"."String" AS "s", count(*) AS "n" ' +
+    'FROM service."/service/service1" "t1" ' +
+    'JOIN service."/service/service2" "t2" ON "t1"."Integer" = "t2"."Integer" ' +
+    'GROUP BY "t1"."String" ORDER BY count(*) DESC',
+    [
+      // placeholder: never compared (assertLambda/assertJSON are false); present so
+      // TestConfig.relation() selects relationSources(). See the block comment above.
+      c({| FlatInput.all()->project(
+            ~[ Boolean: x | $x.booleanIn, Integer: x | $x.integerIn, Float: x | $x.floatIn, Decimal: x | $x.decimalIn, StrictDate: x | $x.strictDateIn, DateTime: x | $x.dateTimeIn, String: x | $x.stringIn])
+        }, false, false)
+    ]
+  )
+}
+
+// Both sides project a column called String under different output names, and the
+// key names the second one. Matching on the rendered name alone would drop the
+// qualifier and pick "a", so the key is matched on its full name parts first.
+//
+// Compiles either way - both "a" and "b" exist - so this asserts nothing beyond
+// that. What discriminates is the parity case of the same shape, which compares
+// rows: sorting by the wrong side shows up there as FAIL, not ERROR.
+function <<test.Test>> meta::external::query::sql::transformation::queryToPure::tests::testOrderByQualifiedKeyPicksTheNamedJoinSide():Boolean[1]
+{
+  test(
+    'SELECT "t1"."String" AS "a", "t2"."String" AS "b" ' +
+    'FROM service."/service/service1" "t1" ' +
+    'JOIN service."/service/service2" "t2" ON "t1"."Integer" = "t2"."Integer" ' +
+    'ORDER BY "t2"."String"',
+    [
+      // placeholder: never compared (assertLambda/assertJSON are false); present so
+      // TestConfig.relation() selects relationSources(). See the block comment above.
+      c({| FlatInput.all()->project(
+            ~[ Boolean: x | $x.booleanIn, Integer: x | $x.integerIn, Float: x | $x.floatIn, Decimal: x | $x.decimalIn, StrictDate: x | $x.strictDateIn, DateTime: x | $x.dateTimeIn, String: x | $x.stringIn])
+        }, false, false)
+    ]
+  )
+}
+
 function meta::external::query::sql::transformation::queryToPure::tests::testSources():SQLSource[*]
 {
   [


### PR DESCRIPTION
processOrderBy runs after the projection but resolved its sort keys through the
pre-projection context, so it named columns the sorted relation no longer had.
Over a join, processDuplicateRenames has suffixed each side, so an ordinary
two-table query with an ORDER BY failed to compile:

SELECT p.name, d.name AS dept_name
FROM persons p INNER JOIN departments d ON p.dept_id = d.id ORDER BY 1

The column 'name_p' can't be found in the relation (name:String, dept_name:String)


Resolving against the select list instead is not sufficient on its own, because
the projection uses two naming schemes. When it renames, an output column takes
the select item's AS alias; when it does not - allColumnsSimpleSelect, or an
unaliased item on the GROUP BY path - the column keeps the physical suffixed
name. Deriving from the context always yields the latter, deriving from the
select list always yields the former, and each breaks the other's queries.
So projectedSortKeyName derives both and lets the relation decide: the output
name of the select item the key names, then the context resolution, then the
context-free rendering that names a key processProjection materialised into an
extend. The first candidate present in context.columns wins - that is the exact
post-projection schema, recomputed by processProjection's closing clone and
altered by neither having nor sort. When no candidate is present, or the schema
is empty, the context name stands, so unresolvable keys report as before.
A candidate is only accepted if the relation has a column of that name, and the
first two are join-side precise: the select-list one matches a qualified key on
its full name parts, so ORDER BY d.name over SELECT p.name, d.name AS dept_name
picks dept_name rather than the first item ending in 'name'. Only the last
resort is a bare name, reached only when neither precise candidate exists.
extractColumnNameFromExpression and both createSortItemFunction overloads are
unchanged: GROUP BY keys and ordered aggregation run before the projection and
must keep resolving against the context.
Fixes 27 parity cases (54 rows across TDS and Relation): plain joins with an
ORDER BY, self-joins, three-table joins, SELECT table.* with a join, ORDER BY on
an aggregate the projection aliased, statement-level NULLS FIRST/LAST over a
join, and qualified keys the projection renamed away.
Two cases move ERROR -> FAIL and are recorded as such, with the cause in a
comment on each. They expose a separate pre-existing defect: processExtend
materialises an order-by key against projectedContext, whose contexts list is
empty, so a qualifier cannot resolve and the inner reference falls back to a
bare name. ORDER BY UPPER(d.name) builds upper("name_p"). The sort key now
resolves correctly; the column it resolves to holds the wrong value.
Adds four transpile tests and four crcs_g4 parity cases covering the ordinal,
qualified-rename, aliased-aggregate and join-side-disambiguation shapes.