### PR TITLE
M2M: fix class-mapping id resolution for optional class-typed properties

### DIFF
--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/ClassMappingThirdPassBuilder.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/ClassMappingThirdPassBuilder.java
@@ -97,22 +97,43 @@ public class ClassMappingThirdPassBuilder implements ClassMappingVisitor<SetImpl
             if (property._genericType()._rawType()._classifierGenericType()._rawType()._name().equals("Class"))
             {
                 SetImplementation setImplementation;
+                // `optionalProp: []` on a [0..1] class-typed property is a no-op — no target mapping needed.
+                boolean unmappedOptionalPassThrough = isEmptyTransformOnOptionalClassProperty(last, property);
                 if (p._targetSetImplementationId() != null && !p._targetSetImplementationId().equals(""))
                 {
                     setImplementation = Root_meta_pure_mapping__classMappingByIdRecursive_Mapping_1__String_MANY__SetImplementation_MANY_(this.parentMapping, Lists.fixedSize.with(p._targetSetImplementationId()), this.context.pureModel.getExecutionSupport()).getFirst();
-                    boolean allowComplexPropertyMappingPassThrough = setImplementation == null && HelperModelBuilder.getTypeFullPath(property._genericType()._rawType(), "_", this.context.pureModel.getExecutionSupport()).equals(p._targetSetImplementationId()) && checkTransformTypeMatchesPropertyType(property, last, context);
+                    boolean idIsSyntheticDefault = HelperModelBuilder.getTypeFullPath(property._genericType()._rawType(), "_", this.context.pureModel.getExecutionSupport()).equals(p._targetSetImplementationId());
+                    // id is a compiler-generated placeholder — resolve class mapping by class, same as the no-id branch below.
+                    // Stamp the resolved SetImplementation's real id back onto the property mapping so downstream
+                    // consumers (router, JSON serializer, plan generator) navigate to the exact target we found
+                    // instead of re-resolving by class and picking a different SetImplementation.
+                    if (setImplementation == null && idIsSyntheticDefault)
+                    {
+                        setImplementation = Root_meta_pure_mapping__classMappingByClass_Mapping_1__Class_1__SetImplementation_MANY_(this.parentMapping, (org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class<?>) property._genericType()._rawType(), this.context.pureModel.getExecutionSupport()).getFirst();
+                        if (setImplementation != null)
+                        {
+                            p._targetSetImplementationId(setImplementation._id());
+                        }
+                    }
+                    boolean allowComplexPropertyMappingPassThrough = setImplementation == null && idIsSyntheticDefault && checkTransformTypeMatchesPropertyType(property, last, context);
                     if (allowComplexPropertyMappingPassThrough)
                     {
                         // We need to have this as we have been adding defaultId to property mappings when users don't provide something explicitly. This is valid now but having it raises wrong warning
                         p._targetSetImplementationId("");
                     }
-                    Assert.assertTrue((setImplementation != null) || (allowComplexPropertyMappingPassThrough), () -> "Can't find class mapping '" + p._targetSetImplementationId() + "'", pSourceInformation, EngineErrorType.COMPILATION);
+                    if (setImplementation == null && !allowComplexPropertyMappingPassThrough && unmappedOptionalPassThrough && idIsSyntheticDefault)
+                    {
+                        p._targetSetImplementationId("");
+                    }
+                    Assert.assertTrue((setImplementation != null) || allowComplexPropertyMappingPassThrough || unmappedOptionalPassThrough,
+                            () -> "Can't find class mapping for property '" + property._name() + "' of type '" + HelperModelBuilder.getElementFullPath((org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement) property._genericType()._rawType(), this.context.pureModel.getExecutionSupport()) + "' in mapping '" + HelperModelBuilder.getElementFullPath(this.parentMapping, this.context.pureModel.getExecutionSupport()) + "' or any included mapping",
+                            pSourceInformation, EngineErrorType.COMPILATION);
                 }
                 else
                 {
                     setImplementation = Root_meta_pure_mapping__classMappingByClass_Mapping_1__Class_1__SetImplementation_MANY_(this.parentMapping, (org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class<?>) property._genericType()._rawType(), this.context.pureModel.getExecutionSupport()).getFirst();
                     boolean allowComplexPropertyMappingPassThrough = setImplementation == null && checkTransformTypeMatchesPropertyType(property, last, context);
-                    Assert.assertTrue((setImplementation != null) || (allowComplexPropertyMappingPassThrough), () -> "Can't find class mapping for '" + HelperModelBuilder.getElementFullPath((org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement) property._genericType()._rawType(), this.context.pureModel.getExecutionSupport()) + "'", pSourceInformation, EngineErrorType.COMPILATION);
+                    Assert.assertTrue((setImplementation != null) || allowComplexPropertyMappingPassThrough || unmappedOptionalPassThrough, () -> "Can't find class mapping for '" + HelperModelBuilder.getElementFullPath((org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement) property._genericType()._rawType(), this.context.pureModel.getExecutionSupport()) + "'", pSourceInformation, EngineErrorType.COMPILATION);
                 }
 
                 List<? extends InstanceSetImplementation> setImpls = setImplementation != null ? core_pure_router_operations_router_operations.Root_meta_pure_router_routing_resolveOperation_SetImplementation_MANY__Mapping_1__InstanceSetImplementation_MANY_(Lists.immutable.of(setImplementation), this.parentMapping, this.context.pureModel.getExecutionSupport()).toList() : Collections.emptyList();
@@ -260,7 +281,6 @@ public class ClassMappingThirdPassBuilder implements ClassMappingVisitor<SetImpl
     }
 
 
