### PR TITLE
Set allowUnderscoresInHost for Snowflake connections

### DIFF
--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-execution/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/ds/specifications/SnowflakeDataSourceSpecification.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-execution/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/ds/specifications/SnowflakeDataSourceSpecification.java
@@ -40,6 +40,7 @@ public class SnowflakeDataSourceSpecification extends DataSourceSpecification
     public static final String SNOWFLAKE_NON_PROXY_HOSTS = "nonProxyHosts";
     public static final String SNOWFLAKE_USE_PROXY = "useProxy";
     public static final String SNOWFLAKE_ROLE = "role";
+    public static final String SNOWFLAKE_ALLOW_UNDERSCORES_IN_HOST = "allowUnderscoresInHost";
     public static final String SNOWFLAKE_ENABLE_QUERY_TAGS = "enableQueryTags";
 
     public static final String SNOWFLAKE_TEMP_TABLE_DB = "LEGEND_TEMP_DB";
@@ -68,6 +69,11 @@ public class SnowflakeDataSourceSpecification extends DataSourceSpecification
         this.extraDatasourceProperties.put("warehouse", warehouseName);
         this.extraDatasourceProperties.put("db", databaseName);
         this.extraDatasourceProperties.put("ocspFailOpen", true);
+        // Snowflake JDBC 3.13.25 flipped the default of allowUnderscoresInHost to false, which rewrites '_' to '-'
+        // in the host and breaks PrivateLink accounts whose name contains underscores. The driver reads the value
+        // with a cast to String, so a Boolean here would make the whole connect string unparseable.
+        // https://docs.snowflake.com/en/release-notes/clients-drivers/jdbc-2022#version-31325-november-16-2022
+        this.extraDatasourceProperties.putIfAbsent(SNOWFLAKE_ALLOW_UNDERSCORES_IN_HOST, "true");
 
         if (key.getAccountType() != null)
         {

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-execution/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/connection/ds/SnowflakeDataSourceSpecificationTest.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-execution/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/connection/ds/SnowflakeDataSourceSpecificationTest.java
@@ -192,6 +192,7 @@ public class SnowflakeDataSourceSpecificationTest extends SnowflakeDataSourceSpe
         Assert.assertEquals("jdbc:snowflake://organisation_division.organisationSample.us-east-1.aws.privatelink.snowflakecomputing.com", url);
 
         Properties properties = profile.getConnectionProperties();
+        Assert.assertEquals("true", properties.getProperty(SnowflakeDataSourceSpecification.SNOWFLAKE_ALLOW_UNDERSCORES_IN_HOST));
         Assert.assertEquals("organisation_division", properties.getProperty(SnowflakeDataSourceSpecification.SNOWFLAKE_ACCOUNT_NAME));
         Assert.assertEquals("us-east-1", properties.getProperty(SnowflakeDataSourceSpecification.SNOWFLAKE_REGION));
         Assert.assertEquals("aws", properties.getProperty(SnowflakeDataSourceSpecification.SNOWFLAKE_CLOUD_TYPE));
@@ -229,6 +230,7 @@ public class SnowflakeDataSourceSpecificationTest extends SnowflakeDataSourceSpe
         Assert.assertEquals("jdbc:snowflake://organisation_division.us-east-1.privatelink.snowflakecomputing.com", url);
 
         Properties properties = profile.getConnectionProperties();
+        Assert.assertEquals("true", properties.getProperty(SnowflakeDataSourceSpecification.SNOWFLAKE_ALLOW_UNDERSCORES_IN_HOST));
         Assert.assertEquals("organisation_division", properties.getProperty(SnowflakeDataSourceSpecification.SNOWFLAKE_ACCOUNT_NAME));
         Assert.assertEquals("us-east-1", properties.getProperty(SnowflakeDataSourceSpecification.SNOWFLAKE_REGION));
         Assert.assertEquals("privatelink", properties.getProperty(SnowflakeDataSourceSpecification.SNOWFLAKE_CLOUD_TYPE));
@@ -266,6 +268,7 @@ public class SnowflakeDataSourceSpecificationTest extends SnowflakeDataSourceSpe
         Assert.assertEquals("jdbc:snowflake://organisation_division.us-east-1.privatelink.snowflakecomputing.com", url);
 
         Properties properties = profile.getConnectionProperties();
+        Assert.assertEquals("true", properties.getProperty(SnowflakeDataSourceSpecification.SNOWFLAKE_ALLOW_UNDERSCORES_IN_HOST));
         Assert.assertEquals("organisation_division", properties.getProperty(SnowflakeDataSourceSpecification.SNOWFLAKE_ACCOUNT_NAME));
         Assert.assertEquals("us-east-1", properties.getProperty(SnowflakeDataSourceSpecification.SNOWFLAKE_REGION));
         Assert.assertEquals("privatelink", properties.getProperty(SnowflakeDataSourceSpecification.SNOWFLAKE_CLOUD_TYPE));
@@ -301,6 +304,7 @@ public class SnowflakeDataSourceSpecificationTest extends SnowflakeDataSourceSpe
         Assert.assertEquals("jdbc:snowflake://account1.us-east-1.aws.snowflakecomputing.com", url);
 
         Properties properties = profile.getConnectionProperties();
+        Assert.assertEquals("true", properties.getProperty(SnowflakeDataSourceSpecification.SNOWFLAKE_ALLOW_UNDERSCORES_IN_HOST));
         Assert.assertEquals("us-east-1", properties.getProperty(SnowflakeDataSourceSpecification.SNOWFLAKE_REGION));
         Assert.assertEquals("aws", properties.getProperty(SnowflakeDataSourceSpecification.SNOWFLAKE_CLOUD_TYPE));
         Assert.assertEquals(false, properties.get(SnowflakeDataSourceSpecification.SNOWFLAKE_QUOTE_IDENTIFIERS));
@@ -453,5 +457,29 @@ public class SnowflakeDataSourceSpecificationTest extends SnowflakeDataSourceSpe
     {
         RelationalDatabaseConnection connection = getConnectionWithQuotedIdentifiersIgnoreCase(true, false);
         Assert.assertEquals("false", computeAndGetQuotedIdentifiersIgnoreCaseFromJdbcProperties(connection));
+    }
+
+    @Test
+    public void testSnowflakeDataSourceSpecificationAllowsUnderscoresInHostByDefault()
+    {
+        SnowflakeDataSourceSpecification ds = buildSnowflakeDataSource("organisation_division", "us-east-1", "DEMO_WH", "DEMO_DB", "aws", false);
+        Properties properties = ds.getConnectionProperties();
+        Assert.assertEquals("true", properties.getProperty(SnowflakeDataSourceSpecification.SNOWFLAKE_ALLOW_UNDERSCORES_IN_HOST));
+    }
+
+    @Test
+    public void testSnowflakeDataSourceSpecificationAllowUnderscoresInHostCanBeOverridden()
+    {
+        Properties extraUserProperties = new Properties();
+        extraUserProperties.put(SnowflakeDataSourceSpecification.SNOWFLAKE_ALLOW_UNDERSCORES_IN_HOST, "false");
+
+        SnowflakeDataSourceSpecification ds = new SnowflakeDataSourceSpecification(
+                new SnowflakeDataSourceSpecificationKey("organisation_division", "us-east-1", "DEMO_WH", "DEMO_DB", "aws", false),
+                new SnowflakeManager(),
+                new SnowflakePublicAuthenticationStrategy("SF_KEY", "SF_PASS", "LEGEND_RO_PIERRE"),
+                extraUserProperties);
+
+        Properties properties = ds.getConnectionProperties();
+        Assert.assertEquals("false", properties.getProperty(SnowflakeDataSourceSpecification.SNOWFLAKE_ALLOW_UNDERSCORES_IN_HOST));
     }
 }


