### PR TITLE
Legend SQL - fix ORDER BY expression key computed from the wrong join side

### DIFF
--- a/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/src/test/resources/parity-tests/structural/column_resolution_across_renames.yaml
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/src/test/resources/parity-tests/structural/column_resolution_across_renames.yaml
@@ -101,20 +101,12 @@ tests:
     expected_tds_status: PASS
     expected_rel_status: PASS
 
-  # FAIL, not ERROR, and the distinction is the whole point: the sort key now
-  # resolves, which exposes that the helper column it resolves to holds the wrong
-  # value. processProjection materialises UPPER(d.name) with processExtend against
-  # projectedContext, whose contexts list is empty, so the qualifier `d` cannot
-  # resolve and the inner reference falls back to the bare name `name` -- p's
-  # column. The generated SQL reads upper("name_p"). Resolving the key against the
-  # projected relation did not cause this and cannot repair it; the fix is to
-  # rewrite the key's references to their output names before extending.
   - id: colres_e3_order_by_expression_over_join
     sql: "SELECT p.name AS name, d.name AS dept_name FROM persons p INNER JOIN departments d ON p.dept_id = d.id ORDER BY UPPER(d.name), name"
     feature: "ORDER BY expression over a join"
     category: "column_resolution"
-    expected_tds_status: FAIL
-    expected_rel_status: FAIL
+    expected_tds_status: PASS
+    expected_rel_status: PASS
 
   # --- design guards -----------------------------------------------------
   #

--- a/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/src/test/resources/parity-tests/structural/column_resolution_corpus_shapes.yaml
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/src/test/resources/parity-tests/structural/column_resolution_corpus_shapes.yaml
@@ -661,17 +661,12 @@ tests:
     expected_tds_status: ERROR
     expected_rel_status: ERROR
 
-  # FAIL rather than ERROR: the key resolves to its materialised helper column, and
-  # that column holds UPPER(p.name). See colres_e3_order_by_expression_over_join in
-  # column_resolution_across_renames.yaml for the root cause -- processExtend cannot
-  # resolve the qualifier `d` against projectedContext, so d.name falls back to the
-  # bare name and picks up p's column instead.
   - id: crcs_g4_order_by_expression_over_join
     sql: "SELECT p.name AS name, d.name AS dept_name FROM persons p INNER JOIN departments d ON p.dept_id = d.id ORDER BY UPPER(d.name), p.name"
     feature: "statement ORDER BY an expression over a join"
     category: "column_resolution_corpus"
-    expected_tds_status: FAIL
-    expected_rel_status: FAIL
+    expected_tds_status: PASS
+    expected_rel_status: PASS
 
   - id: crcs_g4_order_by_aggregate_expression_over_join
     sql: "SELECT p.dept_id AS dept_id, COUNT(*) AS n FROM persons p INNER JOIN departments d ON p.dept_id = d.id GROUP BY p.dept_id ORDER BY COUNT(*) DESC, p.dept_id"

--- a/legend-engine-xts-sql/legend-engine-xt-sql-transformation/legend-engine-xt-sql-pure/src/main/resources/core_external_query_sql/binding/fromPure/fromPure.pure
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-transformation/legend-engine-xt-sql-pure/src/main/resources/core_external_query_sql/binding/fromPure/fromPure.pure
@@ -743,13 +743,18 @@ function <<access.private>> meta::external::query::sql::transformation::queryToP
   //while an ORDER BY key does not: routing them together would extend a computed select item twice.
   //Aggregates and windows are excluded (their grouping runs after the projection and would discard the
   //helper column), DISTINCT because an extra column changes which rows are distinct.
+  //
+  //The key is rewritten to name output columns before it becomes an extend - see
+  //projectedKeyExpression. processOrderBy applies the same rewrite when it derives the name to sort
+  //by, so the two agree; both read the same select list, because orderByExtensions is empty whenever
+  //$extendRequired is true and only then does processProjection hand on a re-aliased one.
   let orderByExtensions = if ($isAggregate || $isWindow || $originalSelect.distinct,
     | [],
     | $orderBy->map(o | $o->match([
         i:IntegerLiteral[1] | [],
         q:QualifiedNameReference[1] | [],
         e:meta::external::query::sql::metamodel::Expression[1] | $e
-      ]))->map(e | ^SingleColumn(expression = $e)));
+      ]))->map(e | ^SingleColumn(expression = projectedKeyExpression($e, $originalSelect.selectItems))));
 
   let columns = $context.columns.name;
 
