### PR TITLE
Add tests for the time zone a relational connection names

### DIFF
--- a/docs/emit/emit.md
+++ b/docs/emit/emit.md
@@ -932,6 +932,7 @@ so live in the `mapping:` domain alongside their relational counterparts:
 |---|---|
 | `execution:bigquery-function` | BigQuery function activator |
 | `execution:binding` | External format binding |
+| `execution:connection-time-zone` | Time zone named on a relational connection, settling the zone a TIMESTAMP column's wall clock is read out of |
 | `execution:data-element` | Data element definition |
 | `execution:external-format` | External format specification |
 | `execution:external-format-binding` | External format binding |

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-connection-time-zone.emit.yaml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-connection-time-zone.emit.yaml
@@ -1,0 +1,40 @@
+name: relational-connection-time-zone
+title: "Time Zone Named on a Relational Connection"
+description: |
+  One table holding one wall clock, and a Service per way of naming the time
+  zone the database keeps it in: no zone at all, a region (`Pacific/Guam`), a
+  bare offset (`+1000`), a UTC prefixed offset (`UTC+1000`), an offset that is
+  not a whole hour (`UTC+0530`), and a region inside daylight saving time
+  (`America/New_York`). Each service test asserts the moment the stored wall
+  clock stands for in that zone, so the suite pins both that the zone is
+  applied and that the several spellings of one zone agree.
+
+  The test data sits on each connection rather than in the test, since a test
+  carrying its own `connections:` block has the connection rebuilt without its
+  time zone.
+
+modelSources:
+  model:
+    root: relational-connection-time-zone
+    files:
+      - model/model.pure
+      - connection/connections.pure
+      - service/services.pure
+
+features:
+  - scaffolding:class
+  - scaffolding:relational-connection
+  - scaffolding:relational-mapping
+  - scaffolding:relational-store
+  - scaffolding:runtime
+  - execution:connection-time-zone
+  - execution:service
+  - execution:service-test
+stores:
+  - relational
+complexity: basic
+tags:
+  - h2
+  - time-zone
+  - service-test
+  - date-time

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-connection-time-zone/connection/connections.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-connection-time-zone/connection/connections.pure
@@ -1,0 +1,182 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// A connection per way of naming a time zone, each carrying the same row. The
+// test data rides on the connection rather than on the test, because a test
+// that brings its own `connections:` block has its connection rebuilt by
+// RelationalConnectionFactory.buildH2TestConnection, which keeps the store and
+// drops everything else the connection said -- the time zone included.
+
+###Connection
+RelationalDatabaseConnection demo::connection::ShiftGmtConnection
+{
+  store: demo::store::ShiftDB;
+  type: H2;
+  specification: LocalH2
+  {
+    testDataSetupCSV: 'default\nshiftTable\nid,startedAt\n1,2012-05-20T13:10:52.501\n---';
+  };
+  auth: DefaultH2;
+}
+
+RelationalDatabaseConnection demo::connection::ShiftRegionConnection
+{
+  store: demo::store::ShiftDB;
+  type: H2;
+  timezone: 'Pacific/Guam';
+  specification: LocalH2
+  {
+    testDataSetupCSV: 'default\nshiftTable\nid,startedAt\n1,2012-05-20T13:10:52.501\n---';
+  };
+  auth: DefaultH2;
+}
+
+RelationalDatabaseConnection demo::connection::ShiftOffsetConnection
+{
+  store: demo::store::ShiftDB;
+  type: H2;
+  timezone: +1000;
+  specification: LocalH2
+  {
+    testDataSetupCSV: 'default\nshiftTable\nid,startedAt\n1,2012-05-20T13:10:52.501\n---';
+  };
+  auth: DefaultH2;
+}
+
+RelationalDatabaseConnection demo::connection::ShiftUtcPrefixedOffsetConnection
+{
+  store: demo::store::ShiftDB;
+  type: H2;
+  timezone: 'UTC+1000';
+  specification: LocalH2
+  {
+    testDataSetupCSV: 'default\nshiftTable\nid,startedAt\n1,2012-05-20T13:10:52.501\n---';
+  };
+  auth: DefaultH2;
+}
+
+RelationalDatabaseConnection demo::connection::ShiftHalfHourOffsetConnection
+{
+  store: demo::store::ShiftDB;
+  type: H2;
+  timezone: 'UTC+0530';
+  specification: LocalH2
+  {
+    testDataSetupCSV: 'default\nshiftTable\nid,startedAt\n1,2012-05-20T13:10:52.501\n---';
+  };
+  auth: DefaultH2;
+}
+
+RelationalDatabaseConnection demo::connection::ShiftDaylightSavingConnection
+{
+  store: demo::store::ShiftDB;
+  type: H2;
+  timezone: 'America/New_York';
+  specification: LocalH2
+  {
+    testDataSetupCSV: 'default\nshiftTable\nid,startedAt\n1,2012-05-20T13:10:52.501\n---';
+  };
+  auth: DefaultH2;
+}
+
+###Runtime
+Runtime demo::runtime::ShiftGmtRuntime
+{
+  mappings:
+  [
+    demo::ShiftMapping
+  ];
+  connections:
+  [
+    demo::store::ShiftDB:
+    [
+      h2: demo::connection::ShiftGmtConnection
+    ]
+  ];
+}
+
+Runtime demo::runtime::ShiftRegionRuntime
+{
+  mappings:
+  [
+    demo::ShiftMapping
+  ];
+  connections:
+  [
+    demo::store::ShiftDB:
+    [
+      h2: demo::connection::ShiftRegionConnection
+    ]
+  ];
+}
+
+Runtime demo::runtime::ShiftOffsetRuntime
+{
+  mappings:
+  [
+    demo::ShiftMapping
+  ];
+  connections:
+  [
+    demo::store::ShiftDB:
+    [
+      h2: demo::connection::ShiftOffsetConnection
+    ]
+  ];
+}
+
+Runtime demo::runtime::ShiftUtcPrefixedOffsetRuntime
+{
+  mappings:
+  [
+    demo::ShiftMapping
+  ];
+  connections:
+  [
+    demo::store::ShiftDB:
+    [
+      h2: demo::connection::ShiftUtcPrefixedOffsetConnection
+    ]
+  ];
+}
+
+Runtime demo::runtime::ShiftHalfHourOffsetRuntime
+{
+  mappings:
+  [
+    demo::ShiftMapping
+  ];
+  connections:
+  [
+    demo::store::ShiftDB:
+    [
+      h2: demo::connection::ShiftHalfHourOffsetConnection
+    ]
+  ];
+}
+
+Runtime demo::runtime::ShiftDaylightSavingRuntime
+{
+  mappings:
+  [
+    demo::ShiftMapping
+  ];
+  connections:
+  [
+    demo::store::ShiftDB:
+    [
+      h2: demo::connection::ShiftDaylightSavingConnection
+    ]
+  ];
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-connection-time-zone/model/model.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-connection-time-zone/model/model.pure
@@ -1,0 +1,49 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// A table holding one wall clock, and a mapping over it. Every Runtime in
+// `connections.pure` reaches this same row; only the time zone its connection
+// names differs.
+
+###Pure
+Class demo::Shift
+{
+  id: Integer[1];
+  startedAt: DateTime[0..1];
+}
+
+###Relational
+Database demo::store::ShiftDB
+(
+  Table shiftTable
+  (
+    id INTEGER PRIMARY KEY,
+    startedAt TIMESTAMP
+  )
+)
+
+###Mapping
+Mapping demo::ShiftMapping
+(
+  *demo::Shift: Relational
+  {
+    ~primaryKey
+    (
+      [demo::store::ShiftDB]shiftTable.id
+    )
+    ~mainTable [demo::store::ShiftDB]shiftTable
+    id: [demo::store::ShiftDB]shiftTable.id,
+    startedAt: [demo::store::ShiftDB]shiftTable.startedAt
+  }
+)

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-connection-time-zone/service/services.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-emit/src/test/resources/relational-emit-models/relational-connection-time-zone/service/services.pure
@@ -1,0 +1,270 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// One service per connection, each asking the same question of the same row.
+// A TIMESTAMP column holds a wall clock the database keeps in the zone the
+// connection names, and a Pure DateTime is a moment, so the answer moves with
+// the zone. The three services naming +10:00 three different ways have to give
+// the same answer as each other.
+
+###Service
+// No time zone named. A connection carrying none settles on GMT upstream, so
+// the wall clock is read as though the database kept it in GMT and the moment
+// is the wall clock itself. This is the baseline the others move away from.
+Service demo::service::ShiftGmtService
+{
+  pattern: '/api/shifts/gmt';
+  documentation: 'Shifts read through a connection naming its time zone one way.';
+  autoActivateUpdates: true;
+  execution: Single
+  {
+    query: |demo::Shift.all()->project([x|$x.id, x|$x.startedAt], ['Id', 'Started At']);
+    mapping: demo::ShiftMapping;
+    runtime: demo::runtime::ShiftGmtRuntime;
+  }
+  testSuites:
+  [
+    shiftSuite:
+    {
+      tests:
+      [
+        startedAt:
+        {
+          serializationFormat: PURE_TDSOBJECT;
+          asserts:
+          [
+            shouldReadTheStoredWallClockAsThatMoment:
+              EqualToJson
+              #{
+                expected:
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '[{"Id":1,"Started At":"2012-05-20T13:10:52.501000000+0000"}]';
+                  }#;
+              }#
+          ]
+        }
+      ]
+    }
+  ]
+}
+
+// A region name. Pacific/Guam is +10:00 the year round, and java.util reads a
+// region name correctly on its own.
+Service demo::service::ShiftRegionService
+{
+  pattern: '/api/shifts/region';
+  documentation: 'Shifts read through a connection naming its time zone one way.';
+  autoActivateUpdates: true;
+  execution: Single
+  {
+    query: |demo::Shift.all()->project([x|$x.id, x|$x.startedAt], ['Id', 'Started At']);
+    mapping: demo::ShiftMapping;
+    runtime: demo::runtime::ShiftRegionRuntime;
+  }
+  testSuites:
+  [
+    shiftSuite:
+    {
+      tests:
+      [
+        startedAt:
+        {
+          serializationFormat: PURE_TDSOBJECT;
+          asserts:
+          [
+            shouldReadTheStoredWallClockAsThatMoment:
+              EqualToJson
+              #{
+                expected:
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '[{"Id":1,"Started At":"2012-05-20T03:10:52.501000000+0000"}]';
+                  }#;
+              }#
+          ]
+        }
+      ]
+    }
+  ]
+}
+
+// The same zone written as a bare offset, which the grammar takes unquoted.
+// java.util takes an offset only with a GMT prefix and answers every other name
+// it does not know with GMT, so this used to be no shift at all. It has to read
+// the row as the same moment Pacific/Guam does.
+Service demo::service::ShiftOffsetService
+{
+  pattern: '/api/shifts/offset';
+  documentation: 'Shifts read through a connection naming its time zone one way.';
+  autoActivateUpdates: true;
+  execution: Single
+  {
+    query: |demo::Shift.all()->project([x|$x.id, x|$x.startedAt], ['Id', 'Started At']);
+    mapping: demo::ShiftMapping;
+    runtime: demo::runtime::ShiftOffsetRuntime;
+  }
+  testSuites:
+  [
+    shiftSuite:
+    {
+      tests:
+      [
+        startedAt:
+        {
+          serializationFormat: PURE_TDSOBJECT;
+          asserts:
+          [
+            shouldReadTheStoredWallClockAsThatMoment:
+              EqualToJson
+              #{
+                expected:
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '[{"Id":1,"Started At":"2012-05-20T03:10:52.501000000+0000"}]';
+                  }#;
+              }#
+          ]
+        }
+      ]
+    }
+  ]
+}
+
+// The same offset again, written with a UTC prefix. Before Java 21,
+// TimeZone.getTimeZone(ZoneId) passes this form to a lookup that knows region
+// names and GMT prefixed offsets only, and so reads it as GMT.
+Service demo::service::ShiftUtcPrefixedOffsetService
+{
+  pattern: '/api/shifts/utcprefixedoffset';
+  documentation: 'Shifts read through a connection naming its time zone one way.';
+  autoActivateUpdates: true;
+  execution: Single
+  {
+    query: |demo::Shift.all()->project([x|$x.id, x|$x.startedAt], ['Id', 'Started At']);
+    mapping: demo::ShiftMapping;
+    runtime: demo::runtime::ShiftUtcPrefixedOffsetRuntime;
+  }
+  testSuites:
+  [
+    shiftSuite:
+    {
+      tests:
+      [
+        startedAt:
+        {
+          serializationFormat: PURE_TDSOBJECT;
+          asserts:
+          [
+            shouldReadTheStoredWallClockAsThatMoment:
+              EqualToJson
+              #{
+                expected:
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '[{"Id":1,"Started At":"2012-05-20T03:10:52.501000000+0000"}]';
+                  }#;
+              }#
+          ]
+        }
+      ]
+    }
+  ]
+}
+
+// An offset that is not a whole number of hours, so an hours-only reading of
+// the shift would not show up as wrong here.
+Service demo::service::ShiftHalfHourOffsetService
+{
+  pattern: '/api/shifts/halfhouroffset';
+  documentation: 'Shifts read through a connection naming its time zone one way.';
+  autoActivateUpdates: true;
+  execution: Single
+  {
+    query: |demo::Shift.all()->project([x|$x.id, x|$x.startedAt], ['Id', 'Started At']);
+    mapping: demo::ShiftMapping;
+    runtime: demo::runtime::ShiftHalfHourOffsetRuntime;
+  }
+  testSuites:
+  [
+    shiftSuite:
+    {
+      tests:
+      [
+        startedAt:
+        {
+          serializationFormat: PURE_TDSOBJECT;
+          asserts:
+          [
+            shouldReadTheStoredWallClockAsThatMoment:
+              EqualToJson
+              #{
+                expected:
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '[{"Id":1,"Started At":"2012-05-20T07:40:52.501000000+0000"}]';
+                  }#;
+              }#
+          ]
+        }
+      ]
+    }
+  ]
+}
+
+// A region that keeps daylight saving time. 2012-05-20 is inside it, so the
+// offset is -04:00 rather than the -05:00 the zone keeps in winter.
+Service demo::service::ShiftDaylightSavingService
+{
+  pattern: '/api/shifts/daylightsaving';
+  documentation: 'Shifts read through a connection naming its time zone one way.';
+  autoActivateUpdates: true;
+  execution: Single
+  {
+    query: |demo::Shift.all()->project([x|$x.id, x|$x.startedAt], ['Id', 'Started At']);
+    mapping: demo::ShiftMapping;
+    runtime: demo::runtime::ShiftDaylightSavingRuntime;
+  }
+  testSuites:
+  [
+    shiftSuite:
+    {
+      tests:
+      [
+        startedAt:
+        {
+          serializationFormat: PURE_TDSOBJECT;
+          asserts:
+          [
+            shouldReadTheStoredWallClockAsThatMoment:
+              EqualToJson
+              #{
+                expected:
+                  ExternalFormat
+                  #{
+                    contentType: 'application/json';
+                    data: '[{"Id":1,"Started At":"2012-05-20T17:10:52.501000000+0000"}]';
+                  }#;
+              }#
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/legend-engine-xts-service/legend-engine-language-pure-dsl-service-execution/src/test/java/org/finos/legend/engine/language/pure/dsl/service/execution/TestServiceRunner.java
+++ b/legend-engine-xts-service/legend-engine-language-pure-dsl-service-execution/src/test/java/org/finos/legend/engine/language/pure/dsl/service/execution/TestServiceRunner.java
@@ -1237,6 +1237,11 @@ public class TestServiceRunner
 
     public static SingleExecutionPlan buildPlanForFetchFunction(String modelCodeResource, String fetchFunctionName)
     {
+        return buildPlanForFetchFunction(modelCodeResource, fetchFunctionName, "test::Runtime");
+    }
+
+    public static SingleExecutionPlan buildPlanForFetchFunction(String modelCodeResource, String fetchFunctionName, String runtimeName)
+    {
         try
         {
             InputStreamReader inputStreamReader = new InputStreamReader(Objects.requireNonNull(TestServiceRunner.class.getResourceAsStream(modelCodeResource)));
@@ -1249,7 +1254,7 @@ public class TestServiceRunner
             return PlanGenerator.generateExecutionPlan(
                     HelperValueSpecificationBuilder.buildLambda(fetchFunction.body, fetchFunction.parameters, new CompileContext.Builder(pureModel).build()),
                     pureModel.getMapping("test::Map"),
-                    pureModel.getRuntime("test::Runtime"),
+                    pureModel.getRuntime(runtimeName),
                     null,
                     pureModel,
                     "vX_X_X",
@@ -1304,6 +1309,43 @@ public class TestServiceRunner
         catch (Exception e)
         {
             Assert.assertEquals("Error instantiating property 'name' on Target class 'test::targetPerson [test_targetPerson]' on Mapping 'test::Map'.\n" + "Cannot cast a collection of size 0 to multiplicity [1]", e.getMessage());
+        }
+    }
+
+    /**
+     * A connection's time zone names the zone the database keeps its wall clocks in, and a Pure
+     * DateTime is a moment, so reading a TIMESTAMP column shifts it out of that zone. The stored
+     * wall clock is the same row in every case; only the Runtime differs.
+     */
+    @Test
+    public void testConnectionTimeZoneShiftsATimestampOutOfTheZoneItNames()
+    {
+        Assert.assertEquals("no time zone named, so GMT", shiftStartedAt("2012-05-20T13:10:52.501000000"), runShiftService("test::Runtime"));
+        Assert.assertEquals("Pacific/Guam", shiftStartedAt("2012-05-20T03:10:52.501000000"), runShiftService("test::RuntimeRegion"));
+        Assert.assertEquals("America/New_York, inside daylight saving time", shiftStartedAt("2012-05-20T17:10:52.501000000"), runShiftService("test::RuntimeDaylightSaving"));
+    }
+
+    private static String runShiftService(String runtime)
+    {
+        return new TimeZoneServiceRunner(runtime).run(ServiceRunnerInput.newInstance().withSerializationFormat(SerializationFormat.PURE));
+    }
+
+    private static String shiftStartedAt(String moment)
+    {
+        return "{\"id\":1,\"startedAt\":\"" + moment + "\"}";
+    }
+
+    private static class TimeZoneServiceRunner extends AbstractServicePlanExecutor
+    {
+        TimeZoneServiceRunner(String runtime)
+        {
+            super("test::Service", buildPlanForFetchFunction("/org/finos/legend/engine/pure/dsl/service/execution/test/relationalServiceTimeZones.pure", "test::fetchShift__String_1_", runtime), true);
+        }
+
+        @Override
+        public List<ServiceVariable> getServiceVariables()
+        {
+            return Collections.emptyList();
         }
     }
 }

--- a/legend-engine-xts-service/legend-engine-language-pure-dsl-service-execution/src/test/resources/org/finos/legend/engine/pure/dsl/service/execution/test/relationalServiceTimeZones.pure
+++ b/legend-engine-xts-service/legend-engine-language-pure-dsl-service-execution/src/test/resources/org/finos/legend/engine/pure/dsl/service/execution/test/relationalServiceTimeZones.pure
@@ -1,0 +1,139 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// One store, one mapping, one query, and a Runtime per way of naming a time
+// zone. The table holds a wall clock the database keeps in the zone the
+// connection names, and a Pure DateTime is a moment, so each Runtime reads the
+// same stored row as a different instant.
+
+###Pure
+Class test::Shift
+{
+  id: Integer[1];
+  startedAt: DateTime[0..1];
+}
+
+function test::fetchShift(): String[1]
+{
+  test::Shift.all()->graphFetch(#{test::Shift{id, startedAt}}#)->serialize(#{test::Shift{id, startedAt}}#)
+}
+
+###Relational
+Database test::DB
+(
+  Table shiftTable
+  (
+    ID INTEGER PRIMARY KEY,
+    STARTED_AT TIMESTAMP
+  )
+)
+
+###Mapping
+Mapping test::Map
+(
+  *test::Shift: Relational
+  {
+    ~primaryKey
+    (
+      [test::DB]shiftTable.ID
+    )
+    ~mainTable [test::DB]shiftTable
+    id: [test::DB]shiftTable.ID,
+    startedAt: [test::DB]shiftTable.STARTED_AT
+  }
+)
+
+###Runtime
+Runtime test::Runtime
+{
+  mappings:
+  [
+    test::Map
+  ];
+  connections:
+  [
+    test::DB:
+    [
+      connection_default:
+      #{
+        RelationalDatabaseConnection
+        {
+          store: test::DB;
+          type: H2;
+          specification: LocalH2
+          {
+            testDataSetupCSV: 'default\nshiftTable\nID,STARTED_AT\n1,2012-05-20T13:10:52.501\n---';
+          };
+          auth: DefaultH2;
+        }
+      }#
+    ]
+  ];
+}
+
+Runtime test::RuntimeRegion
+{
+  mappings:
+  [
+    test::Map
+  ];
+  connections:
+  [
+    test::DB:
+    [
+      connection_region:
+      #{
+        RelationalDatabaseConnection
+        {
+          store: test::DB;
+          type: H2;
+          timezone: 'Pacific/Guam';
+          specification: LocalH2
+          {
+            testDataSetupCSV: 'default\nshiftTable\nID,STARTED_AT\n1,2012-05-20T13:10:52.501\n---';
+          };
+          auth: DefaultH2;
+        }
+      }#
+    ]
+  ];
+}
+
+Runtime test::RuntimeDaylightSaving
+{
+  mappings:
+  [
+    test::Map
+  ];
+  connections:
+  [
+    test::DB:
+    [
+      connection_daylight:
+      #{
+        RelationalDatabaseConnection
+        {
+          store: test::DB;
+          type: H2;
+          timezone: 'America/New_York';
+          specification: LocalH2
+          {
+            testDataSetupCSV: 'default\nshiftTable\nID,STARTED_AT\n1,2012-05-20T13:10:52.501\n---';
+          };
+          auth: DefaultH2;
+        }
+      }#
+    ]
+  ];
+}


### PR DESCRIPTION
Follow-up to finos/legend-engine#5183, which changed how a time zone name is resolved and how a date or timestamp column is read. Tests only: no behavior changes here.

A connection's `timeZone` names the zone the database keeps its wall clocks in. A Pure DateTime is a moment, so reading a TIMESTAMP column shifts it out of that zone — and which spellings of a zone name are understood is exactly what #5183 changed. Nothing covered that from a model, on either of the two readings the engine actually uses.

### Two readings, two tests

The engine reads a relational column two different ways, and they do not share code, so each needs its own test.

**TDS, through `ResultColumn`** — covered by a new EMIT model, `relational-connection-time-zone`. One table holding one wall clock, and a Service per way of naming the zone: none at all, a region (`Pacific/Guam`), a bare offset (`+1000`), a UTC prefixed offset (`UTC+1000`), an offset that is not a whole hour (`UTC+0530`), and a region inside daylight saving time (`America/New_York`). Each service test asserts the moment the stored wall clock stands for in that zone.

**Graph fetch, through generated Java** — covered by `relationalServiceTimeZones.pure` and two tests in `TestServiceRunner`. One store, one mapping, one query, and a Runtime per zone.

Both suites guard themselves without anything having to be reverted. Every Runtime and every Service reaches the same stored row, so a reading that ignored the connection's zone would answer the same wall clock every time and most of the assertions would fail.

### Notes for reviewers

- The test data rides on each connection rather than in the test. A test that brings its own `connections:` block has the connection rebuilt by `RelationalConnectionFactory.buildH2TestConnection`, which keeps the store and drops everything else the connection said — the time zone included. A fixture written that way would assert nothing about time zones while reading as though it did. This is worth knowing before writing the next one.
- `buildPlanForFetchFunction` gains a runtime parameter, having hard coded `test::Runtime` before. Every existing caller keeps the runtime it had.
- `execution:connection-time-zone` is a new EMIT taxonomy entry, added in this PR as `emit-authoring.md` asks.
- The EMIT fixture covers the offset spellings and the `TestServiceRunner` one covers only the regions. That is deliberate: the offsets are **not** applied on the graph fetch reading, which is a separate defect with its own PR to follow.

### Verification

`RelationalEMITTests` 477 tests, up from 457. `TestServiceRunner` 57 tests, no skips. No failures and no checkstyle violations in either module.