### PR DESCRIPTION
#### What type of PR is this?

Bug Fix

#### What does this PR do / why is it needed ?

The Snowflake JDBC upgrade to `4.3.2` pulls in the behaviour change introduced in driver version **3.13.25**, which flipped the default of `allowUnderscoresInHost` from `true` to `false`:

> Version 3.13.25 of the Snowflake JDBC driver changes the default value of the `allowUnderscoresInHost` parameter to `false`. This change impacts PrivateLink customers whose account names contain underscores. In this situation, you must override the default value by setting `allowUnderscoresInHost` to `true`.
>
> https://docs.snowflake.com/en/release-notes/clients-drivers/jdbc-2022#version-31325-november-16-2022

With the default now `false`, `SnowflakeConnectString.parse` rewrites `_` to `-` in the host whenever the account name contains underscores. `SnowflakeManager.buildURL` builds PrivateLink URLs as `<accountName>.<region>.privatelink.snowflakecomputing.com`, so an account such as `organisation_division` is silently rewritten to `organisation-division...`, which does not resolve for PrivateLink customers and the connection fails.

This PR defaults `allowUnderscoresInHost` to `"true"` in `SnowflakeDataSourceSpecification`'s datasource properties, restoring the pre-3.13.25 behaviour. It is applied via `putIfAbsent`, so a value supplied through the extra user properties still wins.

Note the value is deliberately a `String` and not a `Boolean`: the driver reads it with a cast to `String`, and a `Boolean` would throw inside `SnowflakeConnectString.parse`, which catches the exception and returns an invalid connect string — failing the connection entirely rather than just ignoring the property.

#### Which issue(s) this PR fixes:

Fixes #

#### Other notes for reviewers:

- Single code path: both the strategic connection manager (`SnowflakeConnectionExtension`) and `SnowflakeManager.getLocalDataSourceSpecification` build their datasource through `SnowflakeDataSourceSpecification`, so the property is picked up everywhere.
- Tests: `SnowflakeDataSourceSpecificationTest` now asserts the property on the VPS / MultiTenant / no-account-type PrivateLink cases and on the plain (non-PrivateLink) case, plus two new tests covering the default and the user override.

#### Does this PR introduce a user-facing change?

No — it restores the connection behaviour that existed before the driver upgrade.