@@ -835,8 +840,10 @@ function <<access.private>> meta::external::query::sql::transformation::queryToP
   //will sort; processQuerySpec's closing restrict drops the helper again before it reaches the caller.
   //
   //processExtend names the column with an empty context while processOrderBy resolves through the
-  //post-projection one. Those agree for a key built from output columns, which is what this targets. A
-  //key still written against pre-projection source columns is not covered and fails as before.
+  //post-projection one. Those agree for a key built from output columns, which is what this targets.
+  //A key written against pre-projection source columns is brought into that form first, by
+  //projectedKeyExpression - it has to be, because $projected carries no child contexts for a
+  //qualifier to resolve against and the lookup would otherwise silently drop the qualifier.
   let projected = projectedContext($context, $distinctExp);
 
   //Skip a key whose column already exists: 'SELECT upper(s) FROM t ORDER BY upper(s)' is already named
@@ -1923,6 +1930,29 @@ function <<access.private>> meta::external::query::sql::transformation::queryToP
     | $columns->filter(si | extractNameFromExpression($si.expression, []) == $rendered)->first());
 }
 
+//An ORDER BY key rewritten to name the projection's output columns instead of its source columns.
+//
+//processProjection materialises an expression key into an extend over projectedContext, which has
+//contexts = [] because the projected relation no longer has per-join-side scopes. A qualified
+//reference inside the key therefore finds no scope in columnByNameParts, and the lookup silently
+//degrades to a bare-name one: 'UPPER(d.name)' over 'SELECT p.name AS name, d.name AS dept_name'
+//looks up 'name', finds p's column, and sorts by the wrong side without erroring. Where the bare
+//name matches nothing the same degrade surfaces as 'no column found named'.
+//
+//Rewriting each reference to the output name of the select item it denotes means the extend never
+//has to resolve a qualifier against a context that cannot represent one. A reference matching no
+//select item is left alone, and fails exactly as it did before.
+function <<access.private>> meta::external::query::sql::transformation::queryToPure::projectedKeyExpression(e:meta::external::query::sql::metamodel::Expression[1], selectItems:SelectItem[*]):meta::external::query::sql::metamodel::Expression[1]
+{
+  $e->walk([
+    q:QualifiedNameReference[1] |
+      let found = projectedSortKeySelectItem($q, $selectItems);
+      if ($found->isEmpty(),
+        | $q,
+        | ^QualifiedNameReference(name = ^QualifiedName(parts = $found->toOne()->extractNameFromSingleColumn([]))));
+  ])->toOne();
+}
+
 //The statement-level sibling of extensionColumnName and materialisedKeyName. processOrderBy runs
 //after the projection, so its keys have to name columns of the relation the projection produced -
 //and there is no single derivation that always does.
@@ -1954,10 +1984,12 @@ function <<access.private>> meta::external::query::sql::transformation::queryToP
     e:meta::external::query::sql::metamodel::Expression[1] | projectedSortKeySelectItem($e, $selectItems)->map(si | $si->extractNameFromSingleColumn([]))
   ]);
 
-  //an ordinal names a select item, never a materialised key, so it has no extend to fall back on
+  //an ordinal names a select item, never a materialised key, so it has no extend to fall back on.
+  //processProjection rewrites a key's references to output names before extending, so the same
+  //rewrite has to be applied here or the name would not match the column it created.
   let extendName = $sortKey->match([
     i:IntegerLiteral[1] | [],
-    e:meta::external::query::sql::metamodel::Expression[1] | extractNameFromExpression($e, [])
+    e:meta::external::query::sql::metamodel::Expression[1] | extractNameFromExpression(projectedKeyExpression($e, $selectItems), [])
   ]);
 
   let candidates = $outputName->concatenate($contextName)->concatenate($extendName)->removeDuplicates();

--- a/legend-engine-xts-sql/legend-engine-xt-sql-transformation/legend-engine-xt-sql-pure/src/main/resources/core_external_query_sql/binding/fromPure/tests/testTranspile.pure
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-transformation/legend-engine-xt-sql-pure/src/main/resources/core_external_query_sql/binding/fromPure/tests/testTranspile.pure
@@ -5735,12 +5735,40 @@ function <<test.Test>> meta::external::query::sql::transformation::queryToPure::
 // casing-correction pass emits it whenever stored column casing differs from
 // the view SQL's.
 //
