### PR TITLE
Fix Databricks percentile PCT expected error

### DIFF
--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-databricks/legend-engine-xt-relationalStore-databricks-PCT/src/main/resources/pct-manifests/relational-databricks/StandardFunctions_manifest.json
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-databricks/legend-engine-xt-relationalStore-databricks-PCT/src/main/resources/pct-manifests/relational-databricks/StandardFunctions_manifest.json
@@ -167,7 +167,7 @@
     "expectedError" : "\"Unused format args. [5] arguments provided to expression \"mode(%s)\"\""
   }, {
     "test" : "meta::pure::functions::math::tests::percentile::testPercentile_Function_1__Boolean_1_",
-    "expectedError" : "The first parameter requires the (\"NUMERIC\""
+    "expectedError" : "[DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE]"
   }, {
     "test" : "meta::pure::functions::math::tests::percentile::testPercentile_Relation_Window_Function_1__Boolean_1_",
     "expectedError" : "\nexpected: '#TDS\\n   id,val,newCol\\n   1,1.0,1.8\\n   1,2.0,1.8\\n   1,3.0,1.8\\n   2,1.5,2.3\\n   2,2.5,2.3\\n   2,3.5,2.3\\n   3,1.0,1.4\\n   3,1.5,1.4\\n   3,2.0,1.4\\n#'\nactual:   '#TDS\\n   id,val,newCol\\n   1,1.0,1.8\\n   1,2.0,1.8\\n   1,3.0,1.8\\n   2,1.5,2.3\\n   2,2.5,2.3\\n   2,3.5,2.3\\n   3,1.0,1.4000000000000001\\n   3,1.5,1.4000000000000001\\n   3,2.0,1.4000000000000001\\n#'"


### PR DESCRIPTION
#### What type of PR is this?

Bug Fix

#### What does this PR do / why is it needed ?

Updates the Databricks percentile PCT exclusion to match the stable `DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE` error class instead of a rendered type-signature fragment.

Databricks changed the message from `The first parameter requires the ("NUMERIC"` to `The first parameter requires the (("NUMERIC" ...`, causing an expected-failure mismatch in both master and release builds.

Failing master job: https://github.com/finos/legend-engine/actions/runs/34315877963/job/102385665805
Failing release job: https://github.com/finos/legend-engine/actions/runs/34326769401/job/102402604474

#### Which issue(s) this PR fixes:

N/A

#### Other notes for reviewers:

Validation: JSON parsing and `git diff --check`. The Databricks PCT requires the CI-managed Databricks environment.

#### Does this PR introduce a user-facing change?

No.