### PR TITLE
Review fix unqualified columns in subquery

### DIFF
--- a/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/src/test/resources/parity-tests/structural/subqueries.yaml
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/src/test/resources/parity-tests/structural/subqueries.yaml
@@ -327,3 +327,57 @@ tests:
     category: "subqueries"
     expected_tds_status: ERROR
     expected_rel_status: PASS
+
+  # Correlated EXISTS reading an UNQUALIFIED outer column. 'salary' only exists on
+  # the outer relation (persons), so Postgres resolves the bare name against the
+  # enclosing query.
+  - id: subquery_exists_correlated_unqualified_outer_column
+    sql: "SELECT p.name FROM persons p WHERE EXISTS (SELECT 1 FROM orders o WHERE o.person_id = p.id AND o.amount > salary / 1000) ORDER BY 1"
+    feature: "Correlated EXISTS with unqualified outer column"
+    category: "subqueries"
+    expected_tds_status: ERROR
+    expected_rel_status: PASS
+
+  # Same shape as above with a different outer-only column ('dept_id'). orders has
+  # no dept_id, so the bare name is unambiguously outer.
+  - id: subquery_exists_correlated_unqualified_outer_dept_id
+    sql: "SELECT p.name FROM persons p WHERE EXISTS (SELECT 1 FROM orders o WHERE o.person_id = p.id AND dept_id IS NOT NULL) ORDER BY 1"
+    feature: "Correlated EXISTS with unqualified outer column"
+    category: "subqueries"
+    expected_tds_status: ERROR
+    expected_rel_status: PASS
+
+  # Control: bare column ('amount') is present on the INNER relation, so it must
+  # resolve locally rather than being routed to the outer p. Guards the fix from
+  # over-reaching to columns that already resolve.
+  - id: subquery_exists_unqualified_inner_column_control
+    sql: "SELECT p.name FROM persons p WHERE EXISTS (SELECT 1 FROM orders o WHERE o.person_id = p.id AND amount > 100) ORDER BY 1"
+    feature: "Correlated EXISTS with unqualified inner column"
+    category: "subqueries"
+    expected_tds_status: ERROR
+    expected_rel_status: PASS
+
+  # Outer subquery alias reuses an alias used inside the subquery ('root' appears
+  # both as the inner FROM alias and as the outer derived-table alias).
+  - id: subquery_alias_collision_outer_reuses_inner_alias
+    sql: "SELECT root.computed_flag FROM (SELECT CASE WHEN b.dept_id IS NULL THEN 0 ELSE 1 END AS computed_flag FROM persons AS root LEFT OUTER JOIN persons AS b ON root.dept_id = b.dept_id) AS root ORDER BY computed_flag"
+    feature: "outer subquery alias reuses inner FROM alias"
+    category: "subqueries"
+    expected_tds_status: PASS
+    expected_rel_status: PASS
+
+  # Control for the case above - same shape with all distinct aliases; must keep passing.
+  - id: subquery_alias_collision_different_names_control
+    sql: "SELECT sub.computed_flag FROM (SELECT CASE WHEN b.dept_id IS NULL THEN 0 ELSE 1 END AS computed_flag FROM persons AS p LEFT OUTER JOIN persons AS b ON p.dept_id = b.dept_id) AS sub ORDER BY computed_flag"
+    feature: "distinct outer/inner aliases (control)"
+    category: "subqueries"
+    expected_tds_status: PASS
+    expected_rel_status: PASS
+
+  # Outer alias 'b' matches the inner LEFT JOIN RHS alias 'b'.
+  - id: subquery_alias_collision_outer_matches_inner_join_side
+    sql: "SELECT b.computed_flag FROM (SELECT CASE WHEN b.dept_id IS NULL THEN 0 ELSE 1 END AS computed_flag FROM persons AS p LEFT OUTER JOIN persons AS b ON p.dept_id = b.dept_id) AS b ORDER BY computed_flag"
+    feature: "outer alias matches inner join RHS alias"
+    category: "subqueries"
+    expected_tds_status: PASS
+    expected_rel_status: PASS