-// These assert compile-and-schema only, via c(<expected>, false, false).
-// test() calls context.lambda(), which compiles the generated relation lambda,
-// so a stale column reference fails here as it does in production. The expected
-// lambda is a never-compared placeholder present so TestConfig.relation()
-// selects relationSources(). To upgrade one to a full output assertion, run it,
-// take the actual lambda and set both flags true.
+// Most of these now assert the generated lambda and its JSON, via the one-argument
+// c(<expected>). test() calls context.lambda(), which compiles the generated
+// relation lambda, so a stale column reference fails here as it does in production.
+//
+// The rest still use c(<expected>, false, false) and assert compile-and-schema only,
+// their expected lambda a never-compared placeholder present so TestConfig.relation()
+// selects relationSources(). That is not laziness - their lambda cannot be written in
+// source at all, for two reasons that bite together:
+//
+//   * A typed lambda parameter in a column specification compiles to a NULL body.
+//     This holds for every colspec form - funcColSpec over a class, aggColSpec (which
+//     fails harder, with an internal ClassInstance/RelationType cast error) and
+//     funcColSpec2 for window functions - so the printed lambda, which annotates every
+//     parameter, cannot be pasted back as source.
+//   * Strip those annotations and a column read off a JOIN infers [0..1] rather than
+//     [1], so anything needing [1] no longer resolves: toUpper(_:String[0..1]),
+//     coalesce(_:Float4[0..1], ...). Single-table cases are unaffected, which is why
+//     'upper(String)' asserts fine elsewhere in this file but not over a join.
+//
+// coalesce is doubly stuck: it prints as the three-argument coalesce($x.c, 0, []),
+// which does not resolve as source however the parameter is typed.
+//
+// So the remaining placeholders are the window cases and anything applying a function
+// to a join column. If a later legend-pure makes the printed form round-trip, they can
+// be converted the way the others were: set the flags true, run, and paste the actual
+// lambda from the assertion failure.
+//
+// Two ways round it where a placeholder is not good enough. Pick a key whose translation
+// tolerates [0..1] - a CASE key becomes isEmpty()->if(...) and asserts fine, which is why
+// testOrderByCaseKeyOverJoinResolvesQualifier sits alongside its unassertable upper()
+// sibling. Or assert the output schema directly, with processQuery plus
+// resolveRelationColumns, as testGroupByExpressionKeyOverJoin does - that catches a
+// wrong-shaped result, though not a wrongly computed one, because the closing restrict
+// drops any order-by helper before the caller sees it.
 // ---------------------------------------------------------------------------
 
 // GROUP BY key resolved against the pre-rename relation: processGroupBy took its
@@ -5754,11 +5782,22 @@ function <<test.Test>> meta::external::query::sql::transformation::queryToPure::
     'JOIN service."/service/service2" "t2" ON "t1"."Integer" = "t2"."Integer" ' +
     'GROUP BY "t1"."String"',
     [
-      // placeholder: never compared (assertLambda/assertJSON are false); present so
-      // TestConfig.relation() selects relationSources(). See the block comment above.
-      c({| FlatInput.all()->project(
-            ~[ Boolean: x | $x.booleanIn, Integer: x | $x.integerIn, Float: x | $x.floatIn, Decimal: x | $x.decimalIn, StrictDate: x | $x.strictDateIn, DateTime: x | $x.dateTimeIn, String: x | $x.stringIn])
-        }, false, false)
+      c({| meta::external::query::sql::transformation::queryToPure::tests::FlatInput.all()
+          ->project(~[Boolean : x | $x.booleanIn, Integer : x | $x.integerIn, Float : x | $x.floatIn, Decimal : x | $x.decimalIn, StrictDate : x | $x.strictDateIn, DateTime : x | $x.dateTimeIn, String : x | $x.stringIn])
+          ->rename(~Boolean, ~Boolean_t1)
+          ->rename(~Integer, ~Integer_t1)
+          ->rename(~Float, ~Float_t1)
+          ->rename(~Decimal, ~Decimal_t1)
+          ->rename(~StrictDate, ~StrictDate_t1)
+          ->rename(~DateTime, ~DateTime_t1)
+          ->rename(~String, ~String_t1)
+          ->join(meta::external::query::sql::transformation::queryToPure::tests::FlatInput.all()
+            ->project(~[ID : x | $x.idIn, Integer : x | $x.integerIn, String : x | $x.stringIn])
+            ->rename(~ID, ~ID_t2)
+            ->rename(~Integer, ~Integer_t2)
+            ->rename(~String, ~String_t2), meta::pure::functions::relation::JoinKind.INNER, {row1, row2 | $row1.Integer_t1 == $row2.Integer_t2})
+          ->rename(~String_t1, ~String)
+          ->groupBy(~[String], ~[maxInt : x | $x.Integer_t2 : y | $y->max()])})
     ]
   )
 }