-
     private static void checkPureMappingCompatibility(CompileContext context, Type actualReturnType, Type signatureType, String errorStub, SourceInformation errorSourceInformation)
     {
         //In a pure mapping. The src implementation  can be anywhere in the class hierarchy of the return type
@@ -274,5 +294,16 @@ public class ClassMappingThirdPassBuilder implements ClassMappingVisitor<SetImpl
     {
         RichIterable<? extends Type> classesTaxonomy = Root_meta_pure_functions_meta_getAllTypeGeneralisations_Type_1__Type_MANY_(expression._genericType()._rawType(), context.getExecutionSupport());
         return classesTaxonomy.contains(property._genericType()._rawType());
+    }
+
+    // True when the transform is empty (`[]`, upper mult 0) and the property is optional (lower mult 0).
+    // Such a mapping needs no target class mapping — the field is deterministically empty.
+    private static boolean isEmptyTransformOnOptionalClassProperty(
+            org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.ValueSpecification last,
+            org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.property.Property<?, ?> property)
+    {
+        Long transformUpper = last._multiplicity() == null ? null : last._multiplicity()._upperBound() == null ? null : last._multiplicity()._upperBound()._value();
+        Long propertyLower = property._multiplicity() == null ? null : property._multiplicity()._lowerBound() == null ? null : property._multiplicity()._lowerBound()._value();
+        return transformUpper != null && transformUpper == 0L && propertyLower != null && propertyLower == 0L;
     }
 }

--- a/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/test/java/org/finos/legend/engine/language/pure/compiler/test/fromGrammar/TestMappingCompilationFromGrammar.java
+++ b/legend-engine-core/legend-engine-core-base/legend-engine-core-language-pure/legend-engine-language-pure-compiler/src/test/java/org/finos/legend/engine/language/pure/compiler/test/fromGrammar/TestMappingCompilationFromGrammar.java
@@ -702,7 +702,78 @@ public class TestMappingCompilationFromGrammar extends TestCompilationFromGramma
                 "    employees[model_Person_1]: $src.em\n" +
                 "  }\n" +
                 ")\n" +
-                "\n", "COMPILATION error at [46:5-38]: Can't find class mapping 'model_Person_1'");
+                "\n", "COMPILATION error at [46:5-38]: Can't find class mapping for property 'employees' of type 'model::Person' in mapping 'model::mapping1' or any included mapping");
+    }
+
+    // Resolve class-typed property mappings by class when the id is a synthetic default, and accept empty transforms on optional class properties.
+
+    private static final String OPTIONAL_CLASS_PROPERTY_SHARED_MODEL =
+            "Class test::Target { name: String[1]; }\n" +
+            "Class test::TargetSrc { name: String[1]; }\n" +
+            "Class test::Parent {\n" +
+            "  label: String[1];\n" +
+            "  opt: test::Target[0..1];\n" +
+            "}\n" +
+            "Class test::Parent2 {\n" +
+            "  label: String[1];\n" +
+            "  required: test::Target[1];\n" +
+            "}\n" +
+            "Class test::ParentSrc {\n" +
+            "  label: String[1];\n" +
+            "}\n";
+
+    @Test
+    public void testEmptyTransformOnOptionalClassPropertyWithIncludedIdMapping()
+    {
+        // Parent `include`s a child that maps Target under `[T]`; parent leaves optional property as `[]`.
+        // Must compile — empty transform on an optional property needs no target mapping.
+        test(OPTIONAL_CLASS_PROPERTY_SHARED_MODEL +
+                "###Mapping\n" +
+                "Mapping test::child (\n" +
+                "  test::Target[T]: Pure {\n" +
+                "    ~src test::TargetSrc\n" +
+                "    name: $src.name\n" +
+                "  }\n" +
+                ")\n" +
+                "Mapping test::parent (\n" +
+                "  include test::child\n" +
+                "  *test::Parent: Pure {\n" +
+                "    ~src test::ParentSrc\n" +
+                "    label: $src.label,\n" +
+                "    opt: []\n" +
+                "  }\n" +
+                ")\n");
+    }
+
+    @Test
+    public void testEmptyTransformOnOptionalClassPropertyUnmappedClass()
+    {
+        // No child mapping. Optional property left as `[]` on an unmapped class — must compile.
+        test(OPTIONAL_CLASS_PROPERTY_SHARED_MODEL +
+                "###Mapping\n" +
+                "Mapping test::parent (\n" +
+                "  *test::Parent: Pure {\n" +
+                "    ~src test::ParentSrc\n" +
+                "    label: $src.label,\n" +
+                "    opt: []\n" +
+                "  }\n" +
+                ")\n");
+    }
+
+    @Test
+    public void testEmptyTransformOnMandatoryClassPropertyStillFails()
+    {
+        // Guard: empty transform on a *mandatory* [1] class-typed property with no mapping must still fail.
+        test(OPTIONAL_CLASS_PROPERTY_SHARED_MODEL +
+                "###Mapping\n" +
+                "Mapping test::parent2 (\n" +
+                "  *test::Parent2: Pure {\n" +
+                "    ~src test::ParentSrc\n" +
+                "    label: $src.label,\n" +
+                "    required: []\n" +
+                "  }\n" +
+                ")\n",
+                "COMPILATION error at [19:5-16]: Can't find class mapping for property 'required' of type 'test::Target' in mapping 'test::parent2' or any included mapping");
     }
 
     @Test
