### PR TITLE
Strip quotes from time zone ids in the relational connection parser

### DIFF
--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-executionPlan-execution/legend-engine-executionPlan-execution/src/main/java/org/finos/legend/engine/plan/execution/result/freemarker/PlanDateParameter.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-executionPlan-execution/legend-engine-executionPlan-execution/src/main/java/org/finos/legend/engine/plan/execution/result/freemarker/PlanDateParameter.java
@@ -37,7 +37,9 @@ class PlanDateParameter implements freemarker.template.TemplateDateModel
 
     public PlanDateParameter(LocalDateTime date, DateTimeFormatter dateTimeFormatter, String targetTz)
     {
-        String validTargetTz = targetTz.replaceAll("^['\"]+|['\"]+$", ""); // Sanitize the targetTz input by trimming any leading or trailing quotes before processing it
+        // Compatibility only: the connection grammar quotes a zone id and the parser now strips those quotes, so a
+        // zone id arrives bare. Plans generated before that fix carry the quotes, and ZoneId.of rejects them.
+        String validTargetTz = targetTz.replaceAll("^['\"]+|['\"]+$", "");
         LocalDateTime dateTimeAdjustedForTargetTz = getTargetZonedDateTime(date, validTargetTz);
         formattedDate = dateTimeAdjustedForTargetTz.format(dateTimeFormatter);
         processedDate = Date.from(dateTimeAdjustedForTargetTz.atZone(ZoneId.of(validTargetTz)).toInstant());

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/RelationalDatabaseConnectionParseTreeWalker.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/RelationalDatabaseConnectionParseTreeWalker.java
@@ -68,7 +68,13 @@ public class RelationalDatabaseConnectionParseTreeWalker
         connectionValue.queryTimeOutInSeconds = queryTimeOutInSecondsCtx != null ? Integer.parseInt(queryTimeOutInSecondsCtx.INTEGER().getText()) : null;
         // timezone (optional)
         RelationalDatabaseConnectionParserGrammar.DbConnectionTimezoneContext timezoneCtx = PureGrammarParserUtility.validateAndExtractOptionalField(ctx.dbConnectionTimezone(), "timezone", connectionValue.sourceInformation);
-        connectionValue.timeZone = timezoneCtx != null ? timezoneCtx.TIMEZONE().getText() : null;
+        if (timezoneCtx != null)
+        {
+            // A time zone is written either as a quoted zone id ('US/Arizona') or as a bare offset from UTC (-0500). The
+            // quotes are grammar syntax and not part of the id, so they have to come off: "'US/Arizona'" names no zone.
+            String tzText = timezoneCtx.TIMEZONE().getText();
+            connectionValue.timeZone = tzText.startsWith("'") ? PureGrammarParserUtility.fromGrammarString(tzText, true) : tzText;
+        }
         // quoteIdentifiers (optional)
         RelationalDatabaseConnectionParserGrammar.DbQuoteIdentifiersContext quoteIdentifiersContext = PureGrammarParserUtility.validateAndExtractOptionalField(ctx.dbQuoteIdentifiers(), "quoteIdentifiers", connectionValue.sourceInformation);
         connectionValue.quoteIdentifiers = quoteIdentifiersContext != null ? Boolean.parseBoolean(quoteIdentifiersContext.BOOLEAN().getText()) : null;

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/RelationalGrammarComposerExtension.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/RelationalGrammarComposerExtension.java
@@ -16,9 +16,9 @@ package org.finos.legend.engine.language.pure.grammar.to;
 
 import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.function.Function3;
+import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.tuple.Pair;
-import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.LazyIterate;
@@ -27,11 +27,15 @@ import org.finos.legend.engine.language.pure.grammar.from.RelationalGrammarParse
 import org.finos.legend.engine.language.pure.grammar.to.data.RelationalEmbeddedDataComposer;
 import org.finos.legend.engine.language.pure.grammar.to.extension.ContentWithType;
 import org.finos.legend.engine.language.pure.grammar.to.extension.PureGrammarComposerExtension;
+import org.finos.legend.engine.protocol.pure.m3.PackageableElement;
 import org.finos.legend.engine.protocol.pure.v1.model.context.PackageableElementPointer;
 import org.finos.legend.engine.protocol.pure.v1.model.data.EmbeddedData;
-import org.finos.legend.engine.protocol.pure.m3.PackageableElement;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.connection.Connection;
-import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapper.*;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapper.DatabaseMapper;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapper.RelationalMapper;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapper.SchemaMapper;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapper.SchemaPtr;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapper.TableMapper;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.AssociationMapping;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.ClassMapping;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.mappingTest.InputData;
@@ -56,17 +60,22 @@ import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.r
 
 import java.util.Collections;
 import java.util.List;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static org.finos.legend.engine.language.pure.grammar.to.PureGrammarComposer.buildSectionComposer;
-import static org.finos.legend.engine.language.pure.grammar.to.PureGrammarComposerUtility.*;
+import static org.finos.legend.engine.language.pure.grammar.to.PureGrammarComposerUtility.appendTabString;
+import static org.finos.legend.engine.language.pure.grammar.to.PureGrammarComposerUtility.convertString;
+import static org.finos.legend.engine.language.pure.grammar.to.PureGrammarComposerUtility.getTabString;
 
 public class RelationalGrammarComposerExtension implements IRelationalGrammarComposerExtension
 {
+    private static final Pattern TIME_ZONE_OFFSET = Pattern.compile("[+-][0-9]{4}");
+
     @Override
     public MutableList<String> group()
     {
-        return org.eclipse.collections.impl.factory.Lists.mutable.with("Store", "Relational", "-Core");
+        return Lists.mutable.with("Store", "Relational", "-Core");
     }
 
     private MutableList<Function2<PackageableElement, PureGrammarComposerContext, String>> renderers = Lists.mutable.with((element, context) ->
@@ -254,7 +263,7 @@ public class RelationalGrammarComposerExtension implements IRelationalGrammarCom
                 return Tuples.pair(RelationalGrammarParserExtension.RELATIONAL_DATABASE_CONNECTION_TYPE, context.getIndentationString() + getTabString(baseIndentation) + "{\n" +
                         (relationalDatabaseConnection.element != null ? (context.getIndentationString() + getTabString(baseIndentation + 1) + "store: " + relationalDatabaseConnection.element + ";\n") : "") +
                         context.getIndentationString() + getTabString(baseIndentation + 1) + "type: " + relationalDatabaseConnection.type.name() + ";\n" +
-                        (relationalDatabaseConnection.timeZone != null ? (context.getIndentationString() + getTabString(baseIndentation + 1) + "timezone: " + relationalDatabaseConnection.timeZone + ";\n") : "") +
+                        (relationalDatabaseConnection.timeZone != null ? (context.getIndentationString() + getTabString(baseIndentation + 1) + "timezone: " + renderTimeZone(relationalDatabaseConnection.timeZone) + ";\n") : "") +
                         (relationalDatabaseConnection.quoteIdentifiers != null ? (context.getIndentationString() + getTabString(baseIndentation + 1) + "quoteIdentifiers: " + relationalDatabaseConnection.quoteIdentifiers + ";\n") : "") +
                         // HACKY: this is a hack to make local mode works, we will need to rethink about this
                         (relationalDatabaseConnection.localMode != null && relationalDatabaseConnection.localMode ? (context.getIndentationString() + getTabString(baseIndentation + 1) + "mode: local;\n") : "") +
@@ -271,6 +280,15 @@ public class RelationalGrammarComposerExtension implements IRelationalGrammarCom
             }
             return null;
         });
+    }
+
+    /**
+     * Mirrors the parser: a bare offset from UTC goes back out as written, and anything else is a zone id, which
+     * the grammar takes only in quotes.
+     */
+    private static String renderTimeZone(String timeZone)
+    {
+        return TIME_ZONE_OFFSET.matcher(timeZone).matches() ? timeZone : convertString(timeZone, true);
     }
 
     private static String renderDatabase(Database database, PureGrammarComposerContext PUREcontext)

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestRelationalConnectionGrammarParser.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestRelationalConnectionGrammarParser.java
@@ -19,6 +19,10 @@ import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.list.mutable.ListAdapter;
 import org.finos.legend.engine.language.pure.grammar.from.antlr4.connection.ConnectionParserGrammar;
 import org.finos.legend.engine.language.pure.grammar.from.antlr4.connection.RelationalDatabaseConnectionParserGrammar;
