### PR TITLE
Add compilation check to ensure that only mappingProvider dataspace contexts can be missing runtime

### DIFF
--- a/legend-engine-xts-data-space/legend-engine-xt-data-space-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/DataSpaceCompilerExtension.java
+++ b/legend-engine-xts-data-space/legend-engine-xt-data-space-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/DataSpaceCompilerExtension.java
@@ -136,6 +136,10 @@ public class DataSpaceCompilerExtension implements CompilerExtension, EmbeddedDa
                     {
                         if (executionContextSet.add(executionContext.name))
                         {
+                            if (executionContext.defaultRuntime == null && executionContext.mapping != null && executionContext.mappingProvider == null)
+                            {
+                                throw new EngineException("Data space execution context '" + executionContext.name + "' must specify a defaultRuntime when a mapping is set", executionContext.sourceInformation, EngineErrorType.COMPILATION);
+                            }
                             Root_meta_pure_runtime_PackageableRuntime runtime = executionContext.defaultRuntime != null ? context.resolvePackageableRuntime(executionContext.defaultRuntime.path, executionContext.defaultRuntime.sourceInformation) : null;
                             Mapping mapping = executionContext.mapping != null
                                     ? context.resolveMapping(executionContext.mapping.path, executionContext.mapping.sourceInformation)

--- a/legend-engine-xts-data-space/legend-engine-xt-data-space-compiler/src/test/java/org/finos/legend/engine/language/pure/compiler/test/TestDataSpaceCompilationFromGrammar.java
+++ b/legend-engine-xts-data-space/legend-engine-xt-data-space-compiler/src/test/java/org/finos/legend/engine/language/pure/compiler/test/TestDataSpaceCompilationFromGrammar.java
@@ -714,6 +714,30 @@ public class TestDataSpaceCompilationFromGrammar extends TestCompilationFromGram
     }
 
     @Test
+    public void testDataSpaceExecutionContextWithMappingMissingDefaultRuntime()
+    {
+        test("###Mapping\n" +
+                "Mapping model::dummyMapping\n" +
+                "(\n" +
+                ")\n" +
+                "\n" +
+                "\n" +
+                "###DataSpace\n" +
+                "DataSpace model::dataSpace" +
+                "{\n" +
+                "  executionContexts:\n" +
+                "  [\n" +
+                "    {\n" +
+                "      name: 'Context 1';\n" +
+                "      description: 'some information about the context';\n" +
+                "      mapping: model::dummyMapping;\n" +
+                "    }\n" +
+                "  ];\n" +
+                "  defaultExecutionContext: 'Context 1';\n" +
+                "}\n", "COMPILATION error at [11:5-15:5]: Data space execution context 'Context 1' must specify a defaultRuntime when a mapping is set");
+    }
+
+    @Test
     public void testDataSpaceWithElements()
     {
         test("Class model::element {}\n" +
@@ -1611,32 +1635,6 @@ public class TestDataSpaceCompilationFromGrammar extends TestCompilationFromGram
                 "      query: src: model::element[1]|$src;\n" +
                 "    }\n" +
                 "  ];\n" +
-                "}\n");
-    }
-
-    @Test
-    public void testDataSpaceWithExecutionContextWithoutRuntimeCompiles()
-    {
-        String models = "Class model::element {}\n" +
-                "###Mapping\n" +
-                "Mapping model::dummyMapping\n" +
-                "(\n" +
-                ")\n" +
-                "\n";
-
-        test(models +
-                "###DataSpace\n" +
-                "DataSpace model::dataSpace\n" +
-                "{\n" +
-                "  executionContexts:\n" +
-                "  [\n" +
-                "    {\n" +
-                "      name: 'Context 1';\n" +
-                "      mapping: model::dummyMapping;\n" +
-                "    }\n" +
-                "  ];\n" +
-                "  defaultExecutionContext: 'Context 1';\n" +
-                "  title: 'some title';\n" +
                 "}\n");
     }
 


### PR DESCRIPTION
Add compilation check to ensure that only mappingProvider dataspace contexts can be missing runtime

#### What type of PR is this?

<!--
Choose one of the following labels :
- Improvement
- Bug Fix
-->

#### What does this PR do / why is it needed ?

<!--
Describe change being introduced by this PR.
-->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
