### PR TITLE
Fix exponential plan-generation time for deeply nested case() expressions

### DIFF
--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/relationalExtension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/relationalExtension.pure
@@ -402,12 +402,12 @@ function <<access.private>> meta::relational::functions::typeInference::getDynaF
          'case',
          list([
             pair(
+               {params: RelationalOperationElement[*] | true},
                {params: RelationalOperationElement[*] | let size = ($params->size()-1)/2;
                                                         let range = range(0, $size->floor()*2, 2);
-                                                        $range->map(o | $params->at($o + 1)->inferRelationalType())->concatenate($params->at($params->size()-1)->inferRelationalType())->isSafeTypePossible();},
-               {params: RelationalOperationElement[*] | let size = ($params->size()-1)/2;
-                                                        let range = range(0, $size->floor()*2, 2);
-                                                        $range->map(o | $params->at($o + 1)->inferRelationalType())->concatenate($params->at($params->size()-1)->inferRelationalType())->getSafeType();}
+                                                        let types = $range->map(o | $params->at($o + 1)->inferRelationalType())->concatenate($params->at($params->size()-1)->inferRelationalType());
+                                                        assert($types->isSafeTypePossible(), 'Type inference not supported yet! Dyna function: case');
+                                                        $types->getSafeType();}
             )
          ])
       ),


### PR DESCRIPTION
#### What type of PR is this?
-Improvement
<!--
Choose one of the following labels :
- Improvement
- Bug Fix
-->

#### What does this PR do / why is it needed ?
meta::relational::functions::typeInference::inferDynaFunctionReturnType's 'case' entry had its match-predicate and return-type function each independently re-infer the type of every branch, including the recursively nested "else" branch. For a right-nested case(cond, then, case(...)) chain of depth N, this doubles work at every level: T(N) = 2*T(N-1) + O(1), i.e. O(2^N) total invocations. Hand-written multi-way string-normalization mappings (e.g. EnumerationMappings covering 20+ raw source variants as a case() chain) hit this directly, hanging plan generation. Rewrite the 'case' entry so the branch-type list is computed once, in the return-type function only, making the match-predicate a trivial true (case() only ever has one candidate pair, so it was never disambiguating between alternatives - only gating on type-safety, which the return-type function now does itself before computing the safe type). This changes the recurrence to T(N) = T(N-1) + O(1) = O(N).
<!--
Describe change being introduced by this PR.
-->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
