### PR TITLE
[Backport release-legend-release-4.99] M2M: support multi-subtype graphFetch routing

### DIFF
--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/mapping/mappingExtension.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/mapping/mappingExtension.pure
@@ -243,17 +243,50 @@ function meta::pure::router::routing::findMappingsFromProperty(p:AbstractPropert
                                        )))
                           );
 
-       // We don't find anything in the old flow (if the source is an operation and the target type is not directly mapped...
-       if ($classMapping->isEmpty(),
-          |let mappings = $state.routingStrategy->cast(@meta::pure::router::store::metamodel::StoreMappingRoutingStrategy).classMappingsForClass($p->functionReturnType().rawType->toOne()->cast(@Class<Any>));
-           if ($mappings->isEmpty(),
-               |^M2MEmbeddedSetImplementation(id='embdedded_todo', root=true, class=$p->functionReturnType().rawType->toOne()->cast(@Class<Any>), parent = $mapping, property=$p->cast(@Property<Nil,Any|*>), targetSetImplementationId='todo', sourceSetImplementationId='todo'),
-               |$mappings
-           );,
-          |$classMapping
-       );
-   );
+     // Fallback when direct class-mapping lookup fails: resolve sub-type target set-impls
+     // from the source operation, dedupe, and union > 1 result into a synthesized
+     // OperationSetImplementation. This is the multi-subtype graphFetch routing path.
+
+        if ($classMapping->isEmpty(),
+                | let subtypeMappings = $sourceMappings->resolveOperation($mapping)
+                     ->cast(@PropertyMappingsImplementation)
+                     ->map(s | $s->_propertyMappingsByPropertyName($p.name->toOne())).targetSetImplementationId
+                     ->removeDuplicates()
+                     ->map(id | $mapping->classMappingById($id));
+                  if ($subtypeMappings->size() > 1,
+                     | let containers = $subtypeMappings->map(cm | ^SetImplementationContainer(id = $cm.id, setImplementation = $cm));
+                       ^OperationSetImplementation(
+                          id = 'synthesized_' + $c->cast(@Class<Any>).name->toOne() + '_union',
+                          root = true,
+                          class = $c->cast(@Class<Any>),
+                          parent = $mapping,
+                          parameters = $containers,
+                          operation = meta::pure::router::operations::union_OperationSetImplementation_1__SetImplementation_MANY_
+                       );,
+                     | if ($subtypeMappings->size() == 1,
+                          | $subtypeMappings,
+                          | let mappings = $state.routingStrategy
+                               ->cast(@meta::pure::router::store::metamodel::StoreMappingRoutingStrategy)
+                               .classMappingsForClass($p->functionReturnType().rawType->toOne()->cast(@Class<Any>));
+                            if ($mappings->isEmpty(),
+                               | ^M2MEmbeddedSetImplementation(
+                                    id = 'embdedded_todo',
+                                    root = true,
+                                    class = $p->functionReturnType().rawType->toOne()->cast(@Class<Any>),
+                                    parent = $mapping,
+                                    property = $p->cast(@Property<Nil, Any|*>),
+                                    targetSetImplementationId = 'todo',
+                                    sourceSetImplementationId = 'todo'
+                                 ),
+                               | $mappings
+                            );
+                       );
+                  );,
+                | $classMapping
+        );
+    );
 }