@@ -5774,11 +5813,23 @@ function <<test.Test>> meta::external::query::sql::transformation::queryToPure::
     'JOIN service."/service/service2" "t2" ON "t1"."Integer" = "t2"."Integer" ' +
     'GROUP BY "t1"."String", "t2"."ID"',
     [
-      // placeholder: never compared (assertLambda/assertJSON are false); present so
-      // TestConfig.relation() selects relationSources(). See the block comment above.
-      c({| FlatInput.all()->project(
-            ~[ Boolean: x | $x.booleanIn, Integer: x | $x.integerIn, Float: x | $x.floatIn, Decimal: x | $x.decimalIn, StrictDate: x | $x.strictDateIn, DateTime: x | $x.dateTimeIn, String: x | $x.stringIn])
-        }, false, false)
+      c({| meta::external::query::sql::transformation::queryToPure::tests::FlatInput.all()
+          ->project(~[Boolean : x | $x.booleanIn, Integer : x | $x.integerIn, Float : x | $x.floatIn, Decimal : x | $x.decimalIn, StrictDate : x | $x.strictDateIn, DateTime : x | $x.dateTimeIn, String : x | $x.stringIn])
+          ->rename(~Boolean, ~Boolean_t1)
+          ->rename(~Integer, ~Integer_t1)
+          ->rename(~Float, ~Float_t1)
+          ->rename(~Decimal, ~Decimal_t1)
+          ->rename(~StrictDate, ~StrictDate_t1)
+          ->rename(~DateTime, ~DateTime_t1)
+          ->rename(~String, ~String_t1)
+          ->join(meta::external::query::sql::transformation::queryToPure::tests::FlatInput.all()
+            ->project(~[ID : x | $x.idIn, Integer : x | $x.integerIn, String : x | $x.stringIn])
+            ->rename(~ID, ~ID_t2)
+            ->rename(~Integer, ~Integer_t2)
+            ->rename(~String, ~String_t2), meta::pure::functions::relation::JoinKind.INNER, {row1, row2 | $row1.Integer_t1 == $row2.Integer_t2})
+          ->rename(~String_t1, ~String)
+          ->rename(~ID_t2, ~ID)
+          ->groupBy(~[String, ID], ~[total : x | $x.Integer_t1 : y | $y->sum()])})
     ]
   )
 }
@@ -5827,11 +5878,12 @@ function <<test.Test>> meta::external::query::sql::transformation::queryToPure::
     'SELECT "String", "Integer" FROM service."/service/service1" ' +
     'ORDER BY CASE WHEN "String" IS NULL THEN 1 ELSE 0 END DESC, "String"',
     [
-      // placeholder: never compared (assertLambda/assertJSON are false); present so
-      // TestConfig.relation() selects relationSources(). See the block comment above.
-      c({| FlatInput.all()->project(
-            ~[ Boolean: x | $x.booleanIn, Integer: x | $x.integerIn, Float: x | $x.floatIn, Decimal: x | $x.decimalIn, StrictDate: x | $x.strictDateIn, DateTime: x | $x.dateTimeIn, String: x | $x.stringIn])
-        }, false, false)
+      c({| meta::external::query::sql::transformation::queryToPure::tests::FlatInput.all()
+          ->project(~[Boolean : x | $x.booleanIn, Integer : x | $x.integerIn, Float : x | $x.floatIn, Decimal : x | $x.decimalIn, StrictDate : x | $x.strictDateIn, DateTime : x | $x.dateTimeIn, String : x | $x.stringIn])
+          ->select(~[String, Integer])
+          ->extend(~['CASE WHEN String IS NULL THEN 1 ELSE 0 END' : x | $x.String->isEmpty()->if(|1, |0)])
+          ->sort([~'CASE WHEN String IS NULL THEN 1 ELSE 0 END'->descending(), ~String->ascending()])
+          ->select(~[String, Integer])})
     ]
   )
 }
