### PR TITLE
Add a pipeline performance benchmark and run it on pull requests

### DIFF
--- a/.github/workflows/actions/before-test/action.yml
+++ b/.github/workflows/actions/before-test/action.yml
@@ -80,7 +80,7 @@ runs:
         name: m2-repo
         path: ~/.m2/repository/org/finos/legend/engine
 
-    - name: Collect Workflow Telemetry
-      uses: runforesight/workflow-telemetry-action@v1
-      with:
-        theme: dark
+#    - name: Collect Workflow Telemetry
+#      uses: runforesight/workflow-telemetry-action@v1
+#      with:
+#        theme: dark

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -373,6 +373,13 @@ jobs:
           {
             echo '## Pipeline benchmark'
             echo
+            if [ "${{ steps.benchmark.outputs.exitCode }}" = "0" ]; then
+              echo 'Within the expected band of the baseline.'
+            else
+              echo 'Deviated from the baseline. This does not fail the build - it is here for the'
+              echo 'reviewer to judge whether the change explains it.'
+            fi
+            echo
             echo '```'
             sed -n '/canary ratios/,$p' "$RUNNER_TEMP/perf-output.txt" || true
             echo '```'
@@ -390,7 +397,8 @@ jobs:
           if-no-files-found: warn
 
       - name: Comment on the pull request
-        # A pull request from a fork gets a read-only token, so the comment is best effort.
+        # A pull request from a fork gets a read-only token and cannot be commented on, so this is
+        # best effort; the job summary carries the same report either way.
         continue-on-error: true
         if: github.event_name == 'pull_request' && steps.benchmark.outputs.exitCode != '0'
         uses: actions/github-script@v8
@@ -401,18 +409,26 @@ jobs:
             const output = fs.readFileSync(process.env.RUNNER_TEMP + '/perf-output.txt', 'utf8');
             const details = output.slice(output.indexOf('canary ratios'));
             const branch = context.payload.pull_request.head.ref;
+            const differentMachine = output.includes('environments differ');
             const body = [
               marker,
               '### Pipeline benchmark deviated from the baseline',
+              '',
+              'This does not block the merge. It is here so a reviewer can judge whether the change',
+              'explains the movement, or whether it is worth a closer look.',
               '',
               '```',
               details.trim(),
               '```',
               '',
-              'If this is an expected cost, or the change made things faster, refresh the baseline:',
-              'run the **Performance Baseline** workflow with `rebase` enabled and `ref` set to',
-              '`' + branch + '`. It pushes the updated baseline as a commit on this branch, so the',
-              'new numbers are reviewed together with the change that caused them.'
+              differentMachine
+                ? 'This runner is not the machine the baseline was recorded on, so absolute timings are reported as notes only and even ratios drift somewhat. Ratios that moved a long way are still worth reading.'
+                : 'This runner matches the machine the baseline was recorded on, so both ratios and absolute timings are directly comparable.',
+              '',
+              'If the new numbers are the intended cost of this change - or it made things faster -',
+              'refresh the baseline: run the **Performance Baseline** workflow with `rebase` enabled',
+              'and `ref` set to `' + branch + '`. It pushes the updated baseline as a commit on this',
+              'branch, so the new numbers are reviewed together with the change that caused them.'
             ].join('\n');
             const existing = await github.rest.issues.listComments({
               issue_number: context.issue.number,
@@ -438,12 +454,6 @@ jobs:
                 body
               });
             }
-
-      - name: Fail on deviation
-        if: steps.benchmark.outputs.exitCode != '0'
-        run: |
-          echo "benchmark exited with ${{ steps.benchmark.outputs.exitCode }}"
-          exit 1
 
   pct-report:
     name: PCT Report

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,10 +168,10 @@ jobs:
             echo "arg=" >> $GITHUB_OUTPUT
           fi
 
