### PR TITLE
Fix time zone resolution, and read date and timestamp columns as values

### DIFF
--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-executionPlan-execution/legend-engine-executionPlan-execution/src/main/java/org/finos/legend/engine/plan/execution/result/freemarker/PlanDateParameter.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-executionPlan-execution/legend-engine-executionPlan-execution/src/main/java/org/finos/legend/engine/plan/execution/result/freemarker/PlanDateParameter.java
@@ -15,6 +15,7 @@
 package org.finos.legend.engine.plan.execution.result.freemarker;
 
 import freemarker.template.TemplateDateModel;
+import org.finos.legend.pure.m4.tools.time.TimeZones;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -42,7 +43,7 @@ class PlanDateParameter implements freemarker.template.TemplateDateModel
         String validTargetTz = targetTz.replaceAll("^['\"]+|['\"]+$", "");
         LocalDateTime dateTimeAdjustedForTargetTz = getTargetZonedDateTime(date, validTargetTz);
         formattedDate = dateTimeAdjustedForTargetTz.format(dateTimeFormatter);
-        processedDate = Date.from(dateTimeAdjustedForTargetTz.atZone(ZoneId.of(validTargetTz)).toInstant());
+        processedDate = Date.from(dateTimeAdjustedForTargetTz.atZone(TimeZones.parse(validTargetTz)).toInstant());
     }
 
     private LocalDateTime getTargetZonedDateTime(LocalDateTime dateTime, String targetTz)
@@ -55,7 +56,7 @@ class PlanDateParameter implements freemarker.template.TemplateDateModel
         else
         {
             ZonedDateTime dateTimeGMT = ZonedDateTime.of(dateTime, gmtZoneId);
-            dateTimeInTargetZone = dateTimeGMT.withZoneSameInstant(ZoneId.of(targetTz)).toLocalDateTime();
+            dateTimeInTargetZone = dateTimeGMT.withZoneSameInstant(TimeZones.parse(targetTz)).toLocalDateTime();
         }
         return dateTimeInTargetZone;
     }

--- a/legend-engine-xts-arrow/legend-engine-xt-arrow-runtime/pom.xml
+++ b/legend-engine-xts-arrow/legend-engine-xt-arrow-runtime/pom.xml
@@ -30,6 +30,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-m4</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-executionPlan-execution</artifactId>
         </dependency>

--- a/legend-engine-xts-arrow/legend-engine-xt-arrow-runtime/src/main/java/org/finos/legend/engine/external/format/arrow/ArrowDataWriter.java
+++ b/legend-engine-xts-arrow/legend-engine-xt-arrow-runtime/src/main/java/org/finos/legend/engine/external/format/arrow/ArrowDataWriter.java
@@ -16,8 +16,6 @@ package org.finos.legend.engine.external.format.arrow;
 
 import java.nio.charset.Charset;
 import java.util.Calendar;
-import java.util.GregorianCalendar;
-import java.util.TimeZone;
 
 import org.apache.arrow.adapter.jdbc.JdbcToArrowConfig;
 import org.apache.arrow.adapter.jdbc.JdbcToArrowConfigBuilder;
@@ -30,6 +28,7 @@ import org.apache.arrow.vector.ipc.ArrowStreamWriter;
 import org.apache.arrow.vector.types.TimeUnit;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.finos.legend.engine.external.shared.runtime.write.ExternalFormatWriter;
