### PR TITLE
Add fix for snowflake-arrow driver update

### DIFF
--- a/legend-engine-xts-arrow/legend-engine-xt-arrow-runtime/src/main/java/org/finos/legend/engine/external/format/arrow/ArrowDataWriter.java
+++ b/legend-engine-xts-arrow/legend-engine-xt-arrow-runtime/src/main/java/org/finos/legend/engine/external/format/arrow/ArrowDataWriter.java
@@ -21,16 +21,20 @@ import java.util.TimeZone;
 
 import org.apache.arrow.adapter.jdbc.JdbcToArrowConfig;
 import org.apache.arrow.adapter.jdbc.JdbcToArrowConfigBuilder;
+import org.apache.arrow.adapter.jdbc.JdbcToArrowUtils;
 import org.apache.arrow.adapter.jdbc.LegendArrowVectorIterator;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.ipc.ArrowStreamWriter;
+import org.apache.arrow.vector.types.TimeUnit;
+import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.finos.legend.engine.external.shared.runtime.write.ExternalFormatWriter;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.sql.SQLException;
+import java.sql.Types;
 import org.finos.legend.engine.plan.execution.stores.relational.result.RelationalResult;
 
 public class ArrowDataWriter extends ExternalFormatWriter implements AutoCloseable
@@ -45,7 +49,22 @@ public class ArrowDataWriter extends ExternalFormatWriter implements AutoCloseab
         Calendar calendar = resultSet.getRelationalDatabaseTimeZone() == null ?
                 new GregorianCalendar(TimeZone.getTimeZone("GMT")) :
                 new GregorianCalendar(TimeZone.getTimeZone(resultSet.getRelationalDatabaseTimeZone()));
-        JdbcToArrowConfig config = new JdbcToArrowConfigBuilder(allocator, calendar).setReuseVectorSchemaRoot(true).build();
+        // Newer JDBC drivers (Snowflake 4.x, H2 2.x, ...) report TIMESTAMP_TZ / TIMESTAMP_LTZ columns as
+        // java.sql.Types.TIMESTAMP_WITH_TIMEZONE (2014), which the default arrow-jdbc type converter
+        // does not handle (see JdbcToArrowUtils.getArrowTypeFromJdbcType). Map it to the same
+        // ArrowType.Timestamp the converter uses for plain Types.TIMESTAMP so downstream schema and
+        // consumer wiring are unchanged.
+        JdbcToArrowConfig config = new JdbcToArrowConfigBuilder(allocator, calendar)
+                .setReuseVectorSchemaRoot(true)
+                .setJdbcToArrowTypeConverter((fieldInfo) ->
+                {
+                    if (fieldInfo.getJdbcType() == Types.TIMESTAMP_WITH_TIMEZONE)
+                    {
+                        return new ArrowType.Timestamp(TimeUnit.MILLISECOND, calendar.getTimeZone().getID());
+                    }
+                    return JdbcToArrowUtils.getArrowTypeFromJdbcType(fieldInfo, calendar);
+                })
+                .build();
         this.iterator = LegendArrowVectorIterator.create(resultSet.getResultSet(), config);
 
     }

--- a/legend-engine-xts-arrow/legend-engine-xt-arrow-runtime/src/test/java/TestArrowNodeExecutor.java
+++ b/legend-engine-xts-arrow/legend-engine-xt-arrow-runtime/src/test/java/TestArrowNodeExecutor.java
@@ -122,6 +122,50 @@ public class TestArrowNodeExecutor
 
     }
 
+    @Test
+    public void testExternalizeTimestampWithTimeZone() throws Exception
+    {
+        // Reproduces the Snowflake 4.x arrow failure: the JDBC driver now surfaces
+        // TIMESTAMP_TZ / TIMESTAMP_LTZ columns as java.sql.Types.TIMESTAMP_WITH_TIMEZONE (2014).
+        // H2 2.x does the same for TIMESTAMP WITH TIME ZONE columns, so we can trigger the
+        // same code path (JdbcToArrowUtils.getArrowTypeFromJdbcType -> "Unmapped JDBC type: 2014")
+        // without needing a live Snowflake connection.
+        ArrowRuntimeExtension extension = new ArrowRuntimeExtension();
+        ExternalFormatExternalizeTDSExecutionNode node = new ExternalFormatExternalizeTDSExecutionNode();
+        RelationalExecutionNode mockExecutionNode = Mockito.mock(RelationalExecutionNode.class);
+        DatabaseConnection mockDatabaseConnection = Mockito.mock(DatabaseConnection.class);
+
+        mockExecutionNode.connection = mockDatabaseConnection;
+        Mockito.when(mockDatabaseConnection.accept(any())).thenReturn(false);
+
+        try (Connection conn = DriverManager.getConnection("jdbc:h2:mem:test;TIME ZONE=America/New_York", "sa", "");
+             ByteArrayOutputStream outputStream = new ByteArrayOutputStream())
+        {
+            conn.createStatement().execute("DROP TABLE IF EXISTS testtz");
+            conn.createStatement().execute("CREATE TABLE testtz (testInt INTEGER, testTsTz TIMESTAMP WITH TIME ZONE)");
+            conn.createStatement().execute("INSERT INTO testtz (testInt, testTsTz) VALUES "
+                    + "(1, TIMESTAMP WITH TIME ZONE '2020-01-01 00:00:00-05:00'), "
+                    + "(2, TIMESTAMP WITH TIME ZONE '2020-01-01 00:00:00-02:00')");
+
+            RelationalResult result = new RelationalResult(
+                    FastList.newListWith(new RelationalExecutionActivity("SELECT * FROM testtz", null)),
+                    mockExecutionNode,
+                    FastList.newListWith(
+                            new SQLResultColumn("testInt", "INTEGER"),
+                            new SQLResultColumn("testTsTz", "TIMESTAMP")),
+                    null, "America/New_York", conn,
+                    Identity.getAnonymousIdentity(), null, null, new RequestContext());
+
+            ExternalFormatSerializeResult nodeExecute = (ExternalFormatSerializeResult) extension.executeExternalizeTDSExecutionNode(node, result, Identity.getAnonymousIdentity(), null);
+            nodeExecute.stream(outputStream, SerializationFormat.DEFAULT);
+
+            String expected = "TESTINT\tTESTTSTZ\n"
+                    + "1\t1577854800000\n"
+                    + "2\t1577844000000\n";
+            assertArrow(outputStream, expected);
+        }
+    }
+
     private void assertArrow(ByteArrayOutputStream actualOutputStream, String expectedTSV) throws IOException //input a TSV String
     {
         actualOutputStream.flush();


### PR DESCRIPTION
#### What type of PR is this?
- Bug Fix


#### What does this PR do / why is it needed ?

Required for updating the snowflake JDBC version 4.X . This version enables returning timestamp with timezone by default and needs to be handled in Arrow

The PR adds a test reproducing the error in H2 and the fix


#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
Yes
