### PR TITLE
M2M: Add constrained interface to generated models from new operator

### DIFF
--- a/docs/emit/emit.md
+++ b/docs/emit/emit.md
@@ -845,6 +845,7 @@ infrastructure rather than the feature under test:
 | `mapping:enumeration-mapping` | Enumeration value mapping / transform |
 | `mapping:m2m-derived-source-property` | Derived property on M2M source class |
 | `mapping:m2m-local-property` | Local property in M2M mapping |
+| `mapping:m2m-target-instantiation` | Target class constructed with the `new` operator (`^Target(...)`) inside an M2M transform |
 | `mapping:m2m-transform` | Model-to-model transform expression |
 | `mapping:mapping` | Generic mapping (legacy tag) |
 | `mapping:mapping-include` | Mapping include composition |

--- a/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/m2m-emit-models/m2m-target-instantiation-constrained.emit.yaml
+++ b/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/m2m-emit-models/m2m-target-instantiation-constrained.emit.yaml
@@ -1,0 +1,37 @@
+name: m2m-target-instantiation-constrained
+title: "Constraint on an M2M Target Class Built with the `new` Operator"
+description: |
+  The companion to `m2m-target-instantiation`: the sub-class reached only through the
+  `new` operator (`^Population(...)`) also carries a class constraint, so the constructed
+  instance has to be constraint-checked and not merely survive the graph-fetch node's
+  cast. Feeding it a value that violates `positivePopulation` raises
+  "Constraint :[positivePopulation] violated in the Class Population" -- which is what
+  distinguishes a real fix from an `instanceof`-guarded cast, since guarding the cast
+  would make the sibling fixture pass while silently never evaluating this constraint.
+  Only the satisfying input is asserted here: EMIT's JUnit builder has no negative-test
+  support, and `graphFetchChecked` (which would turn the violation into an assertable
+  defect list) hits an unrelated serializer-codegen bug on this model shape.
+
+modelSources:
+  model:
+    root: m2m-target-instantiation-constrained
+    files:
+      - model.pure
+      - mapping.pure
+
+features:
+  - execution:test-data
+  - grammar:constraint
+  - grammar:function
+  - mapping:m2m-target-instantiation
+  - mapping:mapping
+  - scaffolding:class
+  - scaffolding:m2m-mapping
+stores: []
+complexity: basic
+tags:
+  - m2m
+  - new-operator
+  - graph-fetch
+  - constraints
+  - mapping-test

--- a/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/m2m-emit-models/m2m-target-instantiation-constrained/mapping.pure
+++ b/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/m2m-emit-models/m2m-target-instantiation-constrained/mapping.pure
@@ -1,0 +1,64 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Mapping
+Mapping demo::m2m::instantiation::constrained::CityMapping
+(
+  *demo::m2m::instantiation::constrained::target::City: Pure
+  {
+    ~src demo::m2m::instantiation::constrained::source::S_City
+
+    code: $src.code,
+    population: $src->demo::m2m::instantiation::constrained::makePopulation()
+  }
+
+  testSuites:
+  [
+    constrainedInstantiationSuite:
+    {
+      function: |demo::m2m::instantiation::constrained::target::City.all()->graphFetch(#{demo::m2m::instantiation::constrained::target::City{code, population{count}}}#)->serialize(#{demo::m2m::instantiation::constrained::target::City{code, population{count}}}#);
+      tests:
+      [
+        satisfiesConstraint:
+        {
+          data:
+          [
+            ModelStore: ModelStore
+              #{
+                demo::m2m::instantiation::constrained::source::S_City:
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '{"code":"MAD","population":3223000}';
+                  }#
+              }#
+          ];
+          asserts:
+          [
+            expected:
+              EqualToJson
+              #{
+                expected:
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '{"code":"MAD","population":{"count":3223000}}';
+                  }#;
+              }#
+          ];
+        }
+      ];
+    }
+  ]
+)

