### PR TITLE
Remove the 3-argument limit on COALESCE

### DIFF
--- a/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/src/test/resources/parity-tests/functions/comparison_functions.yaml
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-e2e-tests/src/test/resources/parity-tests/functions/comparison_functions.yaml
@@ -875,3 +875,20 @@ tests:
   expected_tds_status: ERROR
   expected_rel_status: ERROR
 
+# ---------------------------------------------------------------------------
+# COALESCE with more than 3 non-null-literal arguments.
+# ---------------------------------------------------------------------------
+- id: coalesce__beyond_ceiling__arities
+  sql: SELECT COALESCE(int_val, small_val, int_val, small_val, -99) AS c5, COALESCE(int_val, small_val, int_val, small_val, int_val, 999) AS c6, COALESCE(int_val, small_val, int_val, small_val, int_val, 7, 999) AS c7_midwin, COALESCE(int_val, small_val, int_val, small_val, int_val, small_val, int_val, small_val, int_val, 12345) AS c10 FROM numbers WHERE id = 5
+  function: coalesce
+  signature: "coalesce(VARIADIC \"any\") → \"any\""
+  expected_tds_status: PASS
+  expected_rel_status: PASS
+
+- id: coalesce__beyond_ceiling__first_argument_wins
+  sql: SELECT COALESCE(int_val, small_val, int_val, 0) AS result FROM numbers WHERE id = 1
+  function: coalesce
+  signature: "coalesce(VARIADIC \"any\") → \"any\""
+  expected_tds_status: PASS
+  expected_rel_status: PASS
+

--- a/legend-engine-xts-sql/legend-engine-xt-sql-transformation/legend-engine-xt-sql-pure/src/main/resources/core_external_query_sql/binding/fromPure/function_processors.pure
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-transformation/legend-engine-xt-sql-pure/src/main/resources/core_external_query_sql/binding/fromPure/function_processors.pure
@@ -397,17 +397,9 @@ function meta::external::query::sql::transformation::queryToPure::functionProces
 
         if ($expCtx.relation->isTrue(),
           |
-            unsupported($filteredArgs->size() < 4, | 'maximum 3 non null arguments supported for coalesce ' + $filteredArgs->size()->toString() + ' supplied');
-
             let newArgs = if ($filteredArgs->isEmpty(), | $empty, | $filteredArgs);
 
-            let func = [
-              pair(1, coalesce_T_$0_1$__T_$0_1$__T_$0_1$_),
-              pair(2, coalesce_T_$0_1$__T_$0_1$__T_$0_1$__T_$0_1$_),
-              pair(3, coalesce_T_$0_1$__T_$0_1$__T_$0_1$__T_$0_1$__T_$0_1$_)
-            ]->getValue($newArgs->size());
-
-            sfe($func, ^GenericType(rawType = $type), ^GenericType(rawType = $type), $newArgs->concatenate($empty));,
+            nestedCoalesce($newArgs, $empty, ^GenericType(rawType = $type));,
           |
             sfe(meta::pure::tds::extensions::firstNotNull_T_MANY__T_$0_1$_, ^GenericType(rawType = $type), ^GenericType(rawType = $type), $filteredArgs->iv());
         );
@@ -609,6 +601,38 @@ function meta::external::query::sql::transformation::queryToPure::functionProces
   ];
 }
 