@@ -898,7 +969,7 @@ public class TestMappingCompilationFromGrammar extends TestCompilationFromGramma
                         "    dog: $src.name\n" +
                         "  }\n" +
                         ")\n",
-                "COMPILATION error at [20:5-18]: Can't find class mapping 'ui_Dog'");
+                "COMPILATION error at [20:5-18]: Can't find class mapping for property 'dog' of type 'ui::Dog' in mapping 'ui::a' or any included mapping");
     }
 
     @Test
@@ -931,7 +1002,7 @@ public class TestMappingCompilationFromGrammar extends TestCompilationFromGramma
                         "    breed: 'dogBreed'\n" +
                         "  }\n" +
                         ")\n",
-                "COMPILATION error at [19:5-28]: Can't find class mapping 'imMissing'"
+                "COMPILATION error at [19:5-28]: Can't find class mapping for property 'dog' of type 'ui::Dog' in mapping 'ui::a' or any included mapping"
         );
     }
 


### PR DESCRIPTION
#### What type of PR is this?
- Bug Fix

## Problem
An M2M mapping that includes sub-mappings and leaves an optional (`[0..1]`) class-typed property mapped to `[]` fails to compile:

```
Compilation failed: Can't find class mapping 'datamarts_ops_..._SingleStorePaymentConfirmation'
```

That id in the error message is not something the user wrote. It's an internal placeholder the compiler generated for itself. Legacy Pure accepts the same input without any issue — this is a regression in legend-engine.

## Why it happens

When a class-typed property mapping doesn't have an explicit `[id]`, the grammar layer auto-fills one by taking the property's class name and replacing `::` with `_`. That gives us a placeholder like `datamarts_ops_..._SingleStorePaymentConfirmation`.

The compiler then does two things that combine badly:

1. **Looks up that placeholder id verbatim in the include graph.** The included sub-mapping uses a real, user-chosen id (e.g. `[PAYMENTCONFIRMATION]`), so the lookup misses.
2. **The escape hatch can't rescue it.** The existing fallback only fires when the transform's return type matches the property class. For `optionalProp: []` the transform returns `Nil`, so the fallback doesn't fire either.

Both routes closed → hard error, and the internal placeholder id is echoed back at the user.

## The fix

All changes are in `ClassMappingThirdPassBuilder.visit(PureInstanceClassMapping)` plus one small helper. No changes to grammar, protocol, plan generation, or execution.

1. **Fall back to lookup-by-class when the id is a placeholder.** If the `_targetSetImplementationId` matches the synthetic default the grammar layer would have generated (class FQN with `_`), and the by-id lookup fails, retry using `classMappingByClass` recursively across includes — the same lookup the sibling `else`-branch already uses. When that finds a target, overwrite the placeholder on the property mapping with the resolved SetImplementation's real id. Downstream consumers (router, JSON serializer, plan generator) read that id at runtime; leaving the placeholder in place would cause them to re-resolve by class and pick the wrong SetImplementation when the class is mapped in more than one place.
2. **Accept `optionalProp: []` on class-typed properties.** If the transform is empty (upper multiplicity 0) and the property is optional (lower multiplicity 0), treat it as an explicit "leave empty" — no target class mapping required. Matches legacy Pure.
3. **Better error message on the residual failure path.** When resolution genuinely can't find anything, report _property name, class FQN, and parent mapping FQN_ instead of the internal placeholder id.

## Tests

New in `TestMappingCompilationFromGrammar`:

- Ticket shape: parent includes a child that maps `Target[T]`, parent has `opt: []` on a `Target[0..1]` property → compiles.
- No child mapping at all, `opt: []` on `Target[0..1]` → compiles.
- `required: []` on a mandatory `Target[1]` → still fails, with the new error message.

#### What does this PR do / why is it needed ?

<!--
Describe change being introduced by this PR.
-->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