--- a/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/m2m-emit-models/m2m-target-instantiation-constrained/model.pure
+++ b/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/m2m-emit-models/m2m-target-instantiation-constrained/model.pure
@@ -1,0 +1,39 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+Class demo::m2m::instantiation::constrained::source::S_City
+{
+  code: String[1];
+  population: Integer[1];
+}
+
+Class demo::m2m::instantiation::constrained::target::City
+{
+  code: String[1];
+  population: demo::m2m::instantiation::constrained::target::Population[1];
+}
+
+Class demo::m2m::instantiation::constrained::target::Population
+[
+  positivePopulation: $this.count > 0
+]
+{
+  count: Integer[1];
+}
+
+function demo::m2m::instantiation::constrained::makePopulation(src: demo::m2m::instantiation::constrained::source::S_City[1]): demo::m2m::instantiation::constrained::target::Population[1]
+{
+  ^demo::m2m::instantiation::constrained::target::Population(count = $src.population)
+}

--- a/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/m2m-emit-models/m2m-target-instantiation.emit.yaml
+++ b/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/m2m-emit-models/m2m-target-instantiation.emit.yaml
@@ -1,0 +1,38 @@
+name: m2m-target-instantiation
+title: "M2M Target Class Instantiated with the `new` Operator"
+description: |
+  A model-to-model mapping whose complex property is filled by a function that
+  constructs the target class directly with the `new` operator (`^Target(...)`)
+  rather than by a class mapping -- the sub-class has no class mapping at all.
+  The embedded test suite graph-fetches through that complex property, so the
+  constructed instance has to survive the graph-fetch node's constraint pass,
+  not merely be produced. This is the combination "M2M: remove restriction on
+  creating target objects" opened up but did not cover: its own test reads a
+  primitive back off the constructed object, so the object never lands in a
+  complex property slot and the constraint walk is never generated. Here it is,
+  and the generated `allConstraints` casts whatever occupies the slot to
+  `Constrained`, which the `new`-generated `_pure.internal.*_Impl` did not
+  implement.
+
+modelSources:
+  model:
+    root: m2m-target-instantiation
+    files:
+      - model.pure
+      - mapping.pure
+
+features:
+  - execution:test-data
+  - grammar:function
+  - mapping:m2m-target-instantiation
+  - mapping:mapping
+  - scaffolding:class
+  - scaffolding:m2m-mapping
+stores: []
+complexity: basic
+tags:
+  - m2m
+  - new-operator
+  - graph-fetch
+  - constraints
+  - mapping-test

--- a/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/m2m-emit-models/m2m-target-instantiation/mapping.pure
+++ b/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/m2m-emit-models/m2m-target-instantiation/mapping.pure
@@ -1,0 +1,64 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Mapping
+Mapping demo::m2m::instantiation::CountryMapping
+(
+  *demo::m2m::instantiation::target::Country: Pure
+  {
+    ~src demo::m2m::instantiation::source::S_Country
+
+    code: $src.code,
+    details: $src->demo::m2m::instantiation::makeDetails()
+  }
+
+  testSuites:
+  [
+    targetInstantiationSuite:
+    {
+      function: |demo::m2m::instantiation::target::Country.all()->graphFetch(#{demo::m2m::instantiation::target::Country{code, details{name, capital{capitalName}}}}#)->serialize(#{demo::m2m::instantiation::target::Country{code, details{name, capital{capitalName}}}}#);
+      tests:
+      [
+        constructedComplexProperty:
+        {
+          data:
+          [
+            ModelStore: ModelStore
+              #{
+                demo::m2m::instantiation::source::S_Country:
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '{"code":"ES","name":"Spain","capitalName":"Madrid"}';
+                  }#
+              }#
+          ];
+          asserts:
+          [
+            expected:
+              EqualToJson
+              #{
+                expected:
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '{"code":"ES","details":{"name":"Spain","capital":{"capitalName":"Madrid"}}}';
+                  }#;
+              }#
+          ];
+        }
+      ];
+    }
+  ]
+)