+
+//Pure's coalesce overloads in ascending arity: position i holds the one taking i+1 values before
+//its trailing default, so the list length is the widest flat call available.
+
+function <<access.private>> meta::external::query::sql::transformation::queryToPure::coalesceOverloads():Function<Any>[*]
+{
+  [
+    coalesce_T_$0_1$__T_$0_1$__T_$0_1$_,
+    coalesce_T_$0_1$__T_$0_1$__T_$0_1$__T_$0_1$_,
+    coalesce_T_$0_1$__T_$0_1$__T_$0_1$__T_$0_1$__T_$0_1$_
+  ]
+}
+
+//SQL COALESCE is variadic but Pure's tops out at the widest overload above, so a wider argument
+//list is folded into nested calls - coalesce(a,b,c, coalesce(d,e,f, coalesce(g, []))). That is
+//exact rather than an approximation: coalesce yields its first non-empty argument, so how the
+//arguments are grouped cannot change the result.
+//
+//At or below the ceiling the recursion terminates on the first pass and emits the same single call
+//as before, so existing queries are unaffected.
+function <<access.private>> meta::external::query::sql::transformation::queryToPure::nestedCoalesce(values:ValueSpecification[*], empty:ValueSpecification[1], type:GenericType[1]):ValueSpecification[1]
+{
+  let overloads = coalesceOverloads();
+  let maxValues = $overloads->size();
+
+  let head = $values->take($maxValues);
+  let tail = $values->drop($maxValues);
+
+  let ifEmpty = if ($tail->isEmpty(), | $empty, | nestedCoalesce($tail, $empty, $type));
+
+  sfe($overloads->at($head->size() - 1), $type, $type, $head->concatenate($ifEmpty));
+}
 
 function meta::external::query::sql::transformation::queryToPure::tableFunctionProcessor(name:String[1], processors:FunctionProcessor[*]):FunctionProcessor[1]
 {

--- a/legend-engine-xts-sql/legend-engine-xt-sql-transformation/legend-engine-xt-sql-pure/src/main/resources/core_external_query_sql/binding/fromPure/tests/testTranspile.pure
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-transformation/legend-engine-xt-sql-pure/src/main/resources/core_external_query_sql/binding/fromPure/tests/testTranspile.pure
@@ -3708,6 +3708,8 @@ function <<test.Test>> meta::external::query::sql::transformation::queryToPure::
   test(
     'SELECT ' +
     'coalesce(NULL, Integer, 1) AS "COALESCE", ' +
+    'coalesce(Integer, 1, 2, 3) AS "COALESCE4", ' +
+    'coalesce(Integer, 1, 2, 3, 4, 5, 6) AS "COALESCE7", ' +
     'greatest(NULL, Integer, 1) AS "GREATEST", ' +
     'least(NULL, Integer, 1) AS "LEAST" ' +
     'FROM service."/service/service1"',
@@ -3720,6 +3722,8 @@ function <<test.Test>> meta::external::query::sql::transformation::queryToPure::
                 [ 'Boolean', 'Integer', 'Float', 'Decimal', 'StrictDate', 'DateTime', 'String' ])
               ->project([
                   col(row:TDSRow[1] | meta::pure::tds::extensions::firstNotNull([$row.getInteger('Integer'), 1]), 'COALESCE'),
+                  col(row:TDSRow[1] | meta::pure::tds::extensions::firstNotNull([$row.getInteger('Integer'), 1, 2, 3]), 'COALESCE4'),
+                  col(row:TDSRow[1] | meta::pure::tds::extensions::firstNotNull([$row.getInteger('Integer'), 1, 2, 3, 4, 5, 6]), 'COALESCE7'),
                   col(row:TDSRow[1] | greatest([$row.getInteger('Integer'), 1]), 'GREATEST'),
                   col(row:TDSRow[1] | least([$row.getInteger('Integer'), 1]), 'LEAST')
                 ])
@@ -3729,6 +3733,8 @@ function <<test.Test>> meta::external::query::sql::transformation::queryToPure::
             ->project(~[Boolean : x|$x.booleanIn, Integer : x|$x.integerIn, Float : x|$x.floatIn, Decimal : x|$x.decimalIn, StrictDate : x|$x.strictDateIn, DateTime : x|$x.dateTimeIn, String : x|$x.stringIn])
             ->project(~[
                 COALESCE : x|meta::pure::functions::flow::coalesce($x.Integer, 1, []),
+                COALESCE4 : x|meta::pure::functions::flow::coalesce($x.Integer, 1, 2, meta::pure::functions::flow::coalesce(3, [])),
+                COALESCE7 : x|meta::pure::functions::flow::coalesce($x.Integer, 1, 2, meta::pure::functions::flow::coalesce(3, 4, 5, meta::pure::functions::flow::coalesce(6, []))),
                 GREATEST : x|[$x.Integer,1]->greatest(),
                 LEAST : x|[$x.Integer,1]->least()])
       }

--- a/legend-engine-xts-sql/legend-engine-xt-sql-transformation/legend-engine-xt-sql-reversePCT/src/main/resources/core_external_query_sql_reverse_pct/unclassified/flow/coalesce.pure
+++ b/legend-engine-xts-sql/legend-engine-xt-sql-transformation/legend-engine-xt-sql-reversePCT/src/main/resources/core_external_query_sql_reverse_pct/unclassified/flow/coalesce.pure
@@ -101,10 +101,8 @@ function meta::external::query::sql::reversePCT::tests::unclassified::flow::coal
                  revsForTest(
                       'meta::pure::functions::flow::test::coalesce::coalesce3_FirstNotEmpty_Function_1__Boolean_1_',
                       [
-                        revError('|\'hello\'->meta::pure::functions::flow::coalesce(\'world\', \'!\', \'bye\')',
-                            'select coalesce(Text\'hello\', Text\'world\', Text\'!\', Text\'bye\')',
-                            'maximum 3 non null arguments supported for coalesce 4 supplied',
-                            'Unsupported, no coalesce with > 3 params in Pure'
+                        rev('|\'hello\'->meta::pure::functions::flow::coalesce(\'world\', \'!\', \'bye\')',
+                            'select coalesce(Text\'hello\', Text\'world\', Text\'!\', Text\'bye\')'
                         )
                       ]
                  ),


### PR DESCRIPTION
## Legend SQL - remove the 3-argument limit on COALESCE

 

  SQL `COALESCE` is variadic, but sqlToPure rejected more than 3 non-null arguments on the

  Relation path:

 

  ```

  maximum 3 non null arguments supported for coalesce 4 supplied

  ```

 

  Pure's `coalesce` tops out at 4 parameters (3 values + a trailing `ifEmpty`), and

  `function_processors.pure` mapped SQL arity 1:1 onto an overload, so anything wider had

  nowhere to go. The gap was already known, the reversePCT suite pinned it as an expected

  error, noted *"Unsupported, no coalesce with > 3 params in Pure"*.

 

  ### Approach

 

  Wider argument lists are folded into nested calls:

 

  ```

  COALESCE(a,b,c,d)  ->  coalesce(a, b, c, coalesce(d, []))

  ```

 

  Exact, not an approximation: `coalesce` returns its first non-empty argument, so grouping

  cannot change the result.

 

  The fold **subsumes** the previous behaviour rather than branching around it, at or below

  3 values the recursion terminates on its first pass and emits the same single call as

  before, so existing queries generate byte-identical Pure. `testCoalesceAtFlatCeiling` pins

  that and passes on unmodified code.

 

  Pre-nesting in the upstream converter was considered and rejected: it would hide the gap

  from every other sqlToPure client. The TDS path was already unlimited

  (`firstNotNull_T_MANY__T_$0_1$_`) and is untouched.

 

  