+
 
 function meta::pure::router::routing::allSuperSetImplementationIds(idToClassMapping:Map<String, List<SetImplementation>>[1], id:String[1]):String[*]
 {

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/graphWithSubTypes/testMultipleSubTypeWithAbstractClass.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/graphWithSubTypes/testMultipleSubTypeWithAbstractClass.pure
@@ -1,0 +1,126 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::pure::extension::*;
+import meta::core::runtime::*;
+import meta::pure::graphFetch::execution::*;
+import meta::external::store::model::*;
+import meta::pure::graphFetch::tests::sourceTreeCalc::withSubType::mostSpecific::*;
+
+Class meta::pure::graphFetch::tests::sourceTreeCalc::withSubType::mostSpecific::TData
+{
+}
+Class meta::pure::graphFetch::tests::sourceTreeCalc::withSubType::mostSpecific::TPayment extends TData
+{
+ paymentField: String[0..1];
+}
+Class meta::pure::graphFetch::tests::sourceTreeCalc::withSubType::mostSpecific::TAdjust extends TPayment
+{
+ adjustField: String[1];
+}
+Class meta::pure::graphFetch::tests::sourceTreeCalc::withSubType::mostSpecific::TWrapper
+{
+ data: TData[0..1];
+}
+Class meta::pure::graphFetch::tests::sourceTreeCalc::withSubType::mostSpecific::SData
+{
+}
+Class meta::pure::graphFetch::tests::sourceTreeCalc::withSubType::mostSpecific::SPayment extends SData
+{
+ paymentField: String[0..1];
+}
+Class meta::pure::graphFetch::tests::sourceTreeCalc::withSubType::mostSpecific::SAdjust extends SPayment
+{
+ adjustField: String[1];
+}
+Class meta::pure::graphFetch::tests::sourceTreeCalc::withSubType::mostSpecific::SWrapper
+{
+ data: SData[1];
+}
+
+function <<meta::pure::profiles::test.Test, meta::pure::profiles::test.AlloyOnly>> {meta::pure::executionPlan::profiles::serverVersion.start='v1_29_0'}
+meta::pure::mapping::modelToModel::test::alloy::simple::withSubType::mostSpecific::testMostSpecificWins():Boolean[1]
+{
+ let tree = #{
+    TWrapper {
+       data->subType(@TAdjust) {
+          paymentField,
+          adjustField
+       }
+    }
+ }#;
+ let mapping = meta::pure::graphFetch::tests::sourceTreeCalc::withSubType::mostSpecific::testMappingMostSpecific;
+ let query   = {|TWrapper.all()->graphFetch($tree)->serialize($tree)};
+ let runtime = ^Runtime(
+    connectionStores = [
+       ^ConnectionStore(
+          element = ^ModelStore(),
+          connection = ^JsonModelConnection(
+             class = SWrapper,
+             url = 'data:application/json,[{"data":{"paymentField":"P1","adjustField":"A1","@type":"meta::pure::graphFetch::tests::sourceTreeCalc::withSubType::mostSpecific::SAdjust"}}]'
+          )
+       )]);
+ let result = execute($query, $mapping, $runtime, defaultExtensions()).values;
+ assertJsonStringsEqual('{"data":{"paymentField":"P1","adjustField":"A1"}}', $result);
+}
+
+// Abstract 'data' routes for a single-match base input
+function <<meta::pure::profiles::test.Test, meta::pure::profiles::test.AlloyOnly>> {meta::pure::executionPlan::profiles::serverVersion.start='v1_29_0'}
+meta::pure::mapping::modelToModel::test::alloy::simple::withSubType::mostSpecific::testAbstractPropertyRoutes():Boolean[1]
+{
+ let tree = #{
+    TWrapper {
+       data->subType(@TPayment) {
+          paymentField
+       }
+    }
+ }#;
+ let mapping = meta::pure::graphFetch::tests::sourceTreeCalc::withSubType::mostSpecific::testMappingMostSpecific;
+ let query   = {|TWrapper.all()->graphFetch($tree)->serialize($tree)};
+ let runtime = ^Runtime(
+    connectionStores = [
+       ^ConnectionStore(
+          element = ^ModelStore(),
+          connection = ^JsonModelConnection(
+             class = SWrapper,
+             url = 'data:application/json,[{"data":{"paymentField":"P1","@type":"meta::pure::graphFetch::tests::sourceTreeCalc::withSubType::mostSpecific::SPayment"}}]'
+          )
+       )]);
+ let result = execute($query, $mapping, $runtime, defaultExtensions()).values;
+ assertJsonStringsEqual('{"data":{"paymentField":"P1"}}', $result);
+}
+
+###Mapping
+import meta::pure::graphFetch::tests::sourceTreeCalc::withSubType::mostSpecific::*;
+
+Mapping meta::pure::graphFetch::tests::sourceTreeCalc::withSubType::mostSpecific::testMappingMostSpecific
+(
+ *TWrapper: Pure
+ {
+    ~src SWrapper
+    data[PAY]: if($src.data->instanceOf(SPayment), | $src.data->cast(@SPayment), | []),
+    data[ADJ]: if($src.data->instanceOf(SAdjust), | $src.data->cast(@SAdjust), | [])
+ }
+ TPayment[PAY]: Pure
+ {
+    ~src SPayment
+    paymentField: $src.paymentField
+ }
+ TAdjust[ADJ]: Pure
+ {
+    ~src SAdjust
+    paymentField: $src.paymentField,
+    adjustField: $src.adjustField
+ }
+)