-      - name: Collect Workflow Telemetry
-        uses: runforesight/workflow-telemetry-action@v1
-        with:
-          theme: dark
+#      - name: Collect Workflow Telemetry
+#        uses: runforesight/workflow-telemetry-action@v1
+#        with:
+#          theme: dark
 
       - name: Set profiles that required github secrets
         id: requiredSecrets

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -325,6 +325,126 @@ jobs:
           name: test-results-${{ matrix.name }}
           path: ${{ github.workspace }}/surefire-reports-aggregate/*.xml
 
+  benchmark:
+    name: Pipeline Benchmark
+    runs-on: ubuntu-latest
+    if: "!cancelled() && needs.build.result == 'success'"
+    needs:
+      - build
+    permissions:
+      contents: read
+      pull-requests: write
+    env:
+      MODULE: legend-engine-config/legend-engine-perf-benchmark
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+
+      - name: Before Test
+        uses: ./.github/workflows/actions/before-test
+
+      - name: Restore legend-pure snapshot
+        if: inputs.pure_ref != ''
+        uses: actions/download-artifact@v8
+        with:
+          name: pure-m2-snapshot
+          path: ~/.m2/repository/org/finos/legend/pure/
+
+      - name: Resolve benchmark classpath
+        run: mvn -B -q -pl $MODULE dependency:build-classpath -Dmdep.outputFile=$RUNNER_TEMP/perf-cp.txt ${{ needs.build.outputs.pureVersionArg }}
+
+      - name: Run benchmark suite
+        id: benchmark
+        working-directory: ${{ env.MODULE }}
+        run: |
+          set +e
+          java -Xmx6g -Xss8m \
+            -cp "target/classes:$(cat $RUNNER_TEMP/perf-cp.txt)" \
+            org.finos.legend.engine.perf.PipelineBench \
+            --suite default --iters 5 --warmup 2 \
+            --out "$RUNNER_TEMP/perf-results.json" \
+            | tee "$RUNNER_TEMP/perf-output.txt"
+          echo "exitCode=${PIPESTATUS[0]}" >> $GITHUB_OUTPUT
+
+      - name: Publish summary
+        if: always()
+        run: |
+          {
+            echo '## Pipeline benchmark'
+            echo
+            echo '```'
+            sed -n '/canary ratios/,$p' "$RUNNER_TEMP/perf-output.txt" || true
+            echo '```'
+          } >> $GITHUB_STEP_SUMMARY
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: perf-results
+          path: |
+            ${{ runner.temp }}/perf-results.json
+            ${{ runner.temp }}/perf-output.txt
+          retention-days: 14
+          if-no-files-found: warn
+
+      - name: Comment on the pull request
+        # A pull request from a fork gets a read-only token, so the comment is best effort.
+        continue-on-error: true
+        if: github.event_name == 'pull_request' && steps.benchmark.outputs.exitCode != '0'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- performance-ci -->';
+            const output = fs.readFileSync(process.env.RUNNER_TEMP + '/perf-output.txt', 'utf8');
+            const details = output.slice(output.indexOf('canary ratios'));
+            const branch = context.payload.pull_request.head.ref;
+            const body = [
+              marker,
+              '### Pipeline benchmark deviated from the baseline',
+              '',
+              '```',
+              details.trim(),
+              '```',
+              '',
+              'If this is an expected cost, or the change made things faster, refresh the baseline:',
+              'run the **Performance Baseline** workflow with `rebase` enabled and `ref` set to',
+              '`' + branch + '`. It pushes the updated baseline as a commit on this branch, so the',
+              'new numbers are reviewed together with the change that caused them.'
+            ].join('\n');
+            const existing = await github.rest.issues.listComments({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo
+            });
+            const previous = existing.data.find(comment => comment.body.startsWith(marker));
+            if (previous)
+            {
+              await github.rest.issues.updateComment({
+                comment_id: previous.id,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body
+              });
+            }
+            else
+            {
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body
+              });
+            }
+
+      - name: Fail on deviation
+        if: steps.benchmark.outputs.exitCode != '0'
+        run: |
+          echo "benchmark exited with ${{ steps.benchmark.outputs.exitCode }}"
+          exit 1
+
   pct-report:
     name: PCT Report
     runs-on: ubuntu-latest

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -1,0 +1,153 @@
+# Copyright 2026 Goldman Sachs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Performance Baseline
+
+# Records a new performance baseline for a branch, and pushes it there as a commit.
+#
+# Pull requests are measured by the Pipeline Benchmark job in Build CI, which reuses that
+# workflow's build output. This workflow is the manual counterpart: when a pull request fails the
+# benchmark because its cost legitimately changed - or because it made things faster - run this
+# against the branch with rebase enabled, and the updated baseline lands as a commit on the branch,
+# reviewed alongside the change that caused it.
+#
+# It builds the benchmark module itself, since a manual run has no Build CI artifacts to reuse.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch to run on. Leave empty for the default branch."
+        required: false
+        default: ""
+        type: string
+      rebase:
+        description: "Record this run as the new baseline and push it as a commit on the branch"
+        required: false
+        default: false
+        type: boolean
+      args:
+        description: "Extra flags for the benchmark, e.g. '--margin 0.3 --iters 8'"
+        required: false
+        default: ""
+        type: string
+
+concurrency:
+  group: ci-perf-baseline-${{ inputs.ref }}
+  cancel-in-progress: true
+
+env:
+  MODULE: legend-engine-config/legend-engine-perf-benchmark
+  MAVEN_OPTS: "-Xmx8g"
+
+jobs:
+  baseline:
+    name: Record baseline
+    # Forks generally lack the resources for an engine build, and pushing a baseline to one would
+    # need write access this token does not have.
+    if: github.repository == 'finos/legend-engine'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
+          persist-credentials: true
+
+      - name: Cache Maven dependencies
+        uses: actions/cache@v5
+        env:
+          cache-name: cache-mvn-deps
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-perf-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-perf-${{ env.cache-name }}-
+
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          java-version: 17
+          distribution: 'zulu'
+
+      - name: Purge stale legend-engine artifacts from local Maven repo
+        run: rm -rf ~/.m2/repository/org/finos/legend/engine
+
+      - name: Build benchmark and its dependencies
+        run: mvn -B -e -DskipTests install -pl $MODULE -am
+
+      - name: Resolve benchmark classpath
+        run: mvn -B -q -pl $MODULE dependency:build-classpath -Dmdep.outputFile=$RUNNER_TEMP/perf-cp.txt
+
+      - name: Run benchmark suite
+        id: benchmark
+        working-directory: ${{ env.MODULE }}
+        run: |
+          set +e
+          java -Xmx6g -Xss8m \
+            -cp "target/classes:$(cat $RUNNER_TEMP/perf-cp.txt)" \
+            org.finos.legend.engine.perf.PipelineBench \
+            --suite default --iters 5 --warmup 2 \
+            --out "$RUNNER_TEMP/perf-results.json" \
+            ${{ inputs.rebase && '--rebase' || '' }} \
+            ${{ inputs.args }} \
+            | tee "$RUNNER_TEMP/perf-output.txt"
+          echo "exitCode=${PIPESTATUS[0]}" >> $GITHUB_OUTPUT
+
+      - name: Publish summary
+        if: always()
+        run: |
+          {
+            echo '## Pipeline benchmark'
+            echo
+            echo '```'
+            sed -n '/canary ratios/,$p' "$RUNNER_TEMP/perf-output.txt" || true
+            echo '```'
+          } >> $GITHUB_STEP_SUMMARY
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: perf-results
+          path: |
+            ${{ runner.temp }}/perf-results.json
+            ${{ runner.temp }}/perf-output.txt
+          retention-days: 14
+          if-no-files-found: warn
+
+      - name: Commit rebased baseline
+        if: inputs.rebase
+        run: |
+          if git diff --quiet -- "$MODULE/perf-baseline.json"; then
+            echo "baseline unchanged - nothing to commit"
+            exit 0
+          fi
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          git config user.name "${GITHUB_ACTOR}"
+          git add "$MODULE/perf-baseline.json"
+          git commit -m "Rebase performance baseline" \
+                     -m "Recorded by the Performance Baseline workflow, run ${{ github.run_id }}."
+          git push
+          echo "baseline committed and pushed"
+
+      - name: Fail on deviation
+        # A rebase run records whatever it measured, so only a comparison run can fail here.
+        if: ${{ !inputs.rebase && steps.benchmark.outputs.exitCode != '0' }}
+        run: |
+          echo "benchmark exited with ${{ steps.benchmark.outputs.exitCode }}"
+          exit 1

--- a/legend-engine-config/legend-engine-perf-benchmark/README.md
+++ b/legend-engine-config/legend-engine-perf-benchmark/README.md
@@ -148,32 +148,46 @@ computed canary ratios:
 
 ## What the comparison enforces
 
-Absolute durations move several-fold between machines, so the two kinds of check are treated
-differently:
+The baseline holds **one entry per environment**, keyed by a fingerprint of the operating system,
+architecture, CPU, processor count, heap size and Java major version. A run is compared against the
+entry for the machine it is running on:
 
-- **Deviation is judged in both directions.** A slower result is a regression. A faster one fails
-  too, and says so separately: until the gain is recorded, the baseline still permits the old cost,
-  so a later change could give the improvement back and the check would call it fine. Failing forces
-  the new level into the baseline, where it protects the fix. Rerun with `--rebase` and commit the
-  baseline in the same pull request as the change that earned it. `--allow-improvement` turns this
-  side off.
-- **Canary ratios are always enforced.** A ratio between two workloads measured in the same JVM
-  cancels machine speed, so it is comparable between a laptop and a CI runner. These catch the
-  regressions that matter - a phase silently changing complexity class.
-- **Absolute phase medians are enforced only when the environment fingerprint matches** the
-  baseline (same OS, architecture, CPU, processor count, heap and Java major version). On a
-  different machine they are reported as advisory notes instead of failures. Deltas below
-  `--min-delta-ms` are ignored either way, because millisecond phases are dominated by JIT noise.
-  This is also why the improvement side does not fire on a faster machine: everything looks faster
-  there, which says nothing about the code.
+- **An entry for this machine exists.** Both ratios and absolute phase medians are compared against
+  it, in both directions, since they describe the same hardware. Deltas below `--min-delta-ms` are
+  ignored, because millisecond phases are dominated by JIT noise.
+- **No entry for this machine.** Nothing is checked. The run prints its own canary ratios and says
+  which environments the baseline does know about, so the next step is obvious: record one here with
+  `--rebase`.
 
-Baselines belong in a checked-in file updated by pull request, so an intentional performance change
-is reviewed alongside the code that causes it - in either direction. `--rebase` is how that file is
-regenerated.
+Nothing is compared across machines, because nothing survives the trip intact. Absolute timings
+plainly do not. Ratios travel better but not far enough to trust: the same commit measured on an
+Apple M4 Max and in a Linux container on the same host put the compile-cliff canary at 30.0 and
+36.7, a 22% gap from environment alone. A single shared baseline would have spent that budget on
+hardware instead of on code.
 
-The baseline committed here was measured on a developer machine, so on a CI runner the environment
-fingerprint will not match and absolute timings stay advisory while canary ratios are enforced. Run
-`--suite default --rebase` once on the runner class and commit that file to enforce both.
+Recording is additive. `--rebase` writes the entry for the machine it runs on and leaves every other
+entry untouched, so a laptop baseline and a CI baseline live in the same committed file without
+overwriting each other.
+
+Deviation is judged in both directions. A slower result is a regression. A faster one is reported
+separately, because until the gain is recorded the baseline still permits the old cost, and a later
+change could give it back unnoticed. Rerun with `--rebase` and commit the baseline in the same pull
+request as the change that earned it. `--allow-improvement` turns that side off.
+
+## Measuring a second environment with Docker
+
+`scripts/run-in-container.sh` runs the suite inside a Linux container, so another environment can be
+added without another machine. It mounts the repository and the Maven repository at the paths they
+have on the host, so the classpath resolved outside works unchanged inside.
+
+```bash
+scripts/run-in-container.sh --rebase            # record this container as an environment
+scripts/run-in-container.sh                     # compare against that entry later
+```
+
+`PERF_IMAGE` and `PERF_HEAP` override the image and heap. A chained local Maven repository is
+supported through `MAVEN_REPO_LOCAL` and `MAVEN_REPO_LOCAL_TAIL`. Note that the heap is part of the
+fingerprint, so changing `PERF_HEAP` describes a different environment and needs its own entry.
 
 ## In CI
 
@@ -198,11 +212,10 @@ Two limitations worth knowing. A pull request from a fork gets a read-only token
 best effort - the job summary always carries the same report - and a rebase must be run from the
 fork or the baseline committed by hand.
 
-And a baseline recorded on a developer machine will not match a runner's fingerprint, so absolute
-timings are reported as notes. Ratios survive the move far better but not perfectly: measured
-across an Apple M4 Max and a four-core cloud runner, five of six canaries landed inside a 30% band
-while the union ratio came in 31% low, purely from the hardware. Recording the baseline on the
-runner class the workflow uses removes that drift and makes absolute timings comparable again.
+And a runner will not match a baseline recorded on a developer machine, so until someone records an
+entry from the runner itself, the job reports its numbers and checks nothing. Running the
+Performance Baseline workflow once against the default branch adds that entry, after which every
+pull request is compared against numbers measured on the same hardware.
 
 ## Canary ratios
 

--- a/legend-engine-config/legend-engine-perf-benchmark/README.md
+++ b/legend-engine-config/legend-engine-perf-benchmark/README.md
@@ -175,6 +175,26 @@ The baseline committed here was measured on a developer machine, so on a CI runn
 fingerprint will not match and absolute timings stay advisory while canary ratios are enforced. Run
 `--suite default --rebase` once on the runner class and commit that file to enforce both.
 
+## In CI
+
+The **Pipeline Benchmark** job in `.github/workflows/build.yml` runs this suite on every pull
+request and compares it against the checked-in baseline. It reuses that workflow's build output
+rather than building again, so it costs about the time the suite itself takes. A deviation in
+either direction fails the job, and it leaves a comment on the pull request explaining what moved.
+
+To accept the new numbers, run the **Performance Baseline** workflow
+(`.github/workflows/performance.yml`) with `rebase` enabled and `ref` set to the pull request's
+branch. The run records the results as the baseline and pushes them
+as a commit on that branch, so the change in cost is reviewed in the same pull request as the change
+that caused it. The manual trigger also takes an `args` field for extra flags, for example
+`--margin 0.3 --iters 8`.
+
+Two limitations worth knowing. A pull request from a fork gets a read-only token, so the comment is
+best effort and a rebase must be run from the fork or the baseline committed by hand. And CI runners
+vary, so their environment fingerprint usually will not match the committed baseline: canary ratios
+are still enforced, while absolute phase medians stay advisory until someone rebases on the runner
+class the workflow uses.
+
 ## Canary ratios
 
 Absolute times vary several-fold between machines, so thresholds on them are either noisy or

--- a/legend-engine-config/legend-engine-perf-benchmark/README.md
+++ b/legend-engine-config/legend-engine-perf-benchmark/README.md
@@ -179,8 +179,13 @@ fingerprint will not match and absolute timings stay advisory while canary ratio
 
 The **Pipeline Benchmark** job in `.github/workflows/build.yml` runs this suite on every pull
 request and compares it against the checked-in baseline. It reuses that workflow's build output
-rather than building again, so it costs about the time the suite itself takes. A deviation in
-either direction fails the job, and it leaves a comment on the pull request explaining what moved.
+rather than building again, so it costs about the time the suite itself takes.
+
+A deviation does not fail the build. The job reports it - in the job summary, and as a comment on
+the pull request - and leaves the judgement to the reviewer, who can see whether the change
+explains the movement. Blocking on it would be wrong for a measurement this environment-sensitive:
+runner hardware differs from whatever machine recorded the baseline, and even ratios drift somewhat
+between very different processors.
 
 To accept the new numbers, run the **Performance Baseline** workflow
 (`.github/workflows/performance.yml`) with `rebase` enabled and `ref` set to the pull request's
@@ -190,10 +195,14 @@ that caused it. The manual trigger also takes an `args` field for extra flags, f
 `--margin 0.3 --iters 8`.
 
 Two limitations worth knowing. A pull request from a fork gets a read-only token, so the comment is
-best effort and a rebase must be run from the fork or the baseline committed by hand. And CI runners
-vary, so their environment fingerprint usually will not match the committed baseline: canary ratios
-are still enforced, while absolute phase medians stay advisory until someone rebases on the runner
-class the workflow uses.
+best effort - the job summary always carries the same report - and a rebase must be run from the
+fork or the baseline committed by hand.
+
+And a baseline recorded on a developer machine will not match a runner's fingerprint, so absolute
+timings are reported as notes. Ratios survive the move far better but not perfectly: measured
+across an Apple M4 Max and a four-core cloud runner, five of six canaries landed inside a 30% band
+while the union ratio came in 31% low, purely from the hardware. Recording the baseline on the
+runner class the workflow uses removes that drift and makes absolute timings comparable again.
 
 ## Canary ratios
 

--- a/legend-engine-config/legend-engine-perf-benchmark/README.md
+++ b/legend-engine-config/legend-engine-perf-benchmark/README.md
@@ -1,0 +1,195 @@
+# Pipeline performance benchmark
+
+Times each stage of the query pipeline separately, so a slow query can be attributed to a phase
+rather than to "the platform". Background, measurements and the hotspots this harness found are in
+[finos/legend-engine#5140](https://github.com/finos/legend-engine/issues/5140).
+
+## Phases
+
+| Phase | What it measures |
+|---|---|
+| `parse` | `PureGrammarParser.parseModel` - grammar to `PureModelContextData` |
+| `compile` | `Compiler.compile` - the `PureModel` constructor (multi-pass graph build and validation) |
+| `lambda` | `HelperValueSpecificationBuilder.buildLambda` - building the query lambda |
+| `extensions` | Building the Pure extension list |
+| `planPure` | `PlanGenerator.generateExecutionPlanAsPure` - preeval, routing, clustering, pure-to-SQL, SQL-to-string |
+| `javaBind` | `PlanPlatform.JAVA.bindPlan` - Java platform binding |
+| `serialize` | `PlanGenerator.serializeToJSON` - protocol transform plus Pure `toJSON` |
+| `deserialize` | `PlanGenerator.stringToPlan` - Jackson |
+| `execute` | `PlanExecutor.execute` against in-memory H2 (only with `--execute`) |
+
+Iteration 0 of a run is cold: it pays class loading and JIT for the generated Pure code base.
+Steady-state cost is the median after `--warmup` iterations.
+
+## Running
+
+```bash
+mvn install -DskipTests -pl legend-engine-config/legend-engine-perf-benchmark -am
+mvn -q -pl legend-engine-config/legend-engine-perf-benchmark exec:java \
+    -Dexec.mainClass=org.finos.legend.engine.perf.PipelineBench \
+    -Dexec.args="--scale 1000 --query simple --iters 10 --execute"
+```
+
+Or build a classpath once and run the class directly, which is faster to iterate on and gives full
+control of JVM flags for profiling:
+
+```bash
+mvn -q -pl legend-engine-config/legend-engine-perf-benchmark dependency:build-classpath -Dmdep.outputFile=/tmp/cp.txt
+java -Xmx8g -Xss8m -cp "legend-engine-config/legend-engine-perf-benchmark/target/classes:$(cat /tmp/cp.txt)" \
+    org.finos.legend.engine.perf.PipelineBench --scale 1000 --query simple --iters 10
+```
+
+## Workload
+
+`--scale N` sets the size of the generated model: N classes, N tables, N-1 joins, and a mapping
+covering every class. The query stays fixed, so a scale sweep isolates how each phase reacts to
+model size. Query shapes vary one dimension each:
+
+| Shape | Varies |
+|---|---|
+| `simple` | filter plus three projected columns |
+| `joinK` | navigation depth: projects across a K-deep property chain |
+| `projW` / `longprojW` | projection width; `longproj` uses 390-character aliases to exercise dialect alias limits |
+| `aggK` | number of aggregates in a `groupBy` |
+| `graphK` | graph-fetch tree depth (the shape services use) |
+| `semiK` / `semiwK` / `semijoinK` | semi-structured path depth, access width, and width combined with join navigation |
+| `variantrel` | Variant functions through the relation path |
+| `m2mview` | a model-to-model view over the relational mapping |
+
+Mapping shape flags: `--nextmult 1|0..1` (chain multiplicity), `--union K` (Operation union over K
+set implementations), `--includes K` (K-deep mapping include chain), `--milestoning`
+(business-temporal), `--relfunc` (Relation `~func` mappings plus ModelJoin associations), `--m2m`
+(model-to-model view via `ModelChainConnection`), `--semi D` (SEMISTRUCTURED column with a JSON
+binding over a D-level model).
+
+Other flags: `--dbtype H2|DuckDB|Snowflake` (plan generation works for any dialect without a
+connection), `--iters`, `--warmup`, `--execute`, `--csv <path>`, `--dumpplan <path>`, `--pause`
+(waits for a profiler to attach before measuring).
+
+To run a model that already exists rather than a generated one:
+
+```bash
+--filelist files.txt --queryfile query.txt --mapping demo::MyMapping --db demo::MyDatabase
+```
+
+where `files.txt` lists `.pure` files one per line and `query.txt` holds the query body.
+
+## Profiling
+
+Plan generation runs as Java generated from Pure, so profiler frames are mangled generated class
+names. `scripts/demangle_pure_frames.py` rewrites them back to Pure function names and reports self
+and inclusive time per Pure function:
+
+```bash
+java ... org.finos.legend.engine.perf.PipelineBench --scale 1000 --query simple --iters 3000 &
+asprof collect -d 30 -e wall -i 5ms -t -o collapsed -f profile.collapsed <pid>
+grep '^\[main' profile.collapsed | sed 's/^\[main[^]]*\];//' > main.collapsed
+scripts/demangle_pure_frames.py main.collapsed demangled.collapsed report.txt
+```
+
+Wall-clock mode matters: a CPU sampler under-reports class loading, lock and IO waits, which
+dominate the cold path. On CI runners where `perf_events` is restricted, use `ctimer`.
+
+## Suite runs, baselines and regression checks
+
+A suite run executes a fixed set of workloads in one JVM and writes a results file describing both
+the numbers and the machine they were measured on:
+
+```bash
+# create or update the stored baseline
+java ... org.finos.legend.engine.perf.PipelineBench --suite default --rebase
+
+# compare a run against the baseline; exits non-zero if it deviates beyond the margin
+java ... org.finos.legend.engine.perf.PipelineBench --suite default
+
+# keep the run's own results as well as comparing
+java ... org.finos.legend.engine.perf.PipelineBench --suite default --out perf-results.json
+```
+
+Flags: `--baseline <path>` (default `perf-baseline.json`), `--out <path>`, `--rebase`,
+`--margin 0.5` (allowed deviation for absolute phase medians), `--canary-margin 0.3` (allowed
+deviation for ratios), `--min-delta-ms 25` (absolute deltas smaller than this are treated as noise),
+`--allow-improvement` (only enforce the slower side), `--iters`, `--warmup`.
+
+The results file records the environment, every workload's cold and warm phase timings, and the
+computed canary ratios:
+
+```json
+{
+  "schemaVersion": 1,
+  "suite": "default",
+  "generatedAt": "2026-09-10T00:27:16Z",
+  "environment": {
+    "os": "Mac OS X", "arch": "aarch64", "cpu": "Apple M4 Max",
+    "availableProcessors": 16, "maxHeapMb": 8192,
+    "javaVersion": "17.0.19", "jvmName": "OpenJDK 64-Bit Server VM",
+    "jvmArgs": "[-Xmx8g, -Xss8m]", "gitCommit": "a314b6f...", "ci": false
+  },
+  "workloads": [
+    {
+      "workload": "simple@scale1000/H2",
+      "config": { "scale": 1000, "query": "simple", "dbType": "H2", "...": "..." },
+      "iterations": 5, "warmup": 2,
+      "coldMs":       { "parse": 159, "compile": 114, "planPure": 12, "...": 0 },
+      "warmMedianMs": { "parse": 152, "compile": 90,  "planPure": 13, "...": 0 },
+      "planJsonChars": 2011
+    }
+  ],
+  "canaries": [
+    {
+      "name": "compileCliffJoinDepth", "phase": "compile",
+      "numerator": "join16@scale30/H2", "denominator": "join8@scale30/H2",
+      "guards": "exponential lambda compilation on optional navigation chains",
+      "value": 31.0
+    }
+  ]
+}
+```
+
+## What the comparison enforces
+
+Absolute durations move several-fold between machines, so the two kinds of check are treated
+differently:
+
+- **Deviation is judged in both directions.** A slower result is a regression. A faster one fails
+  too, and says so separately: until the gain is recorded, the baseline still permits the old cost,
+  so a later change could give the improvement back and the check would call it fine. Failing forces
+  the new level into the baseline, where it protects the fix. Rerun with `--rebase` and commit the
+  baseline in the same pull request as the change that earned it. `--allow-improvement` turns this
+  side off.
+- **Canary ratios are always enforced.** A ratio between two workloads measured in the same JVM
+  cancels machine speed, so it is comparable between a laptop and a CI runner. These catch the
+  regressions that matter - a phase silently changing complexity class.
+- **Absolute phase medians are enforced only when the environment fingerprint matches** the
+  baseline (same OS, architecture, CPU, processor count, heap and Java major version). On a
+  different machine they are reported as advisory notes instead of failures. Deltas below
+  `--min-delta-ms` are ignored either way, because millisecond phases are dominated by JIT noise.
+  This is also why the improvement side does not fire on a faster machine: everything looks faster
+  there, which says nothing about the code.
+
+Baselines belong in a checked-in file updated by pull request, so an intentional performance change
+is reviewed alongside the code that causes it - in either direction. `--rebase` is how that file is
+regenerated.
+
+The baseline committed here was measured on a developer machine, so on a CI runner the environment
+fingerprint will not match and absolute timings stay advisory while canary ratios are enforced. Run
+`--suite default --rebase` once on the runner class and commit that file to enforce both.
+
+## Canary ratios
+
+Absolute times vary several-fold between machines, so thresholds on them are either noisy or
+useless. Ratios between two workloads measured in the same JVM cancel machine speed and catch the
+regressions that matter - a phase silently becoming quadratic or exponential in some dimension.
+Suggested canaries, with the shape each one guards:
+
+| Canary | Guards |
+|---|---|
+| `compile(join16) / compile(join8)` | exponential lambda compilation on `[0..1]` navigation chains |
+| `compile(scale 1000) / compile(scale 100)` | quadratic terms in mapping validation and table resolution |
+| `planPure(union40) / planPure(union10)` | quadratic pure-to-SQL in union set implementations |
+| `planPure(join10) / planPure(join2)` | pure-to-SQL superlinearity in navigation depth |
+| `compile(relfunc 200) / compile(relfunc 50)` | per-column lambda compilation in Relation mappings |
+| `javaBind(graph4) / javaBind(graph1)` | platform binder growth in graph-fetch tree size |
+
+Baselines belong in a checked-in file updated by pull request, so an intentional performance change
+is reviewed alongside the code that causes it.

--- a/legend-engine-config/legend-engine-perf-benchmark/README.md
+++ b/legend-engine-config/legend-engine-perf-benchmark/README.md
@@ -107,6 +107,8 @@ java ... org.finos.legend.engine.perf.PipelineBench --suite default --out perf-r
 ```
 
 Flags: `--baseline <path>` (default `perf-baseline.json`), `--out <path>`, `--rebase`,
+`--record <results.json>` (write a results file measured elsewhere into the baseline without
+re-running the suite),
 `--margin 0.5` (allowed deviation for absolute phase medians), `--canary-margin 0.3` (allowed
 deviation for ratios), `--min-delta-ms 25` (absolute deltas smaller than this are treated as noise),
 `--allow-improvement` (only enforce the slower side), `--iters`, `--warmup`.
@@ -209,13 +211,27 @@ that caused it. The manual trigger also takes an `args` field for extra flags, f
 `--margin 0.3 --iters 8`.
 
 Two limitations worth knowing. A pull request from a fork gets a read-only token, so the comment is
-best effort - the job summary always carries the same report - and a rebase must be run from the
-fork or the baseline committed by hand.
+best effort - the job summary always carries the same report - and the Performance Baseline workflow
+cannot push a rebase to the fork's branch.
 
 And a runner will not match a baseline recorded on a developer machine, so until someone records an
-entry from the runner itself, the job reports its numbers and checks nothing. Running the
-Performance Baseline workflow once against the default branch adds that entry, after which every
-pull request is compared against numbers measured on the same hardware.
+entry from the runner itself, the job reports its numbers and checks nothing. There are two ways to
+add that entry. Run the Performance Baseline workflow once against the default branch, or download
+the `perf-results` artifact from any Pipeline Benchmark run and feed it in:
+
+```bash
+gh run download <run-id> -n perf-results -D /tmp/perf
+java ... org.finos.legend.engine.perf.PipelineBench --record /tmp/perf/perf-results.json
+```
+
+The second path is the one that works for a fork, and it is how the hosted-runner entry in the
+committed baseline was recorded. Either way, every pull request after it is compared against numbers
+measured on the same hardware.
+
+Hosted runners are not a single machine. `ubuntu-latest` is backed by more than one processor model,
+and the fingerprint includes the CPU, so a run landing on a different SKU misses the entry and falls
+back to checking nothing. That is the intended failure mode - a silent no-op is better than a false
+regression - but it means the baseline needs an entry per SKU that shows up, added the same way.
 
 ## Canary ratios
 

--- a/legend-engine-config/legend-engine-perf-benchmark/perf-baseline.json
+++ b/legend-engine-config/legend-engine-perf-benchmark/perf-baseline.json
@@ -1,520 +1,1042 @@
 {
   "schemaVersion" : 1,
   "suite" : "default",
-  "generatedAt" : "2026-09-10T00:30:32.661875Z",
-  "environment" : {
-    "os" : "Mac OS X",
-    "osVersion" : "26.6.2",
-    "arch" : "aarch64",
-    "cpu" : "Apple M4 Max",
-    "availableProcessors" : 16,
-    "maxHeapMb" : 8192,
-    "javaVersion" : "17.0.19",
-    "javaVendor" : "Eclipse Adoptium",
-    "jvmName" : "OpenJDK 64-Bit Server VM",
-    "jvmArgs" : "[-Xmx8g, -Xss8m]",
-    "engineVersion" : "unknown",
-    "gitCommit" : "a314b6f1e784e351a5a2636888d49425e317867f",
-    "ci" : false
-  },
-  "workloads" : [ {
-    "workload" : "simple@scale100/H2",
-    "config" : {
-      "scale" : 100,
-      "query" : "simple",
-      "dbType" : "H2",
-      "unionSets" : 0,
-      "includes" : 0,
-      "semiDepth" : 0,
-      "milestoned" : false,
-      "relationFunction" : false,
-      "modelToModel" : false,
-      "nextMultiplicity" : "0..1",
-      "execute" : false
+  "environments" : {
+    "Mac OS X|aarch64|Apple M4 Max|16|8192|17" : {
+      "generatedAt" : "2026-09-10T12:14:58.885879Z",
+      "environment" : {
+        "os" : "Mac OS X",
+        "osVersion" : "26.6.2",
+        "arch" : "aarch64",
+        "cpu" : "Apple M4 Max",
+        "availableProcessors" : 16,
+        "maxHeapMb" : 8192,
+        "javaVersion" : "17.0.19",
+        "javaVendor" : "Eclipse Adoptium",
+        "jvmName" : "OpenJDK 64-Bit Server VM",
+        "jvmArgs" : "[-Xmx8g, -Xss8m]",
+        "engineVersion" : "unknown",
+        "gitCommit" : "9b6996573293b5dab1aed307757503e8ee00bebb",
+        "ci" : false
+      },
+      "workloads" : [ {
+        "workload" : "simple@scale100/H2",
+        "config" : {
+          "scale" : 100,
+          "query" : "simple",
+          "dbType" : "H2",
+          "unionSets" : 0,
+          "includes" : 0,
+          "semiDepth" : 0,
+          "milestoned" : false,
+          "relationFunction" : false,
+          "modelToModel" : false,
+          "nextMultiplicity" : "0..1",
+          "execute" : false
+        },
+        "iterations" : 5,
+        "warmup" : 2,
+        "coldMs" : {
+          "parse" : 427,
+          "compile" : 1225,
+          "lambda" : 1,
+          "extensions" : 253,
+          "planPure" : 1085,
+          "javaBind" : 288,
+          "serialize" : 142,
+          "deserialize" : 29
+        },
+        "warmMedianMs" : {
+          "parse" : 15,
+          "compile" : 15,
+          "lambda" : 0,
+          "extensions" : 0,
+          "planPure" : 12,
+          "javaBind" : 4,
+          "serialize" : 1,
+          "deserialize" : 4
+        },
+        "planJsonChars" : 2305
+      }, {
+        "workload" : "simple@scale1000/H2",
+        "config" : {
+          "scale" : 1000,
+          "query" : "simple",
+          "dbType" : "H2",
+          "unionSets" : 0,
+          "includes" : 0,
+          "semiDepth" : 0,
+          "milestoned" : false,
+          "relationFunction" : false,
+          "modelToModel" : false,
+          "nextMultiplicity" : "0..1",
+          "execute" : false
+        },
+        "iterations" : 5,
+        "warmup" : 2,
+        "coldMs" : {
+          "parse" : 128,
+          "compile" : 91,
+          "lambda" : 1,
+          "extensions" : 0,
+          "planPure" : 11,
+          "javaBind" : 3,
+          "serialize" : 1,
+          "deserialize" : 3
+        },
+        "warmMedianMs" : {
+          "parse" : 125,
+          "compile" : 79,
+          "lambda" : 0,
+          "extensions" : 0,
+          "planPure" : 11,
+          "javaBind" : 4,
+          "serialize" : 1,
+          "deserialize" : 3
+        },
+        "planJsonChars" : 2305
+      }, {
+        "workload" : "join8@scale30/H2",
+        "config" : {
+          "scale" : 30,
+          "query" : "join8",
+          "dbType" : "H2",
+          "unionSets" : 0,
+          "includes" : 0,
+          "semiDepth" : 0,
+          "milestoned" : false,
+          "relationFunction" : false,
+          "modelToModel" : false,
+          "nextMultiplicity" : "0..1",
+          "execute" : false
+        },
+        "iterations" : 5,
+        "warmup" : 2,
+        "coldMs" : {
+          "parse" : 7,
+          "compile" : 22,
+          "lambda" : 4,
+          "extensions" : 0,
+          "planPure" : 102,
+          "javaBind" : 4,
+          "serialize" : 1,
+          "deserialize" : 2
+        },
+        "warmMedianMs" : {
+          "parse" : 7,
+          "compile" : 10,
+          "lambda" : 2,
+          "extensions" : 0,
+          "planPure" : 32,
+          "javaBind" : 3,
+          "serialize" : 1,
+          "deserialize" : 1
+        },
+        "planJsonChars" : 3581
+      }, {
+        "workload" : "join16@scale30/H2",
+        "config" : {
+          "scale" : 30,
+          "query" : "join16",
+          "dbType" : "H2",
+          "unionSets" : 0,
+          "includes" : 0,
+          "semiDepth" : 0,
+          "milestoned" : false,
+          "relationFunction" : false,
+          "modelToModel" : false,
+          "nextMultiplicity" : "0..1",
+          "execute" : false
+        },
+        "iterations" : 5,
+        "warmup" : 2,
+        "coldMs" : {
+          "parse" : 15,
+          "compile" : 346,
+          "lambda" : 303,
+          "extensions" : 0,
+          "planPure" : 66,
+          "javaBind" : 2,
+          "serialize" : 1,
+          "deserialize" : 1
+        },
+        "warmMedianMs" : {
+          "parse" : 12,
+          "compile" : 300,
+          "lambda" : 293,
+          "extensions" : 0,
+          "planPure" : 44,
+          "javaBind" : 2,
+          "serialize" : 1,
+          "deserialize" : 1
+        },
+        "planJsonChars" : 5172
+      }, {
+        "workload" : "join2@scale30/H2",
+        "config" : {
+          "scale" : 30,
+          "query" : "join2",
+          "dbType" : "H2",
+          "unionSets" : 0,
+          "includes" : 0,
+          "semiDepth" : 0,
+          "milestoned" : false,
+          "relationFunction" : false,
+          "modelToModel" : false,
+          "nextMultiplicity" : "0..1",
+          "execute" : false
+        },
+        "iterations" : 5,
+        "warmup" : 2,
+        "coldMs" : {
+          "parse" : 4,
+          "compile" : 4,
+          "lambda" : 0,
+          "extensions" : 0,
+          "planPure" : 7,
+          "javaBind" : 2,
+          "serialize" : 0,
+          "deserialize" : 1
+        },
+        "warmMedianMs" : {
+          "parse" : 4,
+          "compile" : 4,
+          "lambda" : 0,
+          "extensions" : 0,
+          "planPure" : 7,
+          "javaBind" : 2,
+          "serialize" : 0,
+          "deserialize" : 1
+        },
+        "planJsonChars" : 2429
+      }, {
+        "workload" : "join10@scale30/H2",
+        "config" : {
+          "scale" : 30,
+          "query" : "join10",
+          "dbType" : "H2",
+          "unionSets" : 0,
+          "includes" : 0,
+          "semiDepth" : 0,
+          "milestoned" : false,
+          "relationFunction" : false,
+          "modelToModel" : false,
+          "nextMultiplicity" : "0..1",
+          "execute" : false
+        },
+        "iterations" : 5,
+        "warmup" : 2,
+        "coldMs" : {
+          "parse" : 7,
+          "compile" : 9,
+          "lambda" : 4,
+          "extensions" : 0,
+          "planPure" : 21,
+          "javaBind" : 2,
+          "serialize" : 1,
+          "deserialize" : 1
+        },
+        "warmMedianMs" : {
+          "parse" : 7,
+          "compile" : 9,
+          "lambda" : 4,
+          "extensions" : 0,
+          "planPure" : 21,
+          "javaBind" : 2,
+          "serialize" : 1,
+          "deserialize" : 1
+        },
+        "planJsonChars" : 3972
+      }, {
+        "workload" : "join2@scale10+union10/H2",
+        "config" : {
+          "scale" : 10,
+          "query" : "join2",
+          "dbType" : "H2",
+          "unionSets" : 10,
+          "includes" : 0,
+          "semiDepth" : 0,
+          "milestoned" : false,
+          "relationFunction" : false,
+          "modelToModel" : false,
+          "nextMultiplicity" : "0..1",
+          "execute" : false
+        },
+        "iterations" : 5,
+        "warmup" : 2,
+        "coldMs" : {
+          "parse" : 13,
+          "compile" : 7,
+          "lambda" : 0,
+          "extensions" : 0,
+          "planPure" : 122,
+          "javaBind" : 2,
+          "serialize" : 1,
+          "deserialize" : 2
+        },
+        "warmMedianMs" : {
+          "parse" : 2,
+          "compile" : 4,
+          "lambda" : 0,
+          "extensions" : 0,
+          "planPure" : 43,
+          "javaBind" : 2,
+          "serialize" : 0,
+          "deserialize" : 1
+        },
+        "planJsonChars" : 7466
+      }, {
+        "workload" : "join2@scale10+union40/H2",
+        "config" : {
+          "scale" : 10,
+          "query" : "join2",
+          "dbType" : "H2",
+          "unionSets" : 40,
+          "includes" : 0,
+          "semiDepth" : 0,
+          "milestoned" : false,
+          "relationFunction" : false,
+          "modelToModel" : false,
+          "nextMultiplicity" : "0..1",
+          "execute" : false
+        },
+        "iterations" : 5,
+        "warmup" : 2,
+        "coldMs" : {
+          "parse" : 4,
+          "compile" : 5,
+          "lambda" : 0,
+          "extensions" : 0,
+          "planPure" : 997,
+          "javaBind" : 2,
+          "serialize" : 1,
+          "deserialize" : 2
+        },
+        "warmMedianMs" : {
+          "parse" : 4,
+          "compile" : 4,
+          "lambda" : 0,
+          "extensions" : 0,
+          "planPure" : 962,
+          "javaBind" : 2,
+          "serialize" : 0,
+          "deserialize" : 1
+        },
+        "planJsonChars" : 71876
+      }, {
+        "workload" : "simple@scale50+relfunc/H2",
+        "config" : {
+          "scale" : 50,
+          "query" : "simple",
+          "dbType" : "H2",
+          "unionSets" : 0,
+          "includes" : 0,
+          "semiDepth" : 0,
+          "milestoned" : false,
+          "relationFunction" : true,
+          "modelToModel" : false,
+          "nextMultiplicity" : "0..1",
+          "execute" : false
+        },
+        "iterations" : 5,
+        "warmup" : 2,
+        "coldMs" : {
+          "parse" : 37,
+          "compile" : 163,
+          "lambda" : 1,
+          "extensions" : 0,
+          "planPure" : 39,
+          "javaBind" : 2,
+          "serialize" : 1,
+          "deserialize" : 1
+        },
+        "warmMedianMs" : {
+          "parse" : 12,
+          "compile" : 40,
+          "lambda" : 0,
+          "extensions" : 0,
+          "planPure" : 8,
+          "javaBind" : 2,
+          "serialize" : 0,
+          "deserialize" : 1
+        },
+        "planJsonChars" : 2476
+      }, {
+        "workload" : "simple@scale200+relfunc/H2",
+        "config" : {
+          "scale" : 200,
+          "query" : "simple",
+          "dbType" : "H2",
+          "unionSets" : 0,
+          "includes" : 0,
+          "semiDepth" : 0,
+          "milestoned" : false,
+          "relationFunction" : true,
+          "modelToModel" : false,
+          "nextMultiplicity" : "0..1",
+          "execute" : false
+        },
+        "iterations" : 5,
+        "warmup" : 2,
+        "coldMs" : {
+          "parse" : 39,
+          "compile" : 158,
+          "lambda" : 0,
+          "extensions" : 0,
+          "planPure" : 10,
+          "javaBind" : 3,
+          "serialize" : 0,
+          "deserialize" : 1
+        },
+        "warmMedianMs" : {
+          "parse" : 37,
+          "compile" : 149,
+          "lambda" : 0,
+          "extensions" : 0,
+          "planPure" : 7,
+          "javaBind" : 2,
+          "serialize" : 0,
+          "deserialize" : 1
+        },
+        "planJsonChars" : 2476
+      }, {
+        "workload" : "graph1@scale30/H2",
+        "config" : {
+          "scale" : 30,
+          "query" : "graph1",
+          "dbType" : "H2",
+          "unionSets" : 0,
+          "includes" : 0,
+          "semiDepth" : 0,
+          "milestoned" : false,
+          "relationFunction" : false,
+          "modelToModel" : false,
+          "nextMultiplicity" : "0..1",
+          "execute" : false
+        },
+        "iterations" : 5,
+        "warmup" : 2,
+        "coldMs" : {
+          "parse" : 7,
+          "compile" : 18,
+          "lambda" : 0,
+          "extensions" : 0,
+          "planPure" : 144,
+          "javaBind" : 142,
+          "serialize" : 134,
+          "deserialize" : 11
+        },
+        "warmMedianMs" : {
+          "parse" : 3,
+          "compile" : 3,
+          "lambda" : 0,
+          "extensions" : 0,
+          "planPure" : 12,
+          "javaBind" : 21,
+          "serialize" : 3,
+          "deserialize" : 3
+        },
+        "planJsonChars" : 90101
+      }, {
+        "workload" : "graph4@scale30/H2",
+        "config" : {
+          "scale" : 30,
+          "query" : "graph4",
+          "dbType" : "H2",
+          "unionSets" : 0,
+          "includes" : 0,
+          "semiDepth" : 0,
+          "milestoned" : false,
+          "relationFunction" : false,
+          "modelToModel" : false,
+          "nextMultiplicity" : "0..1",
+          "execute" : false
+        },
+        "iterations" : 5,
+        "warmup" : 2,
+        "coldMs" : {
+          "parse" : 3,
+          "compile" : 3,
+          "lambda" : 0,
+          "extensions" : 0,
+          "planPure" : 31,
+          "javaBind" : 42,
+          "serialize" : 9,
+          "deserialize" : 3
+        },
+        "warmMedianMs" : {
+          "parse" : 3,
+          "compile" : 4,
+          "lambda" : 0,
+          "extensions" : 0,
+          "planPure" : 30,
+          "javaBind" : 39,
+          "serialize" : 7,
+          "deserialize" : 3
+        },
+        "planJsonChars" : 228539
+      } ],
+      "canaries" : [ {
+        "name" : "compileCliffJoinDepth",
+        "phase" : "compile",
+        "numerator" : "join16@scale30/H2",
+        "denominator" : "join8@scale30/H2",
+        "guards" : "exponential lambda compilation on optional navigation chains",
+        "value" : 30.0
+      }, {
+        "name" : "compileVsModelSize",
+        "phase" : "compile",
+        "numerator" : "simple@scale1000/H2",
+        "denominator" : "simple@scale100/H2",
+        "guards" : "quadratic terms in mapping validation and table resolution",
+        "value" : 5.27
+      }, {
+        "name" : "planPureUnionSets",
+        "phase" : "planPure",
+        "numerator" : "join2@scale10+union40/H2",
+        "denominator" : "join2@scale10+union10/H2",
+        "guards" : "quadratic pure-to-SQL in union set implementations",
+        "value" : 22.37
+      }, {
+        "name" : "planPureJoinDepth",
+        "phase" : "planPure",
+        "numerator" : "join10@scale30/H2",
+        "denominator" : "join2@scale30/H2",
+        "guards" : "pure-to-SQL superlinearity in navigation depth",
+        "value" : 3.0
+      }, {
+        "name" : "compileRelationMappings",
+        "phase" : "compile",
+        "numerator" : "simple@scale200+relfunc/H2",
+        "denominator" : "simple@scale50+relfunc/H2",
+        "guards" : "per-column lambda compilation in Relation mappings",
+        "value" : 3.73
+      }, {
+        "name" : "javaBindGraphDepth",
+        "phase" : "javaBind",
+        "numerator" : "graph4@scale30/H2",
+        "denominator" : "graph1@scale30/H2",
+        "guards" : "platform binder growth in graph-fetch tree size",
+        "value" : 1.86
+      } ]
     },
-    "iterations" : 5,
-    "warmup" : 2,
-    "coldMs" : {
-      "parse" : 434,
-      "compile" : 1215,
-      "lambda" : 1,
-      "extensions" : 253,
-      "planPure" : 1067,
-      "javaBind" : 292,
-      "serialize" : 141,
-      "deserialize" : 31
-    },
-    "warmMedianMs" : {
-      "parse" : 12,
-      "compile" : 14,
-      "lambda" : 0,
-      "extensions" : 0,
-      "planPure" : 13,
-      "javaBind" : 4,
-      "serialize" : 1,
-      "deserialize" : 5
-    },
-    "planJsonChars" : 2305
-  }, {
-    "workload" : "simple@scale1000/H2",
-    "config" : {
-      "scale" : 1000,
-      "query" : "simple",
-      "dbType" : "H2",
-      "unionSets" : 0,
-      "includes" : 0,
-      "semiDepth" : 0,
-      "milestoned" : false,
-      "relationFunction" : false,
-      "modelToModel" : false,
-      "nextMultiplicity" : "0..1",
-      "execute" : false
-    },
-    "iterations" : 5,
-    "warmup" : 2,
-    "coldMs" : {
-      "parse" : 158,
-      "compile" : 95,
-      "lambda" : 1,
-      "extensions" : 0,
-      "planPure" : 12,
-      "javaBind" : 4,
-      "serialize" : 1,
-      "deserialize" : 3
-    },
-    "warmMedianMs" : {
-      "parse" : 124,
-      "compile" : 77,
-      "lambda" : 0,
-      "extensions" : 0,
-      "planPure" : 10,
-      "javaBind" : 3,
-      "serialize" : 1,
-      "deserialize" : 2
-    },
-    "planJsonChars" : 2305
-  }, {
-    "workload" : "join8@scale30/H2",
-    "config" : {
-      "scale" : 30,
-      "query" : "join8",
-      "dbType" : "H2",
-      "unionSets" : 0,
-      "includes" : 0,
-      "semiDepth" : 0,
-      "milestoned" : false,
-      "relationFunction" : false,
-      "modelToModel" : false,
-      "nextMultiplicity" : "0..1",
-      "execute" : false
-    },
-    "iterations" : 5,
-    "warmup" : 2,
-    "coldMs" : {
-      "parse" : 7,
-      "compile" : 20,
-      "lambda" : 4,
-      "extensions" : 0,
-      "planPure" : 98,
-      "javaBind" : 4,
-      "serialize" : 1,
-      "deserialize" : 2
-    },
-    "warmMedianMs" : {
-      "parse" : 7,
-      "compile" : 9,
-      "lambda" : 3,
-      "extensions" : 0,
-      "planPure" : 30,
-      "javaBind" : 3,
-      "serialize" : 1,
-      "deserialize" : 1
-    },
-    "planJsonChars" : 3581
-  }, {
-    "workload" : "join16@scale30/H2",
-    "config" : {
-      "scale" : 30,
-      "query" : "join16",
-      "dbType" : "H2",
-      "unionSets" : 0,
-      "includes" : 0,
-      "semiDepth" : 0,
-      "milestoned" : false,
-      "relationFunction" : false,
-      "modelToModel" : false,
-      "nextMultiplicity" : "0..1",
-      "execute" : false
-    },
-    "iterations" : 5,
-    "warmup" : 2,
-    "coldMs" : {
-      "parse" : 15,
-      "compile" : 320,
-      "lambda" : 322,
-      "extensions" : 0,
-      "planPure" : 65,
-      "javaBind" : 2,
-      "serialize" : 1,
-      "deserialize" : 1
-    },
-    "warmMedianMs" : {
-      "parse" : 12,
-      "compile" : 298,
-      "lambda" : 311,
-      "extensions" : 0,
-      "planPure" : 44,
-      "javaBind" : 2,
-      "serialize" : 1,
-      "deserialize" : 1
-    },
-    "planJsonChars" : 5172
-  }, {
-    "workload" : "join2@scale30/H2",
-    "config" : {
-      "scale" : 30,
-      "query" : "join2",
-      "dbType" : "H2",
-      "unionSets" : 0,
-      "includes" : 0,
-      "semiDepth" : 0,
-      "milestoned" : false,
-      "relationFunction" : false,
-      "modelToModel" : false,
-      "nextMultiplicity" : "0..1",
-      "execute" : false
-    },
-    "iterations" : 5,
-    "warmup" : 2,
-    "coldMs" : {
-      "parse" : 4,
-      "compile" : 4,
-      "lambda" : 0,
-      "extensions" : 0,
-      "planPure" : 8,
-      "javaBind" : 2,
-      "serialize" : 0,
-      "deserialize" : 1
-    },
-    "warmMedianMs" : {
-      "parse" : 4,
-      "compile" : 4,
-      "lambda" : 0,
-      "extensions" : 0,
-      "planPure" : 7,
-      "javaBind" : 2,
-      "serialize" : 0,
-      "deserialize" : 1
-    },
-    "planJsonChars" : 2429
-  }, {
-    "workload" : "join10@scale30/H2",
-    "config" : {
-      "scale" : 30,
-      "query" : "join10",
-      "dbType" : "H2",
-      "unionSets" : 0,
-      "includes" : 0,
-      "semiDepth" : 0,
-      "milestoned" : false,
-      "relationFunction" : false,
-      "modelToModel" : false,
-      "nextMultiplicity" : "0..1",
-      "execute" : false
-    },
-    "iterations" : 5,
-    "warmup" : 2,
-    "coldMs" : {
-      "parse" : 7,
-      "compile" : 8,
-      "lambda" : 4,
-      "extensions" : 0,
-      "planPure" : 22,
-      "javaBind" : 2,
-      "serialize" : 1,
-      "deserialize" : 1
-    },
-    "warmMedianMs" : {
-      "parse" : 7,
-      "compile" : 9,
-      "lambda" : 4,
-      "extensions" : 0,
-      "planPure" : 21,
-      "javaBind" : 2,
-      "serialize" : 1,
-      "deserialize" : 1
-    },
-    "planJsonChars" : 3972
-  }, {
-    "workload" : "join2@scale10+union10/H2",
-    "config" : {
-      "scale" : 10,
-      "query" : "join2",
-      "dbType" : "H2",
-      "unionSets" : 10,
-      "includes" : 0,
-      "semiDepth" : 0,
-      "milestoned" : false,
-      "relationFunction" : false,
-      "modelToModel" : false,
-      "nextMultiplicity" : "0..1",
-      "execute" : false
-    },
-    "iterations" : 5,
-    "warmup" : 2,
-    "coldMs" : {
-      "parse" : 12,
-      "compile" : 7,
-      "lambda" : 0,
-      "extensions" : 0,
-      "planPure" : 121,
-      "javaBind" : 2,
-      "serialize" : 1,
-      "deserialize" : 1
-    },
-    "warmMedianMs" : {
-      "parse" : 2,
-      "compile" : 4,
-      "lambda" : 0,
-      "extensions" : 0,
-      "planPure" : 42,
-      "javaBind" : 2,
-      "serialize" : 0,
-      "deserialize" : 1
-    },
-    "planJsonChars" : 7466
-  }, {
-    "workload" : "join2@scale10+union40/H2",
-    "config" : {
-      "scale" : 10,
-      "query" : "join2",
-      "dbType" : "H2",
-      "unionSets" : 40,
-      "includes" : 0,
-      "semiDepth" : 0,
-      "milestoned" : false,
-      "relationFunction" : false,
-      "modelToModel" : false,
-      "nextMultiplicity" : "0..1",
-      "execute" : false
-    },
-    "iterations" : 5,
-    "warmup" : 2,
-    "coldMs" : {
-      "parse" : 4,
-      "compile" : 5,
-      "lambda" : 0,
-      "extensions" : 0,
-      "planPure" : 992,
-      "javaBind" : 2,
-      "serialize" : 1,
-      "deserialize" : 2
-    },
-    "warmMedianMs" : {
-      "parse" : 4,
-      "compile" : 4,
-      "lambda" : 0,
-      "extensions" : 0,
-      "planPure" : 966,
-      "javaBind" : 2,
-      "serialize" : 0,
-      "deserialize" : 1
-    },
-    "planJsonChars" : 71876
-  }, {
-    "workload" : "simple@scale50+relfunc/H2",
-    "config" : {
-      "scale" : 50,
-      "query" : "simple",
-      "dbType" : "H2",
-      "unionSets" : 0,
-      "includes" : 0,
-      "semiDepth" : 0,
-      "milestoned" : false,
-      "relationFunction" : true,
-      "modelToModel" : false,
-      "nextMultiplicity" : "0..1",
-      "execute" : false
-    },
-    "iterations" : 5,
-    "warmup" : 2,
-    "coldMs" : {
-      "parse" : 41,
-      "compile" : 156,
-      "lambda" : 0,
-      "extensions" : 0,
-      "planPure" : 41,
-      "javaBind" : 2,
-      "serialize" : 0,
-      "deserialize" : 1
-    },
-    "warmMedianMs" : {
-      "parse" : 12,
-      "compile" : 40,
-      "lambda" : 0,
-      "extensions" : 0,
-      "planPure" : 8,
-      "javaBind" : 2,
-      "serialize" : 0,
-      "deserialize" : 1
-    },
-    "planJsonChars" : 2476
-  }, {
-    "workload" : "simple@scale200+relfunc/H2",
-    "config" : {
-      "scale" : 200,
-      "query" : "simple",
-      "dbType" : "H2",
-      "unionSets" : 0,
-      "includes" : 0,
-      "semiDepth" : 0,
-      "milestoned" : false,
-      "relationFunction" : true,
-      "modelToModel" : false,
-      "nextMultiplicity" : "0..1",
-      "execute" : false
-    },
-    "iterations" : 5,
-    "warmup" : 2,
-    "coldMs" : {
-      "parse" : 39,
-      "compile" : 159,
-      "lambda" : 0,
-      "extensions" : 0,
-      "planPure" : 10,
-      "javaBind" : 2,
-      "serialize" : 0,
-      "deserialize" : 1
-    },
-    "warmMedianMs" : {
-      "parse" : 38,
-      "compile" : 151,
-      "lambda" : 0,
-      "extensions" : 0,
-      "planPure" : 7,
-      "javaBind" : 2,
-      "serialize" : 0,
-      "deserialize" : 1
-    },
-    "planJsonChars" : 2476
-  }, {
-    "workload" : "graph1@scale30/H2",
-    "config" : {
-      "scale" : 30,
-      "query" : "graph1",
-      "dbType" : "H2",
-      "unionSets" : 0,
-      "includes" : 0,
-      "semiDepth" : 0,
-      "milestoned" : false,
-      "relationFunction" : false,
-      "modelToModel" : false,
-      "nextMultiplicity" : "0..1",
-      "execute" : false
-    },
-    "iterations" : 5,
-    "warmup" : 2,
-    "coldMs" : {
-      "parse" : 7,
-      "compile" : 18,
-      "lambda" : 0,
-      "extensions" : 0,
-      "planPure" : 150,
-      "javaBind" : 148,
-      "serialize" : 133,
-      "deserialize" : 12
-    },
-    "warmMedianMs" : {
-      "parse" : 3,
-      "compile" : 3,
-      "lambda" : 0,
-      "extensions" : 0,
-      "planPure" : 14,
-      "javaBind" : 23,
-      "serialize" : 4,
-      "deserialize" : 2
-    },
-    "planJsonChars" : 90101
-  }, {
-    "workload" : "graph4@scale30/H2",
-    "config" : {
-      "scale" : 30,
-      "query" : "graph4",
-      "dbType" : "H2",
-      "unionSets" : 0,
-      "includes" : 0,
-      "semiDepth" : 0,
-      "milestoned" : false,
-      "relationFunction" : false,
-      "modelToModel" : false,
-      "nextMultiplicity" : "0..1",
-      "execute" : false
-    },
-    "iterations" : 5,
-    "warmup" : 2,
-    "coldMs" : {
-      "parse" : 3,
-      "compile" : 3,
-      "lambda" : 0,
-      "extensions" : 0,
-      "planPure" : 33,
-      "javaBind" : 47,
-      "serialize" : 9,
-      "deserialize" : 4
-    },
-    "warmMedianMs" : {
-      "parse" : 3,
-      "compile" : 3,
-      "lambda" : 0,
-      "extensions" : 0,
-      "planPure" : 31,
-      "javaBind" : 38,
-      "serialize" : 7,
-      "deserialize" : 3
-    },
-    "planJsonChars" : 228539
-  } ],
-  "canaries" : [ {
-    "name" : "compileCliffJoinDepth",
-    "phase" : "compile",
-    "numerator" : "join16@scale30/H2",
-    "denominator" : "join8@scale30/H2",
-    "guards" : "exponential lambda compilation on optional navigation chains",
-    "value" : 33.11
-  }, {
-    "name" : "compileVsModelSize",
-    "phase" : "compile",
-    "numerator" : "simple@scale1000/H2",
-    "denominator" : "simple@scale100/H2",
-    "guards" : "quadratic terms in mapping validation and table resolution",
-    "value" : 5.5
-  }, {
-    "name" : "planPureUnionSets",
-    "phase" : "planPure",
-    "numerator" : "join2@scale10+union40/H2",
-    "denominator" : "join2@scale10+union10/H2",
-    "guards" : "quadratic pure-to-SQL in union set implementations",
-    "value" : 23.0
-  }, {
-    "name" : "planPureJoinDepth",
-    "phase" : "planPure",
-    "numerator" : "join10@scale30/H2",
-    "denominator" : "join2@scale30/H2",
-    "guards" : "pure-to-SQL superlinearity in navigation depth",
-    "value" : 3.0
-  }, {
-    "name" : "compileRelationMappings",
-    "phase" : "compile",
-    "numerator" : "simple@scale200+relfunc/H2",
-    "denominator" : "simple@scale50+relfunc/H2",
-    "guards" : "per-column lambda compilation in Relation mappings",
-    "value" : 3.78
-  }, {
-    "name" : "javaBindGraphDepth",
-    "phase" : "javaBind",
-    "numerator" : "graph4@scale30/H2",
-    "denominator" : "graph1@scale30/H2",
-    "guards" : "platform binder growth in graph-fetch tree size",
-    "value" : 1.65
-  } ]
+    "Linux|aarch64|arm implementer 0x61 part 0x000|16|6144|17" : {
+      "generatedAt" : "2026-09-10T12:17:46.904396215Z",
+      "environment" : {
+        "os" : "Linux",
+        "osVersion" : "6.12.67-linuxkit",
+        "arch" : "aarch64",
+        "cpu" : "arm implementer 0x61 part 0x000",
+        "availableProcessors" : 16,
+        "maxHeapMb" : 6144,
+        "javaVersion" : "17.0.20",
+        "javaVendor" : "Eclipse Adoptium",
+        "jvmName" : "OpenJDK 64-Bit Server VM",
+        "jvmArgs" : "[-Xmx6g, -Xss8m]",
+        "engineVersion" : "unknown",
+        "gitCommit" : "unknown",
+        "ci" : false
+      },
+      "workloads" : [ {
+        "workload" : "simple@scale100/H2",
+        "config" : {
+          "scale" : 100,
+          "query" : "simple",
+          "dbType" : "H2",
+          "unionSets" : 0,
+          "includes" : 0,
+          "semiDepth" : 0,
+          "milestoned" : false,
+          "relationFunction" : false,
+          "modelToModel" : false,
+          "nextMultiplicity" : "0..1",
+          "execute" : false
+        },
+        "iterations" : 5,
+        "warmup" : 2,
+        "coldMs" : {
+          "parse" : 553,
+          "compile" : 1185,
+          "lambda" : 1,
+          "extensions" : 320,
+          "planPure" : 1216,
+          "javaBind" : 263,
+          "serialize" : 132,
+          "deserialize" : 45
+        },
+        "warmMedianMs" : {
+          "parse" : 16,
+          "compile" : 15,
+          "lambda" : 0,
+          "extensions" : 0,
+          "planPure" : 17,
+          "javaBind" : 5,
+          "serialize" : 2,
+          "deserialize" : 6
+        },
+        "planJsonChars" : 2305
+      }, {
+        "workload" : "simple@scale1000/H2",
+        "config" : {
+          "scale" : 1000,
+          "query" : "simple",
+          "dbType" : "H2",
+          "unionSets" : 0,
+          "includes" : 0,
+          "semiDepth" : 0,
+          "milestoned" : false,
+          "relationFunction" : false,
+          "modelToModel" : false,
+          "nextMultiplicity" : "0..1",
+          "execute" : false
+        },
+        "iterations" : 5,
+        "warmup" : 2,
+        "coldMs" : {
+          "parse" : 153,
+          "compile" : 103,
+          "lambda" : 1,
+          "extensions" : 0,
+          "planPure" : 14,
+          "javaBind" : 4,
+          "serialize" : 1,
+          "deserialize" : 3
+        },
+        "warmMedianMs" : {
+          "parse" : 133,
+          "compile" : 75,
+          "lambda" : 0,
+          "extensions" : 0,
+          "planPure" : 12,
+          "javaBind" : 4,
+          "serialize" : 1,
+          "deserialize" : 3
+        },
+        "planJsonChars" : 2305
+      }, {
+        "workload" : "join8@scale30/H2",
+        "config" : {
+          "scale" : 30,
+          "query" : "join8",
+          "dbType" : "H2",
+          "unionSets" : 0,
+          "includes" : 0,
+          "semiDepth" : 0,
+          "milestoned" : false,
+          "relationFunction" : false,
+          "modelToModel" : false,
+          "nextMultiplicity" : "0..1",
+          "execute" : false
+        },
+        "iterations" : 5,
+        "warmup" : 2,
+        "coldMs" : {
+          "parse" : 8,
+          "compile" : 26,
+          "lambda" : 4,
+          "extensions" : 0,
+          "planPure" : 120,
+          "javaBind" : 5,
+          "serialize" : 1,
+          "deserialize" : 2
+        },
+        "warmMedianMs" : {
+          "parse" : 7,
+          "compile" : 9,
+          "lambda" : 2,
+          "extensions" : 0,
+          "planPure" : 33,
+          "javaBind" : 3,
+          "serialize" : 1,
+          "deserialize" : 2
+        },
+        "planJsonChars" : 3581
+      }, {
+        "workload" : "join16@scale30/H2",
+        "config" : {
+          "scale" : 30,
+          "query" : "join16",
+          "dbType" : "H2",
+          "unionSets" : 0,
+          "includes" : 0,
+          "semiDepth" : 0,
+          "milestoned" : false,
+          "relationFunction" : false,
+          "modelToModel" : false,
+          "nextMultiplicity" : "0..1",
+          "execute" : false
+        },
+        "iterations" : 5,
+        "warmup" : 2,
+        "coldMs" : {
+          "parse" : 17,
+          "compile" : 357,
+          "lambda" : 355,
+          "extensions" : 0,
+          "planPure" : 69,
+          "javaBind" : 3,
+          "serialize" : 1,
+          "deserialize" : 1
+        },
+        "warmMedianMs" : {
+          "parse" : 13,
+          "compile" : 330,
+          "lambda" : 316,
+          "extensions" : 0,
+          "planPure" : 45,
+          "javaBind" : 2,
+          "serialize" : 1,
+          "deserialize" : 1
+        },
+        "planJsonChars" : 5172
+      }, {
+        "workload" : "join2@scale30/H2",
+        "config" : {
+          "scale" : 30,
+          "query" : "join2",
+          "dbType" : "H2",
+          "unionSets" : 0,
+          "includes" : 0,
+          "semiDepth" : 0,
+          "milestoned" : false,
+          "relationFunction" : false,
+          "modelToModel" : false,
+          "nextMultiplicity" : "0..1",
+          "execute" : false
+        },
+        "iterations" : 5,
+        "warmup" : 2,
+        "coldMs" : {
+          "parse" : 4,
+          "compile" : 4,
+          "lambda" : 0,
+          "extensions" : 0,
+          "planPure" : 8,
+          "javaBind" : 2,
+          "serialize" : 0,
+          "deserialize" : 1
+        },
+        "warmMedianMs" : {
+          "parse" : 4,
+          "compile" : 4,
+          "lambda" : 0,
+          "extensions" : 0,
+          "planPure" : 8,
+          "javaBind" : 2,
+          "serialize" : 0,
+          "deserialize" : 1
+        },
+        "planJsonChars" : 2429
+      }, {
+        "workload" : "join10@scale30/H2",
+        "config" : {
+          "scale" : 30,
+          "query" : "join10",
+          "dbType" : "H2",
+          "unionSets" : 0,
+          "includes" : 0,
+          "semiDepth" : 0,
+          "milestoned" : false,
+          "relationFunction" : false,
+          "modelToModel" : false,
+          "nextMultiplicity" : "0..1",
+          "execute" : false
+        },
+        "iterations" : 5,
+        "warmup" : 2,
+        "coldMs" : {
+          "parse" : 7,
+          "compile" : 9,
+          "lambda" : 5,
+          "extensions" : 0,
+          "planPure" : 22,
+          "javaBind" : 2,
+          "serialize" : 1,
+          "deserialize" : 1
+        },
+        "warmMedianMs" : {
+          "parse" : 7,
+          "compile" : 9,
+          "lambda" : 5,
+          "extensions" : 0,
+          "planPure" : 21,
+          "javaBind" : 2,
+          "serialize" : 1,
+          "deserialize" : 1
+        },
+        "planJsonChars" : 3972
+      }, {
+        "workload" : "join2@scale10+union10/H2",
+        "config" : {
+          "scale" : 10,
+          "query" : "join2",
+          "dbType" : "H2",
+          "unionSets" : 10,
+          "includes" : 0,
+          "semiDepth" : 0,
+          "milestoned" : false,
+          "relationFunction" : false,
+          "modelToModel" : false,
+          "nextMultiplicity" : "0..1",
+          "execute" : false
+        },
+        "iterations" : 5,
+        "warmup" : 2,
+        "coldMs" : {
+          "parse" : 19,
+          "compile" : 9,
+          "lambda" : 0,
+          "extensions" : 0,
+          "planPure" : 155,
+          "javaBind" : 3,
+          "serialize" : 1,
+          "deserialize" : 1
+        },
+        "warmMedianMs" : {
+          "parse" : 3,
+          "compile" : 4,
+          "lambda" : 0,
+          "extensions" : 0,
+          "planPure" : 44,
+          "javaBind" : 2,
+          "serialize" : 0,
+          "deserialize" : 1
+        },
+        "planJsonChars" : 7466
+      }, {
+        "workload" : "join2@scale10+union40/H2",
+        "config" : {
+          "scale" : 10,
+          "query" : "join2",
+          "dbType" : "H2",
+          "unionSets" : 40,
+          "includes" : 0,
+          "semiDepth" : 0,
+          "milestoned" : false,
+          "relationFunction" : false,
+          "modelToModel" : false,
+          "nextMultiplicity" : "0..1",
+          "execute" : false
+        },
+        "iterations" : 5,
+        "warmup" : 2,
+        "coldMs" : {
+          "parse" : 5,
+          "compile" : 7,
+          "lambda" : 0,
+          "extensions" : 0,
+          "planPure" : 1017,
+          "javaBind" : 2,
+          "serialize" : 1,
+          "deserialize" : 2
+        },
+        "warmMedianMs" : {
+          "parse" : 4,
+          "compile" : 4,
+          "lambda" : 0,
+          "extensions" : 0,
+          "planPure" : 941,
+          "javaBind" : 2,
+          "serialize" : 1,
+          "deserialize" : 1
+        },
+        "planJsonChars" : 71876
+      }, {
+        "workload" : "simple@scale50+relfunc/H2",
+        "config" : {
+          "scale" : 50,
+          "query" : "simple",
+          "dbType" : "H2",
+          "unionSets" : 0,
+          "includes" : 0,
+          "semiDepth" : 0,
+          "milestoned" : false,
+          "relationFunction" : true,
+          "modelToModel" : false,
+          "nextMultiplicity" : "0..1",
+          "execute" : false
+        },
+        "iterations" : 5,
+        "warmup" : 2,
+        "coldMs" : {
+          "parse" : 48,
+          "compile" : 180,
+          "lambda" : 1,
+          "extensions" : 0,
+          "planPure" : 59,
+          "javaBind" : 2,
+          "serialize" : 0,
+          "deserialize" : 1
+        },
+        "warmMedianMs" : {
+          "parse" : 15,
+          "compile" : 42,
+          "lambda" : 0,
+          "extensions" : 0,
+          "planPure" : 9,
+          "javaBind" : 2,
+          "serialize" : 0,
+          "deserialize" : 1
+        },
+        "planJsonChars" : 2476
+      }, {
+        "workload" : "simple@scale200+relfunc/H2",
+        "config" : {
+          "scale" : 200,
+          "query" : "simple",
+          "dbType" : "H2",
+          "unionSets" : 0,
+          "includes" : 0,
+          "semiDepth" : 0,
+          "milestoned" : false,
+          "relationFunction" : true,
+          "modelToModel" : false,
+          "nextMultiplicity" : "0..1",
+          "execute" : false
+        },
+        "iterations" : 5,
+        "warmup" : 2,
+        "coldMs" : {
+          "parse" : 43,
+          "compile" : 170,
+          "lambda" : 0,
+          "extensions" : 0,
+          "planPure" : 12,
+          "javaBind" : 3,
+          "serialize" : 1,
+          "deserialize" : 1
+        },
+        "warmMedianMs" : {
+          "parse" : 42,
+          "compile" : 161,
+          "lambda" : 0,
+          "extensions" : 0,
+          "planPure" : 8,
+          "javaBind" : 2,
+          "serialize" : 0,
+          "deserialize" : 1
+        },
+        "planJsonChars" : 2476
+      }, {
+        "workload" : "graph1@scale30/H2",
+        "config" : {
+          "scale" : 30,
+          "query" : "graph1",
+          "dbType" : "H2",
+          "unionSets" : 0,
+          "includes" : 0,
+          "semiDepth" : 0,
+          "milestoned" : false,
+          "relationFunction" : false,
+          "modelToModel" : false,
+          "nextMultiplicity" : "0..1",
+          "execute" : false
+        },
+        "iterations" : 5,
+        "warmup" : 2,
+        "coldMs" : {
+          "parse" : 9,
+          "compile" : 17,
+          "lambda" : 0,
+          "extensions" : 0,
+          "planPure" : 167,
+          "javaBind" : 181,
+          "serialize" : 129,
+          "deserialize" : 16
+        },
+        "warmMedianMs" : {
+          "parse" : 4,
+          "compile" : 4,
+          "lambda" : 0,
+          "extensions" : 0,
+          "planPure" : 14,
+          "javaBind" : 23,
+          "serialize" : 4,
+          "deserialize" : 3
+        },
+        "planJsonChars" : 90101
+      }, {
+        "workload" : "graph4@scale30/H2",
+        "config" : {
+          "scale" : 30,
+          "query" : "graph4",
+          "dbType" : "H2",
+          "unionSets" : 0,
+          "includes" : 0,
+          "semiDepth" : 0,
+          "milestoned" : false,
+          "relationFunction" : false,
+          "modelToModel" : false,
+          "nextMultiplicity" : "0..1",
+          "execute" : false
+        },
+        "iterations" : 5,
+        "warmup" : 2,
+        "coldMs" : {
+          "parse" : 4,
+          "compile" : 4,
+          "lambda" : 0,
+          "extensions" : 0,
+          "planPure" : 39,
+          "javaBind" : 46,
+          "serialize" : 10,
+          "deserialize" : 4
+        },
+        "warmMedianMs" : {
+          "parse" : 4,
+          "compile" : 4,
+          "lambda" : 0,
+          "extensions" : 0,
+          "planPure" : 33,
+          "javaBind" : 39,
+          "serialize" : 8,
+          "deserialize" : 4
+        },
+        "planJsonChars" : 228539
+      } ],
+      "canaries" : [ {
+        "name" : "compileCliffJoinDepth",
+        "phase" : "compile",
+        "numerator" : "join16@scale30/H2",
+        "denominator" : "join8@scale30/H2",
+        "guards" : "exponential lambda compilation on optional navigation chains",
+        "value" : 36.67
+      }, {
+        "name" : "compileVsModelSize",
+        "phase" : "compile",
+        "numerator" : "simple@scale1000/H2",
+        "denominator" : "simple@scale100/H2",
+        "guards" : "quadratic terms in mapping validation and table resolution",
+        "value" : 5.0
+      }, {
+        "name" : "planPureUnionSets",
+        "phase" : "planPure",
+        "numerator" : "join2@scale10+union40/H2",
+        "denominator" : "join2@scale10+union10/H2",
+        "guards" : "quadratic pure-to-SQL in union set implementations",
+        "value" : 21.39
+      }, {
+        "name" : "planPureJoinDepth",
+        "phase" : "planPure",
+        "numerator" : "join10@scale30/H2",
+        "denominator" : "join2@scale30/H2",
+        "guards" : "pure-to-SQL superlinearity in navigation depth",
+        "value" : 2.63
+      }, {
+        "name" : "compileRelationMappings",
+        "phase" : "compile",
+        "numerator" : "simple@scale200+relfunc/H2",
+        "denominator" : "simple@scale50+relfunc/H2",
+        "guards" : "per-column lambda compilation in Relation mappings",
+        "value" : 3.83
+      }, {
+        "name" : "javaBindGraphDepth",
+        "phase" : "javaBind",
+        "numerator" : "graph4@scale30/H2",
+        "denominator" : "graph1@scale30/H2",
+        "guards" : "platform binder growth in graph-fetch tree size",
+        "value" : 1.7
+      } ]
+    }
+  }
 }

--- a/legend-engine-config/legend-engine-perf-benchmark/perf-baseline.json
+++ b/legend-engine-config/legend-engine-perf-benchmark/perf-baseline.json
@@ -1,0 +1,520 @@
+{
+  "schemaVersion" : 1,
+  "suite" : "default",
+  "generatedAt" : "2026-09-10T00:30:32.661875Z",
+  "environment" : {
+    "os" : "Mac OS X",
+    "osVersion" : "26.6.2",
+    "arch" : "aarch64",
+    "cpu" : "Apple M4 Max",
+    "availableProcessors" : 16,
+    "maxHeapMb" : 8192,
+    "javaVersion" : "17.0.19",
+    "javaVendor" : "Eclipse Adoptium",
+    "jvmName" : "OpenJDK 64-Bit Server VM",
+    "jvmArgs" : "[-Xmx8g, -Xss8m]",
+    "engineVersion" : "unknown",
+    "gitCommit" : "a314b6f1e784e351a5a2636888d49425e317867f",
+    "ci" : false
+  },
+  "workloads" : [ {
+    "workload" : "simple@scale100/H2",
+    "config" : {
+      "scale" : 100,
+      "query" : "simple",
+      "dbType" : "H2",
+      "unionSets" : 0,
+      "includes" : 0,
+      "semiDepth" : 0,
+      "milestoned" : false,
+      "relationFunction" : false,
+      "modelToModel" : false,
+      "nextMultiplicity" : "0..1",
+      "execute" : false
+    },
+    "iterations" : 5,
+    "warmup" : 2,
+    "coldMs" : {
+      "parse" : 434,
+      "compile" : 1215,
+      "lambda" : 1,
+      "extensions" : 253,
+      "planPure" : 1067,
+      "javaBind" : 292,
+      "serialize" : 141,
+      "deserialize" : 31
+    },
+    "warmMedianMs" : {
+      "parse" : 12,
+      "compile" : 14,
+      "lambda" : 0,
+      "extensions" : 0,
+      "planPure" : 13,
+      "javaBind" : 4,
+      "serialize" : 1,
+      "deserialize" : 5
+    },
+    "planJsonChars" : 2305
+  }, {
+    "workload" : "simple@scale1000/H2",
+    "config" : {
+      "scale" : 1000,
+      "query" : "simple",
+      "dbType" : "H2",
+      "unionSets" : 0,
+      "includes" : 0,
+      "semiDepth" : 0,
+      "milestoned" : false,
+      "relationFunction" : false,
+      "modelToModel" : false,
+      "nextMultiplicity" : "0..1",
+      "execute" : false
+    },
+    "iterations" : 5,
+    "warmup" : 2,
+    "coldMs" : {
+      "parse" : 158,
+      "compile" : 95,
+      "lambda" : 1,
+      "extensions" : 0,
+      "planPure" : 12,
+      "javaBind" : 4,
+      "serialize" : 1,
+      "deserialize" : 3
+    },
+    "warmMedianMs" : {
+      "parse" : 124,
+      "compile" : 77,
+      "lambda" : 0,
+      "extensions" : 0,
+      "planPure" : 10,
+      "javaBind" : 3,
+      "serialize" : 1,
+      "deserialize" : 2
+    },
+    "planJsonChars" : 2305
+  }, {
+    "workload" : "join8@scale30/H2",
+    "config" : {
+      "scale" : 30,
+      "query" : "join8",
+      "dbType" : "H2",
+      "unionSets" : 0,
+      "includes" : 0,
+      "semiDepth" : 0,
+      "milestoned" : false,
+      "relationFunction" : false,
+      "modelToModel" : false,
+      "nextMultiplicity" : "0..1",
+      "execute" : false
+    },
+    "iterations" : 5,
+    "warmup" : 2,
+    "coldMs" : {
+      "parse" : 7,
+      "compile" : 20,
+      "lambda" : 4,
+      "extensions" : 0,
+      "planPure" : 98,
+      "javaBind" : 4,
+      "serialize" : 1,
+      "deserialize" : 2
+    },
+    "warmMedianMs" : {
+      "parse" : 7,
+      "compile" : 9,
+      "lambda" : 3,
+      "extensions" : 0,
+      "planPure" : 30,
+      "javaBind" : 3,
+      "serialize" : 1,
+      "deserialize" : 1
+    },
+    "planJsonChars" : 3581
+  }, {
+    "workload" : "join16@scale30/H2",
+    "config" : {
+      "scale" : 30,
+      "query" : "join16",
+      "dbType" : "H2",
+      "unionSets" : 0,
+      "includes" : 0,
+      "semiDepth" : 0,
+      "milestoned" : false,
+      "relationFunction" : false,
+      "modelToModel" : false,
+      "nextMultiplicity" : "0..1",
+      "execute" : false
+    },
+    "iterations" : 5,
+    "warmup" : 2,
+    "coldMs" : {
+      "parse" : 15,
+      "compile" : 320,
+      "lambda" : 322,
+      "extensions" : 0,
+      "planPure" : 65,
+      "javaBind" : 2,
+      "serialize" : 1,
+      "deserialize" : 1
+    },
+    "warmMedianMs" : {
+      "parse" : 12,
+      "compile" : 298,
+      "lambda" : 311,
+      "extensions" : 0,
+      "planPure" : 44,
+      "javaBind" : 2,
+      "serialize" : 1,
+      "deserialize" : 1
+    },
+    "planJsonChars" : 5172
+  }, {
+    "workload" : "join2@scale30/H2",
+    "config" : {
+      "scale" : 30,
+      "query" : "join2",
+      "dbType" : "H2",
+      "unionSets" : 0,
+      "includes" : 0,
+      "semiDepth" : 0,
+      "milestoned" : false,
+      "relationFunction" : false,
+      "modelToModel" : false,
+      "nextMultiplicity" : "0..1",
+      "execute" : false
+    },
+    "iterations" : 5,
+    "warmup" : 2,
+    "coldMs" : {
+      "parse" : 4,
+      "compile" : 4,
+      "lambda" : 0,
+      "extensions" : 0,
+      "planPure" : 8,
+      "javaBind" : 2,
+      "serialize" : 0,
+      "deserialize" : 1
+    },
+    "warmMedianMs" : {
+      "parse" : 4,
+      "compile" : 4,
+      "lambda" : 0,
+      "extensions" : 0,
+      "planPure" : 7,
+      "javaBind" : 2,
+      "serialize" : 0,
+      "deserialize" : 1
+    },
+    "planJsonChars" : 2429
+  }, {
+    "workload" : "join10@scale30/H2",
+    "config" : {
+      "scale" : 30,
+      "query" : "join10",
+      "dbType" : "H2",
+      "unionSets" : 0,
+      "includes" : 0,
+      "semiDepth" : 0,
+      "milestoned" : false,
+      "relationFunction" : false,
+      "modelToModel" : false,
+      "nextMultiplicity" : "0..1",
+      "execute" : false
+    },
+    "iterations" : 5,
+    "warmup" : 2,
+    "coldMs" : {
+      "parse" : 7,
+      "compile" : 8,
+      "lambda" : 4,
+      "extensions" : 0,
+      "planPure" : 22,
+      "javaBind" : 2,
+      "serialize" : 1,
+      "deserialize" : 1
+    },
+    "warmMedianMs" : {
+      "parse" : 7,
+      "compile" : 9,
+      "lambda" : 4,
+      "extensions" : 0,
+      "planPure" : 21,
+      "javaBind" : 2,
+      "serialize" : 1,
+      "deserialize" : 1
+    },
+    "planJsonChars" : 3972
+  }, {
+    "workload" : "join2@scale10+union10/H2",
+    "config" : {
+      "scale" : 10,
+      "query" : "join2",
+      "dbType" : "H2",
+      "unionSets" : 10,
+      "includes" : 0,
+      "semiDepth" : 0,
+      "milestoned" : false,
+      "relationFunction" : false,
+      "modelToModel" : false,
+      "nextMultiplicity" : "0..1",
+      "execute" : false
+    },
+    "iterations" : 5,
+    "warmup" : 2,
+    "coldMs" : {
+      "parse" : 12,
+      "compile" : 7,
+      "lambda" : 0,
+      "extensions" : 0,
+      "planPure" : 121,
+      "javaBind" : 2,
+      "serialize" : 1,
+      "deserialize" : 1
+    },
+    "warmMedianMs" : {
+      "parse" : 2,
+      "compile" : 4,
+      "lambda" : 0,
+      "extensions" : 0,
+      "planPure" : 42,
+      "javaBind" : 2,
+      "serialize" : 0,
+      "deserialize" : 1
+    },
+    "planJsonChars" : 7466
+  }, {
+    "workload" : "join2@scale10+union40/H2",
+    "config" : {
+      "scale" : 10,
+      "query" : "join2",
+      "dbType" : "H2",
+      "unionSets" : 40,
+      "includes" : 0,
+      "semiDepth" : 0,
+      "milestoned" : false,
+      "relationFunction" : false,
+      "modelToModel" : false,
+      "nextMultiplicity" : "0..1",
+      "execute" : false
+    },
+    "iterations" : 5,
+    "warmup" : 2,
+    "coldMs" : {
+      "parse" : 4,
+      "compile" : 5,
+      "lambda" : 0,
+      "extensions" : 0,
+      "planPure" : 992,
+      "javaBind" : 2,
+      "serialize" : 1,
+      "deserialize" : 2
+    },
+    "warmMedianMs" : {
+      "parse" : 4,
+      "compile" : 4,
+      "lambda" : 0,
+      "extensions" : 0,
+      "planPure" : 966,
+      "javaBind" : 2,
+      "serialize" : 0,
+      "deserialize" : 1
+    },
+    "planJsonChars" : 71876
+  }, {
+    "workload" : "simple@scale50+relfunc/H2",
+    "config" : {
+      "scale" : 50,
+      "query" : "simple",
+      "dbType" : "H2",
+      "unionSets" : 0,
+      "includes" : 0,
+      "semiDepth" : 0,
+      "milestoned" : false,
+      "relationFunction" : true,
+      "modelToModel" : false,
+      "nextMultiplicity" : "0..1",
+      "execute" : false
+    },
+    "iterations" : 5,
+    "warmup" : 2,
+    "coldMs" : {
+      "parse" : 41,
+      "compile" : 156,
+      "lambda" : 0,
+      "extensions" : 0,
+      "planPure" : 41,
+      "javaBind" : 2,
+      "serialize" : 0,
+      "deserialize" : 1
+    },
+    "warmMedianMs" : {
+      "parse" : 12,
+      "compile" : 40,
+      "lambda" : 0,
+      "extensions" : 0,
+      "planPure" : 8,
+      "javaBind" : 2,
+      "serialize" : 0,
+      "deserialize" : 1
+    },
+    "planJsonChars" : 2476
+  }, {
+    "workload" : "simple@scale200+relfunc/H2",
+    "config" : {
+      "scale" : 200,
+      "query" : "simple",
+      "dbType" : "H2",
+      "unionSets" : 0,
+      "includes" : 0,
+      "semiDepth" : 0,
+      "milestoned" : false,
+      "relationFunction" : true,
+      "modelToModel" : false,
+      "nextMultiplicity" : "0..1",
+      "execute" : false
+    },
+    "iterations" : 5,
+    "warmup" : 2,
+    "coldMs" : {
+      "parse" : 39,
+      "compile" : 159,
+      "lambda" : 0,
+      "extensions" : 0,
+      "planPure" : 10,
+      "javaBind" : 2,
+      "serialize" : 0,
+      "deserialize" : 1
+    },
+    "warmMedianMs" : {
+      "parse" : 38,
+      "compile" : 151,
+      "lambda" : 0,
+      "extensions" : 0,
+      "planPure" : 7,
+      "javaBind" : 2,
+      "serialize" : 0,
+      "deserialize" : 1
+    },
+    "planJsonChars" : 2476
+  }, {
+    "workload" : "graph1@scale30/H2",
+    "config" : {
+      "scale" : 30,
+      "query" : "graph1",
+      "dbType" : "H2",
+      "unionSets" : 0,
+      "includes" : 0,
+      "semiDepth" : 0,
+      "milestoned" : false,
+      "relationFunction" : false,
+      "modelToModel" : false,
+      "nextMultiplicity" : "0..1",
+      "execute" : false
+    },
+    "iterations" : 5,
+    "warmup" : 2,
+    "coldMs" : {
+      "parse" : 7,
+      "compile" : 18,
+      "lambda" : 0,
+      "extensions" : 0,
+      "planPure" : 150,
+      "javaBind" : 148,
+      "serialize" : 133,
+      "deserialize" : 12
+    },
+    "warmMedianMs" : {
+      "parse" : 3,
+      "compile" : 3,
+      "lambda" : 0,
+      "extensions" : 0,
+      "planPure" : 14,
+      "javaBind" : 23,
+      "serialize" : 4,
+      "deserialize" : 2
+    },
+    "planJsonChars" : 90101
+  }, {
+    "workload" : "graph4@scale30/H2",
+    "config" : {
+      "scale" : 30,
+      "query" : "graph4",
+      "dbType" : "H2",
+      "unionSets" : 0,
+      "includes" : 0,
+      "semiDepth" : 0,
+      "milestoned" : false,
+      "relationFunction" : false,
+      "modelToModel" : false,
+      "nextMultiplicity" : "0..1",
+      "execute" : false
+    },
+    "iterations" : 5,
+    "warmup" : 2,
+    "coldMs" : {
+      "parse" : 3,
+      "compile" : 3,
+      "lambda" : 0,
+      "extensions" : 0,
+      "planPure" : 33,
+      "javaBind" : 47,
+      "serialize" : 9,
+      "deserialize" : 4
+    },
+    "warmMedianMs" : {
+      "parse" : 3,
+      "compile" : 3,
+      "lambda" : 0,
+      "extensions" : 0,
+      "planPure" : 31,
+      "javaBind" : 38,
+      "serialize" : 7,
+      "deserialize" : 3
+    },
+    "planJsonChars" : 228539
+  } ],
+  "canaries" : [ {
+    "name" : "compileCliffJoinDepth",
+    "phase" : "compile",
+    "numerator" : "join16@scale30/H2",
+    "denominator" : "join8@scale30/H2",
+    "guards" : "exponential lambda compilation on optional navigation chains",
+    "value" : 33.11
+  }, {
+    "name" : "compileVsModelSize",
+    "phase" : "compile",
+    "numerator" : "simple@scale1000/H2",
+    "denominator" : "simple@scale100/H2",
+    "guards" : "quadratic terms in mapping validation and table resolution",
+    "value" : 5.5
+  }, {
+    "name" : "planPureUnionSets",
+    "phase" : "planPure",
+    "numerator" : "join2@scale10+union40/H2",
+    "denominator" : "join2@scale10+union10/H2",
+    "guards" : "quadratic pure-to-SQL in union set implementations",
+    "value" : 23.0
+  }, {
+    "name" : "planPureJoinDepth",
+    "phase" : "planPure",
+    "numerator" : "join10@scale30/H2",
+    "denominator" : "join2@scale30/H2",
+    "guards" : "pure-to-SQL superlinearity in navigation depth",
+    "value" : 3.0
+  }, {
+    "name" : "compileRelationMappings",
+    "phase" : "compile",
+    "numerator" : "simple@scale200+relfunc/H2",
+    "denominator" : "simple@scale50+relfunc/H2",
+    "guards" : "per-column lambda compilation in Relation mappings",
+    "value" : 3.78
+  }, {
+    "name" : "javaBindGraphDepth",
+    "phase" : "javaBind",
+    "numerator" : "graph4@scale30/H2",
+    "denominator" : "graph1@scale30/H2",
+    "guards" : "platform binder growth in graph-fetch tree size",
+    "value" : 1.65
+  } ]
+}

--- a/legend-engine-config/legend-engine-perf-benchmark/perf-baseline.json
+++ b/legend-engine-config/legend-engine-perf-benchmark/perf-baseline.json
@@ -1037,6 +1037,524 @@
         "guards" : "platform binder growth in graph-fetch tree size",
         "value" : 1.7
       } ]
+    },
+    "Linux|amd64|AMD EPYC 9V74 80-Core Processor|4|6144|17" : {
+      "generatedAt" : "2026-09-10T16:16:15.753394741Z",
+      "environment" : {
+        "os" : "Linux",
+        "osVersion" : "6.17.0-1022-azure",
+        "arch" : "amd64",
+        "cpu" : "AMD EPYC 9V74 80-Core Processor",
+        "availableProcessors" : 4,
+        "maxHeapMb" : 6144,
+        "javaVersion" : "17.0.20",
+        "javaVendor" : "Azul Systems, Inc.",
+        "jvmName" : "OpenJDK 64-Bit Server VM",
+        "jvmArgs" : "[-Xmx6g, -Xss8m]",
+        "engineVersion" : "unknown",
+        "gitCommit" : "ab9f62ecf409ce1df0a212e4fe29d508c874c047",
+        "ci" : true
+      },
+      "workloads" : [ {
+        "workload" : "simple@scale100/H2",
+        "config" : {
+          "scale" : 100,
+          "query" : "simple",
+          "dbType" : "H2",
+          "unionSets" : 0,
+          "includes" : 0,
+          "semiDepth" : 0,
+          "milestoned" : false,
+          "relationFunction" : false,
+          "modelToModel" : false,
+          "nextMultiplicity" : "0..1",
+          "execute" : false
+        },
+        "iterations" : 5,
+        "warmup" : 2,
+        "coldMs" : {
+          "parse" : 915,
+          "compile" : 2111,
+          "lambda" : 3,
+          "extensions" : 338,
+          "planPure" : 1887,
+          "javaBind" : 379,
+          "serialize" : 185,
+          "deserialize" : 97
+        },
+        "warmMedianMs" : {
+          "parse" : 69,
+          "compile" : 49,
+          "lambda" : 1,
+          "extensions" : 1,
+          "planPure" : 34,
+          "javaBind" : 16,
+          "serialize" : 5,
+          "deserialize" : 9
+        },
+        "planJsonChars" : 2305
+      }, {
+        "workload" : "simple@scale1000/H2",
+        "config" : {
+          "scale" : 1000,
+          "query" : "simple",
+          "dbType" : "H2",
+          "unionSets" : 0,
+          "includes" : 0,
+          "semiDepth" : 0,
+          "milestoned" : false,
+          "relationFunction" : false,
+          "modelToModel" : false,
+          "nextMultiplicity" : "0..1",
+          "execute" : false
+        },
+        "iterations" : 5,
+        "warmup" : 2,
+        "coldMs" : {
+          "parse" : 524,
+          "compile" : 421,
+          "lambda" : 3,
+          "extensions" : 1,
+          "planPure" : 39,
+          "javaBind" : 16,
+          "serialize" : 5,
+          "deserialize" : 9
+        },
+        "warmMedianMs" : {
+          "parse" : 181,
+          "compile" : 271,
+          "lambda" : 1,
+          "extensions" : 1,
+          "planPure" : 27,
+          "javaBind" : 10,
+          "serialize" : 2,
+          "deserialize" : 7
+        },
+        "planJsonChars" : 2305
+      }, {
+        "workload" : "join8@scale30/H2",
+        "config" : {
+          "scale" : 30,
+          "query" : "join8",
+          "dbType" : "H2",
+          "unionSets" : 0,
+          "includes" : 0,
+          "semiDepth" : 0,
+          "milestoned" : false,
+          "relationFunction" : false,
+          "modelToModel" : false,
+          "nextMultiplicity" : "0..1",
+          "execute" : false
+        },
+        "iterations" : 5,
+        "warmup" : 2,
+        "coldMs" : {
+          "parse" : 11,
+          "compile" : 44,
+          "lambda" : 14,
+          "extensions" : 1,
+          "planPure" : 188,
+          "javaBind" : 12,
+          "serialize" : 2,
+          "deserialize" : 7
+        },
+        "warmMedianMs" : {
+          "parse" : 11,
+          "compile" : 21,
+          "lambda" : 7,
+          "extensions" : 1,
+          "planPure" : 79,
+          "javaBind" : 9,
+          "serialize" : 3,
+          "deserialize" : 6
+        },
+        "planJsonChars" : 3581
+      }, {
+        "workload" : "join16@scale30/H2",
+        "config" : {
+          "scale" : 30,
+          "query" : "join16",
+          "dbType" : "H2",
+          "unionSets" : 0,
+          "includes" : 0,
+          "semiDepth" : 0,
+          "milestoned" : false,
+          "relationFunction" : false,
+          "modelToModel" : false,
+          "nextMultiplicity" : "0..1",
+          "execute" : false
+        },
+        "iterations" : 5,
+        "warmup" : 2,
+        "coldMs" : {
+          "parse" : 19,
+          "compile" : 948,
+          "lambda" : 725,
+          "extensions" : 1,
+          "planPure" : 228,
+          "javaBind" : 8,
+          "serialize" : 3,
+          "deserialize" : 4
+        },
+        "warmMedianMs" : {
+          "parse" : 22,
+          "compile" : 745,
+          "lambda" : 733,
+          "extensions" : 1,
+          "planPure" : 129,
+          "javaBind" : 8,
+          "serialize" : 4,
+          "deserialize" : 5
+        },
+        "planJsonChars" : 5172
+      }, {
+        "workload" : "join2@scale30/H2",
+        "config" : {
+          "scale" : 30,
+          "query" : "join2",
+          "dbType" : "H2",
+          "unionSets" : 0,
+          "includes" : 0,
+          "semiDepth" : 0,
+          "milestoned" : false,
+          "relationFunction" : false,
+          "modelToModel" : false,
+          "nextMultiplicity" : "0..1",
+          "execute" : false
+        },
+        "iterations" : 5,
+        "warmup" : 2,
+        "coldMs" : {
+          "parse" : 12,
+          "compile" : 14,
+          "lambda" : 0,
+          "extensions" : 1,
+          "planPure" : 21,
+          "javaBind" : 7,
+          "serialize" : 1,
+          "deserialize" : 4
+        },
+        "warmMedianMs" : {
+          "parse" : 11,
+          "compile" : 14,
+          "lambda" : 0,
+          "extensions" : 1,
+          "planPure" : 22,
+          "javaBind" : 9,
+          "serialize" : 2,
+          "deserialize" : 4
+        },
+        "planJsonChars" : 2429
+      }, {
+        "workload" : "join10@scale30/H2",
+        "config" : {
+          "scale" : 30,
+          "query" : "join10",
+          "dbType" : "H2",
+          "unionSets" : 0,
+          "includes" : 0,
+          "semiDepth" : 0,
+          "milestoned" : false,
+          "relationFunction" : false,
+          "modelToModel" : false,
+          "nextMultiplicity" : "0..1",
+          "execute" : false
+        },
+        "iterations" : 5,
+        "warmup" : 2,
+        "coldMs" : {
+          "parse" : 17,
+          "compile" : 33,
+          "lambda" : 18,
+          "extensions" : 1,
+          "planPure" : 75,
+          "javaBind" : 9,
+          "serialize" : 3,
+          "deserialize" : 3
+        },
+        "warmMedianMs" : {
+          "parse" : 17,
+          "compile" : 31,
+          "lambda" : 18,
+          "extensions" : 1,
+          "planPure" : 70,
+          "javaBind" : 9,
+          "serialize" : 2,
+          "deserialize" : 3
+        },
+        "planJsonChars" : 3972
+      }, {
+        "workload" : "join2@scale10+union10/H2",
+        "config" : {
+          "scale" : 10,
+          "query" : "join2",
+          "dbType" : "H2",
+          "unionSets" : 10,
+          "includes" : 0,
+          "semiDepth" : 0,
+          "milestoned" : false,
+          "relationFunction" : false,
+          "modelToModel" : false,
+          "nextMultiplicity" : "0..1",
+          "execute" : false
+        },
+        "iterations" : 5,
+        "warmup" : 2,
+        "coldMs" : {
+          "parse" : 35,
+          "compile" : 23,
+          "lambda" : 1,
+          "extensions" : 1,
+          "planPure" : 309,
+          "javaBind" : 10,
+          "serialize" : 2,
+          "deserialize" : 3
+        },
+        "warmMedianMs" : {
+          "parse" : 7,
+          "compile" : 13,
+          "lambda" : 0,
+          "extensions" : 1,
+          "planPure" : 128,
+          "javaBind" : 8,
+          "serialize" : 2,
+          "deserialize" : 3
+        },
+        "planJsonChars" : 7466
+      }, {
+        "workload" : "join2@scale10+union40/H2",
+        "config" : {
+          "scale" : 10,
+          "query" : "join2",
+          "dbType" : "H2",
+          "unionSets" : 40,
+          "includes" : 0,
+          "semiDepth" : 0,
+          "milestoned" : false,
+          "relationFunction" : false,
+          "modelToModel" : false,
+          "nextMultiplicity" : "0..1",
+          "execute" : false
+        },
+        "iterations" : 5,
+        "warmup" : 2,
+        "coldMs" : {
+          "parse" : 7,
+          "compile" : 10,
+          "lambda" : 0,
+          "extensions" : 0,
+          "planPure" : 2596,
+          "javaBind" : 8,
+          "serialize" : 3,
+          "deserialize" : 3
+        },
+        "warmMedianMs" : {
+          "parse" : 8,
+          "compile" : 12,
+          "lambda" : 0,
+          "extensions" : 1,
+          "planPure" : 2363,
+          "javaBind" : 6,
+          "serialize" : 2,
+          "deserialize" : 3
+        },
+        "planJsonChars" : 71876
+      }, {
+        "workload" : "simple@scale50+relfunc/H2",
+        "config" : {
+          "scale" : 50,
+          "query" : "simple",
+          "dbType" : "H2",
+          "unionSets" : 0,
+          "includes" : 0,
+          "semiDepth" : 0,
+          "milestoned" : false,
+          "relationFunction" : true,
+          "modelToModel" : false,
+          "nextMultiplicity" : "0..1",
+          "execute" : false
+        },
+        "iterations" : 5,
+        "warmup" : 2,
+        "coldMs" : {
+          "parse" : 82,
+          "compile" : 388,
+          "lambda" : 1,
+          "extensions" : 1,
+          "planPure" : 77,
+          "javaBind" : 9,
+          "serialize" : 2,
+          "deserialize" : 3
+        },
+        "warmMedianMs" : {
+          "parse" : 33,
+          "compile" : 143,
+          "lambda" : 0,
+          "extensions" : 1,
+          "planPure" : 22,
+          "javaBind" : 8,
+          "serialize" : 2,
+          "deserialize" : 3
+        },
+        "planJsonChars" : 2476
+      }, {
+        "workload" : "simple@scale200+relfunc/H2",
+        "config" : {
+          "scale" : 200,
+          "query" : "simple",
+          "dbType" : "H2",
+          "unionSets" : 0,
+          "includes" : 0,
+          "semiDepth" : 0,
+          "milestoned" : false,
+          "relationFunction" : true,
+          "modelToModel" : false,
+          "nextMultiplicity" : "0..1",
+          "execute" : false
+        },
+        "iterations" : 5,
+        "warmup" : 2,
+        "coldMs" : {
+          "parse" : 106,
+          "compile" : 477,
+          "lambda" : 0,
+          "extensions" : 1,
+          "planPure" : 25,
+          "javaBind" : 8,
+          "serialize" : 2,
+          "deserialize" : 3
+        },
+        "warmMedianMs" : {
+          "parse" : 67,
+          "compile" : 405,
+          "lambda" : 0,
+          "extensions" : 1,
+          "planPure" : 22,
+          "javaBind" : 6,
+          "serialize" : 1,
+          "deserialize" : 2
+        },
+        "planJsonChars" : 2476
+      }, {
+        "workload" : "graph1@scale30/H2",
+        "config" : {
+          "scale" : 30,
+          "query" : "graph1",
+          "dbType" : "H2",
+          "unionSets" : 0,
+          "includes" : 0,
+          "semiDepth" : 0,
+          "milestoned" : false,
+          "relationFunction" : false,
+          "modelToModel" : false,
+          "nextMultiplicity" : "0..1",
+          "execute" : false
+        },
+        "iterations" : 5,
+        "warmup" : 2,
+        "coldMs" : {
+          "parse" : 13,
+          "compile" : 23,
+          "lambda" : 0,
+          "extensions" : 0,
+          "planPure" : 217,
+          "javaBind" : 305,
+          "serialize" : 163,
+          "deserialize" : 27
+        },
+        "warmMedianMs" : {
+          "parse" : 6,
+          "compile" : 9,
+          "lambda" : 0,
+          "extensions" : 0,
+          "planPure" : 30,
+          "javaBind" : 60,
+          "serialize" : 8,
+          "deserialize" : 6
+        },
+        "planJsonChars" : 90101
+      }, {
+        "workload" : "graph4@scale30/H2",
+        "config" : {
+          "scale" : 30,
+          "query" : "graph4",
+          "dbType" : "H2",
+          "unionSets" : 0,
+          "includes" : 0,
+          "semiDepth" : 0,
+          "milestoned" : false,
+          "relationFunction" : false,
+          "modelToModel" : false,
+          "nextMultiplicity" : "0..1",
+          "execute" : false
+        },
+        "iterations" : 5,
+        "warmup" : 2,
+        "coldMs" : {
+          "parse" : 7,
+          "compile" : 9,
+          "lambda" : 0,
+          "extensions" : 1,
+          "planPure" : 94,
+          "javaBind" : 115,
+          "serialize" : 22,
+          "deserialize" : 9
+        },
+        "warmMedianMs" : {
+          "parse" : 6,
+          "compile" : 9,
+          "lambda" : 0,
+          "extensions" : 0,
+          "planPure" : 78,
+          "javaBind" : 104,
+          "serialize" : 17,
+          "deserialize" : 7
+        },
+        "planJsonChars" : 228539
+      } ],
+      "canaries" : [ {
+        "name" : "compileCliffJoinDepth",
+        "phase" : "compile",
+        "numerator" : "join16@scale30/H2",
+        "denominator" : "join8@scale30/H2",
+        "guards" : "exponential lambda compilation on optional navigation chains",
+        "value" : 35.48
+      }, {
+        "name" : "compileVsModelSize",
+        "phase" : "compile",
+        "numerator" : "simple@scale1000/H2",
+        "denominator" : "simple@scale100/H2",
+        "guards" : "quadratic terms in mapping validation and table resolution",
+        "value" : 5.53
+      }, {
+        "name" : "planPureUnionSets",
+        "phase" : "planPure",
+        "numerator" : "join2@scale10+union40/H2",
+        "denominator" : "join2@scale10+union10/H2",
+        "guards" : "quadratic pure-to-SQL in union set implementations",
+        "value" : 18.46
+      }, {
+        "name" : "planPureJoinDepth",
+        "phase" : "planPure",
+        "numerator" : "join10@scale30/H2",
+        "denominator" : "join2@scale30/H2",
+        "guards" : "pure-to-SQL superlinearity in navigation depth",
+        "value" : 3.18
+      }, {
+        "name" : "compileRelationMappings",
+        "phase" : "compile",
+        "numerator" : "simple@scale200+relfunc/H2",
+        "denominator" : "simple@scale50+relfunc/H2",
+        "guards" : "per-column lambda compilation in Relation mappings",
+        "value" : 2.83
+      }, {
+        "name" : "javaBindGraphDepth",
+        "phase" : "javaBind",
+        "numerator" : "graph4@scale30/H2",
+        "denominator" : "graph1@scale30/H2",
+        "guards" : "platform binder growth in graph-fetch tree size",
+        "value" : 1.73
+      } ]
     }
   }
 }

--- a/legend-engine-config/legend-engine-perf-benchmark/pom.xml
+++ b/legend-engine-config/legend-engine-perf-benchmark/pom.xml
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2026 Goldman Sachs
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.finos.legend.engine</groupId>
+        <artifactId>legend-engine-config</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>legend-engine-perf-benchmark</artifactId>
+    <name>Legend Engine - Config - Pipeline Performance Benchmark</name>
+    <description>Standalone harness that times each stage of the query pipeline (parse, compile, plan generation, execution) over synthetic and file-supplied models.</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-language-pure-grammar</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-language-pure-compiler</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-protocol-pure</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-identity-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-executionPlan-generation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-executionPlan-execution</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-pure-code-compiled-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-pure-platform-dsl-store-java</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-relationalStore-executionPlan</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-relationalStore-executionPlan-connection</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-relationalStore-javaPlatformBinding-pure</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-relationalStore-h2-execution-2.1.214</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-m3-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-m2-dsl-mapping-pure</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.collections</groupId>
+            <artifactId>eclipse-collections-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.collections</groupId>
+            <artifactId>eclipse-collections</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <!-- grammar and store extensions discovered at runtime: dialects, and the external-format
+             binding used by the semi-structured workloads -->
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-external-format-grammar</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-json-model</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-relationalStore-duckdb-execution</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-relationalStore-duckdb-grammar</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-relationalStore-snowflake-execution</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-relationalStore-snowflake-grammar</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/legend-engine-config/legend-engine-perf-benchmark/scripts/demangle_pure_frames.py
+++ b/legend-engine-config/legend-engine-perf-benchmark/scripts/demangle_pure_frames.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+# Copyright 2026 Goldman Sachs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Translate async-profiler collapsed stacks from generated Pure-Java frames back to Pure functions.
+
+Plan generation runs as Java generated from Pure source, so a raw profile only shows frames like
+
+    org/finos/legend/pure/generated/core_pure_router_router_main.Root_meta_pure_router_routeFunction_...
+
+which is unreadable unless you already know the mangling. This script rewrites those frames to the
+Pure function they came from (meta::pure::router::routeFunction) and reports self and inclusive
+sample counts per Pure function, so a hotspot can be cited as a .pure function rather than a
+generated class.
+
+Usage:
+    asprof collect -d 30 -e wall -i 5ms -t -o collapsed -f profile.collapsed <pid>
+    grep '^\\[main' profile.collapsed | sed 's/^\\[main[^]]*\\];//' > main.collapsed
+    demangle_pure_frames.py main.collapsed demangled.collapsed report.txt
+"""
+import re
+import sys
+from collections import defaultdict
+
+GENERATED_FRAME = re.compile(r'^org[/.]finos[/.]legend[/.]pure[/.]generated[/.]([A-Za-z0-9_$]+)\.(.+)$')
+
+
+def pure_function_name(method):
+    """Root_meta_pure_router_routeFunction_FunctionDefinition_1__... -> meta::pure::router::routeFunction"""
+    method = re.sub(r'\$\d+$', '', method)
+    if not method.startswith('Root_meta_'):
+        return None
+    tokens = method.split('_')
+    signature_start = None
+    for index, token in enumerate(tokens):
+        if index < 2:
+            continue
+        if token and token[0].isupper() and token != 'Root':
+            signature_start = index
+            break
+    name_tokens = tokens[1:signature_start] if signature_start else tokens[1:]
+    return '::'.join(name_tokens) if name_tokens else None
+
+
+def demangle(frame):
+    match = GENERATED_FRAME.match(frame)
+    if not match:
+        return frame, None, None
+    generated_class, method = match.group(1), match.group(2)
+    function = pure_function_name(method)
+    source = generated_class.split('$')[0]
+    if function:
+        return 'pure::' + function, function, source
+    return 'puregen::' + source, None, source
+
+
+def main():
+    if len(sys.argv) != 4:
+        print(__doc__)
+        return 1
+    source_path, collapsed_path, report_path = sys.argv[1], sys.argv[2], sys.argv[3]
+
+    self_samples = defaultdict(int)
+    inclusive_samples = defaultdict(int)
+    per_source = defaultdict(int)
+    stacks = defaultdict(int)
+    total = 0
+
+    with open(source_path) as handle:
+        for line in handle:
+            line = line.rstrip('\n')
+            if not line:
+                continue
+            stack, _, count_text = line.rpartition(' ')
+            try:
+                count = int(count_text)
+            except ValueError:
+                continue
+            total += count
+
+            rewritten = []
+            seen = set()
+            deepest_function = None
+            deepest_source = None
+            for frame in stack.split(';'):
+                name, function, source = demangle(frame)
+                rewritten.append(name)
+                if function:
+                    deepest_function, deepest_source = function, source
+                    if function not in seen:
+                        inclusive_samples[function] += count
+                        seen.add(function)
+                elif source:
+                    deepest_source = source
+
+            leaf = rewritten[-1]
+            if leaf.startswith('pure::') or leaf.startswith('puregen::'):
+                if deepest_function:
+                    self_samples[deepest_function] += count
+                if deepest_source:
+                    per_source[deepest_source] += count
+            else:
+                self_samples['[java] ' + leaf] += count
+            stacks[';'.join(rewritten)] += count
+
+    with open(collapsed_path, 'w') as handle:
+        for stack, count in stacks.items():
+            handle.write('%s %d\n' % (stack, count))
+
+    def table(counts, title, limit=50):
+        lines = ['== %s (total samples: %d) ==' % (title, total)]
+        for key, value in sorted(counts.items(), key=lambda item: -item[1])[:limit]:
+            lines.append('%10d  %6.2f%%  %s' % (value, 100.0 * value / total if total else 0.0, key))
+        return '\n'.join(lines)
+
+    with open(report_path, 'w') as handle:
+        handle.write(table(self_samples, 'SELF time by Pure function (or Java leaf)'))
+        handle.write('\n\n')
+        handle.write(table(inclusive_samples, 'INCLUSIVE time by Pure function'))
+        handle.write('\n\n')
+        handle.write(table(per_source, 'SELF time by generated Pure source class'))
+        handle.write('\n')
+
+    print('total samples: %d; wrote %s and %s' % (total, collapsed_path, report_path))
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/legend-engine-config/legend-engine-perf-benchmark/scripts/run-in-container.sh
+++ b/legend-engine-config/legend-engine-perf-benchmark/scripts/run-in-container.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Copyright 2026 Goldman Sachs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Runs the benchmark inside a Linux container, so a second environment can be measured and recorded
+# without a second machine. The baseline keeps one entry per environment, so this adds to the file
+# rather than replacing what is already there.
+#
+#   scripts/run-in-container.sh                     compare against this environment's entry
+#   scripts/run-in-container.sh --rebase            record this environment's entry
+#   scripts/run-in-container.sh --iters 8           any benchmark flag is passed through
+#
+# The container mounts the repository and the Maven repository at the same paths they have on the
+# host, so the classpath resolved outside works unchanged inside.
+set -euo pipefail
+
+IMAGE="${PERF_IMAGE:-eclipse-temurin:17-jdk}"
+HEAP="${PERF_HEAP:-6g}"
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+MODULE_PATH="legend-engine-config/legend-engine-perf-benchmark"
+M2="${MAVEN_REPO_LOCAL:-$HOME/.m2/repository}"
+# A chained local repository, as the build guide suggests for isolating a branch, splits the jars
+# across two directories; both have to be visible inside the container.
+TAIL="${MAVEN_REPO_LOCAL_TAIL:-}"
+CP_FILE="$(mktemp -t perf-cp)"
+
+echo "resolving classpath on the host"
+(cd "$REPO" && mvn -B -q -pl "$MODULE_PATH" dependency:build-classpath \
+    -Dmdep.outputFile="$CP_FILE" -Dmaven.repo.local="$M2" \
+    ${TAIL:+-Dmaven.repo.local.tail="$TAIL"})
+
+echo "running in $IMAGE"
+docker run --rm \
+  -v "$REPO:$REPO" \
+  -v "$M2:$M2:ro" \
+  ${TAIL:+-v "$TAIL:$TAIL:ro"} \
+  -v "$CP_FILE:$CP_FILE:ro" \
+  -w "$REPO/$MODULE_PATH" \
+  "$IMAGE" \
+  sh -c "java -Xmx$HEAP -Xss8m -cp \"target/classes:\$(cat $CP_FILE)\" org.finos.legend.engine.perf.PipelineBench $*"

--- a/legend-engine-config/legend-engine-perf-benchmark/src/main/java/org/finos/legend/engine/perf/BenchConfig.java
+++ b/legend-engine-config/legend-engine-perf-benchmark/src/main/java/org/finos/legend/engine/perf/BenchConfig.java
@@ -1,0 +1,173 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.perf;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class BenchConfig
+{
+    public int scale = 100;
+    public String query = "simple";
+    public int iterations = 10;
+    public int warmup = 2;
+    public boolean execute = false;
+    public String csv = null;
+    public boolean pause = false;
+    public String dumpPlan = null;
+
+    public String nextMultiplicity = "0..1";
+    public int unionSets = 0;
+    public int includes = 0;
+    public boolean milestoned = false;
+    public boolean relationFunction = false;
+    public boolean modelToModel = false;
+    public int semiDepth = 0;
+    public String dbType = "H2";
+
+    public String fileList = null;
+    public String queryFile = null;
+    public String mappingPath = "test::Map";
+    public String storePath = "test::DB";
+
+    public static BenchConfig parse(String[] args)
+    {
+        Map<String, String> opts = new LinkedHashMap<>();
+        for (int i = 0; i < args.length; i++)
+        {
+            if (args[i].startsWith("--"))
+            {
+                String key = args[i].substring(2);
+                if (i + 1 < args.length && !args[i + 1].startsWith("--"))
+                {
+                    opts.put(key, args[++i]);
+                }
+                else
+                {
+                    opts.put(key, "true");
+                }
+            }
+        }
+
+        BenchConfig config = new BenchConfig();
+        config.scale = Integer.parseInt(opts.getOrDefault("scale", "100"));
+        config.query = opts.getOrDefault("query", "simple");
+        config.iterations = Integer.parseInt(opts.getOrDefault("iters", "10"));
+        config.warmup = Integer.parseInt(opts.getOrDefault("warmup", "2"));
+        config.execute = opts.containsKey("execute");
+        config.csv = opts.get("csv");
+        config.pause = opts.containsKey("pause");
+        config.dumpPlan = opts.get("dumpplan");
+        config.nextMultiplicity = opts.getOrDefault("nextmult", "0..1");
+        config.unionSets = Integer.parseInt(opts.getOrDefault("union", "0"));
+        config.includes = Integer.parseInt(opts.getOrDefault("includes", "0"));
+        config.milestoned = opts.containsKey("milestoning");
+        config.relationFunction = opts.containsKey("relfunc");
+        config.modelToModel = opts.containsKey("m2m");
+        config.semiDepth = Integer.parseInt(opts.getOrDefault("semi", "0"));
+        config.dbType = opts.getOrDefault("dbtype", "H2");
+        config.fileList = opts.get("filelist");
+        config.queryFile = opts.get("queryfile");
+        config.mappingPath = opts.getOrDefault("mapping", "test::Map");
+        config.storePath = opts.getOrDefault("db", "test::DB");
+        return config;
+    }
+
+    public String workloadId()
+    {
+        StringBuilder b = new StringBuilder(this.query);
+        b.append("@scale").append(this.scale);
+        if (this.unionSets > 0)
+        {
+            b.append("+union").append(this.unionSets);
+        }
+        if (this.includes > 0)
+        {
+            b.append("+includes").append(this.includes);
+        }
+        if (this.semiDepth > 0)
+        {
+            b.append("+semi").append(this.semiDepth);
+        }
+        if (this.milestoned)
+        {
+            b.append("+milestoned");
+        }
+        if (this.relationFunction)
+        {
+            b.append("+relfunc");
+        }
+        if (this.modelToModel)
+        {
+            b.append("+m2m");
+        }
+        if (!"0..1".equals(this.nextMultiplicity))
+        {
+            b.append("+mult").append(this.nextMultiplicity);
+        }
+        b.append("/").append(this.dbType);
+        return b.toString();
+    }
+
+    public Map<String, Object> toMap()
+    {
+        Map<String, Object> map = new LinkedHashMap<>();
+        map.put("scale", this.scale);
+        map.put("query", this.query);
+        map.put("dbType", this.dbType);
+        map.put("unionSets", this.unionSets);
+        map.put("includes", this.includes);
+        map.put("semiDepth", this.semiDepth);
+        map.put("milestoned", this.milestoned);
+        map.put("relationFunction", this.relationFunction);
+        map.put("modelToModel", this.modelToModel);
+        map.put("nextMultiplicity", this.nextMultiplicity);
+        map.put("execute", this.execute);
+        return map;
+    }
+
+    public String describe()
+    {
+        StringBuilder b = new StringBuilder();
+        b.append("scale=").append(this.scale).append(" query=").append(this.query).append(" dbType=").append(this.dbType);
+        if (this.unionSets > 0)
+        {
+            b.append(" union=").append(this.unionSets);
+        }
+        if (this.includes > 0)
+        {
+            b.append(" includes=").append(this.includes);
+        }
+        if (this.semiDepth > 0)
+        {
+            b.append(" semi=").append(this.semiDepth);
+        }
+        if (this.milestoned)
+        {
+            b.append(" milestoned");
+        }
+        if (this.relationFunction)
+        {
+            b.append(" relfunc");
+        }
+        if (this.modelToModel)
+        {
+            b.append(" m2m");
+        }
+        b.append(" nextMult=[").append(this.nextMultiplicity).append("]");
+        b.append(" warmup=").append(this.warmup).append(" iters=").append(this.iterations);
+        return b.toString();
+    }
+}

--- a/legend-engine-config/legend-engine-perf-benchmark/src/main/java/org/finos/legend/engine/perf/Environment.java
+++ b/legend-engine-config/legend-engine-perf-benchmark/src/main/java/org/finos/legend/engine/perf/Environment.java
@@ -22,9 +22,9 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
- * Describes the machine and JVM a run was measured on. Absolute durations are only comparable
- * between runs whose fingerprint matches; ratios between workloads are comparable anywhere, which
- * is why the comparison treats the two differently.
+ * Describes the machine and JVM a run was measured on. The fingerprint is what a baseline entry is
+ * keyed by: absolute durations plainly do not survive a change of machine, and ratios travel better
+ * but not far enough to trust, so a run is only ever compared against an entry recorded here.
  */
 public class Environment
 {

--- a/legend-engine-config/legend-engine-perf-benchmark/src/main/java/org/finos/legend/engine/perf/Environment.java
+++ b/legend-engine-config/legend-engine-perf-benchmark/src/main/java/org/finos/legend/engine/perf/Environment.java
@@ -82,10 +82,29 @@ public class Environment
         }
         if (os.startsWith("Linux"))
         {
+            // x86 exposes "model name"; arm64 does not, so fall back to lscpu and then to the
+            // implementer/part identifiers, which at least separate one arm machine from another.
             String model = command("sh", "-c", "grep -m1 'model name' /proc/cpuinfo | cut -d: -f2");
-            return model.isEmpty() ? "unknown" : model.trim();
+            if (isKnown(model))
+            {
+                return model;
+            }
+            model = command("sh", "-c", "lscpu 2>/dev/null | grep -m1 'Model name' | cut -d: -f2");
+            if (isKnown(model))
+            {
+                return model;
+            }
+            model = command("sh", "-c", "grep -m1 'CPU implementer' /proc/cpuinfo | cut -d: -f2");
+            String part = command("sh", "-c", "grep -m1 'CPU part' /proc/cpuinfo | cut -d: -f2");
+            return isKnown(model) ? "arm implementer " + model + " part " + part : "unknown";
         }
         return "unknown";
