### PR TITLE
revert addition of semistrctured to 1.33.0 protocol

### DIFF
--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/protocols/pure/v1_33_0/transfers/metamodel_relational.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/protocols/pure/v1_33_0/transfers/metamodel_relational.pure
@@ -410,7 +410,6 @@ function meta::protocols::pure::v1_33_0::transformation::fromPureGraph::store::r
                   r:meta::relational::metamodel::datatype::Real[1]|'REAL',
                   r:meta::relational::metamodel::datatype::Other[1]|'OTHER',
                   r:meta::relational::metamodel::datatype::Array[1]|'ARRAY',
-                  r:meta::relational::metamodel::datatype::SemiStructured[1]|'SEMISTRUCTURED',
                   d:meta::relational::metamodel::datatype::DbSpecificDataType[1]|$d.dbSpecificSql,
                   d:meta::relational::metamodel::datatype::DataType[1]|'' //columns mapped to functions do not yet support specific DataTypes
                 ]


### PR DESCRIPTION
#### What type of PR is this?

- Bug Fix

#### What does this PR do / why is it needed ?

- revert addition of semistrctured to 1.33.0 protocol, this is not needed and was causing test failures in downstream projects