@@ -5905,11 +5957,11 @@ function <<test.Test>> meta::external::query::sql::transformation::queryToPure::
   test(
     'SELECT DISTINCT "String" FROM service."/service/service1" ORDER BY "String"',
     [
-      // placeholder: never compared (assertLambda/assertJSON are false); present so
-      // TestConfig.relation() selects relationSources(). See the block comment above.
-      c({| FlatInput.all()->project(
-            ~[ Boolean: x | $x.booleanIn, Integer: x | $x.integerIn, Float: x | $x.floatIn, Decimal: x | $x.decimalIn, StrictDate: x | $x.strictDateIn, DateTime: x | $x.dateTimeIn, String: x | $x.stringIn])
-        }, false, false)
+      c({| meta::external::query::sql::transformation::queryToPure::tests::FlatInput.all()
+          ->project(~[Boolean : x | $x.booleanIn, Integer : x | $x.integerIn, Float : x | $x.floatIn, Decimal : x | $x.decimalIn, StrictDate : x | $x.strictDateIn, DateTime : x | $x.dateTimeIn, String : x | $x.stringIn])
+          ->select(~[String])
+          ->distinct()
+          ->sort(~String->ascending())})
     ]
   )
 }
@@ -6071,19 +6123,18 @@ function <<test.Test>> meta::external::query::sql::transformation::queryToPure::
 // window keys, resolved by processGroupBy instead of processOlapGroupBy.
 function <<test.Test>> meta::external::query::sql::transformation::queryToPure::tests::testGroupByExpressionKeyOverJoin():Boolean[1]
 {
-  test(
+  let context = processQuery(
     'SELECT upper("t1"."String") AS "u", count(*) AS "n" ' +
     'FROM service."/service/service1" "t1" ' +
     'JOIN service."/service/service2" "t2" ON "t1"."Integer" = "t2"."Integer" ' +
     'GROUP BY upper("t1"."String")',
-    [
-      // placeholder: never compared (assertLambda/assertJSON are false); present so
-      // TestConfig.relation() selects relationSources(). See the block comment above.
-      c({| FlatInput.all()->project(
-            ~[ Boolean: x | $x.booleanIn, Integer: x | $x.integerIn, Float: x | $x.floatIn, Decimal: x | $x.decimalIn, StrictDate: x | $x.strictDateIn, DateTime: x | $x.dateTimeIn, String: x | $x.stringIn])
-        }, false, false)
-    ]
-  )
+    relationSources(), false);
+
+  // The output schema, not just "it transpiled". A groupBy can lose a key column from its declared
+  // output type while still grouping by it, leaving the caller reading a result set of the wrong
+  // shape - an error nothing else here would catch. The lambda itself cannot be asserted: see the
+  // block comment above.
+  assertEquals(['u', 'n'], $context.expression->toOne()->resolveRelationColumns().name);
 }
 
 // Control: the same expression key with no join. It passed before the change and
@@ -6126,11 +6177,22 @@ function <<test.Test>> meta::external::query::sql::transformation::queryToPure::
     'JOIN service."/service/service2" "t2" ON "t1"."Integer" = "t2"."Integer" ' +
     'ORDER BY 1',
     [
-      // placeholder: never compared (assertLambda/assertJSON are false); present so
-      // TestConfig.relation() selects relationSources(). See the block comment above.
-      c({| FlatInput.all()->project(
-            ~[ Boolean: x | $x.booleanIn, Integer: x | $x.integerIn, Float: x | $x.floatIn, Decimal: x | $x.decimalIn, StrictDate: x | $x.strictDateIn, DateTime: x | $x.dateTimeIn, String: x | $x.stringIn])
-        }, false, false)
+      c({| meta::external::query::sql::transformation::queryToPure::tests::FlatInput.all()
+          ->project(~[Boolean : x | $x.booleanIn, Integer : x | $x.integerIn, Float : x | $x.floatIn, Decimal : x | $x.decimalIn, StrictDate : x | $x.strictDateIn, DateTime : x | $x.dateTimeIn, String : x | $x.stringIn])
+          ->rename(~Boolean, ~Boolean_t1)
+          ->rename(~Integer, ~Integer_t1)
+          ->rename(~Float, ~Float_t1)
+          ->rename(~Decimal, ~Decimal_t1)
+          ->rename(~StrictDate, ~StrictDate_t1)
+          ->rename(~DateTime, ~DateTime_t1)
+          ->rename(~String, ~String_t1)
+          ->join(meta::external::query::sql::transformation::queryToPure::tests::FlatInput.all()
+            ->project(~[ID : x | $x.idIn, Integer : x | $x.integerIn, String : x | $x.stringIn])
+            ->rename(~ID, ~ID_t2)
+            ->rename(~Integer, ~Integer_t2)
+            ->rename(~String, ~String_t2), meta::pure::functions::relation::JoinKind.INNER, {row1, row2 | $row1.Integer_t1 == $row2.Integer_t2})
+          ->project(~[String : x | $x.String_t1, other : x | $x.String_t2])
+          ->sort(~String->ascending())})
     ]
   )
 }
