### PR TITLE
Update legendpure@5.98.0 and simplify date format strings

### DIFF
--- a/legend-engine-xts-deephaven/legend-engine-xt-deephaven-PCT/src/main/resources/core_deephaven_pct/pct_deephaven_adapter.pure
+++ b/legend-engine-xts-deephaven/legend-engine-xt-deephaven-PCT/src/main/resources/core_deephaven_pct/pct_deephaven_adapter.pure
@@ -296,7 +296,10 @@ function meta::external::store::deephaven::tests::pct::process::processTDS(tds:m
             $tds->map(
               x | $cols->map(c | $c->eval($x)->match(
                                  [
-                                   x : Date[1] | format('%t{yyyy-MM-dd"T"HH:mm:ss.SSSSSSSSS"Z"}', $x),
+                                   // The optional sections write as much of the time as the date carries,
+                                   // so a date, a second, and a sub-second all go into the CSV, and the
+                                   // zone marker goes with the time rather than trailing a bare date
+                                   x : Date[1] | format('%t{yyyy-MM-dd?["T"HH:mm:ss?[.S*]"Z"]}', $x),
                                    s : Variant[1] | '"' + $s->toString() + '"',
                                    z : Any[1] | $z->toString(),
                                    n : Any[0] | ''

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-PCT/legend-engine-pure-functions-relationalStore-PCT-pure/src/main/resources/core_external_test_connection/pct_relational.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-PCT/legend-engine-pure-functions-relationalStore-PCT-pure/src/main/resources/core_external_test_connection/pct_relational.pure
@@ -704,7 +704,9 @@ function meta::relational::tests::pct::process::processTDS(tds:TDS<Any>[1], stat
             $tds->map(
               x | $cols->map(c|$c->eval($x)->match(
                                 [
-                                  x : Date[1] | format('%t{yyyy-MM-dd"T"HH:mm:ss.SSSSSSSSS}', $x),
+                                  // The optional sections write as much of the time as the date carries,
+                                  // so a date, a second, and a sub-second all go into the CSV
+                                  x : Date[1] | format('%t{yyyy-MM-dd?["T"HH:mm:ss?[.S*]]}', $x),
                                   s : Variant[1] | '"' + $s->toString()->replace('"', '""') + '"',
                                   z : Any[1] | $z->toString(),
                                   n : Any[0] | ''

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-duckdb/legend-engine-xt-relationalStore-duckdb-pure/src/main/resources/core_relational_duckdb/relational/sqlQueryToString/duckdbExtension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-duckdb/legend-engine-xt-relationalStore-duckdb-pure/src/main/resources/core_relational_duckdb/relational/sqlQueryToString/duckdbExtension.pure
@@ -145,15 +145,11 @@ function meta::relational::functions::sqlQueryToString::duckDB::convertDateToSql
 {
    //Default to UTC, if timezone is not specified. GMT is the same as UTC, UTC is not actually a timezone
    let timeZone = if( $dbTimeZone->isEmpty(), | 'GMT', |  $dbTimeZone->toOne());
-   if($date->hasSecond(),
-      | if ($date->hasSubsecond(),
-            | format('%t{[' + $timeZone + ']yyyy-MM-dd HH:mm:ss.SSSSSS}', $date);,
-            | format('%t{[' + $timeZone + ']yyyy-MM-dd HH:mm:ss}', $date);
-           ),
-      | if ($date->hasMonth() || $date->hasDay(),
-            | format('%t{[' + $timeZone + ']yyyy-MM-dd}', $date);,
-            | fail('DuckDB doesn\'t support YEAR and YEAR-MONTH'); '';
-          )
+   //The optional sections write the time only where the date carries one, and S* writes however many
+   //sub-second digits it has, so one format string covers day, second, and sub-second precision.
+   if($date->hasMonth() || $date->hasDay(),
+      | format('%t{[' + $timeZone + ']yyyy-MM-dd?[ HH:mm:ss?[.S*]]}', $date);,
+      | fail('DuckDB doesn\'t support YEAR and YEAR-MONTH'); '';
     );
 }
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-duckdb/legend-engine-xt-relationalStore-duckdb-sqlDialectTranslation-pure/src/main/resources/core_external_store_relational_sql_dialect_translation_duckdb/duckDBSqlDialect.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-duckdb/legend-engine-xt-relationalStore-duckdb-sqlDialectTranslation-pure/src/main/resources/core_external_store_relational_sql_dialect_translation_duckdb/duckDBSqlDialect.pure
@@ -696,16 +696,15 @@ function <<access.private>> meta::external::store::relational::sqlDialectTransla
 {
   //Default to UTC, if timezone is not specified. GMT is the same as UTC, UTC is not actually a timezone
   let timeZone = if( $dbTimeZone->isEmpty(), | 'GMT', |  $dbTimeZone->toOne());
+  //The branches differ in the SQL they wrap the date in, so each keeps its own format string, and
+  //S* writes however many sub-second digits the date has.
   if($date->hasSecond(),
     | if ($date->hasSubsecond(),
-        | let d= format('%t{[' + $timeZone + ']yyyy-MM-dd HH:mm:ss.SSSSSS}', $date);
-          format('TIMESTAMP \'%s\'',$d);,
-        | let d= format('%t{[' + $timeZone + ']yyyy-MM-dd HH:mm:ss}', $date);
-          format('TIMESTAMP_S \'%s\'',$d);
+        | format('TIMESTAMP \'%t{[' + $timeZone + ']yyyy-MM-dd HH:mm:ss.S*}\'', $date),
+        | format('TIMESTAMP_S \'%t{[' + $timeZone + ']yyyy-MM-dd HH:mm:ss}\'', $date)
         ),
     | if ($date->hasMonth() || $date->hasDay(),
-        | let d = format('%t{[' + $timeZone + ']yyyy-MM-dd}', $date);
-          format('DATE \'%s\'',$d);,
+        | format('DATE \'%t{[' + $timeZone + ']yyyy-MM-dd}\'', $date),
         | fail('DuckDB doesn\'t support YEAR and YEAR-MONTH'); '';
       )
   );

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-sqlDialectTranslation-pure/src/main/resources/core_external_store_relational_sql_dialect_translation_memsql/memSQLSqlDialect.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-memsql/legend-engine-xt-relationalStore-memsql-sqlDialectTranslation-pure/src/main/resources/core_external_store_relational_sql_dialect_translation_memsql/memSQLSqlDialect.pure
@@ -1920,16 +1920,12 @@ function <<access.private>> meta::external::store::relational::sqlDialectTransla
 {
   //Default to UTC, if timezone is not specified. GMT is the same as UTC, UTC is not actually a timezone
   let timeZone = if( $dbTimeZone->isEmpty(), | 'GMT', |  $dbTimeZone->toOne());
+  //Both timestamp branches wrapped the date in the same SQL, so the optional section that writes the
+  //sub-second digits where the date has them collapses them into one.
   if($date->hasSecond(),
-    | if ($date->hasSubsecond(),
-        | let d= format('%t{[' + $timeZone + ']yyyy-MM-dd HH:mm:ss.SSSSSS}', $date);
-          format('TIMESTAMP(\'%s\')',$d);,
-        | let d= format('%t{[' + $timeZone + ']yyyy-MM-dd HH:mm:ss}', $date);
-          format('TIMESTAMP(\'%s\')',$d);
-        ),
+    | format('TIMESTAMP(\'%t{[' + $timeZone + ']yyyy-MM-dd HH:mm:ss?[.S*]}\')', $date),
     | if ($date->hasMonth() || $date->hasDay(),
-        | let d = format('%t{[' + $timeZone + ']yyyy-MM-dd}', $date);
-          format('DATE(\'%s\')',$d);,
+        | format('DATE(\'%t{[' + $timeZone + ']yyyy-MM-dd}\')', $date),
         | fail('MemSQL doesn\'t support YEAR and YEAR-MONTH'); '';
       )
   );

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-oracle/legend-engine-xt-relationalStore-oracle-pure/src/main/resources/core_relational_oracle/relational/sqlQueryToString/oracleExtension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-oracle/legend-engine-xt-relationalStore-oracle-pure/src/main/resources/core_relational_oracle/relational/sqlQueryToString/oracleExtension.pure
@@ -170,14 +170,16 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::oracl
 {
    //Default to UTC, if timezone is not specified. GMT is the same as UTC, UTC is not actually a timezone
    let timeZone = if( $dbTimeZone->isEmpty(), | 'GMT', |  $dbTimeZone->toOne());
-   if($date->hasSubsecond(), | format('TIMESTAMP\'%t{[' + $timeZone + ']yyyy-MM-dd HH:mm:ss.SSSSSS}\'', $date),
-      | if ($date->hasSecond(), | format('TIMESTAMP\'%t{[' + $timeZone + ']yyyy-MM-dd HH:mm:ss}\'', $date),
-          | if ($date->hasMinute(), | format('TO_TIMESTAMP(\'%t{[' + $timeZone + ']yyyy-MM-dd HH:mm}\', \'YYYY-MM-DD HH24:MI\')', $date),
-            | if ($date->hasHour(), | format('TO_TIMESTAMP(\'%t{[' + $timeZone + ']yyyy-MM-dd HH}\', \'YYYY-MM-DD HH24\')', $date),
-              | if ($date->hasMonth() || $date->hasDay(),
-                | format('DATE\'%t{[' + $timeZone + ']yyyy-MM-dd}\'', $date),
-                | fail('Ensure the target system understands Year or Year-month semantic.'); '';
-      ))))
+   //The branches below differ in the SQL they wrap the date in, so only the two that share a wrapper
+   //merge: the optional section writes the sub-second digits where the date has them, and S* writes
+   //however many that is.
+   if($date->hasSecond(), | format('TIMESTAMP\'%t{[' + $timeZone + ']yyyy-MM-dd HH:mm:ss?[.S*]}\'', $date),
+      | if ($date->hasMinute(), | format('TO_TIMESTAMP(\'%t{[' + $timeZone + ']yyyy-MM-dd HH:mm}\', \'YYYY-MM-DD HH24:MI\')', $date),
+        | if ($date->hasHour(), | format('TO_TIMESTAMP(\'%t{[' + $timeZone + ']yyyy-MM-dd HH}\', \'YYYY-MM-DD HH24\')', $date),
+          | if ($date->hasMonth() || $date->hasDay(),
+            | format('DATE\'%t{[' + $timeZone + ']yyyy-MM-dd}\'', $date),
+            | fail('Ensure the target system understands Year or Year-month semantic.'); '';
+      )))
    );
 }
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/sqlQueryToString/extensionDefaults.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/sqlQueryToString/extensionDefaults.pure
@@ -145,14 +145,11 @@ function meta::relational::functions::sqlQueryToString::default::convertDateToSq
 {
    //Default to UTC, if timezone is not specified. GMT is the same as UTC, UTC is not actually a timezone
    let timeZone = if( $dbTimeZone->isEmpty(), | 'GMT', |  $dbTimeZone->toOne());
-   if($date->hasSecond(),
-      | if ($date->hasSubsecond(),
-            | format('%t{[' + $timeZone + ']yyyy-MM-dd HH:mm:ss.SSSSSS}', $date),
-            | format('%t{[' + $timeZone + ']yyyy-MM-dd HH:mm:ss}', $date)),
-      | if ($date->hasMonth() || $date->hasDay(),
-          | format('%t{[' + $timeZone + ']yyyy-MM-dd}', $date),
-          | fail('Ensure the target system understands Year or Year-month semantic.'); '';
-      )
+   //The optional sections write the time only where the date carries one, and S* writes however many
+   //sub-second digits it has, so one format string covers day, second, and sub-second precision.
+   if($date->hasMonth() || $date->hasDay(),
+      | format('%t{[' + $timeZone + ']yyyy-MM-dd?[ HH:mm:ss?[.S*]]}', $date),
+      | fail('Ensure the target system understands Year or Year-month semantic.'); '';
    );
 }
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/testDataGeneration/testDataGeneration.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/testDataGeneration/testDataGeneration.pure
@@ -666,7 +666,7 @@ function <<access.private>> meta::relational::testDataGeneration::convertValuesT
 {
    let stringToken = $values->map(any | $any->match([
       s:String[1] | '\'' + $s->replace('\'', '\'\'') + '\'';,
-      d:Date[1] |  '\'' + if($d->toString()->length() > 10, |format('%t{[' + 'GMT' + ']yyyy-MM-dd HH:mm:ss.S}', $d), |format('%t{[' + 'GMT' + ']yyyy-MM-dd}', $d)) + '\'',
+      d:Date[1] | format('\'%t{[GMT]yyyy-MM-dd?[ HH:mm:ss?[.S*]]}\'', $d),
       n:Number[1] | $n->toString(),
       f:Float[1] | $f->toString(),
       b:Boolean[1] | if($b, | '1', | '0'),

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-sqlDialectTranslation-pure/src/main/resources/core_external_store_relational_sql_dialect_translation/defaults/sqlDialectDefaults.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-sqlDialectTranslation-pure/src/main/resources/core_external_store_relational_sql_dialect_translation/defaults/sqlDialectDefaults.pure
@@ -988,14 +988,10 @@ function meta::external::store::relational::sqlDialectTranslation::defaults::con
 {
   //Default to UTC, if timezone is not specified. GMT is the same as UTC, UTC is not actually a timezone
   let timeZone = if($dbTimeZone->isEmpty(), |'GMT', |$dbTimeZone->toOne());
-  if($date->hasSecond(),
-  | if ($date->hasSubsecond(),
-      | format('%t{[' + $timeZone + ']yyyy-MM-dd HH:mm:ss.SSSSSS}', $date),
-      | format('%t{[' + $timeZone + ']yyyy-MM-dd HH:mm:ss}', $date)
-    ),
-  | if ($date->hasMonth() || $date->hasDay(),
-      | format('%t{[' + $timeZone + ']yyyy-MM-dd}', $date),
-      | fail('Ensure the target system understands Year or Year-month semantic.'); '';
-    )
+  //The optional sections write the time only where the date carries one, and S* writes however many
+  //sub-second digits it has, so one format string covers day, second, and sub-second precision.
+  if($date->hasMonth() || $date->hasDay(),
+    | format('%t{[' + $timeZone + ']yyyy-MM-dd?[ HH:mm:ss?[.S*]]}', $date),
+    | fail('Ensure the target system understands Year or Year-month semantic.'); '';
   );
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-sqlPlanning-pure/src/main/resources/core_external_store_relational_sql_planning/ruleBasedTransformation/ruleBasedTransformation.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-sqlPlanning-pure/src/main/resources/core_external_store_relational_sql_planning/ruleBasedTransformation/ruleBasedTransformation.pure
@@ -72,7 +72,7 @@ function <<access.private>> meta::external::store::relational::sqlPlanning::rule
       | ^TransformedQuery(hasChanged = false, query = $query),
       | 
         let debugPrefix = '[RuleBasedTransformation] Iteration (' + $currentIteration->toString() + '/' + $maxIterations->toString() + ')';
-        print(if(!$debug.debug, |'', | $debug.space + range(40)->map(x | '-')->joinStrings() + $debugPrefix + format(' (%t{yyyy-MM-dd HH:mm::ss.SSS})', now()) + range(40)->map(x | '-')->joinStrings() + '\n'));
+        print(if(!$debug.debug, |'', | $debug.space + range(40)->map(x | '-')->joinStrings() + $debugPrefix + format(' (%t{yyyy-MM-dd HH:mm::ss.S3})', now()) + range(40)->map(x | '-')->joinStrings() + '\n'));
         print(if(!$debug.debug, |'', | $debug.space + 'Rules: ' + $rules.name->joinStrings('[', ', ', ']') + '\n'));
         print(if(!$debug.debug, |'', | $debug.space + 'Starting Query: ' + $query->printDebugQuery($config, $extensions) + '\n'));
 
@@ -94,7 +94,7 @@ function <<access.private>> meta::external::store::relational::sqlPlanning::rule
               print(if(!$debug.debug, |'', | $debug.space + 'Updated Query: ' + $transformed.query->printDebugQuery($config, $extensions) + '\n'));,
             | print(if(!$debug.debug, |'', | $debug.space + 'Iteration Result: Query Unchanged\n'));
         );
-        print(if(!$debug.debug, |'', | $debug.space + range(40)->map(x | '-')->joinStrings() + $debugPrefix + format(' (%t{yyyy-MM-dd HH:mm::ss.SSS})', now()) + range(40)->map(x | '-')->joinStrings() + '\n\n'));
+        print(if(!$debug.debug, |'', | $debug.space + range(40)->map(x | '-')->joinStrings() + $debugPrefix + format(' (%t{yyyy-MM-dd HH:mm::ss.S3})', now()) + range(40)->map(x | '-')->joinStrings() + '\n\n'));
 
         if ($transformed.hasChanged,
             | $transformed.query->executeRuleBasedTransformersOnQueryTillFixedPointOrMaxIterations($config, $rules, $currentIteration + 1, $maxIterations, $debug, $extensions),

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
         <revision>4.143.1-SNAPSHOT</revision>
 
         <!-- Legend -->
-        <legend.pure.version>5.97.1</legend.pure.version>
+        <legend.pure.version>5.98.0</legend.pure.version>
         <legend.shared.version>0.37.0</legend.shared.version>
         <legend.web-application.version>13.2.0</legend.web-application.version>
         <legend.pylegend.version>0.21.0</legend.pylegend.version>


### PR DESCRIPTION
Upgrades legend-pure to 5.98.0 and migrates the date format patterns onto the syntax that release adds.

## What

[finos/legend-pure#1331](https://github.com/finos/legend-pure/pull/1331) gave the date format language two things it lacked: a sub-second field that takes a width (`S3`, `S<3`, `S*`, `S!3`, and the general `S(min,max,"fill")`), and optional sections — `?[...]` with `|` alternatives — which write a run of the string only where the date can carry it.

legend-engine was the motivating case. A Pure date comes at seven granularities and a format string could address exactly one, so every SQL literal writer here branched on granularity and kept a format string per branch. Not by preference: the language gave it no way to say otherwise. One format string now renders a date at whatever granularity it has.

| Writer | On master | Here |
|---|---|---|
| `default::convertDateToSqlString` | 3 format strings, 2 nested `if` | 1 format string, 1 `if` |
| `sqlDialectTranslation::defaults::convertDateToSqlString` | same | same |
| `duckDB::convertDateToSqlStringDuckDB` | same | same |
| `oracle::convertDateToSqlStringOracle` | 5 branches, 5 format strings | 4 branches, 4 format strings |
| `memSQL::convertDateToSqlStringForMemSQL` | 3 branches, 4 `format` calls | 2 branches, 2 calls |
| `duckDB::convertDateToSqlStringForDuckDB` | 3 branches, 6 `format` calls | 3 branches, 3 calls |
| `testDataGeneration::convertValuesToCsv` | a `toString()->length() > 10` test, 2 format strings, 2 concatenations | 1 call |
| PCT CSV writers (relational, Deephaven) | time and fraction both mandatory | optional sections |

The default writer is the one that carries the most: Oracle and DuckDB are the only dialects that override it, so every other dialect in the repository writes its date literals through the single line it changes.

Where a branch survives because the SQL it wraps the date in genuinely differs, the wrapper moved into the format string that branch already had, the way `oracleExtension` has always written it. That retires the intermediate variable whose only job was carrying a result between two `format` calls.

Reading the new patterns: `yyyy-MM-dd?[ HH:mm:ss?[.S*]]` writes the date, adds the time where there is one, and adds the fraction where there is one. The decimal point sits inside the section because the section carries both, and `S*` writes however many digits the date holds.

## Compatibility

Generated SQL is unchanged. `SSSSSS` is frozen as `S*` by the compatibility guarantee in 5.98.0, so respelling it changes nothing.

That is checked rather than asserted. Each rewrite was run head to head against the branch tree it replaces across all seven granularities, three time zones, and both failure paths, and agrees character for character — the year-month `Date has no day` error and the year `fail` included.

Two writers do change, both widening from an exception rather than altering a value. The PCT CSV writers threw on a date with no time and on one with no fraction of a second; `testDataGeneration` threw on the latter and cut a fraction down to a single digit, so `.070004235` was written `.0`. Both now write what the date carries. Every value that rendered before renders identically, and nothing in the PCT manifests pins the old errors.

## What is deliberately left alone

**`SSSSSS` still means "however many digits the date has", not microseconds.** The design record argues its authors meant a fixed six, and they probably did — but making it a true six-digit field would truncate a nanosecond date inside a SQL predicate so the literal stops denoting the same instant, and it would churn golden SQL across every dialect. That deserves its own PR rather than riding along with a syntax migration.

**The patterns that reach the plan-execution copy of this formatter.** `Library.format` and `PureDate.format` in `legend-engine-executionPlan-dependencies` are a fork of this language that does not understand `S3` or `?[`, and `essential/string.pure` binds Pure's `format` to it, so anything the Java platform binding compiles into a plan gets the fork. `formatDate`, `dateExtension`'s `ISO8601DateTimeFormat()`, and `ResultNormalizer` wait for that uplift. `formatDate`'s "ISO 8601 nanosecond precision" is the one worth coming back for: it writes nine digits only for a date whose fraction already has nine, so `.07` comes out as `.07`.

## Tests

| Suite | Tests |
|---|---|
| `Test_Pure_Relational` | 2,747 |
| H2 PCT | 1,491 |
| DuckDB PCT | 1,491 |
| DuckDB SDT | 434 |
| SQL dialect translation defaults | 61 |
| SQL planning | 24 |
| DuckDB | 12 |
| Oracle | 3 |

MemSQL SDT and Deephaven PCT need Docker and so run in CI rather than locally.

## Design record

[ADR-005: Sub-Second Fields and Optional Sections in the Date Format Language](https://github.com/finos/legend-pure/blob/master/docs/decisions/ADR-005-date-format-subsecond-and-optional-sections.md), which carries the reasoning for the field, the sections, and the compatibility guarantee this change relies on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P1mTH6nP8fHdVmbnSemBRo