--- a/legend-engine-xts-sql/legend-engine-xt-sql-transformation/legend-engine-xt-sql-pure/src/main/resources/core_external_query_sql/binding/fromPure/fromPure.pure
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-transformation/legend-engine-xt-sql-pure/src/main/resources/core_external_query_sql/binding/fromPure/fromPure.pure
@@ -3177,8 +3177,28 @@ function <<access.private>> meta::external::query::sql::transformation::queryToP
 {
   debug(|'processQualififedNameReference', $context.debug);
 
+  // A correlated owner is a NAMED enclosing relation that uniquely owns a bare
+  // column this relation does not own itself.
+  // When one is found, the column metadata comes from it, so the row variable must
+  // come from it too - reading the right column off the wrong row passes here and
+  // then fails downstream in compileViaGrammar with "The column 'x' can't be found
+  // in the relation (...)".
+  let correlated = $context.correlatedOwner($q.name.parts);
+  let ownerName  = if ($correlated->isEmpty(), | '', | $correlated->toOne().name->toOne());
+  let outerVar   = if ($correlated->isEmpty(), | [], | $expContext.varMap->get($ownerName));
 
-  createTdsColumn($q.name, $expContext.var($q.name), $expContext, $context);
+  // CorrelatedOwner only returns named owners in relation mode, so varMap is guaranteed to hold
+  // one - a miss means $context.contexts and $expContext.varMap have drifted apart.
+  assert($correlated->isEmpty() || $outerVar->isNotEmpty(),
+         | 'correlated reference \'' + $q.name.parts->joinStrings('.') +
+           '\' resolved to enclosing relation \'' + $ownerName +
+           '\' but no row variable is mapped for it');
+
+  let var = if ($correlated->isEmpty(),
+                | $expContext.var($q.name),
+                | $outerVar->toOne());
+
+  createTdsColumn($q.name, $var, $expContext, $context);
 }
 
 function <<access.private>> meta::external::query::sql::transformation::queryToPure::processCast(c:Cast[1], expContext:SqlTransformExpressionContext[1], context:SqlTransformContext[1]):ValueSpecification[1]
@@ -4916,22 +4936,50 @@ Class meta::external::query::sql::transformation::queryToPure::SqlTransformConte
   }:String[1];
 
   context(name:String[0..1]){
-      let found = if ($name->isNotEmpty(),
-        | $this.contexts->filter(c | $c.name == $name),
-        | $this);
-
-      if ($found->isEmpty(), | $this, | $found->toOne());
-
+    let inner = $this.contexts->filter(c | $c.name == $name);
+    let found = if ($name->isEmpty() || $this.name == $name || $inner->isEmpty(),
+                    | $this,
+                    | $inner->toOne());
+    $found;
   }:SqlTransformContext[1];