+import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.connection.PackageableConnection;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.RelationalDatabaseConnection;
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.List;
@@ -88,6 +92,27 @@ public class TestRelationalConnectionGrammarParser extends TestGrammarParser.Tes
         // With zone id
         test(getTemplateConnectionWithTz("'EST'"), null);
         test(getTemplateConnectionWithTz("'US/Arizona'"), null);
+    }
+
+    /**
+     * The quotes around a zone id are grammar syntax, so they must not survive into the protocol: the value is
+     * handed to Java as a zone id, and "'US/Arizona'" is not one. An offset carries no quotes to begin with.
+     */
+    @Test
+    public void testTimezoneValueIsUnquoted()
+    {
+        Assert.assertEquals("US/Arizona", parseTimeZone("'US/Arizona'"));
+        Assert.assertEquals("UTC", parseTimeZone("'UTC'"));
+        Assert.assertEquals("EST", parseTimeZone("'EST'"));
+        Assert.assertEquals("+0700", parseTimeZone("+0700"));
+        Assert.assertEquals("-0500", parseTimeZone("-0500"));
+    }
+
+    private String parseTimeZone(String offsetOrCode)
+    {
+        PureModelContextData data = test(getTemplateConnectionWithTz(offsetOrCode));
+        PackageableConnection connection = data.getElementsOfType(PackageableConnection.class).get(0);
+        return ((RelationalDatabaseConnection) connection.connectionValue).timeZone;
     }
 
     @Test

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestRelationalConnectionGrammarRoundtrip.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestRelationalConnectionGrammarRoundtrip.java
@@ -374,4 +374,68 @@ public class TestRelationalConnectionGrammarRoundtrip extends TestGrammarRoundtr
                 "  ];\n" +
                 "}\n");
     }