--- a/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/m2m-emit-models/m2m-target-instantiation/model.pure
+++ b/legend-engine-core/legend-engine-core-emit-tests/src/test/resources/m2m-emit-models/m2m-target-instantiation/model.pure
@@ -1,0 +1,53 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+Class demo::m2m::instantiation::source::S_Country
+{
+  code: String[1];
+  name: String[1];
+  capitalName: String[1];
+}
+
+Class demo::m2m::instantiation::target::Country
+{
+  code: String[1];
+  details: demo::m2m::instantiation::target::Details[1];
+}
+
+Class demo::m2m::instantiation::target::Details
+{
+  name: String[1];
+  capital: demo::m2m::instantiation::target::Capital[1];
+  metadata: demo::m2m::instantiation::target::Metadata[1];
+}
+
+Class demo::m2m::instantiation::target::Capital
+{
+  capitalName: String[1];
+}
+
+Class demo::m2m::instantiation::target::Metadata
+{
+  source: String[1];
+}
+
+function demo::m2m::instantiation::makeDetails(src: demo::m2m::instantiation::source::S_Country[1]): demo::m2m::instantiation::target::Details[1]
+{
+  ^demo::m2m::instantiation::target::Details(
+    name = $src.name,
+    capital = ^demo::m2m::instantiation::target::Capital(capitalName = $src.capitalName),
+    metadata = ^demo::m2m::instantiation::target::Metadata(source = 'system')
+  )
+}

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/testTargetClassCanBeInstantiated.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-compiled-core/src/main/resources/core/store/m2m/tests/legend/testTargetClassCanBeInstantiated.pure
@@ -96,3 +96,93 @@ meta::pure::mapping::modelToModel::test::alloy::simple::TargetClassInstantiation
 
   assert(jsonEquivalent('{"builder":{"_type":"json"},"values":{"j": 1}}'->parseJSON(), $result->toOne()->parseJSON()));
 }
+
+
+function <<meta::pure::profiles::test.Test, meta::pure::profiles::test.AlloyOnly, meta::pure::executionPlan::engine::java::roadmap::feature.M2MBasics>>
+{  serverVersion.start='v1_20_0',
+   doc.doc='Example to test that a target instantiated with the new operator can fill a complex property that the graph fetch tree walks'
+}
+meta::pure::mapping::modelToModel::test::alloy::simple::TargetClassInstantiationForComplexProperty() : Boolean[1]
+{
+  let grammar = '###Pure\n'+
+    'Class test::model::NestedSource\n'+
+    '{\n'+
+    '  i: Integer[1];\n'+
+    '}\n'+
+    '\n'+
+    'Class test::model::NestedTarget\n'+
+    '{\n'+
+    '  child: test::model::NestedChild[1];\n'+
+    '}\n'+
+    '\n'+
+    'Class test::model::NestedChild\n'+
+    '{\n'+
+    '  j: Integer[1];\n'+
+    '}\n'+
+    '\n'+
+    'function test::model::instantiateChild(i: Integer[1]): test::model::NestedChild[1]\n'+
+    '{\n'+
+    '  ^test::model::NestedChild(j=$i);' +
+    '}\n'+
+    '\n'+
+    'function test::query::getNested(): String[1]\n'+
+    '{\n'+
+    '  test::model::NestedTarget.all()->graphFetch(\n'+
+    '    #{\n'+
+    '      test::model::NestedTarget {\n'+
+    '        child {\n'+
+    '          j\n'+
+    '        }\n'+
+    '      }\n'+
+    '    }#\n'+
+    '  )->serialize(\n'+
+    '    #{\n'+
+    '      test::model::NestedTarget {\n'+
+    '        child {\n'+
+    '          j\n'+
+    '        }\n'+
+    '      }\n'+
+    '    }#\n'+
+    '  )->from(test::mapping::M2MNestedMap, test::runtime::nestedRuntime)\n'+
+    '}\n'+
+    '\n'+
+    '###Mapping\n'+
+    'Mapping test::mapping::M2MNestedMap\n'+
+    '(\n'+
+    '  *test::model::NestedTarget: Pure\n'+
+    '  {\n'+
+    '    ~src test::model::NestedSource\n'+
+    '    child: test::model::instantiateChild($src.i)\n'+
+    '  }\n'+
+    ')\n'+
+    '\n'+
+    '###Connection\n'+
+    'JsonModelConnection test::connection::nestedConnection\n'+
+    '{\n'+
+    '  class: test::model::NestedSource;\n'+
+    '  url: \'data:application/json,{"i":1}\';\n'+
+    '}\n'+
+    '\n'+
+    '###Runtime\n'+
+    'Runtime test::runtime::nestedRuntime\n'+
+    '{\n'+
+    '  mappings:\n'+
+    '  [\n'+
+    '    test::mapping::M2MNestedMap\n'+
+    '  ];\n'+
+    '  connections:\n'+
+    '  [\n'+
+    '    ModelStore:\n'+
+    '    [\n'+
+    '      connection_1: test::connection::nestedConnection\n'+
+    '    ]\n'+
+    '  ];\n'+
+    '}';
+
+  let elements = meta::legend::compileLegendGrammar($grammar);
+  let function = $elements->filter(e|$e->instanceOf(FunctionDefinition) && $e->cast(@PackageableElement)->elementToPath() == 'test::query::getNested__String_1_')->at(0)->cast(@FunctionDefinition<{->String[1]}>);
+
+  let result = meta::legend::executeLegendQuery($function, [], meta::pure::extension::defaultExtensions());
+
+  assert(jsonEquivalent('{"builder":{"_type":"json"},"values":{"child":{"j": 1}}}'->parseJSON(), $result->toOne()->parseJSON()));
+}