+
+  // The enclosing relation that owns a BARE column this relation does not own itself.
+  //
+  // Relation mode only: the TDS path builds an empty varMap (rowExpressionContext's
+  // non-relation branch), so an owner found here could never be routed to a row
+  // variable. Named contexts only, for the same reason - varMap is keyed by name,
+  // and unnamed contexts exist (see the isNotEmpty filters in processSubRelation
+  // and processLateralJoin).
+  //
+  // The local-ownership check is what keeps every ordinary query on
+  // its existing path. Loosening it would silently reroute locally-owned columns
+  // to an outer row.
+  correlatedOwner(parts:String[*])
+  {
+    let single   = $parts->size() == 1 && $this.relation->isTrue();
+    let n        = if ($single, | $parts->toOne(), | '');
+    let localHit = $single && $this.columnByName($n, false)->isNotEmpty();
+    let owners   = if (!$single || $localHit,
+                       | [],
+                       | $this.contexts->filter(c |
+                             $c.name->isNotEmpty() && $c.columnByName($n, false)->isNotEmpty()));
+    if ($owners->size() == 1, | $owners->toOne(), | []);
+  }:SqlTransformContext[0..1];
+
   columnByNameParts(parts:String[*], failIfNotFound:Boolean[1])
   {
     let name = if ($parts->size() > 1, | $parts->last(), | $parts)->joinStrings('.');
     let contextName = $parts->init()->joinStrings('.');
 
     let foundContext = $this.contexts->filter(c | $c.name == $contextName);
-    let context = if ($contextName->isEmpty() || $foundContext->isEmpty(), | $this, | $foundContext->toOne());
+    let context = if ($contextName->isEmpty() || $this.name == $contextName || $foundContext->isEmpty(),
+                      | $this,
+                      | $foundContext->toOne());
 
-    $context.columnByName($name, $failIfNotFound);
+    let correlated = $this.correlatedOwner($parts);
+    if ($correlated->isNotEmpty(),
+      | $correlated->toOne().columnByName($name, $failIfNotFound),
+      | $context.columnByName($name, $failIfNotFound));
   }:meta::external::query::sql::transformation::queryToPure::QueryColumn[0..1];
   columnByName(name:String[1], failIfNotFound:Boolean[1]){
     let columns = $this.columns;

--- a/legend-engine-xts-sql/legend-engine-xt-sql-transformation/legend-engine-xt-sql-pure/src/main/resources/core_external_query_sql/binding/fromPure/tests/testTranspile.pure
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-transformation/legend-engine-xt-sql-pure/src/main/resources/core_external_query_sql/binding/fromPure/tests/testTranspile.pure
@@ -4861,6 +4861,81 @@ function <<test.Test>> meta::external::query::sql::transformation::queryToPure::
   )
 }
 