@@ -6145,11 +6207,24 @@ function <<test.Test>> meta::external::query::sql::transformation::queryToPure::
     'JOIN service."/service/service2" "t2" ON "t1"."Integer" = "t2"."Integer" ' +
     'ORDER BY "t1"."String"',
     [
-      // placeholder: never compared (assertLambda/assertJSON are false); present so
-      // TestConfig.relation() selects relationSources(). See the block comment above.
-      c({| FlatInput.all()->project(
-            ~[ Boolean: x | $x.booleanIn, Integer: x | $x.integerIn, Float: x | $x.floatIn, Decimal: x | $x.decimalIn, StrictDate: x | $x.strictDateIn, DateTime: x | $x.dateTimeIn, String: x | $x.stringIn])
-        }, false, false)
+      c({| meta::external::query::sql::transformation::queryToPure::tests::FlatInput.all()
+          ->project(~[Boolean : x | $x.booleanIn, Integer : x | $x.integerIn, Float : x | $x.floatIn, Decimal : x | $x.decimalIn, StrictDate : x | $x.strictDateIn, DateTime : x | $x.dateTimeIn, String : x | $x.stringIn])
+          ->rename(~Boolean, ~Boolean_t1)
+          ->rename(~Integer, ~Integer_t1)
+          ->rename(~Float, ~Float_t1)
+          ->rename(~Decimal, ~Decimal_t1)
+          ->rename(~StrictDate, ~StrictDate_t1)
+          ->rename(~DateTime, ~DateTime_t1)
+          ->rename(~String, ~String_t1)
+          ->join(meta::external::query::sql::transformation::queryToPure::tests::FlatInput.all()
+            ->project(~[ID : x | $x.idIn, Integer : x | $x.integerIn, String : x | $x.stringIn])
+            ->rename(~ID, ~ID_t2)
+            ->rename(~Integer, ~Integer_t2)
+            ->rename(~String, ~String_t2), meta::pure::functions::relation::JoinKind.INNER, {row1, row2 | $row1.Integer_t1 == $row2.Integer_t2})
+          ->select(~[String_t1, ID_t2])
+          ->rename(~String_t1, ~s)
+          ->rename(~ID_t2, ~i)
+          ->sort(~s->ascending())})
     ]
   )
 }
@@ -6165,11 +6240,24 @@ function <<test.Test>> meta::external::query::sql::transformation::queryToPure::
     'JOIN service."/service/service2" "t2" ON "t1"."Integer" = "t2"."Integer" ' +
     'GROUP BY "t1"."String" ORDER BY count(*) DESC',
     [
-      // placeholder: never compared (assertLambda/assertJSON are false); present so
-      // TestConfig.relation() selects relationSources(). See the block comment above.
-      c({| FlatInput.all()->project(
-            ~[ Boolean: x | $x.booleanIn, Integer: x | $x.integerIn, Float: x | $x.floatIn, Decimal: x | $x.decimalIn, StrictDate: x | $x.strictDateIn, DateTime: x | $x.dateTimeIn, String: x | $x.stringIn])
-        }, false, false)
+      c({| meta::external::query::sql::transformation::queryToPure::tests::FlatInput.all()
+          ->project(~[Boolean : x | $x.booleanIn, Integer : x | $x.integerIn, Float : x | $x.floatIn, Decimal : x | $x.decimalIn, StrictDate : x | $x.strictDateIn, DateTime : x | $x.dateTimeIn, String : x | $x.stringIn])
+          ->rename(~Boolean, ~Boolean_t1)
+          ->rename(~Integer, ~Integer_t1)
+          ->rename(~Float, ~Float_t1)
+          ->rename(~Decimal, ~Decimal_t1)
+          ->rename(~StrictDate, ~StrictDate_t1)
+          ->rename(~DateTime, ~DateTime_t1)
+          ->rename(~String, ~String_t1)
+          ->join(meta::external::query::sql::transformation::queryToPure::tests::FlatInput.all()
+            ->project(~[ID : x | $x.idIn, Integer : x | $x.integerIn, String : x | $x.stringIn])
+            ->rename(~ID, ~ID_t2)
+            ->rename(~Integer, ~Integer_t2)
+            ->rename(~String, ~String_t2), meta::pure::functions::relation::JoinKind.INNER, {row1, row2 | $row1.Integer_t1 == $row2.Integer_t2})
+          ->extend(~[s : x | $x.String_t1])
+          ->groupBy(~[String_t1, s], ~[n : x | $x : y | $y->count()])
+          ->sort(~n->descending())
+          ->select(~[s, n])})
     ]
   )
 }