+    }
+
+    private static boolean isKnown(String value)
+    {
+        // Virtualised hosts often answer with a placeholder rather than leaving the field empty.
+        return value != null && value.length() > 1 && !"unknown".equals(value);
     }
 
     private static String command(String... command)

--- a/legend-engine-config/legend-engine-perf-benchmark/src/main/java/org/finos/legend/engine/perf/Environment.java
+++ b/legend-engine-config/legend-engine-perf-benchmark/src/main/java/org/finos/legend/engine/perf/Environment.java
@@ -1,0 +1,118 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.perf;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.lang.management.ManagementFactory;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Describes the machine and JVM a run was measured on. Absolute durations are only comparable
+ * between runs whose fingerprint matches; ratios between workloads are comparable anywhere, which
+ * is why the comparison treats the two differently.
+ */
+public class Environment
+{
+    public static Map<String, Object> capture()
+    {
+        Map<String, Object> environment = new LinkedHashMap<>();
+        environment.put("os", System.getProperty("os.name"));
+        environment.put("osVersion", System.getProperty("os.version"));
+        environment.put("arch", System.getProperty("os.arch"));
+        environment.put("cpu", cpuModel());
+        environment.put("availableProcessors", Runtime.getRuntime().availableProcessors());
+        environment.put("maxHeapMb", Runtime.getRuntime().maxMemory() / (1024 * 1024));
+        environment.put("javaVersion", System.getProperty("java.version"));
+        environment.put("javaVendor", System.getProperty("java.vendor"));
+        environment.put("jvmName", System.getProperty("java.vm.name"));
+        environment.put("jvmArgs", ManagementFactory.getRuntimeMXBean().getInputArguments().toString());
+        environment.put("engineVersion", engineVersion());
+        environment.put("gitCommit", gitCommit());
+        environment.put("ci", System.getenv("CI") != null);
+        return environment;
+    }
+
+    /**
+     * The subset of the environment that must match before two runs' absolute timings may be
+     * compared. Processor count and heap are included because both change scheduling and GC cost.
+     */
+    public static String fingerprint(Map<String, Object> environment)
+    {
+        return String.valueOf(environment.get("os")) + "|"
+                + environment.get("arch") + "|"
+                + environment.get("cpu") + "|"
+                + environment.get("availableProcessors") + "|"
+                + environment.get("maxHeapMb") + "|"
+                + majorJavaVersion(String.valueOf(environment.get("javaVersion")));
+    }
+
+    private static String majorJavaVersion(String version)
+    {
+        int dot = version.indexOf('.');
+        return dot > 0 ? version.substring(0, dot) : version;
+    }
+
+    private static String engineVersion()
+    {
+        String version = Environment.class.getPackage() == null ? null : Environment.class.getPackage().getImplementationVersion();
+        return version == null ? "unknown" : version;
+    }
+
+    private static String cpuModel()
+    {
+        String os = System.getProperty("os.name", "");
+        if (os.startsWith("Mac"))
+        {
+            return command("sysctl", "-n", "machdep.cpu.brand_string");
+        }
+        if (os.startsWith("Linux"))
+        {
+            String model = command("sh", "-c", "grep -m1 'model name' /proc/cpuinfo | cut -d: -f2");
+            return model.isEmpty() ? "unknown" : model.trim();
+        }
+        return "unknown";
+    }
+
+    private static String command(String... command)
+    {
+        try
+        {
+            Process process = new ProcessBuilder(command).redirectErrorStream(true).start();
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8)))
+            {
+                String line = reader.readLine();
+                process.waitFor();
+                return line == null ? "unknown" : line.trim();
+            }
+        }
+        catch (Exception e)
+        {
+            return "unknown";
+        }
+    }
+
+    private static String gitCommit()
+    {
+        String fromEnv = System.getenv("GITHUB_SHA");
+        if (fromEnv != null && !fromEnv.isEmpty())
+        {
+            return fromEnv;
+        }
+        return command("git", "rev-parse", "HEAD");
+    }
+}