+import org.finos.legend.pure.m4.tools.time.TimeZones;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -46,9 +45,7 @@ public class ArrowDataWriter extends ExternalFormatWriter implements AutoCloseab
     {
 
         this.allocator = new RootAllocator();
-        Calendar calendar = resultSet.getRelationalDatabaseTimeZone() == null ?
-                new GregorianCalendar(TimeZone.getTimeZone("GMT")) :
-                new GregorianCalendar(TimeZone.getTimeZone(resultSet.getRelationalDatabaseTimeZone()));
+        Calendar calendar = TimeZones.newCalendar((resultSet.getRelationalDatabaseTimeZone() == null) ? "GMT" : resultSet.getRelationalDatabaseTimeZone());
         // Newer JDBC drivers (Snowflake 4.x, H2 2.x, ...) report TIMESTAMP_TZ / TIMESTAMP_LTZ columns as
         // java.sql.Types.TIMESTAMP_WITH_TIMEZONE (2014), which the default arrow-jdbc type converter
         // does not handle (see JdbcToArrowUtils.getArrowTypeFromJdbcType). Map it to the same

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan-connection/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan-connection/pom.xml
@@ -91,6 +91,13 @@
     </profiles>
 
     <dependencies>
+        <!-- PURE -->
+        <dependency>
+            <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-m4</artifactId>
+        </dependency>
+        <!-- PURE -->
+
         <!-- ENGINE -->
         <dependency>
             <groupId>org.finos.legend.engine</groupId>

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan-connection/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/LegendH2Extensions.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan-connection/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/LegendH2Extensions.java
@@ -22,6 +22,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.similarity.JaroWinklerSimilarity;
 import org.apache.commons.text.similarity.LevenshteinDistance;
 import org.finos.legend.engine.shared.core.ObjectMapperFactory;
+import org.finos.legend.pure.m4.tools.time.TimeZones;
 import org.h2.tools.SimpleResultSet;
 import org.h2.util.DateTimeUtils;
 import org.h2.value.Value;
@@ -405,7 +406,7 @@ public class LegendH2Extensions
         String targetTimezone =  string2.getString();
         LocalDateTime localDateTime = LocalDateTime.parse(((ValueTimestamp) string1).getISOString());
         ZonedDateTime  utcTime = localDateTime.atZone(ZoneId.of("UTC"));
-        ZonedDateTime targetTime = utcTime.withZoneSameInstant(ZoneId.of(targetTimezone));
+        ZonedDateTime targetTime = utcTime.withZoneSameInstant(TimeZones.parse(targetTimezone));
         LocalTime time = targetTime.toLocalTime();
        return DateTimeUtils.parseTimestamp(targetTime.toLocalDateTime().toString(),null,false);
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/pom.xml
@@ -32,8 +32,7 @@
         <!-- Pure -->
         <dependency>
             <groupId>org.finos.legend.pure</groupId>
-            <artifactId>legend-pure-m2-dsl-mapping-pure</artifactId>
-            <scope>test</scope>
+            <artifactId>legend-pure-m4</artifactId>
         </dependency>
         <!-- Pure -->
 
@@ -102,9 +101,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <!-- ENGINE -->
-
-        <!-- ALLOY -->
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-xt-relationalStore-executionPlan-connection</artifactId>
@@ -115,7 +111,7 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <!-- ALLOY -->
+        <!-- ENGINE -->
 
         <!-- XML -->
         <dependency>
@@ -242,6 +238,11 @@
         <dependency>
             <groupId>org.finos.legend.pure</groupId>
             <artifactId>legend-pure-m3-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-m2-dsl-mapping-pure</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/result/RelationalResult.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/result/RelationalResult.java
@@ -19,10 +19,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.opentracing.Span;
 import org.eclipse.collections.api.block.function.Function;
+import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.api.list.MutableList;
-import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.utility.ListIterate;
 import org.finos.legend.engine.plan.dependencies.domain.date.PureDate;
 import org.finos.legend.engine.plan.dependencies.store.relational.IRelationalResult;
@@ -84,14 +84,11 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Timestamp;
 import java.sql.Types;
-import java.util.ArrayList;
 import java.util.Calendar;
-import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.Map;
 import java.util.Spliterator;
 import java.util.Spliterators;
-import java.util.TimeZone;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -550,29 +547,17 @@ public class RelationalResult extends StreamingResult implements IRelationalResu
 
     public Object getTransformedValue(int columnIndex) throws SQLException
     {
-        Object result = null;
-        switch (resultSetMetaData.getColumnType(columnIndex))
+        switch (this.resultSetMetaData.getColumnType(columnIndex))
         {
             case Types.DATE:
             {
                 java.sql.Date date = this.resultSet.getDate(columnIndex);
-                if (date != null)
-                {
-                    result = PureDate.fromSQLDate(date);
-                }
-                break;
+                return (date == null) ? null : PureDate.fromSQLDate(date);
             }
             case Types.TIMESTAMP:
             {
-                java.sql.Timestamp timestamp = this.resultSet.getTimestamp(
-                        columnIndex,
-                        TimeZones.newCalendar((getRelationalDatabaseTimeZone() == null) ? "GMT" : getRelationalDatabaseTimeZone())
-                );
-                if (timestamp != null)
-                {
-                    result = PureDate.fromSQLTimestamp(timestamp);
-                }
-                break;
+                java.sql.Timestamp timestamp = this.resultSet.getTimestamp(columnIndex, getCalendar());
+                return (timestamp == null) ? null : PureDate.fromSQLTimestamp(timestamp);
             }
             case Types.TINYINT:
             case Types.SMALLINT:
@@ -580,28 +565,19 @@ public class RelationalResult extends StreamingResult implements IRelationalResu
             case Types.BIGINT:
             {
                 long num = this.resultSet.getLong(columnIndex);
-                if (!this.resultSet.wasNull())
-                {
-                    result = Long.valueOf(num);
-                }
-                break;
+                return this.resultSet.wasNull() ? null : num;
             }
             case Types.REAL:
             case Types.FLOAT:
             case Types.DOUBLE:
             {
                 double num = this.resultSet.getDouble(columnIndex);
-                if (!this.resultSet.wasNull())
-                {
-                    result = Double.valueOf(num);
-                }
-                break;
+                return this.resultSet.wasNull() ? null : num;
             }
             case Types.DECIMAL:
             case Types.NUMERIC:
             {
-                result = this.resultSet.getBigDecimal(columnIndex);
-                break;
+                return this.resultSet.getBigDecimal(columnIndex);
             }
             case Types.CHAR:
             case Types.VARCHAR:
@@ -611,18 +587,13 @@ public class RelationalResult extends StreamingResult implements IRelationalResu
             case Types.LONGNVARCHAR:
             case Types.OTHER:
             {
-                result = this.resultSet.getString(columnIndex);
-                break;
+                return this.resultSet.getString(columnIndex);
             }
             case Types.BIT:
             case Types.BOOLEAN:
             {
                 boolean bool = this.resultSet.getBoolean(columnIndex);
-                if (!this.resultSet.wasNull())
-                {
-                    result = Boolean.valueOf(bool);
-                }
-                break;  // TODO: check this
+                return this.resultSet.wasNull() ? null : bool;
             }
             case Types.BINARY:
             case Types.VARBINARY:
@@ -630,23 +601,17 @@ public class RelationalResult extends StreamingResult implements IRelationalResu
             case Types.BLOB:
             {
                 byte[] bytes = this.resultSet.getBytes(columnIndex);
-                if (bytes != null)
-                {
-                    result = BinaryUtils.encodeHex(bytes);
-                }
-                break;
+                return (bytes == null) ? null : BinaryUtils.encodeHex(bytes);
             }
             case Types.NULL:
             {
-                // do nothing: value is already assigned to null
-                break;
+                return null;
             }
             default:
             {
-                result = this.resultSet.getObject(columnIndex);
+                return this.resultSet.getObject(columnIndex);
             }
         }
-        return result;
     }
 
     @Override
@@ -737,19 +702,13 @@ public class RelationalResult extends StreamingResult implements IRelationalResu
     private Calendar getCalendar()
     {
         String timeZoneId = getRelationalDatabaseTimeZone();
-        TimeZone timeZone = TimeZones.parseTimeZone((timeZoneId != null) ? timeZoneId : "GMT");
-        if (calendar == null)
+        if (this.calendar == null)
         {
             //TODO, throw exception, TZ should always be specified
             //Till then, default to PURE default which is "GMT"
-            calendar = new GregorianCalendar(timeZone);
+            this.calendar = TimeZones.newCalendar((timeZoneId == null) ? "GMT" : timeZoneId);
         }
-        else
-        {
-            calendar.clear();
-            calendar.setTimeZone(timeZone);
-        }
-        return calendar;
+        return this.calendar;
     }
 
     @Override
@@ -774,14 +733,13 @@ public class RelationalResult extends StreamingResult implements IRelationalResu
     {
         try
         {
-            List<Column> columns = new ArrayList<>(this.resultSetMetaData.getColumnCount());
-            Function<String, String> unquote = s -> s.startsWith("\"") && s.endsWith("\"") ? s.substring(1, s.length() - 1) : s;
+            MutableList<Column> columns = Lists.mutable.ofInitialCapacity(this.resultSetMetaData.getColumnCount());
             for (int i = 1; i <= this.resultSetMetaData.getColumnCount(); i++)
             {
                 String columnType = JDBCType.valueOf(this.resultSetMetaData.getColumnType(i)).getName();
                 String updatedColumnType = columnType.equals("TIMESTAMP_WITH_TIMEZONE") ? "TIMESTAMP WITH TIME ZONE" :
                         columnType.equals("TIME_WITH_TIMEZONE") ? "TIME WITH TIME ZONE" : columnType;
-                columns.add(new Column(unquote.valueOf(this.resultSetMetaData.getColumnLabel(i)), updatedColumnType));
+                columns.add(new Column(unquote(this.resultSetMetaData.getColumnLabel(i)), updatedColumnType));
             }
             return columns;
         }
@@ -790,5 +748,10 @@ public class RelationalResult extends StreamingResult implements IRelationalResu
             this.close();
             throw new RuntimeException(e);
         }
+    }
+
+    private static String unquote(String s)
+    {
+        return (s.startsWith("\"") && s.endsWith("\"")) ? s.substring(1, s.length() - 1) : s;
     }
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/result/RelationalResult.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/result/RelationalResult.java
@@ -84,6 +84,10 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Timestamp;
 import java.sql.Types;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.Calendar;
 import java.util.List;
 import java.util.Map;