+
+    /**
+     * A zone id round-trips through its quotes and a UTC offset round-trips without them, which only holds if the
+     * parser strips the quotes the grammar requires and the composer puts them back.
+     */
+    @Test
+    public void testRelationalDatabaseConnectionTimezone()
+    {
+        test("###Connection\n" +
+                "RelationalDatabaseConnection simple::H2Connection\n" +
+                "{\n" +
+                "  store: apps::pure::studio::relational::tests::dbInc;\n" +
+                "  type: H2;\n" +
+                "  timezone: 'US/Arizona';\n" +
+                "  specification: LocalH2\n" +
+                "  {\n" +
+                "  };\n" +
+                "  auth: DefaultH2;\n" +
+                "}\n");
+        test("###Connection\n" +
+                "RelationalDatabaseConnection simple::H2Connection\n" +
+                "{\n" +
+                "  store: apps::pure::studio::relational::tests::dbInc;\n" +
+                "  type: H2;\n" +
+                "  timezone: 'UTC';\n" +
+                "  specification: LocalH2\n" +
+                "  {\n" +
+                "  };\n" +
+                "  auth: DefaultH2;\n" +
+                "}\n");
+        test("###Connection\n" +
+                "RelationalDatabaseConnection simple::H2Connection\n" +
+                "{\n" +
+                "  store: apps::pure::studio::relational::tests::dbInc;\n" +
+                "  type: H2;\n" +
+                "  timezone: 'GMT+05:00';\n" +
+                "  specification: LocalH2\n" +
+                "  {\n" +
+                "  };\n" +
+                "  auth: DefaultH2;\n" +
+                "}\n");
+        test("###Connection\n" +
+                "RelationalDatabaseConnection simple::H2Connection\n" +
+                "{\n" +
+                "  store: apps::pure::studio::relational::tests::dbInc;\n" +
+                "  type: H2;\n" +
+                "  timezone: +0700;\n" +
+                "  specification: LocalH2\n" +
+                "  {\n" +
+                "  };\n" +
+                "  auth: DefaultH2;\n" +
+                "}\n");
+        test("###Connection\n" +
+                "RelationalDatabaseConnection simple::H2Connection\n" +
+                "{\n" +
+                "  store: apps::pure::studio::relational::tests::dbInc;\n" +
+                "  type: H2;\n" +
+                "  timezone: -0500;\n" +
+                "  specification: LocalH2\n" +
+                "  {\n" +
+                "  };\n" +
+                "  auth: DefaultH2;\n" +
+                "}\n");
+    }
 }