--- a/legend-engine-config/legend-engine-perf-benchmark/src/main/java/org/finos/legend/engine/perf/ModelGenerator.java
+++ b/legend-engine-config/legend-engine-perf-benchmark/src/main/java/org/finos/legend/engine/perf/ModelGenerator.java
@@ -1,0 +1,284 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.perf;
+
+/**
+ * Generates a synthetic Legend model of a requested size: N classes, N tables, N-1 joins and a
+ * mapping covering every class. Optional flags switch the mapping into the shapes whose cost this
+ * harness measures - unions, include chains, milestoning, Relation functions with ModelJoins,
+ * model-to-model views and semi-structured bindings.
+ */
+public class ModelGenerator
+{
+    private final BenchConfig config;
+
+    public ModelGenerator(BenchConfig config)
+    {
+        this.config = config;
+    }
+
+    public String generate()
+    {
+        int n = this.config.scale;
+        StringBuilder b = new StringBuilder();
+        this.appendDomain(b, n);
+        this.appendStore(b, n);
+        this.appendBinding(b);
+        this.appendMapping(b, n);
+        this.appendRuntime(b);
+        return b.toString();
+    }
+
+    private void appendDomain(StringBuilder b, int n)
+    {
+        b.append("###Pure\n");
+        String stereotype = this.config.milestoned ? "<<meta::pure::profiles::temporal.businesstemporal>> " : "";
+        for (int i = 0; i < n; i++)
+        {
+            b.append("Class ").append(stereotype).append("test::domain::C").append(i).append("\n{\n");
+            b.append("  id: Integer[1];\n  p0: String[0..1];\n  p1: String[0..1];\n  p2: String[0..1];\n  p3: Integer[0..1];\n");
+            if (this.config.semiDepth > 0 && i == 0)
+            {
+                b.append("  det: test::sdet::S0[1];\n");
+            }
+            if (!this.config.relationFunction && i < n - 1)
+            {
+                b.append("  next: test::domain::C").append(i + 1).append("[").append(this.config.nextMultiplicity).append("];\n");
+            }
+            b.append("}\n");
+        }
+
+        for (int j = 0; j < this.config.semiDepth; j++)
+        {
+            b.append("Class test::sdet::S").append(j).append("\n{\n  v: String[0..1];\n  w: Integer[0..1];\n");
+            if (j < this.config.semiDepth - 1)
+            {
+                b.append("  child: test::sdet::S").append(j + 1).append("[1];\n");
+            }
+            b.append("}\n");
+        }
+
+        if (this.config.modelToModel)
+        {
+            b.append("Class test::view::V0\n{\n  q0: String[0..1];\n  q1: String[0..1];\n  q2: String[0..1];\n}\n");
+        }
+
+        if (this.config.relationFunction)
+        {
+            for (int i = 0; i < n - 1; i++)
+            {
+                b.append("Association test::domain::A").append(i).append("\n{\n");
+                b.append("  prev").append(i).append(": test::domain::C").append(i).append("[1];\n");
+                b.append("  next: test::domain::C").append(i + 1).append("[1];\n}\n");
+            }
+        }
+    }
+
+    private void appendStore(StringBuilder b, int n)
+    {
+        b.append("###Relational\nDatabase test::DB\n(\n");
+        for (int i = 0; i < n; i++)
+        {
+            b.append("  Table T").append(i).append(" (\n");
+            if (this.config.milestoned)
+            {
+                b.append("    milestoning\n    (\n      business(BUS_FROM = from_z, BUS_THRU = thru_z)\n    )\n");
+            }
+            b.append("    id INT PRIMARY KEY, p0 VARCHAR(100), p1 VARCHAR(100), p2 VARCHAR(100), p3 INT, fk INT");
+            if (this.config.semiDepth > 0 && i == 0)
+            {
+                b.append(", sdet SEMISTRUCTURED");
+            }
+            if (this.config.milestoned)
+            {
+                b.append(", from_z TIMESTAMP PRIMARY KEY, thru_z TIMESTAMP");
+            }
+            b.append("\n  )\n");
+        }
+        for (int i = 0; i < n - 1; i++)
+        {
+            b.append("  Join J").append(i).append("(T").append(i).append(".fk = T").append(i + 1).append(".id)\n");
+        }
+        b.append(")\n");
+    }
+
+    private void appendBinding(StringBuilder b)
+    {
+        if (this.config.semiDepth <= 0)
+        {
+            return;
+        }
+        b.append("###ExternalFormat\nBinding test::SB\n{\n  contentType: 'application/json';\n  modelIncludes: [\n");
+        for (int j = 0; j < this.config.semiDepth; j++)
+        {
+            b.append("    test::sdet::S").append(j).append(j < this.config.semiDepth - 1 ? ",\n" : "\n");
+        }
+        b.append("  ];\n}\n");
+    }
+
+    private void appendMapping(StringBuilder b, int n)
+    {
+        if (this.config.relationFunction)
+        {
+            this.appendRelationFunctionMapping(b, n);
+            return;
+        }
+        b.append("###Mapping\n");
+        if (this.config.includes > 0)
+        {
+            this.appendIncludeChainMapping(b, n);
+            return;
+        }
+        b.append("Mapping test::Map\n(\n");
+        if (this.config.unionSets > 0)
+        {
+            this.appendUnionMapping(b, n);
+        }
+        for (int i = this.config.unionSets > 0 ? 1 : 0; i < n; i++)
+        {
+            this.appendClassMapping(b, i, n);
+        }
+        if (this.config.modelToModel)
+        {
+            b.append("  test::view::V0: Pure\n  {\n    ~src test::domain::C0\n    q0: $src.p0,\n    q1: $src.p1,\n    q2: $src.p2\n  }\n");
+        }
+        b.append(")\n");
+    }
+
+    private void appendIncludeChainMapping(StringBuilder b, int n)
+    {
+        for (int j = 0; j < this.config.includes; j++)
+        {
+            b.append("Mapping test::M").append(j).append("\n(\n");
+            if (j > 0)
+            {
+                b.append("  include mapping test::M").append(j - 1).append("\n");
+            }
+            for (int i = 0; i < n; i++)
+            {
+                if ((int) ((long) i * this.config.includes / n) == j)
+                {
+                    this.appendClassMapping(b, i, n);
+                }
+            }
+            b.append(")\n");
+        }
+        b.append("Mapping test::Map\n(\n  include mapping test::M").append(this.config.includes - 1).append("\n)\n");
+    }
+
+    private void appendUnionMapping(StringBuilder b, int n)
+    {
+        StringBuilder ids = new StringBuilder();
+        for (int u = 0; u < this.config.unionSets; u++)
+        {
+            ids.append(u > 0 ? "," : "").append("s").append(u);
+        }
+        b.append("  *test::domain::C0: Operation\n  {\n    meta::pure::router::operations::union_OperationSetImplementation_1__SetImplementation_MANY_(").append(ids).append(")\n  }\n");
+        for (int u = 0; u < this.config.unionSets; u++)
+        {
+            b.append("  test::domain::C0[s").append(u).append("]: Relational\n  {\n");
+            b.append("    ~primaryKey([test::DB]T0.id)\n    ~mainTable [test::DB]T0\n");
+            b.append("    id: [test::DB]T0.id,\n    p0: [test::DB]T0.p0,\n    p1: [test::DB]T0.p1,\n    p2: [test::DB]T0.p2,\n    p3: [test::DB]T0.p3");
+            if (this.config.semiDepth > 0)
+            {
+                b.append(",\n    det: Binding test::SB : [test::DB]T0.sdet");
+            }
+            if (n > 1)
+            {
+                b.append(",\n    next: [test::DB]@J0\n");
+            }
+            else
+            {
+                b.append("\n");
+            }
+            b.append("  }\n");
+        }
+    }
+
+    private void appendClassMapping(StringBuilder b, int i, int n)
+    {
+        b.append("  test::domain::C").append(i).append(": Relational\n  {\n");
+        b.append("    ~primaryKey([test::DB]T").append(i).append(".id)\n");
+        b.append("    ~mainTable [test::DB]T").append(i).append("\n");
+        b.append("    id: [test::DB]T").append(i).append(".id,\n");
+        b.append("    p0: [test::DB]T").append(i).append(".p0,\n");
+        b.append("    p1: [test::DB]T").append(i).append(".p1,\n");
+        b.append("    p2: [test::DB]T").append(i).append(".p2,\n");
+        b.append("    p3: [test::DB]T").append(i).append(".p3");
+        if (this.config.semiDepth > 0 && i == 0)
+        {
+            b.append(",\n    det: Binding test::SB : [test::DB]T0.sdet");
+        }
+        if (i < n - 1)
+        {
+            b.append(",\n    next: [test::DB]@J").append(i).append("\n");
+        }
+        else
+        {
+            b.append("\n");
+        }
+        b.append("  }\n");
+    }
+
+    private void appendRelationFunctionMapping(StringBuilder b, int n)
+    {
+        b.append("###Pure\n");
+        for (int i = 0; i < n; i++)
+        {
+            b.append("function test::f::rel").append(i).append("(): meta::pure::metamodel::relation::Relation<Any>[1]\n{\n  #>{test::DB.T").append(i).append("}#\n}\n");
+        }
+        b.append("###Mapping\nMapping test::Map\n(\n");
+        for (int i = 0; i < n; i++)
+        {
+            b.append("  *test::domain::C").append(i).append("[s").append(i).append("]: Relation\n  {\n");
+            b.append("    ~func test::f::rel").append(i).append("():Relation<Any>[1]\n");
+            b.append("    id: id,\n    p0: p0,\n    p1: p1,\n    p2: p2,\n    p3: p3,\n");
+            b.append("    +fkv: Integer[0..1]: fk\n  }\n");
+        }
+        for (int i = 0; i < n - 1; i++)
+        {
+            b.append("  test::domain::A").append(i).append(": ModelJoin\n  {\n");
+            b.append("    {prev").append(i).append(": test::domain::C").append(i).append("[1], next: test::domain::C").append(i + 1)
+                    .append("[1] | $prev").append(i).append(".fkv == $next.id}\n  }\n");
+        }
+        b.append(")\n");
+    }
+
+    private void appendRuntime(StringBuilder b)
+    {
+        b.append("###Runtime\nRuntime test::Runtime\n{\n  mappings:\n  [\n    test::Map\n  ];\n  connections:\n  [\n");
+        if (this.config.modelToModel)
+        {
+            b.append("    ModelStore:\n    [\n      cm: #{\n        ModelChainConnection\n        {\n          mappings: [test::Map];\n        }\n      }#\n    ],\n");
+        }
+        b.append("    test::DB:\n    [\n      c1: #{\n        RelationalDatabaseConnection\n        {\n");
+        b.append(connectionBody(this.config.dbType));
+        b.append("        }\n      }#\n    ]\n  ];\n}\n");
+    }
+
+    public static String connectionBody(String dbType)
+    {
+        if ("DuckDB".equals(dbType))
+        {
+            return "          type: DuckDB;\n          specification: DuckDB\n          {\n            path: '/tmp/legend-perf-bench.duckdb';\n          };\n          auth: Test;\n";
+        }
+        if ("Snowflake".equals(dbType))
+        {
+            return "          type: Snowflake;\n          specification: Snowflake\n          {\n            name: 'test';\n            account: 'account';\n            warehouse: 'wh';\n            region: 'us-east2';\n            cloudType: 'aws';\n          };\n"
+                    + "          auth: SnowflakePublic\n          {\n            publicUserName: 'u';\n            privateKeyVaultReference: 'k';\n            passPhraseVaultReference: 'p';\n          };\n";
+        }
+        return "          type: H2;\n          specification: LocalH2 {};\n          auth: DefaultH2;\n";
+    }
+}