--- a/legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-pure/src/main/resources/core_java_platform_binding/legendJavaPlatformBinding/executionPlanNodes/graphFetch/graphFetchCommon.pure
+++ b/legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-pure/src/main/resources/core_java_platform_binding/legendJavaPlatformBinding/executionPlanNodes/graphFetch/graphFetchCommon.pure
@@ -152,20 +152,47 @@ function <<access.private>> meta::pure::executionPlan::platformBinding::legendJa
                ['public'], javaVoid(), $conventions->setterName($p), $param, 
                $field->j_assign($param)
             );
-            let adder  = javaMethod(
+            let adder = javaMethod(
                ['public'], javaVoid(), 'add' + $fieldName->toUpperFirstCharacter()->toOne(), [$object],
                if ($fieldType->isJavaList(),
-                   | [
-                        $field->j_eq(j_null())->j_if($field->j_assign(javaArrayList($elType)->j_new([]))),
-                        $field->j_invoke('add', [$object], javaVoid())
-                     ],
-                   | [
-                        j_cast($field, javaObject())->j_ne(j_null())->j_if(javaIllegalStateException()->j_new(j_string('Found multiple objects for property \'' + $p.name->toOne() + '\' of multiplicity with bound 1'))->j_throw()),
-                        $field->j_assign($object)
-                     ]
+                  | [
+                       $field->j_eq(j_null())->j_if($field->j_assign(javaArrayList($elType)->j_new([]))),
+                       $field->j_invoke('add', [$object], javaVoid())
+                    ],
+                  {|
+                     let returnType = $p->functionReturnType().rawType->toOne();
+                     let subtypes = $context.typeInfos->allClassInfos().type
+                        ->filter(c | $c != $returnType && $c->meta::pure::functions::meta::_subTypeOf($returnType));
+                     let errorMessage = 'Found multiple objects for property \'' + $p.name->toOne() + '\' of multiplicity with bound 1';
+                     if ($subtypes->isEmpty(),
+                        | [
+                             j_cast($field, javaObject())->j_ne(j_null())
+                                ->j_if(javaIllegalStateException()->j_new(j_string($errorMessage))->j_throw()),
+                             $field->j_assign($object)
+                          ],
+                        {|
+                           let ifaces = $subtypes->map(s | $conventions->className($s));
+                           let objMore = $ifaces->tail()->fold(
+                              {s, acc | $acc->j_or($object->j_instanceof($s)->j_and($field->j_instanceof($s)->j_not()))},
+                              $object->j_instanceof($ifaces->at(0))->j_and($field->j_instanceof($ifaces->at(0))->j_not())
+                           );
+                           let fldMore = $ifaces->tail()->fold(
+                              {s, acc | $acc->j_or($field->j_instanceof($s)->j_and($object->j_instanceof($s)->j_not()))},
+                              $field->j_instanceof($ifaces->at(0))->j_and($object->j_instanceof($ifaces->at(0))->j_not())
+                           );
+                           [
+                              $field->j_eq(j_null())->j_or($objMore->j_and($fldMore->j_not()))
+                                 ->j_if(
+                                    $field->j_assign($object),
+                                    $fldMore->j_and($objMore->j_not())->j_not()
+                                       ->j_if(javaIllegalStateException()->j_new(j_string($errorMessage))->j_throw())
+                                 )
+                           ];
+                        }
+                     );
+                  }
                )
             );
-
             $javaClass->addField(javaField(['private'], $fieldType, $fieldName))->addMethods([$getter, $setter, $adder]);
          }
       );


### PR DESCRIPTION
Backport of #5127 to `release-legend-release-4.99`.

Created automatically by the backport workflow. If this PR has
conflicts or CI failures, the assignee (the original author) is
responsible for resolving them.