### PR TITLE
Add grammar support for persistence strategy to dq recon element

### DIFF
--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/DataQualityCompilerExtension.java
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/DataQualityCompilerExtension.java
@@ -334,6 +334,11 @@ public class DataQualityCompilerExtension implements CompilerExtension
                         metamodel._expectedMatch(relationComparison.expectedMatch);
                     }
 
+                    if (relationComparison.persistenceStrategy != null)
+                    {
+                        metamodel._persistenceStrategy(buildPersistenceStrategy(relationComparison.persistenceStrategy, compileContext));
+                    }
+
                     processDataQualityTestSuites(relationComparison.testSuites, metamodel, relationComparison.sourceInformation, compileContext);
 
                     metamodel._validate(true, SourceInformationHelper.toM3SourceInformation(relationComparison.sourceInformation), compileContext.getExecutionSupport());

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-grammar/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/DataQualityParserGrammar.g4
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-grammar/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/DataQualityParserGrammar.g4
@@ -175,6 +175,7 @@ relationComparisonDefinition:   DATAQUALITYRELATIONCOMPARISON qualifiedName
                                         | columnsToCompare
                                         | reconStrategy
                                         | reconExpectedMatch
+                                        | persistenceStrategy
                                         | dqTestSuites
                                     )*
                                 BRACE_CLOSE

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-grammar/src/main/java/org/finos/legend/engine/language/dataquality/grammar/from/DataQualityTreeWalker.java
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-grammar/src/main/java/org/finos/legend/engine/language/dataquality/grammar/from/DataQualityTreeWalker.java
@@ -171,6 +171,12 @@ public class DataQualityTreeWalker
             relationComparison.testSuites = ListIterate.collect(testSuitesContext.dqTestSuite(), this::visitRelationComparisonTestSuite);
         }
 
+        DataQualityParserGrammar.PersistenceStrategyContext persistenceStrategyContext = PureGrammarParserUtility.validateAndExtractOptionalField(ctx.persistenceStrategy(), "persistenceStrategy", relationComparison.sourceInformation);
+        if (Objects.nonNull(persistenceStrategyContext))
+        {
+            relationComparison.persistenceStrategy = IDataQualityGrammarParserExtension.parsePersistenceStrategy(persistenceStrategyContext.islandDefinition(), this.walkerSourceInformation, this.parserContext.getPureGrammarParserExtensions());
+        }
+
         return relationComparison;
     }
 

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-grammar/src/main/java/org/finos/legend/engine/language/dataquality/grammar/to/DataQualityGrammarComposerExtension.java
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-grammar/src/main/java/org/finos/legend/engine/language/dataquality/grammar/to/DataQualityGrammarComposerExtension.java
@@ -28,6 +28,7 @@ import org.finos.legend.engine.language.pure.grammar.to.data.HelperEmbeddedDataG
 import org.finos.legend.engine.language.pure.grammar.to.extension.PureGrammarComposerExtension;
 import org.finos.legend.engine.language.pure.grammar.to.test.assertion.HelperTestAssertionGrammarComposer;
 import org.finos.legend.engine.protocol.dataquality.metamodel.DataQuality;
+import org.finos.legend.engine.protocol.dataquality.metamodel.DataQualityPersistenceStrategy;
 import org.finos.legend.engine.protocol.dataquality.metamodel.DataQualityPropertyGraphFetchTree;
 import org.finos.legend.engine.protocol.dataquality.metamodel.DataQualityRelationComparison;
 import org.finos.legend.engine.protocol.dataquality.metamodel.DataQualityRootGraphFetchTree;
@@ -106,18 +107,18 @@ public class DataQualityGrammarComposerExtension implements PureGrammarComposerE
                 "{\n" +
                 "   query: " + renderRelationQuery(dataqualityRelationValidation, context) +
                 "   validations: " + renderValidations(dataqualityRelationValidation.validations, context) +
-                renderPersistenceStrategy(dataqualityRelationValidation, context) +
+                renderPersistenceStrategy(dataqualityRelationValidation.persistenceStrategy, context) +
                 renderRelationValidationTestSuites(dataqualityRelationValidation, context) +
                 "}";
     }
 
-    private static String renderPersistenceStrategy(DataqualityRelationValidation dataqualityRelationValidation, PureGrammarComposerContext context)
+    private static String renderPersistenceStrategy(DataQualityPersistenceStrategy persistenceStrategy, PureGrammarComposerContext context)
     {
-        if (Objects.isNull(dataqualityRelationValidation.persistenceStrategy))
+        if (Objects.isNull(persistenceStrategy))
         {
             return "";
         }
-        return "   persistenceStrategy: " + IDataQualityGrammarComposerExtension.renderPersistenceStrategy(dataqualityRelationValidation.persistenceStrategy, 1, context) + ";\n";
+        return "   persistenceStrategy: " + IDataQualityGrammarComposerExtension.renderPersistenceStrategy(persistenceStrategy, 1, context) + ";\n";
     }
 
     private static String renderDataQualityRelationComparison(DataQualityRelationComparison relationComparison, PureGrammarComposerContext context)
@@ -134,6 +135,7 @@ public class DataQualityGrammarComposerExtension implements PureGrammarComposerE
                 "   strategy: " + renderReconStrategy(relationComparison.strategy) + ";\n" +
                 (Objects.isNull(relationComparison.expectedMatch) ? "" :
                     "   expectedMatch: " + relationComparison.expectedMatch + ";\n") +
+                renderPersistenceStrategy(relationComparison.persistenceStrategy, context) +
                 renderRelationComparisonTestSuites(relationComparison, context) +
                 "}";
     }

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-protocol/src/main/java/org/finos/legend/engine/protocol/dataquality/metamodel/DataQualityRelationComparison.java
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-protocol/src/main/java/org/finos/legend/engine/protocol/dataquality/metamodel/DataQualityRelationComparison.java
@@ -36,5 +36,6 @@ public class DataQualityRelationComparison extends ModelGenerationSpecification
     public List<String> columnsToCompare = Collections.emptyList();
     public ReconStrategy strategy;
     public Double expectedMatch;
+    public DataQualityPersistenceStrategy persistenceStrategy;
     public List<DataQualityRelationComparisonTestSuite> testSuites;
 }

--- a/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure/src/main/resources/core_dataquality/metamodel/metamodel.pure
+++ b/legend-engine-xts-dataquality/legend-engine-xt-dataquality-pure/src/main/resources/core_dataquality/metamodel/metamodel.pure
@@ -99,6 +99,7 @@ Class meta::external::dataquality::DataQualityRelationComparison extends Package
   columnsToCompare: String[*];
   strategy: ReconStrategy[1];
   expectedMatch: Float[0..1];
+  persistenceStrategy: DataQualityPersistenceStrategy[0..1];
 }
 
 Class meta::external::dataquality::ReconStrategy


### PR DESCRIPTION
#### What type of PR is this?

- Improvement

#### What does this PR do / why is it needed ?

Adds persistence strategy to the data quality relation comparison element. This is done in exactly the same way that was done for the data quality relational element - changes here https://github.com/finos/legend-studio/pull/5445