--- a/legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-pure/src/main/resources/core_java_platform_binding/legendJavaPlatformBinding/planConventions/langLibrary.pure
+++ b/legend-engine-xts-java/legend-engine-xt-javaPlatformBinding-pure/src/main/resources/core_java_platform_binding/legendJavaPlatformBinding/planConventions/langLibrary.pure
@@ -22,6 +22,7 @@ import meta::external::language::java::transform::*;
 import meta::pure::executionPlan::platformBinding::legendJava::*;
 import meta::pure::executionPlan::platformBinding::legendJava::library::lang::*;
 import meta::pure::executionPlan::platformBinding::legendJava::shared::*;
+import meta::pure::executionPlan::platformBinding::legendJava::shared::constraints::*;
 
 function meta::pure::executionPlan::platformBinding::legendJava::library::lang::registerLangLibrary(conventions: Conventions[1]): Conventions[1]
 {
@@ -180,7 +181,14 @@ function meta::pure::executionPlan::platformBinding::legendJava::library::lang::
                                 let e = $k.expression->generateJava($conventions, $debug);
                                 pair($s,$e););
          
-   let typeInfo = meta::pure::executionPlan::platformBinding::typeInfo::newTypeInfoSet()->enrichTypeInfos($cls, []);
+   let typeInfoWithoutConstraints = meta::pure::executionPlan::platformBinding::typeInfo::newTypeInfoSet()->enrichTypeInfos($cls, []);
+   let typeInfo = $typeInfoWithoutConstraints->
+                           meta::pure::executionPlan::platformBinding::typeInfo::forClass($cls).supertypes
+                           ->concatenate($cls)
+                           ->fold(
+                              {class, infos | $infos->meta::pure::executionPlan::platformBinding::typeInfo::addConstraints($class)},
+                              $typeInfoWithoutConstraints
+                           );
     
    let props = $typeInfo->meta::pure::executionPlan::platformBinding::typeInfo::allProperties($cls);
 
@@ -199,6 +207,8 @@ function meta::pure::executionPlan::platformBinding::legendJava::library::lang::
             let nestedDeps = generateInterfacesAndEnums($conventions, $typeInfo, $debug);
 
             let interface = $clsTypeInfo->toOne()->generateInterfaceForClass($conventions,$debug);
+            let generationContext = ^GenerationContext(typeInfos=$typeInfo, conventions=$conventions);
+            let constraintContext = ^ConstraintCheckingGenerationContext(enableConstraints=true, topLevelOnly=false);
             let implementationWithProps = $props->fold({p,c| let var = $conventions->fieldName($p);
                                            let javaType = $conventions->pureTypeToJavaType($p);
                                            let f = javaField(['private'], $javaType, $var);
@@ -222,7 +232,8 @@ function meta::pure::executionPlan::platformBinding::legendJava::library::lang::
 
             let implementationProject = mergeProjects([
                                                        newProject()->addClass($implementationWithProps),
-                                                       $implementationWithProps->createQualifiedPropertiesForClass($cls.qualifiedProperties, $conventions, $debug)
+                                                       $implementationWithProps->createQualifiedPropertiesForClass($cls.qualifiedProperties, $conventions, $debug),
+                                                       $implementationWithProps->createConstraintCheckingForClass($cls, [], $generationContext, $constraintContext, $debug)
                                                     ]);
 
             let implementation = $implementationProject->getClass($implementationWithProps)->toOne();


### PR DESCRIPTION
#### What type of PR is this?
- Bug Fix


#### What does this PR do / why is it needed ?
This PR adds the Constrained interface to Java classes generated from models used in an M2M using the new operator without any explicit mapping