--- a/legend-engine-xts-service/legend-engine-language-pure-dsl-service-execution/src/test/java/org/finos/legend/engine/language/pure/dsl/service/execution/TestServiceRunner.java
+++ b/legend-engine-xts-service/legend-engine-language-pure-dsl-service-execution/src/test/java/org/finos/legend/engine/language/pure/dsl/service/execution/TestServiceRunner.java
@@ -145,7 +145,7 @@ public class TestServiceRunner
     @Test
     public void testSimpleServiceForOptionalDateTimeWithTimeZone()
     {
-        this.testOptionalParameter("test::fetchOptionalEmploymentDateTimeWithTZ_DateTime_$0_1$__Any_MANY_", "optionalDateTimeWithTZ", "2012-05-20T03:10:52.501", "{\"firstName\":\"Peter\",\"lastName\":\"Smith\",\"employmentDateTime\":\"2012-05-20T13:10:52.501000000\"}", "{\"firstName\":\"Bob\",\"lastName\":\"Stevens\",\"employmentDateTime\":null}");
+        this.testOptionalParameter("test::fetchOptionalEmploymentDateTimeWithTZ_DateTime_$0_1$__Any_MANY_", "optionalDateTimeWithTZ", "2012-05-20T03:10:52.501", "{\"firstName\":\"Peter\",\"lastName\":\"Smith\",\"employmentDateTime\":\"2012-05-20T03:10:52.501000000\"}", "{\"firstName\":\"Bob\",\"lastName\":\"Stevens\",\"employmentDateTime\":null}");
     }
 
     @Test
@@ -188,7 +188,7 @@ public class TestServiceRunner
     @Test
     public void testSimpleServiceForOptionalDateTimeWithTZ_Many()
     {
-        this.testOptionalParameter("test::fetchOptionalDateTimeWithTZMany_DateTime_MANY__Any_MANY_", "optionalDateTime", Arrays.asList("2005-03-15T08:47:52", "2012-05-20T03:10:52.501"), "[{\"firstName\":\"Peter\",\"lastName\":\"Smith\",\"employmentDateTime\":\"2012-05-20T13:10:52.501000000\"},{\"firstName\":\"John\",\"lastName\":\"Johnson\",\"employmentDateTime\":\"2005-03-15T18:47:52.000000000\"}]", "[]");
+        this.testOptionalParameter("test::fetchOptionalDateTimeWithTZMany_DateTime_MANY__Any_MANY_", "optionalDateTime", Arrays.asList("2005-03-15T08:47:52", "2012-05-20T03:10:52.501"), "[{\"firstName\":\"Peter\",\"lastName\":\"Smith\",\"employmentDateTime\":\"2012-05-20T03:10:52.501000000\"},{\"firstName\":\"John\",\"lastName\":\"Johnson\",\"employmentDateTime\":\"2005-03-15T08:47:52.000000000\"}]", "[]");
     }
 
     @Test


### PR DESCRIPTION
The connection grammar writes a time zone as either a quoted zone id ('US/Arizona') or a bare UTC offset (-0500), but the parser kept the quotes, so the protocol carried "'US/Arizona'" and nothing resolves that to a zone. legend-pure 5.96.0 silently falls back to GMT; 5.97.0 throws.

The composer now re-quotes anything that is not a bare offset, so grammar and protocol stay bijective.

This changes datetimes read back through a connection with a zone id. RelationalResult resolved the quoted id to GMT and returned the stored local time, while the write path had already converted into the zone, so values came back shifted by the zone offset. Two TestServiceRunner expectations were pinned to that and now round-trip the datetime given.