@@ -122,6 +126,8 @@ public class RelationalResult extends StreamingResult implements IRelationalResu
 
     public Builder builder;
     private Calendar calendar;
+    private boolean readsLocalDate = true;
+    private boolean readsLocalDateTime = true;
 
     public RelationalResult(MutableList<ExecutionActivity> activities, RelationalExecutionNode node, List<SQLResultColumn> sqlResultColumns, String databaseType, String databaseTimeZone, Connection connection, Identity identity, List<String> temporaryTables, Span topSpan)
     {
@@ -551,13 +557,11 @@ public class RelationalResult extends StreamingResult implements IRelationalResu
         {
             case Types.DATE:
             {
-                java.sql.Date date = this.resultSet.getDate(columnIndex);
-                return (date == null) ? null : PureDate.fromSQLDate(date);
+                return readDay(columnIndex);
             }
             case Types.TIMESTAMP:
             {
-                java.sql.Timestamp timestamp = this.resultSet.getTimestamp(columnIndex, getCalendar());
-                return (timestamp == null) ? null : PureDate.fromSQLTimestamp(timestamp);
+                return readMoment(columnIndex);
             }
             case Types.TINYINT:
             case Types.SMALLINT:
@@ -753,5 +757,72 @@ public class RelationalResult extends StreamingResult implements IRelationalResu
     private static String unquote(String s)
     {
         return (s.startsWith("\"") && s.endsWith("\"")) ? s.substring(1, s.length() - 1) : s;
+    }
+
+    /**
+     * Read a date column.
+     *
+     * <p>The column carries a day and no zone, and {@link ResultSet#getObject(int, Class)} for a
+     * {@link LocalDate} hands that day over as it stands. Reading it as a {@link java.sql.Date}
+     * instead gives an instant, which yields a day only once a zone is chosen to read it in, and
+     * drivers do not agree on the zone they built that instant in. A driver need not answer the
+     * first call, and is asked once rather than once a row.
+     */
+    private PureDate readDay(int columnIndex) throws SQLException
+    {
+        if (this.readsLocalDate)
+        {
+            try
+            {
+                LocalDate day = this.resultSet.getObject(columnIndex, LocalDate.class);
+                return (day == null) ? null : toPureDate(day);
+            }
+            catch (SQLException | UnsupportedOperationException | AbstractMethodError unsupported)
+            {
+                this.readsLocalDate = false;
+            }
+        }
+        java.sql.Date date = this.resultSet.getDate(columnIndex);
+        return (date == null) ? null : toPureDate(date.toLocalDate());
+    }
+
+    /**
+     * Read a timestamp column.
+     *
+     * <p>The column carries a wall clock the database keeps in the zone the connection names, and
+     * a Pure date is that moment in UTC, so the wall clock is read and shifted here rather than
+     * by the driver. Handing a driver a calendar and asking it to shift does not work for every
+     * driver: some ignore the calendar and answer as though the connection named UTC, leaving
+     * every timestamp short by the connection zone.
+     */
+    private PureDate readMoment(int columnIndex) throws SQLException
+    {
+        Calendar calendar = getCalendar();
+        if (this.readsLocalDateTime)
+        {
+            try
+            {
+                LocalDateTime wallClock = this.resultSet.getObject(columnIndex, LocalDateTime.class);
+                return (wallClock == null) ? null : toPureDate(wallClock.atZone(calendar.getTimeZone().toZoneId()));
+            }
+            catch (SQLException | UnsupportedOperationException | AbstractMethodError unsupported)
+            {
+                this.readsLocalDateTime = false;
+            }
+        }
+        Timestamp timestamp = this.resultSet.getTimestamp(columnIndex, calendar);
+        return (timestamp == null) ? null : PureDate.fromSQLTimestamp(timestamp);
+    }
+
+    private static PureDate toPureDate(LocalDate day)
+    {
+        return PureDate.newPureDate(day.getYear(), day.getMonthValue(), day.getDayOfMonth());
+    }
+
+    private static PureDate toPureDate(ZonedDateTime moment)
+    {
+        LocalDateTime utc = moment.withZoneSameInstant(ZoneOffset.UTC).toLocalDateTime();
+        return PureDate.newPureDate(utc.getYear(), utc.getMonthValue(), utc.getDayOfMonth(),
+                utc.getHour(), utc.getMinute(), utc.getSecond(), String.format("%09d", utc.getNano()));
     }
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/result/RelationalResult.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/result/RelationalResult.java
@@ -18,30 +18,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.opentracing.Span;
-
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.sql.Array;
-import java.sql.Connection;
-import java.sql.JDBCType;
-import java.sql.ResultSet;
-import java.sql.ResultSetMetaData;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.sql.Timestamp;
-import java.sql.Types;
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.GregorianCalendar;
-import java.util.List;
-import java.util.Map;
-import java.util.Spliterator;
-import java.util.Spliterators;
-import java.util.TimeZone;
-import java.util.function.Consumer;
-import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
-
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.api.list.ImmutableList;
@@ -53,7 +29,10 @@ import org.finos.legend.engine.plan.dependencies.store.relational.IRelationalRes
 import org.finos.legend.engine.plan.execution.nodes.helpers.ExecutionNodeClassResultHelper;
 import org.finos.legend.engine.plan.execution.nodes.helpers.ExecutionNodePartialClassResultHelper;
 import org.finos.legend.engine.plan.execution.nodes.helpers.ExecutionNodeTDSResultHelper;
-import org.finos.legend.engine.plan.execution.result.*;
+import org.finos.legend.engine.plan.execution.result.ExecutionActivity;
+import org.finos.legend.engine.plan.execution.result.Result;
+import org.finos.legend.engine.plan.execution.result.ResultVisitor;
+import org.finos.legend.engine.plan.execution.result.StreamingResult;
 import org.finos.legend.engine.plan.execution.result.builder.Builder;
 import org.finos.legend.engine.plan.execution.result.builder._class.ClassBuilder;
 import org.finos.legend.engine.plan.execution.result.builder._class.ClassMappingInfo;
@@ -91,7 +70,31 @@ import org.finos.legend.engine.shared.core.api.request.RequestContext;
 import org.finos.legend.engine.shared.core.identity.Identity;
 import org.finos.legend.engine.shared.core.operational.logs.LogInfo;
 import org.finos.legend.engine.shared.core.operational.logs.LoggingEventType;
+import org.finos.legend.pure.m4.tools.time.TimeZones;
 import org.slf4j.Logger;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.sql.Array;
+import java.sql.Connection;
+import java.sql.JDBCType;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.List;
+import java.util.Map;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.TimeZone;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 public class RelationalResult extends StreamingResult implements IRelationalResult, StoreExecutable
 {
@@ -563,9 +566,7 @@ public class RelationalResult extends StreamingResult implements IRelationalResu
             {
                 java.sql.Timestamp timestamp = this.resultSet.getTimestamp(
                         columnIndex,
-                        getRelationalDatabaseTimeZone() == null ?
-                                new GregorianCalendar(TimeZone.getTimeZone("GMT")) :
-                                new GregorianCalendar(TimeZone.getTimeZone(getRelationalDatabaseTimeZone()))
+                        TimeZones.newCalendar((getRelationalDatabaseTimeZone() == null) ? "GMT" : getRelationalDatabaseTimeZone())
                 );
                 if (timestamp != null)
                 {
@@ -736,7 +737,7 @@ public class RelationalResult extends StreamingResult implements IRelationalResu
     private Calendar getCalendar()
     {
         String timeZoneId = getRelationalDatabaseTimeZone();
-        TimeZone timeZone = (timeZoneId != null) ? TimeZone.getTimeZone(timeZoneId) : TimeZone.getTimeZone("GMT");
+        TimeZone timeZone = TimeZones.parseTimeZone((timeZoneId != null) ? timeZoneId : "GMT");
         if (calendar == null)
         {
             //TODO, throw exception, TZ should always be specified

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/result/ResultColumn.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/result/ResultColumn.java
@@ -20,19 +20,26 @@ import org.eclipse.collections.impl.tuple.Tuples;
 import org.finos.legend.engine.plan.dependencies.domain.date.PureDate;
 
 import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.sql.Types;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.Calendar;
 import java.util.function.BiFunction;
 
 public class ResultColumn
 {
-    private int columnIndex;
-    private String label;
-    private String dataType;
-    private int dbMetaDataType;
+    private final int columnIndex;
+    private final String label;
+    private final String dataType;
+    private final int dbMetaDataType;
 
     private BiFunction<ResultSet, Calendar, Object> valueExtractor;
     private BiFunction<ResultSet, Calendar, Object> transformedValueExtractor;
+    private boolean readsLocalDate = true;
+    private boolean readsLocalDateTime = true;
 
     ResultColumn(int columnIndex, String label, String dataType, int dbMetaDataType)
     {
@@ -71,24 +78,12 @@ public class ResultColumn
         {
             case Types.DATE:
             {
-                this.transformedValueExtractor = BiFunctionHelper.unchecked(
-                        (resultSet, calendar) ->
-                        {
-                            java.sql.Date date = resultSet.getDate(this.columnIndex);
-                            return date != null ? PureDate.fromSQLDate(date) : null;
-                        }
-                );
+                this.transformedValueExtractor = BiFunctionHelper.unchecked((resultSet, calendar) -> readDay(resultSet));
                 break;
             }
             case Types.TIMESTAMP:
             {
-                this.transformedValueExtractor = BiFunctionHelper.unchecked(
-                        (resultSet, calendar) ->
-                        {
-                            java.sql.Timestamp timestamp = resultSet.getTimestamp(this.columnIndex, calendar);
-                            return timestamp != null ? PureDate.fromSQLTimestamp(timestamp) : null;
-                        }
-                );
+                this.transformedValueExtractor = BiFunctionHelper.unchecked(this::readMoment);
                 break;
             }
             case Types.TINYINT:
@@ -246,5 +241,71 @@ public class ResultColumn
             return Tuples.pair(this.label, "StrictDate");
         }
         return Tuples.pair(this.label, "String"); // Default is String. But shouldn't go here
+    }
+
+    /**
+     * Read a date column.
+     *
+     * <p>The column carries a day and no zone, and {@link ResultSet#getObject(int, Class)} for a
+     * {@link LocalDate} hands that day over as it stands. Reading it as a {@link java.sql.Date}
+     * instead gives an instant, which yields a day only once a zone is chosen to read it in, and
+     * drivers do not agree on the zone they built that instant in. A driver need not answer the
+     * first call, and is asked once rather than once a row.
+     */
+    private PureDate readDay(ResultSet resultSet) throws SQLException
+    {
+        if (this.readsLocalDate)
+        {
+            try
+            {
+                LocalDate day = resultSet.getObject(this.columnIndex, LocalDate.class);
+                return (day == null) ? null : toPureDate(day);
+            }
+            catch (SQLException | UnsupportedOperationException | AbstractMethodError unsupported)
+            {
+                this.readsLocalDate = false;
+            }
+        }
+        java.sql.Date date = resultSet.getDate(this.columnIndex);
+        return (date == null) ? null : toPureDate(date.toLocalDate());
+    }
+
+    /**
+     * Read a timestamp column.
+     *
+     * <p>The column carries a wall clock the database keeps in the zone the connection names, and
+     * a Pure date is that moment in UTC, so the wall clock is read and shifted here rather than
+     * by the driver. Handing a driver a calendar and asking it to shift does not work for every
+     * driver: some ignore the calendar and answer as though the connection named UTC, leaving
+     * every timestamp short by the connection zone.
+     */
+    private PureDate readMoment(ResultSet resultSet, Calendar calendar) throws SQLException
+    {
+        if (this.readsLocalDateTime)
+        {
+            try
+            {
+                LocalDateTime wallClock = resultSet.getObject(this.columnIndex, LocalDateTime.class);
+                return (wallClock == null) ? null : toPureDate(wallClock.atZone(calendar.getTimeZone().toZoneId()));
+            }
+            catch (SQLException | UnsupportedOperationException | AbstractMethodError unsupported)
+            {
+                this.readsLocalDateTime = false;
+            }
+        }
+        java.sql.Timestamp timestamp = resultSet.getTimestamp(this.columnIndex, calendar);
+        return (timestamp == null) ? null : PureDate.fromSQLTimestamp(timestamp);
+    }
+
+    private static PureDate toPureDate(LocalDate day)
+    {
+        return PureDate.newPureDate(day.getYear(), day.getMonthValue(), day.getDayOfMonth());
+    }
+
+    private static PureDate toPureDate(ZonedDateTime moment)
+    {
+        LocalDateTime utc = moment.withZoneSameInstant(ZoneOffset.UTC).toLocalDateTime();
+        return PureDate.newPureDate(utc.getYear(), utc.getMonthValue(), utc.getDayOfMonth(),
+                utc.getHour(), utc.getMinute(), utc.getSecond(), String.format("%09d", utc.getNano()));
     }
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/result/SQLExecutionResult.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/result/SQLExecutionResult.java
@@ -28,15 +28,14 @@ import org.finos.legend.engine.shared.core.api.request.RequestContext;
 import org.finos.legend.engine.shared.core.identity.Identity;
 import org.finos.legend.engine.shared.core.operational.logs.LogInfo;
 import org.finos.legend.engine.shared.core.operational.logs.LoggingEventType;
+import org.finos.legend.pure.m4.tools.time.TimeZones;
 import org.slf4j.Logger;
 
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.util.Calendar;
-import java.util.GregorianCalendar;
 import java.util.List;
-import java.util.TimeZone;
 
 public class SQLExecutionResult extends SQLResult
 {
@@ -71,7 +70,7 @@ public class SQLExecutionResult extends SQLResult
         super("success", connection, SQLExecutionNode.connection, activities, databaseType, temporaryTables, requestContext);
         this.SQLExecutionNode = SQLExecutionNode;
         this.databaseTimeZone = databaseTimeZone;
-        this.calendar = new GregorianCalendar(TimeZone.getTimeZone(databaseTimeZone));
+        this.calendar = TimeZones.newCalendar(databaseTimeZone);
         this.topSpan = topSpan;
         try
         {

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/serialization/StreamingTempTableResultCSVSerializer.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/serialization/StreamingTempTableResultCSVSerializer.java
@@ -37,7 +37,6 @@ import java.lang.reflect.Method;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.TimeZone;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -78,7 +77,7 @@ public class StreamingTempTableResultCSVSerializer extends CsvSerializer
              CSVPrinter csvPrinter = new CSVPrinter(out, this.csvFormat);)
         {
             String connectionTimeZone = this.tempTableStreamingResult.getRelationalDatabaseTimeZone();
-            timeZone = connectionTimeZone == null ? TimeZone.getTimeZone("GMT").toString() : connectionTimeZone;
+            timeZone = (connectionTimeZone == null) ? "GMT" : connectionTimeZone;
 
             final List<TempTableColumnMetaData> columns = this.tempTableStreamingResult.tempTableColumnMetaData;
             columnLabels = columns.stream().map(col -> col.column.label).collect(Collectors.toList());

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/result/TestResultColumn.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-execution/legend-engine-xt-relationalStore-executionPlan/src/test/java/org/finos/legend/engine/plan/execution/stores/relational/result/TestResultColumn.java
@@ -1,0 +1,157 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.plan.execution.stores.relational.result;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Types;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.List;
+import java.util.Properties;
+import java.util.TimeZone;
+
+/**
+ * Tests for how {@link ResultColumn} reads a date or timestamp column, against a database rather
+ * than against a hand built {@link java.sql.Date} or {@link java.sql.Timestamp}, since what a
+ * driver puts in one of those is the whole of the question.
+ */
+public class TestResultColumn
+{
+    /**
+     * A date column carries a day and no zone, and has to be read as that day whatever zone the JVM
+     * runs in.
+     *
+     * <p>Reading it as a {@link java.sql.Date} did not do that. The driver worked the day into an
+     * instant in the JVM default zone, and the day was read back out of that instant in GMT, so a
+     * JVM running east of GMT lost a day on every date. Asking for the day itself carries no
+     * instant and so no zone to disagree over.
+     */
+    @Test
+    public void testDateColumnIsIndependentOfTheDefaultTimeZone() throws SQLException
+    {
+        List<String> days = Arrays.asList("1753-12-31", "1900-01-01", "2014-03-10");
+        TimeZone defaultTimeZone = TimeZone.getDefault();
+        try
+        {
+            for (String zoneId : Arrays.asList("GMT", "America/New_York", "Asia/Tokyo", "Pacific/Kiritimati"))
+            {
+                TimeZone.setDefault(TimeZone.getTimeZone(zoneId));
+                Assert.assertEquals("default " + zoneId, days, readDays(days));
+            }
+        }
+        finally
+        {
+            TimeZone.setDefault(defaultTimeZone);
+        }
+    }
+
+    /**
+     * A timestamp column carries a wall clock the database keeps in the zone the connection names,
+     * and a Pure date is that moment in UTC, so reading one shifts it out of that zone. The shift
+     * is done here rather than by handing the driver a calendar, which not every driver honours.
+     */
+    @Test
+    public void testTimestampColumnIsShiftedOutOfTheConnectionZone() throws SQLException
+    {
+        List<String> stored = Arrays.asList("1753-12-31 00:00:00", "2014-03-10 13:07:44");
+        TimeZone defaultTimeZone = TimeZone.getDefault();
+        try
+        {
+            for (String defaultZoneId : Arrays.asList("GMT", "Asia/Tokyo"))
+            {
+                TimeZone.setDefault(TimeZone.getTimeZone(defaultZoneId));
+                for (String connectionZoneId : Arrays.asList("GMT", "America/New_York", "Asia/Tokyo"))
+                {
+                    List<String> want = new ArrayList<>(stored.size());
+                    for (String moment : stored)
+                    {
+                        want.add(inUtc(moment, connectionZoneId));
+                    }
+                    Assert.assertEquals("default " + defaultZoneId + ", connection " + connectionZoneId,
+                            want, readMoments(stored, connectionZoneId));
+                }
+            }
+        }
+        finally
+        {
+            TimeZone.setDefault(defaultTimeZone);
+        }
+    }
+
+    private static String inUtc(String moment, String connectionZoneId)
+    {
+        LocalDateTime utc = LocalDateTime.parse(moment.replace(' ', 'T'))
+                .atZone(ZoneId.of(connectionZoneId)).withZoneSameInstant(ZoneOffset.UTC).toLocalDateTime();
+        return String.format("%04d-%02d-%02dT%02d:%02d:%02d.%09d", utc.getYear(), utc.getMonthValue(),
+                utc.getDayOfMonth(), utc.getHour(), utc.getMinute(), utc.getSecond(), utc.getNano());
+    }
+
+    private static List<String> readDays(List<String> days) throws SQLException
+    {
+        return read(days, "recorded_on DATE", "DATE", "DATE", Types.DATE, "GMT");
+    }
+
+    private static List<String> readMoments(List<String> stored, String connectionZoneId) throws SQLException
+    {
+        return read(stored, "recorded_at TIMESTAMP", "TIMESTAMP", "TIMESTAMP", Types.TIMESTAMP, connectionZoneId);
+    }
+
+    /**
+     * Connect straight through the driver. Another test in this module can leave DriverManager
+     * without DuckDB registered, and this does not depend on it.
+     */
+    private static Connection connect() throws SQLException
+    {
+        return new org.duckdb.DuckDBDriver().connect("jdbc:duckdb:", new Properties());
+    }
+
+    private static List<String> read(List<String> values, String columnDefinition, String literalType,
+                                     String dataType, int columnType, String calendarZoneId) throws SQLException
+    {
+        String column = columnDefinition.split(" ")[0];
+        try (Connection connection = connect();
+             Statement statement = connection.createStatement())
+        {
+            statement.execute("CREATE TABLE t (" + columnDefinition + ")");
+            for (String value : values)
+            {
+                statement.execute("INSERT INTO t VALUES (" + literalType + " '" + value + "')");
+            }
+
+            ResultColumn resultColumn = new ResultColumn(1, column, dataType, columnType);
+            Calendar calendar = new GregorianCalendar(TimeZone.getTimeZone(calendarZoneId));
+            List<String> read = new ArrayList<>(values.size());
+            try (ResultSet resultSet = statement.executeQuery("SELECT " + column + " FROM t ORDER BY " + column))
+            {
+                while (resultSet.next())
+                {
+                    read.add(String.valueOf(resultColumn.getTransformedValue(resultSet, calendar)));
+                }
+            }
+            return read;
+        }
+    }
+}


### PR DESCRIPTION
The legend-engine half of finos/legend-pure#1332, whose changes are in legend-pure 5.99.0. This bumps to that release and takes both of its fixes here, where the same two things were wrong: how a time zone name is read, and how a date or timestamp is read out of a result set. Both were wrong in ways that produce a plausible looking answer rather than an error.

### One place resolves a time zone name

A name reached these places by three routes. `TimeZone.getTimeZone`, in `RelationalResult`, `SQLExecutionResult`, and `ArrowDataWriter`, takes an offset only with a `GMT` prefix and answers every name it does not know with GMT rather than reporting it, so a connection naming a bare `-0500` read its timestamps in GMT and nothing about the result said so. `ZoneId.of`, in `PlanDateParameter` and `LegendH2Extensions`, reads the offsets but rejects the three letter abbreviations such as `EST`. All of them now go through `TimeZones`, which reads regions, the abbreviations, and offsets in every form, and rejects a name that stands for no zone.

`StreamingTempTableResultCSVSerializer` named GMT as `TimeZone.getTimeZone("GMT").toString()`, which is not `"GMT"` but the whole `ZoneInfo` dump, quotes and all. That name is written into a Pure date format string as `"[" + zone + "]"`, so a connection carrying no time zone built a format string around a zone name nothing could read. It names GMT as `"GMT"` now.

### Columns are read by value, not by instant

A date column carries a day and no zone; a timestamp column carries a wall clock the database keeps in the zone the connection names. Both were read as a `java.sql.Date` or `java.sql.Timestamp`, which carry an instant, and an instant gives a day or a wall clock back only once a zone is chosen to read it in. Drivers do not agree on the zone they built that instant in, so no one choice reads them all.

A date was worse off than that. It was read with no calendar at all, so the driver worked the day into an instant in the JVM default zone, and `PureDate.fromSQLDate` read the day back out of that instant in GMT. Midnight east of GMT belongs to the day before, so **a JVM running ahead of GMT lost a day on every date a query returned** — not only old ones. On a JVM defaulted to `Asia/Tokyo`, stored dates of `1753-12-31`, `1900-01-01`, and `2014-03-10` came back as `1753-12-30`, `1899-12-31`, and `2014-03-09`. Asking the driver for the day itself carries no instant, and so no zone for the two sides to disagree over.

A timestamp is shifted out of the connection's zone here rather than by handing a driver a calendar and asking it to shift, which not every driver honours: some ignore the calendar and answer as though the connection named UTC, leaving every timestamp short by that zone. Shifting here also keeps a moment before a zone kept standard time out of java.util's hands, which holds only the standard offset the zone later adopted where java.time holds its mean solar offset — those few minutes at midnight are a whole day.

A driver need not answer `getObject`, so each reading keeps what it did before as the way back, and a driver is asked once rather than once a row.

### Behavior changes

- **A time zone name that stands for no zone is now rejected**, with `IllegalArgumentException: Unknown time zone: <name>`, where these sites used to answer GMT. An *absent* name is still settled upstream as GMT, so only a name someone wrote can throw.
- **A bare offset** such as `-0500` or `+05:30` on a connection now resolves to that offset rather than to GMT, so timestamps that were being returned unconverted are now converted.
- **A date returned by a query is no longer a day early** on a JVM running ahead of GMT.
- **A timestamp from a driver that ignores the calendar** handed to `getTimestamp` is no longer short by the connection's offset.
- **A null time zone on `SQLExecutionResult`** reported itself as a `NullPointerException` from inside java.util, and now reports the name as unknown.
- **The Arrow schema's zone** comes from the calendar's id, which for a connection named by an offset was GMT and is now that offset.
- **A connection carrying no time zone** no longer builds a Pure date format string around a `ZoneInfo` dump.

### Tests

`TestResultColumn` reads a date column and a timestamp column from a database, across a sweep of JVM default zones and connection zones. What a driver puts in a `java.sql.Date` is the whole of the question, and a date built by hand answers a different one, so the test drives a real driver rather than constructing values itself. Both cases were checked against a reverted fix, and fail.

### Notes

- **Depends on legend-pure 5.99.0**, bumped in the first commit because the second one imports `org.finos.legend.pure.m4.tools.time.TimeZones` from it.
- Four commits, each self contained, and in an order where each builds.
- Three module poms gain `legend-pure-m4`; the fourth module holding a caller had it already. `dependency:analyze` runs with `failOnWarning`, and m4 is the one Pure artifact the root pom's banned dependency rules allow.
- The forked `PureDate` is untouched — only its callers changed. The new path does not use `PureDate.fromTemporal`, which reads a `LocalDateTime` as UTC and routes through a `GregorianCalendar`, losing sub-millisecond precision; it builds through `newPureDate` with an explicit nine digit subsecond instead, matching what `fromSQLTimestamp` produced.
- The raw `getValue` and `valueExtractor` paths still hand back `java.sql` objects for consumers that expect those types, and are unchanged.
- `TestResultColumn` is JUnit 4, against the preference for JUnit 5 in new tests, because that module's test classpath carries no Jupiter.
- It opens its connection with `new DuckDBDriver().connect(...)` rather than through `DriverManager`. It passes on its own but fails in the full module suite with `No suitable driver found for jdbc:duckdb:`, because something else in that module leaves `DriverManager` without DuckDB registered.