@@ -6189,11 +6277,94 @@ function <<test.Test>> meta::external::query::sql::transformation::queryToPure::
     'JOIN service."/service/service2" "t2" ON "t1"."Integer" = "t2"."Integer" ' +
     'ORDER BY "t2"."String"',
     [
+      c({| meta::external::query::sql::transformation::queryToPure::tests::FlatInput.all()
+          ->project(~[Boolean : x | $x.booleanIn, Integer : x | $x.integerIn, Float : x | $x.floatIn, Decimal : x | $x.decimalIn, StrictDate : x | $x.strictDateIn, DateTime : x | $x.dateTimeIn, String : x | $x.stringIn])
+          ->rename(~Boolean, ~Boolean_t1)
+          ->rename(~Integer, ~Integer_t1)
+          ->rename(~Float, ~Float_t1)
+          ->rename(~Decimal, ~Decimal_t1)
+          ->rename(~StrictDate, ~StrictDate_t1)
+          ->rename(~DateTime, ~DateTime_t1)
+          ->rename(~String, ~String_t1)
+          ->join(meta::external::query::sql::transformation::queryToPure::tests::FlatInput.all()
+            ->project(~[ID : x | $x.idIn, Integer : x | $x.integerIn, String : x | $x.stringIn])
+            ->rename(~ID, ~ID_t2)
+            ->rename(~Integer, ~Integer_t2)
+            ->rename(~String, ~String_t2), meta::pure::functions::relation::JoinKind.INNER, {row1, row2 | $row1.Integer_t1 == $row2.Integer_t2})
+          ->project(~[a : x | $x.String_t1, b : x | $x.String_t2])
+          ->sort(~b->ascending())})
+    ]
+  )
+}
+
+// ---------------------------------------------------------------------------
+// An ORDER BY expression key whose column reference names the second join side.
+//
+// processProjection materialises such a key into an extend over projectedContext,
+// which carries contexts = [] because a projected relation has no per-join-side
+// scopes left. The qualifier found no scope in columnByNameParts and the lookup
+// degraded to a bare-name one, so the extend was built from whichever column
+// answered to the bare name - here nothing did, and it failed outright with
+// "no column found named: 'String'". projectedKeyExpression rewrites the key to
+// name output columns first, so no qualifier has to survive the projection.
+//
+// The other face of the same degrade - the bare name matching the WRONG side, and
+// the query silently returning rows ordered by it - is covered by the parity suite,
+// which compares rows against Postgres: colres_e3_order_by_expression_over_join and
+// crcs_g4_order_by_expression_over_join are both that shape.
+// ---------------------------------------------------------------------------
+function <<test.Test>> meta::external::query::sql::transformation::queryToPure::tests::testOrderByExpressionKeyOverJoinResolvesQualifier():Boolean[1]
+{
+  test(
+    'SELECT "t1"."String" AS "name", "t2"."String" AS "dept_name" ' +
+    'FROM service."/service/service1" "t1" ' +
+    'JOIN service."/service/service2" "t2" ON "t1"."Integer" = "t2"."Integer" ' +
+    'ORDER BY upper("t2"."String"), "t1"."String"',
+    [
       // placeholder: never compared (assertLambda/assertJSON are false); present so
       // TestConfig.relation() selects relationSources(). See the block comment above.
       c({| FlatInput.all()->project(
             ~[ Boolean: x | $x.booleanIn, Integer: x | $x.integerIn, Float: x | $x.floatIn, Decimal: x | $x.decimalIn, StrictDate: x | $x.strictDateIn, DateTime: x | $x.dateTimeIn, String: x | $x.stringIn])
         }, false, false)
+    ]
+  )
+}
+
+// The same defect with a key whose lambda can actually be written down, so it asserts rather than
+// merely compiling. A CASE key becomes isEmpty()->if(...), and isEmpty() accepts [0..1] - which is
+// what the upper() sibling above cannot do, since toUpper() needs [1] and a join column infers
+// [0..1] once the parameter annotation is dropped.
+//
+// Both take the same path: a non-QualifiedNameReference key is materialised by orderByExtensions
+// and its inner reference rewritten by projectedKeyExpression. What this one adds is the proof that
+// the rewrite picked t2 - the extend reads $x.dept_name, and would have read $x.name had the
+// qualifier been dropped the way it was before.
+function <<test.Test>> meta::external::query::sql::transformation::queryToPure::tests::testOrderByCaseKeyOverJoinResolvesQualifier():Boolean[1]
+{
+  test(
+    'SELECT "t1"."String" AS "name", "t2"."String" AS "dept_name" ' +
+    'FROM service."/service/service1" "t1" ' +
+    'JOIN service."/service/service2" "t2" ON "t1"."Integer" = "t2"."Integer" ' +
+    'ORDER BY CASE WHEN "t2"."String" IS NULL THEN 0 ELSE 1 END, "t1"."String"',
+    [
+      c({| meta::external::query::sql::transformation::queryToPure::tests::FlatInput.all()
+          ->project(~[Boolean : x | $x.booleanIn, Integer : x | $x.integerIn, Float : x | $x.floatIn, Decimal : x | $x.decimalIn, StrictDate : x | $x.strictDateIn, DateTime : x | $x.dateTimeIn, String : x | $x.stringIn])
+          ->rename(~Boolean, ~Boolean_t1)
+          ->rename(~Integer, ~Integer_t1)
+          ->rename(~Float, ~Float_t1)
+          ->rename(~Decimal, ~Decimal_t1)
+          ->rename(~StrictDate, ~StrictDate_t1)
+          ->rename(~DateTime, ~DateTime_t1)
+          ->rename(~String, ~String_t1)
+          ->join(meta::external::query::sql::transformation::queryToPure::tests::FlatInput.all()
+            ->project(~[ID : x | $x.idIn, Integer : x | $x.integerIn, String : x | $x.stringIn])
+            ->rename(~ID, ~ID_t2)
+            ->rename(~Integer, ~Integer_t2)
+            ->rename(~String, ~String_t2), meta::pure::functions::relation::JoinKind.INNER, {row1, row2 | $row1.Integer_t1 == $row2.Integer_t2})
+          ->project(~[name : x | $x.String_t1, dept_name : x | $x.String_t2])
+          ->extend(~['CASE WHEN dept_name IS NULL THEN 0 ELSE 1 END' : x | $x.dept_name->isEmpty()->if(|0, |1)])
+          ->sort([~'CASE WHEN dept_name IS NULL THEN 0 ELSE 1 END'->ascending(), ~name->ascending()])
+          ->select(~[name, dept_name])})
     ]
   )
 }