+// An unqualified correlated reference: 'Decimal' exists only on the enclosing relation, so it has
+// to resolve outward even though the sub-relation is the innermost scope.
+function <<test.Test>> meta::external::query::sql::transformation::queryToPure::tests::testExistsCorrelatedOnUnqualifiedOuterColumn():Boolean[1]
+{
+  test(
+    'SELECT table1."Boolean" FROM service."/service/service1" table1 WHERE EXISTS (SELECT t2."Integer" FROM service."/service/service2" t2 WHERE t2."ID" = "Decimal")',
+
+    [
+      c({|
+        meta::external::query::sql::transformation::queryToPure::tests::FlatInput.all()
+          ->project(~[Boolean : x | $x.booleanIn, Integer : x | $x.integerIn, Float : x | $x.floatIn, Decimal : x | $x.decimalIn, StrictDate : x | $x.strictDateIn, DateTime : x | $x.dateTimeIn, String : x | $x.stringIn])
+          ->filter(x |
+              meta::external::query::sql::transformation::queryToPure::tests::FlatInput.all()
+                ->project(~[ID : x | $x.idIn, Integer : x | $x.integerIn, String : x | $x.stringIn])
+                ->exists(e | $e.ID == $x.Decimal)
+          )
+          ->select(~[Boolean])
+      })
+    ]
+  )
+}
+
+// A bare name owned by the sub-relation must still bind to the sub-relation: the inner scope
+// shadows the enclosing one, so this must not be dragged outward by the correlation lookup.
+function <<test.Test>> meta::external::query::sql::transformation::queryToPure::tests::testExistsUnqualifiedInnerColumnIsNotCorrelated():Boolean[1]
+{
+  test(
+    'SELECT table1."Boolean" FROM service."/service/service1" table1 WHERE EXISTS (SELECT t2."Integer" FROM service."/service/service2" t2 WHERE "ID" = 1)',
+
+    [
+      c({|
+        meta::external::query::sql::transformation::queryToPure::tests::FlatInput.all()
+          ->project(~[Boolean : x | $x.booleanIn, Integer : x | $x.integerIn, Float : x | $x.floatIn, Decimal : x | $x.decimalIn, StrictDate : x | $x.strictDateIn, DateTime : x | $x.dateTimeIn, String : x | $x.stringIn])
+          ->filter(x |
+              meta::external::query::sql::transformation::queryToPure::tests::FlatInput.all()
+                ->project(~[ID : x | $x.idIn, Integer : x | $x.integerIn, String : x | $x.stringIn])
+                ->exists(e | $e.ID == 1)
+          )
+          ->select(~[Boolean])
+      })
+    ]
+  )
+}
+
+// The same alias at two nesting levels: the outer derived table and the join's left side are both
+// 'root'. Nothing clears the inherited 'contexts', so the stale inner 'root' is still visible when
+// the outer 'root.flag' is resolved - and it does not own 'flag'. The relation has to consult its
+// own name before its children.
+function <<test.Test>> meta::external::query::sql::transformation::queryToPure::tests::testDerivedTableAliasReusedAcrossNestingLevels():Boolean[1]
+{
+  let context = processQuery(
+    'SELECT root."flag" FROM (SELECT CASE WHEN b."ID" IS NULL THEN 0 ELSE 1 END AS "flag" ' +
+    'FROM service."/service/service1" AS root ' +
+    'LEFT OUTER JOIN service."/service/service2" AS b ON root."Integer" = b."Integer") AS root',
+    relationSources(), false);
+
+  // Not merely "it transpiled": the outer 'root' must have resolved to the derived table's own
+  // projection. Asserting the column is present is what distinguishes this from a wrong-scope
+  // resolution that still produces a non-empty expression.
+  assert($context.expression->toOne()->resolveRelationColumns()->exists(c | $c.name == 'flag'));
+}
+
+// A correlated subquery that reuses the outer alias and then references an
+// OUTER-only column through it. The inner FROM shadows the outer for the whole subquery, so
+// 'Decimal' is genuinely out of scope. This used to be accepted by resolving outward past the
+// shadow; it is now rejected, which is what standard SQL requires.
+function <<test.Test>> meta::external::query::sql::transformation::queryToPure::tests::testCorrelatedReusedAliasDoesNotResolvePastShadow():Boolean[1]
+{
+  error(
+    'SELECT t."Boolean" FROM service."/service/service1" t ' +
+    'WHERE EXISTS (SELECT "ID" FROM service."/service/service2" t WHERE t."Decimal" = 1)',
+    'no column found named: \'Decimal\'. Available columns: [ID, Integer, String]'
+  );
+}
+
 function <<test.Test>> meta::external::query::sql::transformation::queryToPure::tests::testNotExistsCorrelated():Boolean[1]
 {
   test(


### PR DESCRIPTION
## Summary

Two independent defects in `fromPure.pure` column resolution — both surfacing as `no column found named: 'X'` on valid SQL — plus one silent-bug correction where invalid SQL was previously accepted.


 **Fix 1** Bare correlated reference `WHERE t2.x = outerCol` fails with `no column found named: 'outerCol'` 
 - Resolves against the enclosing relation 

 **Fix 2** `SELECT root.flag FROM (…) AS root` fails when the derived table's FROM also aliases `root`  
 - Resolves against the outer derived table 


## Fix 1 — unqualified column in a correlated subquery

 

Bare references worked only when qualified, because `columnByNameParts` derives its context name from `parts->init()` — empty for a single-part name — so it never consulted enclosing scopes.

 

New `SqlTransformContext.correlatedOwner`: for a single-part name the current relation doesn't own itself, find the unique **named** enclosing relation that does. `processQualifiedNameReference` then pulls the row variable for that owner from `varMap`, so column metadata and row variable stay in agreement.

 

Deliberately narrow — returns empty (existing behaviour) when the name is qualified, when the relation owns it locally (guards ordinary correlated queries from being silently rerouted), when the owner is unnamed, when more than one enclosing relation owns it, or outside relation mode.

 

## Fix 2 — alias reused across nesting levels

 

`processSubRelation` appends child scopes to `contexts` and nothing clears them, so a stale same-named context stays visible one level out. Given:

 

```sql

SELECT root."flag"

FROM (SELECT CASE WHEN b."ID" IS NULL THEN 0 ELSE 1 END AS "flag"

      FROM service."/service/service1" AS root

      LEFT OUTER JOIN service."/service/service2" AS b

        ON root."Integer" = b."Integer") AS root

```

 

the qualified `root.flag` resolved into the *inner* `root`, which does not own `flag`.

 

`context(name)` and `columnByNameParts` now consult the relation's own name before scanning children (`$[this.name](http://this.name/) == $contextName` → return `$this`).

 