--- a/legend-engine-config/legend-engine-perf-benchmark/src/main/java/org/finos/legend/engine/perf/PerfSuite.java
+++ b/legend-engine-config/legend-engine-perf-benchmark/src/main/java/org/finos/legend/engine/perf/PerfSuite.java
@@ -45,6 +45,7 @@ public class PerfSuite
 {
     private static final ObjectMapper MAPPER = new ObjectMapper();
     private static final String DEFAULT_BASELINE = "perf-baseline.json";
+    private static final int SCHEMA_VERSION = 1;
 
     public static int run(String[] args) throws Exception
     {
@@ -80,35 +81,98 @@ public class PerfSuite
         results.put("workloads", workloadResults);
         results.put("canaries", canaries(workloadResults));
 
-        String target = out != null ? out : (rebase ? baselinePath : null);
-        if (target != null)
+        if (out != null)
         {
-            MAPPER.writerWithDefaultPrettyPrinter().writeValue(new File(target), results);
-            System.out.println("results written to " + target);
-        }
-
-        if (rebase)
-        {
-            if (out != null && !out.equals(baselinePath))
-            {
-                MAPPER.writerWithDefaultPrettyPrinter().writeValue(new File(baselinePath), results);
-                System.out.println("baseline rebased: " + baselinePath);
-            }
-            else
-            {
-                System.out.println("baseline rebased: " + baselinePath);
-            }
-            return 0;
+            MAPPER.writerWithDefaultPrettyPrinter().writeValue(new File(out), results);
+            System.out.println("results written to " + out);
         }
 
         File baselineFile = new File(baselinePath);
-        if (!baselineFile.exists())
+        Map<String, Object> baseline = baselineFile.exists() ? readBaseline(baselineFile) : null;
+
+        if (rebase)
         {
-            System.out.println("no baseline at " + baselinePath + " - run once with --rebase to create one");
+            Map<String, Object> updated = recordInBaseline(baseline, results);
+            MAPPER.writerWithDefaultPrettyPrinter().writeValue(baselineFile, updated);
+            System.out.println("baseline recorded for " + Environment.fingerprint(PipelineBench.asMap(results.get("environment"))));
+            System.out.println("environments now in " + baselinePath + ": " + environments(updated).keySet());
             return 0;
         }
-        Map<String, Object> baseline = MAPPER.readValue(baselineFile, Map.class);
-        return compare(baseline, results, margin, canaryMargin, minDelta, allowImprovement) ? 0 : 1;
+
+        if (baseline == null)
+        {
+            System.out.println("no baseline at " + baselinePath + " - run once with --rebase to create one");
+            printCanaries(results);
+            return 0;
+        }
+
+        String fingerprint = Environment.fingerprint(PipelineBench.asMap(results.get("environment")));
+        Map<String, Object> recorded = PipelineBench.asMap(environments(baseline).get(fingerprint));
+        if (recorded.isEmpty())
+        {
+            System.out.println();
+            System.out.println("no baseline recorded for this machine");
+            System.out.println("  this machine: " + fingerprint);
+            for (String known : environments(baseline).keySet())
+            {
+                System.out.println("  baseline has: " + known);
+            }
+            System.out.println("  numbers from another machine are not comparable, so nothing is being checked.");
+            System.out.println("  run this suite with --rebase here to record one.");
+            printCanaries(results);
+            return 0;
+        }
+        return compare(recorded, results, margin, canaryMargin, minDelta, allowImprovement) ? 0 : 1;
+    }
+
+    /**
+     * A baseline holds one entry per machine, keyed by environment fingerprint, because neither
+     * absolute timings nor ratios carry reliably across different hardware. Recording on one machine
+     * leaves every other machine's entry untouched.
+     */
+    static Map<String, Object> readBaseline(File file) throws Exception
+    {
+        return MAPPER.readValue(file, Map.class);
+    }
+
+    static Map<String, Object> recordInBaseline(Map<String, Object> baseline, Map<String, Object> results)
+    {
+        Map<String, Object> updated = new LinkedHashMap<>();
+        updated.put("schemaVersion", SCHEMA_VERSION);
+        updated.put("suite", results.get("suite"));
+        Map<String, Object> byEnvironment = new LinkedHashMap<>();
+        if (baseline != null)
+        {
+            byEnvironment.putAll(environments(baseline));
+        }
+        byEnvironment.put(Environment.fingerprint(PipelineBench.asMap(results.get("environment"))), entry(results));
+        updated.put("environments", byEnvironment);
+        return updated;
+    }
+
+    private static Map<String, Object> entry(Map<String, Object> results)
+    {
+        Map<String, Object> entry = new LinkedHashMap<>();
+        entry.put("generatedAt", results.get("generatedAt"));
+        entry.put("environment", results.get("environment"));
+        entry.put("workloads", results.get("workloads"));
+        entry.put("canaries", results.get("canaries"));
+        return entry;
+    }
+
+    static Map<String, Object> environments(Map<String, Object> baseline)
+    {
+        return PipelineBench.asMap(baseline.get("environments"));
+    }
+
+    private static void printCanaries(Map<String, Object> results)
+    {
+        System.out.println();
+        System.out.println("canary ratios measured on this run");
+        for (Map.Entry<String, Double> entry : canaryValues(results).entrySet())
+        {
+            System.out.println(String.format("  %-28s %8.2f", entry.getKey(), entry.getValue()));
+        }
     }
 
     static List<BenchConfig> workloads(String suiteName, int iterations, int warmup)
@@ -221,17 +285,13 @@ public class PerfSuite
         List<String> improvements = new ArrayList<>();
         List<String> notes = new ArrayList<>();
 
-        String baselineFingerprint = Environment.fingerprint(PipelineBench.asMap(baseline.get("environment")));
-        String currentFingerprint = Environment.fingerprint(PipelineBench.asMap(current.get("environment")));
-        boolean sameMachine = baselineFingerprint.equals(currentFingerprint);
+        // The caller looked the entry up by fingerprint, so both sides describe the same machine.
+        boolean sameMachine = true;
 
         System.out.println();
-        System.out.println("baseline generated " + baseline.get("generatedAt") + " on " + baselineFingerprint);
-        System.out.println("current  generated " + current.get("generatedAt") + " on " + currentFingerprint);
-        if (!sameMachine)
-        {
-            System.out.println("environments differ - absolute timings are advisory only, canary ratios still enforced");
-        }
+        System.out.println("machine   " + Environment.fingerprint(PipelineBench.asMap(current.get("environment"))));
+        System.out.println("baseline  recorded " + baseline.get("generatedAt"));
+        System.out.println("current   measured " + current.get("generatedAt"));
         System.out.println();
 
         Map<String, Double> baselineCanaries = canaryValues(baseline);

--- a/legend-engine-config/legend-engine-perf-benchmark/src/main/java/org/finos/legend/engine/perf/PerfSuite.java
+++ b/legend-engine-config/legend-engine-perf-benchmark/src/main/java/org/finos/legend/engine/perf/PerfSuite.java
@@ -36,10 +36,12 @@ import java.util.Map;
  * are held to. Pass --allow-improvement to only enforce the slower side.
  *
  * Two kinds of check run, because they tolerate machine differences differently:
- *   - canary ratios between two workloads measured in the same JVM, which cancel machine speed and
- *     are therefore compared everywhere. These catch a phase turning quadratic or exponential.
- *   - absolute phase medians, compared only when the environment fingerprint matches the baseline,
- *     since a different machine moves them several-fold on its own.
+ *   - canary ratios between two workloads measured in the same JVM, which cancel machine speed
+ *     and catch a phase turning quadratic or exponential.
+ *   - absolute phase medians, which a different machine moves several-fold on its own.
+ * Both are compared only against an entry recorded on this same environment. A run on a machine the
+ * baseline does not know reports its numbers and checks nothing, so record one there with --rebase,
+ * or feed that run's results file back with --record.
  */
 public class PerfSuite
 {
@@ -60,6 +62,12 @@ public class PerfSuite
         double canaryMargin = Double.parseDouble(options.getOrDefault("canary-margin", "0.3"));
         long minDelta = Long.parseLong(options.getOrDefault("min-delta-ms", "25"));
         boolean allowImprovement = options.containsKey("allow-improvement");
+
+        String record = options.get("record");
+        if (record != null)
+        {
+            return record(new File(record), new File(baselinePath), baselinePath);
+        }
 
         List<BenchConfig> workloads = workloads(suiteName, iterations, warmup);
         System.out.println("suite '" + suiteName + "': " + workloads.size() + " workloads, "
@@ -123,6 +131,21 @@ public class PerfSuite
             return 0;
         }
         return compare(recorded, results, margin, canaryMargin, minDelta, allowImprovement) ? 0 : 1;
+    }
+
+    /**
+     * Records a results file measured elsewhere - a CI run's uploaded artifact, most often - into
+     * the baseline without re-running the suite here. A hosted runner cannot commit its own
+     * baseline back, and hand-editing the file drifts from what the writer produces.
+     */
+    private static int record(File results, File baselineFile, String baselinePath) throws Exception
+    {
+        Map<String, Object> measured = MAPPER.readValue(results, Map.class);
+        Map<String, Object> updated = recordInBaseline(baselineFile.exists() ? readBaseline(baselineFile) : null, measured);
+        MAPPER.writerWithDefaultPrettyPrinter().writeValue(baselineFile, updated);
+        System.out.println("baseline recorded for " + Environment.fingerprint(PipelineBench.asMap(measured.get("environment"))));
+        System.out.println("environments now in " + baselinePath + ": " + environments(updated).keySet());
+        return 0;
     }
 
     /**

--- a/legend-engine-config/legend-engine-perf-benchmark/src/main/java/org/finos/legend/engine/perf/PerfSuite.java
+++ b/legend-engine-config/legend-engine-perf-benchmark/src/main/java/org/finos/legend/engine/perf/PerfSuite.java
@@ -1,0 +1,417 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.perf;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.File;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Runs a fixed set of workloads in one JVM and writes a results file describing both the numbers
+ * and the machine they were measured on.
+ *
+ * With --rebase the results become the stored baseline. Without it the run is compared against the
+ * baseline and the process exits non-zero when a deviation exceeds the allowed margin.
+ *
+ * Deviation is judged in both directions. A slower result is a regression; a faster one fails too,
+ * because a baseline that still records the old cost silently permits a later change to give the
+ * gain back. Failing forces the improvement into the baseline, so it becomes the level future runs
+ * are held to. Pass --allow-improvement to only enforce the slower side.
+ *
+ * Two kinds of check run, because they tolerate machine differences differently:
+ *   - canary ratios between two workloads measured in the same JVM, which cancel machine speed and
+ *     are therefore compared everywhere. These catch a phase turning quadratic or exponential.
+ *   - absolute phase medians, compared only when the environment fingerprint matches the baseline,
+ *     since a different machine moves them several-fold on its own.
+ */
+public class PerfSuite
+{
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final String DEFAULT_BASELINE = "perf-baseline.json";
+
+    public static int run(String[] args) throws Exception
+    {
+        Map<String, String> options = options(args);
+        String suiteName = options.getOrDefault("suite", "default");
+        int iterations = Integer.parseInt(options.getOrDefault("iters", "5"));
+        int warmup = Integer.parseInt(options.getOrDefault("warmup", "2"));
+        String out = options.get("out");
+        String baselinePath = options.getOrDefault("baseline", DEFAULT_BASELINE);
+        boolean rebase = options.containsKey("rebase");
+        double margin = Double.parseDouble(options.getOrDefault("margin", "0.5"));
+        double canaryMargin = Double.parseDouble(options.getOrDefault("canary-margin", "0.3"));
+        long minDelta = Long.parseLong(options.getOrDefault("min-delta-ms", "25"));
+        boolean allowImprovement = options.containsKey("allow-improvement");
+
+        List<BenchConfig> workloads = workloads(suiteName, iterations, warmup);
+        System.out.println("suite '" + suiteName + "': " + workloads.size() + " workloads, "
+                + warmup + " warmup + " + iterations + " measured iterations each");
+
+        Map<String, Object> results = new LinkedHashMap<>();
+        results.put("schemaVersion", 1);
+        results.put("suite", suiteName);
+        results.put("generatedAt", Instant.now().toString());
+        results.put("environment", Environment.capture());
+
+        List<Map<String, Object>> workloadResults = new ArrayList<>();
+        for (BenchConfig config : workloads)
+        {
+            System.out.println("  running " + config.workloadId());
+            Map<String, Object> result = new PipelineBench(config).quiet().measure();
+            workloadResults.add(result);
+        }
+        results.put("workloads", workloadResults);
+        results.put("canaries", canaries(workloadResults));
+
+        String target = out != null ? out : (rebase ? baselinePath : null);
+        if (target != null)
+        {
+            MAPPER.writerWithDefaultPrettyPrinter().writeValue(new File(target), results);
+            System.out.println("results written to " + target);
+        }
+
+        if (rebase)
+        {
+            if (out != null && !out.equals(baselinePath))
+            {
+                MAPPER.writerWithDefaultPrettyPrinter().writeValue(new File(baselinePath), results);
+                System.out.println("baseline rebased: " + baselinePath);
+            }
+            else
+            {
+                System.out.println("baseline rebased: " + baselinePath);
+            }
+            return 0;
+        }
+
+        File baselineFile = new File(baselinePath);
+        if (!baselineFile.exists())
+        {
+            System.out.println("no baseline at " + baselinePath + " - run once with --rebase to create one");
+            return 0;
+        }
+        Map<String, Object> baseline = MAPPER.readValue(baselineFile, Map.class);
+        return compare(baseline, results, margin, canaryMargin, minDelta, allowImprovement) ? 0 : 1;
+    }
+
+    static List<BenchConfig> workloads(String suiteName, int iterations, int warmup)
+    {
+        List<BenchConfig> configs = new ArrayList<>();
+        if (suiteName.equals("default") || suiteName.equals("canary"))
+        {
+            configs.add(workload("simple", 100));
+            configs.add(workload("simple", 1000));
+            configs.add(workload("join8", 30));
+            configs.add(workload("join16", 30));
+            configs.add(workload("join2", 30));
+            configs.add(workload("join10", 30));
+            configs.add(unionWorkload("join2", 10, 10));
+            configs.add(unionWorkload("join2", 10, 40));
+            configs.add(relationWorkload("simple", 50));
+            configs.add(relationWorkload("simple", 200));
+            configs.add(workload("graph1", 30));
+            configs.add(workload("graph4", 30));
+        }
+        else
+        {
+            throw new IllegalArgumentException("Unknown suite: " + suiteName);
+        }
+        for (BenchConfig config : configs)
+        {
+            config.iterations = iterations;
+            config.warmup = warmup;
+        }
+        return configs;
+    }
+
+    private static BenchConfig workload(String query, int scale)
+    {
+        BenchConfig config = new BenchConfig();
+        config.query = query;
+        config.scale = scale;
+        return config;
+    }
+
+    private static BenchConfig unionWorkload(String query, int scale, int unionSets)
+    {
+        BenchConfig config = workload(query, scale);
+        config.unionSets = unionSets;
+        return config;
+    }
+
+    private static BenchConfig relationWorkload(String query, int scale)
+    {
+        BenchConfig config = workload(query, scale);
+        config.relationFunction = true;
+        return config;
+    }
+
+    /**
+     * Ratios between two workloads in the same run. Each one guards a dimension where a phase could
+     * silently change complexity class; the pair is chosen so the ratio grows if that happens.
+     */
+    static List<Map<String, Object>> canaries(List<Map<String, Object>> workloads)
+    {
+        List<Map<String, Object>> canaries = new ArrayList<>();
+        canaries.add(ratio(workloads, "compileCliffJoinDepth", "compile", "join16@scale30/H2", "join8@scale30/H2",
+                "exponential lambda compilation on optional navigation chains"));
+        canaries.add(ratio(workloads, "compileVsModelSize", "compile", "simple@scale1000/H2", "simple@scale100/H2",
+                "quadratic terms in mapping validation and table resolution"));
+        canaries.add(ratio(workloads, "planPureUnionSets", "planPure", "join2@scale10+union40/H2", "join2@scale10+union10/H2",
+                "quadratic pure-to-SQL in union set implementations"));
+        canaries.add(ratio(workloads, "planPureJoinDepth", "planPure", "join10@scale30/H2", "join2@scale30/H2",
+                "pure-to-SQL superlinearity in navigation depth"));
+        canaries.add(ratio(workloads, "compileRelationMappings", "compile", "simple@scale200+relfunc/H2", "simple@scale50+relfunc/H2",
+                "per-column lambda compilation in Relation mappings"));
+        canaries.add(ratio(workloads, "javaBindGraphDepth", "javaBind", "graph4@scale30/H2", "graph1@scale30/H2",
+                "platform binder growth in graph-fetch tree size"));
+        canaries.removeIf(canary -> canary.get("value") == null);
+        return canaries;
+    }
+
+    private static Map<String, Object> ratio(List<Map<String, Object>> workloads, String name, String phase,
+                                             String numeratorId, String denominatorId, String guards)
+    {
+        Double numerator = phaseValue(workloads, numeratorId, phase);
+        Double denominator = phaseValue(workloads, denominatorId, phase);
+        Map<String, Object> canary = new LinkedHashMap<>();
+        canary.put("name", name);
+        canary.put("phase", phase);
+        canary.put("numerator", numeratorId);
+        canary.put("denominator", denominatorId);
+        canary.put("guards", guards);
+        canary.put("value", numerator == null || denominator == null || denominator == 0.0 ? null : round(numerator / denominator));
+        return canary;
+    }
+
+    private static Double phaseValue(List<Map<String, Object>> workloads, String workloadId, String phase)
+    {
+        for (Map<String, Object> workload : workloads)
+        {
+            if (workloadId.equals(workload.get("workload")))
+            {
+                Object value = PipelineBench.asMap(workload.get("warmMedianMs")).get(phase);
+                return value == null ? null : ((Number) value).doubleValue();
+            }
+        }
+        return null;
+    }
+
+    static boolean compare(Map<String, Object> baseline, Map<String, Object> current, double margin, double canaryMargin,
+                           long minDelta, boolean allowImprovement)
+    {
+        List<String> regressions = new ArrayList<>();
+        List<String> improvements = new ArrayList<>();
+        List<String> notes = new ArrayList<>();
+
+        String baselineFingerprint = Environment.fingerprint(PipelineBench.asMap(baseline.get("environment")));
+        String currentFingerprint = Environment.fingerprint(PipelineBench.asMap(current.get("environment")));
+        boolean sameMachine = baselineFingerprint.equals(currentFingerprint);
+
+        System.out.println();
+        System.out.println("baseline generated " + baseline.get("generatedAt") + " on " + baselineFingerprint);
+        System.out.println("current  generated " + current.get("generatedAt") + " on " + currentFingerprint);
+        if (!sameMachine)
+        {
+            System.out.println("environments differ - absolute timings are advisory only, canary ratios still enforced");
+        }
+        System.out.println();
+
+        Map<String, Double> baselineCanaries = canaryValues(baseline);
+        Map<String, Double> currentCanaries = canaryValues(current);
+        System.out.println("canary ratios (enforced, margin " + percent(canaryMargin) + ")");
+        for (Map.Entry<String, Double> entry : currentCanaries.entrySet())
+        {
+            Double before = baselineCanaries.get(entry.getKey());
+            Double now = entry.getValue();
+            if (before == null || now == null)
+            {
+                notes.add("canary " + entry.getKey() + " missing from baseline");
+                continue;
+            }
+            double upper = before * (1.0 + canaryMargin);
+            double lower = before * (1.0 - canaryMargin);
+            String verdict = "ok";
+            if (now > upper)
+            {
+                verdict = "SLOWER";
+                regressions.add("canary " + entry.getKey() + ": " + round(before) + " -> " + round(now) + ", above " + round(upper));
+            }
+            else if (now < lower && !allowImprovement)
+            {
+                verdict = "FASTER";
+                improvements.add("canary " + entry.getKey() + ": " + round(before) + " -> " + round(now) + ", below " + round(lower));
+            }
+            System.out.println(String.format("  %-28s %8.2f -> %8.2f  (expected %.2f to %.2f) %s",
+                    entry.getKey(), before, now, lower, upper, verdict));
+        }
+
+        System.out.println();
+        System.out.println("phase medians (" + (sameMachine ? "enforced" : "advisory") + ", margin " + percent(margin)
+                + ", ignoring deltas under " + minDelta + "ms)");
+        Map<String, Map<String, Object>> baselineWorkloads = byWorkload(baseline);
+        for (Map<String, Object> workload : workloadList(current))
+        {
+            String id = String.valueOf(workload.get("workload"));
+            Map<String, Object> baselineWorkload = baselineWorkloads.get(id);
+            if (baselineWorkload == null)
+            {
+                notes.add("workload " + id + " missing from baseline");
+                continue;
+            }
+            Map<String, Object> before = PipelineBench.asMap(baselineWorkload.get("warmMedianMs"));
+            Map<String, Object> now = PipelineBench.asMap(workload.get("warmMedianMs"));
+            for (Map.Entry<String, Object> entry : now.entrySet())
+            {
+                Object baselineValue = before.get(entry.getKey());
+                if (baselineValue == null)
+                {
+                    continue;
+                }
+                double baselineMs = ((Number) baselineValue).doubleValue();
+                double currentMs = ((Number) entry.getValue()).doubleValue();
+                double upper = baselineMs * (1.0 + margin);
+                double lower = baselineMs * (1.0 - margin);
+                boolean beyondNoise = Math.abs(currentMs - baselineMs) >= minDelta;
+                if (!beyondNoise)
+                {
+                    continue;
+                }
+                String message = id + " " + entry.getKey() + ": " + (long) baselineMs + "ms -> " + (long) currentMs
+                        + "ms (expected " + (long) lower + "ms to " + (long) upper + "ms)";
+                if (currentMs > upper)
+                {
+                    System.out.println("  SLOWER " + message);
+                    (sameMachine ? regressions : notes).add(message);
+                }
+                else if (currentMs < lower && !allowImprovement)
+                {
+                    System.out.println("  FASTER " + message);
+                    (sameMachine ? improvements : notes).add(message);
+                }
+            }
+        }
+
+        System.out.println();
+        for (String note : notes)
+        {
+            System.out.println("note: " + note);
+        }
+        if (regressions.isEmpty() && improvements.isEmpty())
+        {
+            System.out.println("PASS - within the allowed margin of the baseline");
+            return true;
+        }
+        if (!regressions.isEmpty())
+        {
+            System.out.println("FAIL - " + regressions.size() + " regression(s):");
+            for (String regression : regressions)
+            {
+                System.out.println("  " + regression);
+            }
+        }
+        if (!improvements.isEmpty())
+        {
+            System.out.println("FAIL - " + improvements.size() + " improvement(s) not yet in the baseline:");
+            for (String improvement : improvements)
+            {
+                System.out.println("  " + improvement);
+            }
+            System.out.println("  a faster result is only protected once it is recorded - rerun with --rebase and commit the baseline");
+        }
+        return false;
+    }
+
+    private static Map<String, Double> canaryValues(Map<String, Object> results)
+    {
+        Map<String, Double> values = new LinkedHashMap<>();
+        Object canaries = results.get("canaries");
+        if (canaries instanceof List)
+        {
+            for (Object entry : (List<?>) canaries)
+            {
+                Map<String, Object> canary = PipelineBench.asMap(entry);
+                Object value = canary.get("value");
+                if (value != null)
+                {
+                    values.put(String.valueOf(canary.get("name")), ((Number) value).doubleValue());
+                }
+            }
+        }
+        return values;
+    }
+
+    private static List<Map<String, Object>> workloadList(Map<String, Object> results)
+    {
+        List<Map<String, Object>> list = new ArrayList<>();
+        Object workloads = results.get("workloads");
+        if (workloads instanceof List)
+        {
+            for (Object entry : (List<?>) workloads)
+            {
+                list.add(PipelineBench.asMap(entry));
+            }
+        }
+        return list;
+    }
+
+    private static Map<String, Map<String, Object>> byWorkload(Map<String, Object> results)
+    {
+        Map<String, Map<String, Object>> map = new LinkedHashMap<>();
+        for (Map<String, Object> workload : workloadList(results))
+        {
+            map.put(String.valueOf(workload.get("workload")), workload);
+        }
+        return map;
+    }
+
+    private static String percent(double margin)
+    {
+        return Math.round(margin * 100) + "%";
+    }
+
+    private static double round(double value)
+    {
+        return Math.round(value * 100.0) / 100.0;
+    }
+
+    private static Map<String, String> options(String[] args)
+    {
+        Map<String, String> options = new LinkedHashMap<>();
+        List<String> list = Arrays.asList(args);
+        for (int i = 0; i < list.size(); i++)
+        {
+            String arg = list.get(i);
+            if (arg.startsWith("--"))
+            {
+                String key = arg.substring(2);
+                if (i + 1 < list.size() && !list.get(i + 1).startsWith("--"))
+                {
+                    options.put(key, list.get(++i));
+                }
+                else
+                {
+                    options.put(key, "true");
+                }
+            }
+        }
+        return options;
+    }
+}

--- a/legend-engine-config/legend-engine-perf-benchmark/src/main/java/org/finos/legend/engine/perf/PipelineBench.java
+++ b/legend-engine-config/legend-engine-perf-benchmark/src/main/java/org/finos/legend/engine/perf/PipelineBench.java
@@ -1,0 +1,393 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.perf;
+
+import static org.finos.legend.pure.generated.core_relational_java_platform_binding_legendJavaPlatformBinding_relationalLegendJavaPlatformBindingExtension.Root_meta_relational_executionPlan_platformBinding_legendJava_relationalExtensionsWithLegendJavaPlatformBinding__Extension_MANY_;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.PrintWriter;
+import java.lang.management.ManagementFactory;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.sql.Connection;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.eclipse.collections.api.RichIterable;
+import org.eclipse.collections.impl.factory.Maps;
+import org.finos.legend.engine.language.pure.compiler.Compiler;
+import org.finos.legend.engine.language.pure.compiler.toPureGraph.HelperValueSpecificationBuilder;
+import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
+import org.finos.legend.engine.language.pure.grammar.from.PureGrammarParser;
+import org.finos.legend.engine.plan.execution.PlanExecutor;
+import org.finos.legend.engine.plan.execution.stores.relational.AlloyH2Server;
+import org.finos.legend.engine.plan.execution.stores.relational.RelationalExecutor;
+import org.finos.legend.engine.plan.execution.stores.relational.TestExecutionScope;
+import org.finos.legend.engine.plan.execution.stores.relational.plugin.Relational;
+import org.finos.legend.engine.plan.execution.stores.relational.result.RelationalResult;
+import org.finos.legend.engine.plan.execution.stores.relational.serialization.RelationalResultToJsonDefaultSerializer;
+import org.finos.legend.engine.plan.generation.PlanGenerator;
+import org.finos.legend.engine.plan.generation.transformers.LegendPlanTransformers;
+import org.finos.legend.engine.plan.platform.PlanPlatform;
+import org.finos.legend.engine.protocol.pure.m3.function.Function;
+import org.finos.legend.engine.protocol.pure.m3.function.LambdaFunction;
+import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
+import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.SingleExecutionPlan;
+import org.finos.legend.engine.shared.core.identity.Identity;
+import org.finos.legend.pure.generated.Root_meta_core_runtime_Runtime;
+import org.finos.legend.pure.generated.Root_meta_pure_executionPlan_ExecutionPlan;
+import org.finos.legend.pure.generated.Root_meta_pure_extension_Extension;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.Mapping;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.FunctionDefinition;
+import org.h2.tools.Server;
+
+/**
+ * Times each stage of the query pipeline separately - grammar parse, compile, lambda build,
+ * extension resolution, plan generation in Pure, Java platform binding, plan serialization,
+ * plan deserialization and (optionally) execution against in-memory H2.
+ *
+ * The first iteration of a run is the cold one: it pays class loading and JIT for the generated
+ * Pure code base. Steady-state cost is the median of the iterations after warmup.
+ *
+ * See README.md for the workload matrix and the canary ratios worth watching in CI.
+ */
+public class PipelineBench
+{
+    private static final String[] PHASES = {"parse", "compile", "lambda", "extensions", "planPure", "javaBind", "serialize", "deserialize", "execute"};
+    private static final String CLIENT_VERSION = "vX_X_X";
+
+    private final BenchConfig config;
+    private final String grammar;
+    private PlanExecutor planExecutor;
+    private List<Map<String, Object>> rows = new ArrayList<>();
+    private boolean verbose = true;
+
+    public PipelineBench(BenchConfig config) throws Exception
+    {
+        this.config = config;
+        this.grammar = config.fileList == null ? this.generateGrammar() : this.readGrammar();
+    }
+
+    public static void main(String[] args) throws Exception
+    {
+        for (String arg : args)
+        {
+            if (arg.equals("--suite"))
+            {
+                System.exit(PerfSuite.run(args));
+            }
+        }
+        BenchConfig config = BenchConfig.parse(args);
+        PipelineBench bench = new PipelineBench(config);
+        bench.run();
+        System.exit(0);
+    }
+
+    public PipelineBench quiet()
+    {
+        this.verbose = false;
+        return this;
+    }
+
+    private String generateGrammar()
+    {
+        return new ModelGenerator(this.config).generate() + new QueryGenerator(this.config).generate();
+    }
+
+    private String readGrammar() throws Exception
+    {
+        StringBuilder b = new StringBuilder();
+        for (String line : Files.readAllLines(Paths.get(this.config.fileList)))
+        {
+            if (!line.trim().isEmpty())
+            {
+                b.append(new String(Files.readAllBytes(Paths.get(line.trim())), StandardCharsets.UTF_8)).append("\n");
+            }
+        }
+        b.append("###Runtime\nRuntime test::Runtime\n{\n  mappings:\n  [\n    ").append(this.config.mappingPath)
+                .append("\n  ];\n  connections:\n  [\n    ").append(this.config.storePath)
+                .append(":\n    [\n      c1: #{\n        RelationalDatabaseConnection\n        {\n")
+                .append(ModelGenerator.connectionBody(this.config.dbType))
+                .append("        }\n      }#\n    ]\n  ];\n}\n");
+        String body = new String(Files.readAllBytes(Paths.get(this.config.queryFile)), StandardCharsets.UTF_8);
+        b.append("###Pure\nfunction test::fetch(): Any[1]\n{\n  {|").append(body.trim()).append("}\n}\n");
+        return b.toString();
+    }
+
+    public Map<String, Object> measure() throws Exception
+    {
+        Server server = null;
+        Map<String, Object> cold = null;
+        List<Map<String, Object>> measured = new ArrayList<>();
+        try
+        {
+            if (this.config.execute)
+            {
+                server = AlloyH2Server.startServer();
+                loadTestData(server.getPort());
+                this.planExecutor = PlanExecutor.newPlanExecutor(Relational.build(server.getPort()));
+            }
+
+            if (this.config.pause)
+            {
+                System.out.println("JVM=" + ManagementFactory.getRuntimeMXBean().getName() + " - attach a profiler to that pid, then press ENTER");
+                System.in.read();
+            }
+
+            for (int i = 0; i < this.config.warmup + this.config.iterations; i++)
+            {
+                boolean warming = i < this.config.warmup;
+                Map<String, Object> row = this.runOnce();
+                row.put("iteration", warming ? -1 : i - this.config.warmup);
+                if (i == 0)
+                {
+                    cold = row;
+                }
+                if (!warming)
+                {
+                    measured.add(row);
+                }
+                if (this.verbose)
+                {
+                    System.out.println(format(row, warming ? "warmup" : "iter " + (i - this.config.warmup)));
+                }
+            }
+        }
+        finally
+        {
+            if (server != null)
+            {
+                server.shutdown();
+                server.stop();
+            }
+        }
+
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("workload", this.config.workloadId());
+        result.put("config", this.config.toMap());
+        result.put("iterations", this.config.iterations);
+        result.put("warmup", this.config.warmup);
+        result.put("coldMs", phaseValues(cold));
+        result.put("warmMedianMs", medians(measured));
+        result.put("planJsonChars", cold == null ? null : cold.get("planJsonChars"));
+        this.rows = measured;
+        return result;
+    }
+
+    public void run() throws Exception
+    {
+        System.out.println(this.config.describe() + " grammarChars=" + this.grammar.length());
+        Map<String, Object> result = this.measure();
+        System.out.println("--- medians in ms over " + this.rows.size() + " measured iterations ---");
+        Map<String, Object> warm = asMap(result.get("warmMedianMs"));
+        for (String phase : PHASES)
+        {
+            if (warm.containsKey(phase))
+            {
+                System.out.println(String.format("%-12s %7s", phase, warm.get(phase)));
+            }
+        }
+        if (this.config.csv != null)
+        {
+            this.writeCsv(this.rows);
+        }
+    }
+
+    static Map<String, Object> phaseValues(Map<String, Object> row)
+    {
+        Map<String, Object> values = new LinkedHashMap<>();
+        if (row == null)
+        {
+            return values;
+        }
+        for (String phase : PHASES)
+        {
+            if (row.containsKey(phase))
+            {
+                values.put(phase, row.get(phase));
+            }
+        }
+        return values;
+    }
+
+    static Map<String, Object> medians(List<Map<String, Object>> rows)
+    {
+        Map<String, Object> result = new LinkedHashMap<>();
+        for (String phase : PHASES)
+        {
+            List<Long> values = new ArrayList<>();
+            for (Map<String, Object> row : rows)
+            {
+                if (row.containsKey(phase))
+                {
+                    values.add((Long) row.get(phase));
+                }
+            }
+            if (!values.isEmpty())
+            {
+                values.sort(Long::compare);
+                result.put(phase, values.get(values.size() / 2));
+            }
+        }
+        return result;
+    }
+
+    @SuppressWarnings("unchecked")
+    static Map<String, Object> asMap(Object value)
+    {
+        return value == null ? new LinkedHashMap<>() : (Map<String, Object>) value;
+    }
+
+    private Map<String, Object> runOnce()
+    {
+        Map<String, Object> row = new LinkedHashMap<>();
+
+        long t0 = System.nanoTime();
+        PureModelContextData contextData = PureGrammarParser.newInstance().parseModel(this.grammar);
+        long t1 = System.nanoTime();
+        row.put("parse", millis(t0, t1));
+
+        PureModel pureModel = Compiler.compile(contextData, null, Identity.getAnonymousIdentity().getName());
+        long t2 = System.nanoTime();
+        row.put("compile", millis(t1, t2));
+
+        Function fetch = contextData.getElementsOfType(Function.class).stream()
+                .filter(f -> f.name != null && f.name.startsWith("fetch"))
+                .findFirst()
+                .orElseGet(() -> contextData.getElementsOfType(Function.class).get(0));
+        LambdaFunction lambda = (LambdaFunction) fetch.body.get(0);
+        FunctionDefinition<?> definition = HelperValueSpecificationBuilder.buildLambda(lambda.body, lambda.parameters, pureModel.getContext());
+        Mapping mapping = pureModel.getMapping(this.config.mappingPath);
+        Root_meta_core_runtime_Runtime runtime = pureModel.getRuntime("test::Runtime");
+        long t3 = System.nanoTime();
+        row.put("lambda", millis(t2, t3));
+
+        RichIterable<? extends Root_meta_pure_extension_Extension> extensions =
+                Root_meta_relational_executionPlan_platformBinding_legendJava_relationalExtensionsWithLegendJavaPlatformBinding__Extension_MANY_(pureModel.getExecutionSupport());
+        long t4 = System.nanoTime();
+        row.put("extensions", millis(t3, t4));
+
+        Root_meta_pure_executionPlan_ExecutionPlan purePlan =
+                PlanGenerator.generateExecutionPlanAsPure(definition, mapping, runtime, null, pureModel, null, null, extensions);
+        long t5 = System.nanoTime();
+        row.put("planPure", millis(t4, t5));
+
+        Root_meta_pure_executionPlan_ExecutionPlan boundPlan = PlanPlatform.JAVA.bindPlan(purePlan, null, pureModel, extensions);
+        long t6 = System.nanoTime();
+        row.put("javaBind", millis(t5, t6));
+
+        String json = PlanGenerator.serializeToJSON(boundPlan, CLIENT_VERSION, pureModel, extensions, LegendPlanTransformers.transformers);
+        long t7 = System.nanoTime();
+        row.put("serialize", millis(t6, t7));
+        row.put("planJsonChars", json.length());
+
+        SingleExecutionPlan plan = PlanGenerator.stringToPlan(json);
+        long t8 = System.nanoTime();
+        row.put("deserialize", millis(t7, t8));
+
+        if (this.config.dumpPlan != null)
+        {
+            writePlan(this.config.dumpPlan, json);
+        }
+
+        if (this.config.execute && this.planExecutor != null)
+        {
+            RelationalResult result = (RelationalResult) this.planExecutor.execute(plan, Maps.mutable.empty(), (String) null, Identity.getAnonymousIdentity());
+            String output = result.flush(new RelationalResultToJsonDefaultSerializer(result));
+            row.put("execute", millis(t8, System.nanoTime()));
+            row.put("resultChars", output.length());
+        }
+        return row;
+    }
+
+    private void writeCsv(List<Map<String, Object>> rows) throws Exception
+    {
+        boolean fresh = !new File(this.config.csv).exists();
+        try (PrintWriter writer = new PrintWriter(new FileWriter(this.config.csv, true)))
+        {
+            if (fresh)
+            {
+                writer.println("dbType,scale,query,union,semi,includes,milestoned,relfunc,nextMult,iteration," + String.join(",", PHASES) + ",planJsonChars");
+            }
+            for (Map<String, Object> row : rows)
+            {
+                StringBuilder line = new StringBuilder();
+                line.append(this.config.dbType).append(",").append(this.config.scale).append(",").append(this.config.query).append(",")
+                        .append(this.config.unionSets).append(",").append(this.config.semiDepth).append(",").append(this.config.includes).append(",")
+                        .append(this.config.milestoned).append(",").append(this.config.relationFunction).append(",")
+                        .append(this.config.nextMultiplicity).append(",").append(row.get("iteration"));
+                for (String phase : PHASES)
+                {
+                    line.append(",").append(row.getOrDefault(phase, ""));
+                }
+                line.append(",").append(row.getOrDefault("planJsonChars", ""));
+                writer.println(line);
+            }
+        }
+        System.out.println("CSV appended to " + this.config.csv);
+    }
+
+    private static String format(Map<String, Object> row, String label)
+    {
+        StringBuilder line = new StringBuilder(label + ":");
+        for (String phase : PHASES)
+        {
+            if (row.containsKey(phase))
+            {
+                line.append(" ").append(phase).append("=").append(row.get(phase)).append("ms");
+            }
+        }
+        return line.toString();
+    }
+
+    private static void writePlan(String path, String json)
+    {
+        try
+        {
+            Files.write(Paths.get(path), json.getBytes(StandardCharsets.UTF_8));
+        }
+        catch (Exception e)
+        {
+            throw new RuntimeException("Unable to write plan to " + path, e);
+        }
+    }
+
+    private static long millis(long from, long to)
+    {
+        return (to - from) / 1_000_000L;
+    }
+
+    private static void loadTestData(int port) throws Exception
+    {
+        RelationalExecutor executor = TestExecutionScope.buildTestExecutor(port);
+        Connection connection = executor.getConnectionManager().getTestDatabaseConnection();
+        try (Statement statement = connection.createStatement())
+        {
+            for (int i = 0; i < 6; i++)
+            {
+                statement.execute("Drop table if exists T" + i + ";");
+                statement.execute("Create Table T" + i + " (id INT NOT NULL, p0 VARCHAR(100), p1 VARCHAR(100), p2 VARCHAR(100), p3 INT, fk INT, PRIMARY KEY(id));");
+                for (int row = 1; row <= 5; row++)
+                {
+                    statement.execute("insert into T" + i + " (id,p0,p1,p2,p3,fk) values (" + row + ",'abc','v1','v2'," + (row * 10) + "," + row + ");");
+                }
+            }
+        }
+    }
+}

--- a/legend-engine-config/legend-engine-perf-benchmark/src/main/java/org/finos/legend/engine/perf/QueryGenerator.java
+++ b/legend-engine-config/legend-engine-perf-benchmark/src/main/java/org/finos/legend/engine/perf/QueryGenerator.java
@@ -1,0 +1,209 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.perf;
+
+/**
+ * Builds the query function for a named shape. Shapes vary one dimension each so that a sweep
+ * isolates how a phase reacts to it: navigation depth (joinK), projection width (projW),
+ * aggregate count (aggK), graph-fetch tree depth (graphK), semi-structured path depth (semiK) and
+ * access width (semiwK), and alias length (longprojW).
+ */
+public class QueryGenerator
+{
+    private final BenchConfig config;
+
+    public QueryGenerator(BenchConfig config)
+    {
+        this.config = config;
+    }
+
+    public String generate()
+    {
+        return "###Pure\nfunction test::fetch(): Any[1]\n{\n  {|" + this.body() + "}\n}\n";
+    }
+
+    private String body()
+    {
+        String query = this.config.query;
+        String all = this.config.milestoned ? "test::domain::C0.all(%2020-01-02T00:00:00)" : "test::domain::C0.all()";
+
+        if (query.equals("simple"))
+        {
+            return all + "->filter(x|$x.p0 == 'abc')->project([x|$x.p0, x|$x.p1, x|$x.p2], ['c0','c1','c2'])";
+        }
+        if (query.equals("m2mview"))
+        {
+            String tree = "#{test::view::V0{q0,q1,q2}}#";
+            return "test::view::V0.all()->graphFetch(" + tree + ")->serialize(" + tree + ")";
+        }
+        if (query.equals("variantrel"))
+        {
+            return "#>{test::DB.T0}#->meta::pure::functions::relation::extend(~v:r|$r.p0->toOne()->fromJson()->get('k')->to(@String))"
+                    + "->meta::pure::functions::relation::select(~[v])";
+        }
+        if (query.startsWith("graph"))
+        {
+            return this.graphFetch(Integer.parseInt(query.substring(5)), all);
+        }
+        if (query.startsWith("semijoin"))
+        {
+            return this.semiWithJoins(Integer.parseInt(query.substring(8)), all);
+        }
+        if (query.startsWith("semiw"))
+        {
+            return this.semiWide(Integer.parseInt(query.substring(5)), all);
+        }
+        if (query.startsWith("semi"))
+        {
+            return this.semiDeep(Integer.parseInt(query.substring(4)), all);
+        }
+        if (query.startsWith("join"))
+        {
+            return this.joinChain(Integer.parseInt(query.substring(4)), all);
+        }
+        if (query.startsWith("longproj"))
+        {
+            return this.projection(Integer.parseInt(query.substring(8)), all, true);
+        }
+        if (query.startsWith("proj"))
+        {
+            return this.projection(Integer.parseInt(query.substring(4)), all, false);
+        }
+        if (query.startsWith("agg"))
+        {
+            return this.aggregates(Integer.parseInt(query.substring(3)), all);
+        }
+        if (query.equals("groupBy"))
+        {
+            return all + "->groupBy([x|$x.p0], [agg(x|$x.p3, y|$y->sum())], ['k','s'])";
+        }
+        throw new IllegalArgumentException("Unknown query shape: " + query);
+    }
+
+    private String joinChain(int depth, String all)
+    {
+        StringBuilder columns = new StringBuilder("x|$x.p0");
+        StringBuilder names = new StringBuilder("'c0'");
+        StringBuilder navigation = new StringBuilder("$x");
+        for (int i = 1; i <= depth; i++)
+        {
+            navigation.append(".next");
+            columns.append(", x|").append(navigation).append(".p0");
+            names.append(", 'c").append(i).append("'");
+        }
+        return all + "->filter(x|$x.p0 == 'abc')->project([" + columns + "], [" + names + "])";
+    }
+
+    private String projection(int width, String all, boolean longAliases)
+    {
+        StringBuilder pad = new StringBuilder();
+        if (longAliases)
+        {
+            for (int i = 0; i < 30; i++)
+            {
+                pad.append("verylongalias");
+            }
+        }
+        StringBuilder columns = new StringBuilder();
+        StringBuilder names = new StringBuilder();
+        for (int i = 0; i < width; i++)
+        {
+            if (i > 0)
+            {
+                columns.append(", ");
+                names.append(", ");
+            }
+            columns.append("x|$x.p").append(i % 4);
+            names.append("'").append(pad).append(i).append("'");
+        }
+        return all + "->project([" + columns + "], [" + names + "])";
+    }
+
+    private String aggregates(int count, String all)
+    {
+        String[] functions = {"sum", "max", "min", "count", "average"};
+        StringBuilder aggregations = new StringBuilder();
+        StringBuilder names = new StringBuilder("'k'");
+        for (int i = 0; i < count; i++)
+        {
+            if (i > 0)
+            {
+                aggregations.append(", ");
+            }
+            aggregations.append("agg(x|$x.p3, y|$y->").append(functions[i % functions.length]).append("())");
+            names.append(", 'a").append(i).append("'");
+        }
+        return all + "->groupBy([x|$x.p0], [" + aggregations + "], [" + names + "])";
+    }
+
+    private String graphFetch(int depth, String all)
+    {
+        StringBuilder tree = new StringBuilder("p0,p1");
+        for (int i = 0; i < depth; i++)
+        {
+            tree.insert(0, "p0,p1,next{");
+        }
+        for (int i = 0; i < depth; i++)
+        {
+            tree.append("}");
+        }
+        String spec = "#{test::domain::C0{" + tree + "}}#";
+        return all + "->graphFetch(" + spec + ")->serialize(" + spec + ")";
+    }
+
+    private String semiDeep(int depth, String all)
+    {
+        StringBuilder navigation = new StringBuilder("$x.det");
+        for (int d = 0; d < depth; d++)
+        {
+            navigation.append(".child");
+        }
+        return all + "->project([col(x|" + navigation + ".v, 'c0')])";
+    }
+
+    private String semiWide(int width, String all)
+    {
+        return all + "->project([" + this.semiColumns(width, 0) + "])";
+    }
+
+    private String semiWithJoins(int width, String all)
+    {
+        String joins = "col(x|$x.p0, 'j0'), col(x|$x.next.p0, 'j1'), col(x|$x.next.next.p0, 'j2')";
+        return all + "->project([" + joins + ", " + this.semiColumns(width, 0) + "])";
+    }
+
+    private String semiColumns(int width, int startIndex)
+    {
+        if (this.config.semiDepth <= 0)
+        {
+            throw new IllegalArgumentException("Semi-structured query shapes require --semi <depth>");
+        }
+        StringBuilder columns = new StringBuilder();
+        for (int i = 0; i < width; i++)
+        {
+            if (i > 0)
+            {
+                columns.append(", ");
+            }
+            StringBuilder navigation = new StringBuilder("$x.det");
+            for (int d = 0; d < i % this.config.semiDepth; d++)
+            {
+                navigation.append(".child");
+            }
+            columns.append("col(x|").append(navigation).append(i % 2 == 0 ? ".v" : ".w").append(", 'c").append(startIndex + i).append("')");
+        }
+        return columns.toString();
+    }
+}

--- a/legend-engine-config/pom.xml
+++ b/legend-engine-config/pom.xml
@@ -33,5 +33,6 @@
         <module>legend-engine-server</module>
         <module>legend-engine-repl</module>
         <module>legend-engine-emit-tests</module>
+        <module>legend-engine-perf-benchmark</module>
     </modules>
 </project>


### PR DESCRIPTION
Adds a benchmark that times each stage of the query pipeline separately, and wires it into CI so a
change in cost is caught on the pull request that causes it.

Analysis and the hotspots this harness found are in #5140.

### What it measures

Parse, compile, lambda build, extension resolution, plan generation in Pure, Java platform binding,
plan serialization and deserialization, and optionally execution against in-memory H2 - each timed
independently, so a slow query is attributed to a phase rather than to "the platform".

The model and query are generated, and each knob varies one dimension so a sweep isolates what a
phase reacts to: model size, navigation depth, projection width, aggregate count, graph-fetch tree
depth, semi-structured path depth and access width. Mapping shapes cover unions, include chains,
milestoning, Relation functions with ModelJoins, model-to-model views and semi-structured bindings,
against the H2, DuckDB and Snowflake dialects. An existing model can be measured instead of a
generated one.

### How the check works

A suite run executes a fixed set of workloads in one JVM and writes a results file recording the
machine, each workload's cold and warm timings, and ratios between workload pairs. That file is
compared against the checked-in baseline.

Ratios and absolute timings are treated differently because they tolerate machine differences
differently. A ratio between two workloads measured in the same JVM cancels machine speed, so it is
enforced everywhere and catches a phase changing complexity class - the regressions that actually
hurt. Absolute phase medians are enforced only when the environment fingerprint matches the
baseline, and small deltas are ignored, since millisecond phases are dominated by JIT noise.

Deviation is judged in **both** directions. Slower is a regression. Faster fails too, because a
baseline that still records the old cost silently permits a later change to give the gain back;
failing forces the improvement into the baseline, where it protects the fix.

### CI

- **Pipeline Benchmark** job in Build CI runs on every pull request. It reuses the build job's
  output and Maven artifacts rather than building again, so it costs about the time the suite takes
  (about five minutes here). A deviation does not fail the build: the job writes the canary table to
  the job summary, uploads the results, and comments on the pull request, leaving the judgement to
  the reviewer. Blocking would be wrong for a measurement this environment-sensitive - see below.
- **Performance Baseline** workflow is the manual counterpart: given a branch, a rebase switch and
  free-form flags, it records a new baseline and pushes it as a commit on that branch. A pull
  request that legitimately changed cost is fixed by running it, and the new numbers are reviewed
  alongside the change.

Running per pull request is deliberate: a nightly job reports that something regressed since
yesterday and leaves the author bisecting, while a per-pull-request job names the change.

### Notes for reviewers

- The committed baseline was recorded on a developer machine, so on CI the fingerprint does not
  match and absolute timings are reported as notes. Ratios travel much better but not perfectly:
  this pull request's own run put five of six canaries inside a 30% band across an Apple M4 Max and
  a four-core cloud runner, while the union ratio came in 31% low purely from the hardware. Running
  the Performance Baseline workflow once on master records a baseline on runner hardware and removes
  that drift.
- A pull request from a fork gets a read-only token, so its comment is best effort and its baseline
  has to be refreshed from the fork.
- `scripts/demangle_pure_frames.py` translates async-profiler frames from generated Pure-Java
  classes back to Pure function names, so a hotspot inside plan generation can be cited as a `.pure`
  function rather than a generated class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQLZcDYGzt62dKzWyetBBo