### PR DESCRIPTION
An ORDER BY key that is an expression is not a column, so processProjection
materialises it into an extend for the sort to name. That extend is built over
projectedContext, which sets contexts = [] because a projected relation has no
per-join-side scopes left. A qualified reference inside the key therefore finds
no scope in columnByNameParts, and the lookup degrades to a bare-name one:

SELECT p.name AS name, d.name AS dept_name
FROM persons p INNER JOIN departments d ON p.dept_id = d.id
ORDER BY UPPER(d.name), p.name


'd.name' loses its qualifier, resolves to bare 'name', and finds p's column. The
generated SQL reads upper("name_p"), so the query sorts by UPPER(p.name) and
returns rows in the wrong order without erroring. Where the bare name matches
nothing at all the same degrade surfaces instead as "no column found named".
projectedKeyExpression rewrites each qualified reference in the key to the output
name of the select item it denotes, before the key becomes an extend, so nothing
downstream has to resolve a qualifier against a context that cannot represent
one. It reuses walk() for the traversal and projectedSortKeySelectItem for the
match, so a key is matched on its full name parts before its bare rendering and
picks the side it actually names. A reference matching no select item is left
alone and fails exactly as before.
The rewrite is applied at both ends deliberately. The extend names its column by
stringifying the key; projectedSortKeyName names the column to sort by the same
way. Rewriting only the extend would create UPPER(dept_name) while the sort still
asked for UPPER(name) - trading wrong rows for a hard error. Both derivations
must be the same function of the same input, which is the property whose absence
caused this in the first place.